### PR TITLE
contract: implement sign fn with yield/resume

### DIFF
--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -3750,6 +3750,7 @@ dependencies = [
  "borsh",
  "crypto-shared",
  "k256",
+ "near-gas",
  "near-sdk",
  "near-workspaces",
  "schemars",

--- a/chain-signatures/contract/Cargo.toml
+++ b/chain-signatures/contract/Cargo.toml
@@ -14,6 +14,7 @@ serde_json = "1"
 schemars = "0.8"
 k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde", "arithmetic", "expose-field"] }
 crypto-shared = { path = "../crypto-shared" }
+near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }
 
 [dev-dependencies]
 near-workspaces = { git = "https://github.com/near/near-workspaces-rs", branch = "node/1.40" }

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -14,7 +14,8 @@ use near_sdk::{
 };
 
 use primitives::{
-    CandidateInfo, Candidates, ParticipantInfo, Participants, PkVotes, SignRequest, Votes,
+    CandidateInfo, Candidates, ParticipantInfo, Participants, PkVotes, SignRequest,
+    SignaturePromiseError, SignatureResult, Votes,
 };
 use std::collections::{BTreeMap, HashSet};
 
@@ -23,8 +24,11 @@ const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(250);
 // Register used to receive data id from `promise_await_data`.
 const DATA_ID_REGISTER: u64 = 0;
 
-// Prepaid gas for a `sign_on_finish` call
-const SIGN_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
+// Prepaid gas for a `clear_state_on_finish` call
+const CLEAR_STATE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
+
+// Prepaid gas for a `return_signature_on_finish` call
+const RETURN_SIGNATURE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
 pub struct InitializingContractState {
@@ -216,16 +220,15 @@ impl VersionedMpcContract {
         let predecessor = env::predecessor_account_id();
         let request = SignatureRequest::new(payload, &predecessor, &path);
         if !self.request_already_exists(&request) {
-            self.mark_request_pending(&request);
             match self {
                 Self::V0(mpc_contract) => {
                     let index = mpc_contract.next_available_yield_resume_request_index;
                     mpc_contract.next_available_yield_resume_request_index += 1;
 
                     let yield_promise = env::promise_yield_create(
-                        "sign_on_finish",
+                        "clear_state_on_finish",
                         &serde_json::to_vec(&(index,)).unwrap(),
-                        SIGN_ON_FINISH_CALL_GAS,
+                        CLEAR_STATE_ON_FINISH_CALL_GAS,
                         GasWeight(0),
                         DATA_ID_REGISTER,
                     );
@@ -235,6 +238,16 @@ impl VersionedMpcContract {
                         .expect("")
                         .try_into()
                         .expect("");
+
+                    mpc_contract.add_request(&request, &Some(data_id));
+                    mpc_contract.add_yield_resume_request(
+                        index,
+                        YieldResumeRequest {
+                            data_id,
+                            account_id: env::signer_account_id(),
+                            signature_request: request,
+                        },
+                    );
 
                     log!(
                         "sign: predecessor={}, payload={:?}, path={:?}, key_version={}, data_id={:?}",
@@ -248,18 +261,17 @@ impl VersionedMpcContract {
                         &serde_json::to_string(&near_sdk::env::random_seed_array()).unwrap(),
                     );
 
-                    mpc_contract.add_request(&request, &Some(data_id));
-                    mpc_contract.add_yield_resume_request(
-                        index,
-                        YieldResumeRequest {
-                            data_id,
-                            account_id: env::signer_account_id(),
-                            signature_request: request,
-                        },
+                    let final_yield_promise = env::promise_then(
+                        yield_promise,
+                        env::current_account_id(),
+                        "return_signature_on_finish",
+                        &[],
+                        NearToken::from_near(0),
+                        RETURN_SIGNATURE_ON_FINISH_CALL_GAS,
                     );
                     // The return value for this function call will be the value
                     // returned by the `sign_on_finish` callback.
-                    env::promise_return(yield_promise);
+                    env::promise_return(final_yield_promise);
                 }
             }
         } else {
@@ -268,19 +280,34 @@ impl VersionedMpcContract {
     }
 
     #[private]
-    pub fn sign_on_finish(
+    pub fn return_signature_on_finish(
+        &mut self,
+        #[callback_unwrap] signature: SignatureResult<SignatureResponse, SignaturePromiseError>,
+    ) -> SignatureResponse {
+        match self {
+            Self::V0(_) => match signature {
+                SignatureResult::Ok(signature) => signature,
+                SignatureResult::Err(_) => {
+                    env::panic_str("Signature has timed out");
+                }
+            },
+        }
+    }
+
+    #[private]
+    pub fn clear_state_on_finish(
         &mut self,
         yield_resume_request_index: u64,
         #[callback_result] signature: Result<SignatureResponse, PromiseError>,
-    ) -> SignatureResponse {
+    ) -> SignatureResult<SignatureResponse, SignaturePromiseError> {
         match self {
             Self::V0(mpc_contract) => {
                 // Clean up the local state
                 mpc_contract.remove_request_by_yield_resume_index(yield_resume_request_index);
 
                 match signature {
-                    Ok(signature) => signature,
-                    Err(_) => env::panic_str("signature request timed out"),
+                    Ok(signature) => SignatureResult::Ok(signature),
+                    Err(_) => SignatureResult::Err(SignaturePromiseError::Failed),
                 }
             }
         }
@@ -334,7 +361,7 @@ impl VersionedMpcContract {
                         );
                     } else {
                         env::panic_str(
-                            "such request does not exist in contract's pending requests.",
+                            "this sign request was removed from pending requests: timed out or completed.",
                         )
                     }
                 }
@@ -667,14 +694,6 @@ impl VersionedMpcContract {
         match self {
             Self::V0(mpc_contract) => {
                 mpc_contract.clean_payloads(requests, counter);
-            }
-        }
-    }
-
-    fn mark_request_pending(&mut self, request: &SignatureRequest) {
-        match self {
-            Self::V0(mpc_contract) => {
-                mpc_contract.add_request(request, &None);
             }
         }
     }

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -325,12 +325,6 @@ impl VersionedMpcContract {
                 &response.big_r,
                 &response.s
             );
-            log!(
-                "respond: signer={}, request={:?} response={:?}",
-                &signer,
-                &request,
-                &response
-            );
 
             // generate the expected public key
             let expected_public_key = derive_key(

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -146,9 +146,8 @@ impl MpcContract {
             data_id: _,
             account_id: _,
             signature_request,
-        }) = self.yield_resume_requests.get(&index)
+        }) = self.yield_resume_requests.remove(&index)
         {
-            self.yield_resume_requests.remove(&index);
             self.pending_requests.remove(&signature_request);
             self.request_counter -= 1;
         } else {
@@ -235,9 +234,9 @@ impl VersionedMpcContract {
 
                     // Store the request in the contract's local state
                     let data_id: CryptoHash = env::read_register(DATA_ID_REGISTER)
-                        .expect("")
+                        .expect("read_register failed")
                         .try_into()
-                        .expect("");
+                        .expect("conversion to CryptoHash failed");
 
                     mpc_contract.add_request(&request, &Some(data_id));
                     mpc_contract.add_yield_resume_request(

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -9,8 +9,8 @@ use near_sdk::collections::LookupMap;
 use near_sdk::serde::{Deserialize, Serialize};
 
 use near_sdk::{
-    env, log, near_bindgen, AccountId, BorshStorageKey, Gas, NearToken, Promise, PromiseOrValue,
-    PublicKey,
+    env, log, near_bindgen, AccountId, BorshStorageKey, CryptoHash, Gas, GasWeight, NearToken,
+    PromiseError, PublicKey,
 };
 
 use primitives::{
@@ -19,6 +19,12 @@ use primitives::{
 use std::collections::{BTreeMap, HashSet};
 
 const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(250);
+
+// Register used to receive data id from `promise_await_data`.
+const DATA_ID_REGISTER: u64 = 0;
+
+// Prepaid gas for a `sign_on_finish` call
+const SIGN_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
 pub struct InitializingContractState {
@@ -58,8 +64,18 @@ pub enum ProtocolContractState {
 }
 
 #[derive(BorshSerialize, BorshDeserialize, BorshStorageKey, Hash, Clone, Debug, PartialEq, Eq)]
+#[borsh(crate = "near_sdk::borsh")]
 pub enum StorageKey {
     PendingRequests,
+    YieldResumeRequests,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
+#[borsh(crate = "near_sdk::borsh")]
+pub struct YieldResumeRequest {
+    data_id: CryptoHash,
+    account_id: AccountId,
+    signature_request: SignatureRequest,
 }
 
 #[near_bindgen]
@@ -75,6 +91,7 @@ impl Default for VersionedMpcContract {
 }
 
 #[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug, Clone)]
+#[borsh(crate = "near_sdk::borsh")]
 pub struct SignatureRequest {
     pub epsilon: SerializableScalar,
     pub payload_hash: [u8; 32],
@@ -94,29 +111,44 @@ impl SignatureRequest {
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
 pub struct MpcContract {
     protocol_state: ProtocolContractState,
-    pending_requests: LookupMap<SignatureRequest, Option<SignatureResponse>>,
+    pending_requests: LookupMap<SignatureRequest, Option<CryptoHash>>,
     request_counter: u32,
+    yield_resume_requests: LookupMap<u64, YieldResumeRequest>,
+    next_available_yield_resume_request_index: u64,
 }
 
 impl MpcContract {
-    fn add_request(&mut self, request: &SignatureRequest, result: &Option<SignatureResponse>) {
+    fn add_request(
+        &mut self,
+        request: &SignatureRequest,
+        yield_resume_data_id: &Option<CryptoHash>,
+    ) {
         if self.request_counter > 8 {
             env::panic_str("Too many pending requests. Please, try again later.");
         }
         if !self.pending_requests.contains_key(request) {
             self.request_counter += 1;
         }
-        self.pending_requests.insert(request, result);
+        self.pending_requests.insert(request, yield_resume_data_id);
     }
 
-    fn remove_request(&mut self, payload: &SignatureRequest) {
-        self.pending_requests.remove(payload);
-        self.request_counter -= 1;
+    fn add_yield_resume_request(&mut self, index: u64, yield_resume_request: YieldResumeRequest) {
+        self.yield_resume_requests
+            .insert(&index, &yield_resume_request);
     }
 
-    fn add_sign_result(&mut self, payload: &SignatureRequest, signature: SignatureResponse) {
-        if self.pending_requests.contains_key(payload) {
-            self.pending_requests.insert(payload, &Some(signature));
+    fn remove_request_by_yield_resume_index(&mut self, index: u64) {
+        if let Some(YieldResumeRequest {
+            data_id: _,
+            account_id: _,
+            signature_request,
+        }) = self.yield_resume_requests.get(&index)
+        {
+            self.yield_resume_requests.remove(&index);
+            self.pending_requests.remove(&signature_request);
+            self.request_counter -= 1;
+        } else {
+            env::panic_str("yield resume requests do not contain this request.")
         }
     }
 
@@ -137,6 +169,8 @@ impl MpcContract {
             }),
             pending_requests: LookupMap::new(StorageKey::PendingRequests),
             request_counter: 0,
+            yield_resume_requests: LookupMap::new(StorageKey::YieldResumeRequests),
+            next_available_yield_resume_request_index: 0u64,
         }
     }
 }
@@ -150,7 +184,7 @@ impl VersionedMpcContract {
     /// we ask for a small deposit for each signature request.
     /// The fee changes based on how busy the network is.
     #[payable]
-    pub fn sign(&mut self, request: SignRequest) -> Promise {
+    pub fn sign(&mut self, request: SignRequest) {
         let SignRequest {
             payload,
             path,
@@ -178,23 +212,135 @@ impl VersionedMpcContract {
             env::prepaid_gas(),
             GAS_FOR_SIGN_CALL
         );
-        let predecessor = env::predecessor_account_id();
-        log!(
-            "sign: predecessor={}, payload={:?}, path={:?}, key_version={}",
-            predecessor,
-            payload,
-            path,
-            key_version
-        );
 
+        let predecessor = env::predecessor_account_id();
         let request = SignatureRequest::new(payload, &predecessor, &path);
-        match self.sign_result(&request) {
-            None => {
-                self.add_sign_request(&request);
-                env::log_str(&serde_json::to_string(&near_sdk::env::random_seed_array()).unwrap());
-                Self::ext(env::current_account_id()).sign_helper(request, 0)
+        if !self.request_already_exists(&request) {
+            self.mark_request_pending(&request);
+            match self {
+                Self::V0(mpc_contract) => {
+                    let index = mpc_contract.next_available_yield_resume_request_index;
+                    mpc_contract.next_available_yield_resume_request_index += 1;
+
+                    let yield_promise = env::promise_yield_create(
+                        "sign_on_finish",
+                        &serde_json::to_vec(&(index,)).unwrap(),
+                        SIGN_ON_FINISH_CALL_GAS,
+                        GasWeight(0),
+                        DATA_ID_REGISTER,
+                    );
+
+                    // Store the request in the contract's local state
+                    let data_id: CryptoHash = env::read_register(DATA_ID_REGISTER)
+                        .expect("")
+                        .try_into()
+                        .expect("");
+
+                    log!(
+                        "sign: predecessor={}, payload={:?}, path={:?}, key_version={}, data_id={:?}",
+                        predecessor,
+                        payload,
+                        path,
+                        key_version,
+                        data_id
+                    );
+                    env::log_str(
+                        &serde_json::to_string(&near_sdk::env::random_seed_array()).unwrap(),
+                    );
+
+                    mpc_contract.add_request(&request, &Some(data_id));
+                    mpc_contract.add_yield_resume_request(
+                        index,
+                        YieldResumeRequest {
+                            data_id,
+                            account_id: env::signer_account_id(),
+                            signature_request: request,
+                        },
+                    );
+                    // The return value for this function call will be the value
+                    // returned by the `sign_on_finish` callback.
+                    env::promise_return(yield_promise);
+                }
             }
-            Some(_) => env::panic_str("Signature for this payload already requested"),
+        } else {
+            env::panic_str("Signature for this payload already requested")
+        }
+    }
+
+    #[private]
+    pub fn sign_on_finish(
+        &mut self,
+        yield_resume_request_index: u64,
+        #[callback_result] signature: Result<SignatureResponse, PromiseError>,
+    ) -> SignatureResponse {
+        match self {
+            Self::V0(mpc_contract) => {
+                // Clean up the local state
+                mpc_contract.remove_request_by_yield_resume_index(yield_resume_request_index);
+
+                match signature {
+                    Ok(signature) => signature,
+                    Err(_) => env::panic_str("signature request timed out"),
+                }
+            }
+        }
+    }
+
+    pub fn respond(&mut self, request: SignatureRequest, response: SignatureResponse) {
+        let protocol_state = self.mutable_state();
+        if let ProtocolContractState::Running(_) = protocol_state {
+            let signer = env::signer_account_id();
+            // TODO add back in a check to see that the caller is a participant (it's horrible to test atm)
+            // It's not strictly necessary, since we verify the payload is correct
+            log!(
+                "respond: signer={}, request={:?} big_r={:?} s={:?}",
+                &signer,
+                &request,
+                &response.big_r,
+                &response.s
+            );
+            log!(
+                "respond: signer={}, request={:?} response={:?}",
+                &signer,
+                &request,
+                &response
+            );
+
+            // generate the expected public key
+            let expected_public_key = derive_key(
+                near_public_key_to_affine_point(self.public_key()),
+                request.epsilon.scalar,
+            );
+
+            // Check the signature is correct
+            if check_ec_signature(
+                &expected_public_key,
+                &response.big_r.affine_point,
+                &response.s.scalar,
+                k256::Scalar::from_bytes(&request.payload_hash[..]),
+                response.recovery_id,
+            )
+            .is_err()
+            {
+                env::panic_str("Signature could not be verified");
+            }
+
+            match self {
+                Self::V0(mpc_contract) => {
+                    if let Some(Some(data_id)) = mpc_contract.pending_requests.get(&request) {
+                        env::promise_yield_resume(
+                            &data_id,
+                            &serde_json::to_vec(&response).unwrap(),
+                        );
+                    } else {
+                        env::panic_str(
+                            "such request does not exist in contract's pending requests.",
+                        )
+                    }
+                }
+            }
+        } else {
+            env::panic_str("protocol is not in a running state");
         }
     }
 
@@ -218,45 +364,6 @@ impl VersionedMpcContract {
     // contract version
     pub fn version(&self) -> String {
         env!("CARGO_PKG_VERSION").to_string()
-    }
-
-    pub fn respond(&mut self, request: SignatureRequest, response: SignatureResponse) {
-        let protocol_state = self.mutable_state();
-        if let ProtocolContractState::Running(_) = protocol_state {
-            let signer = env::signer_account_id();
-            // TODO add back in a check to see that the caller is a participant (it's horrible to test atm)
-            // It's not strictly necessary, since we verify the payload is correct
-            log!(
-                "respond: signer={}, request={:?} big_r={:?} s={:?}",
-                &signer,
-                &request,
-                &response.big_r,
-                &response.s
-            );
-
-            // generate the expected public key
-            let expected_public_key = derive_key(
-                near_public_key_to_affine_point(self.public_key()),
-                request.epsilon.scalar,
-            );
-
-            // Check the signature is correct
-            if check_ec_signature(
-                &expected_public_key,
-                &response.big_r.affine_point,
-                &response.s.scalar,
-                k256::Scalar::from_bytes(&request.payload_hash[..]),
-                response.recovery_id,
-            )
-            .is_err()
-            {
-                env::panic_str("Signature could not be verified");
-            }
-
-            self.add_sign_result(&request, response);
-        } else {
-            env::panic_str("protocol is not in a running state");
-        }
     }
 
     pub fn join(
@@ -494,6 +601,7 @@ impl VersionedMpcContract {
             threshold,
             serde_json::to_string(&candidates).unwrap()
         );
+
         Self::V0(MpcContract::init(threshold, candidates))
     }
 
@@ -514,6 +622,7 @@ impl VersionedMpcContract {
             threshold,
             public_key
         );
+
         Self::V0(MpcContract {
             protocol_state: ProtocolContractState::Running(RunningContractState {
                 epoch,
@@ -524,57 +633,11 @@ impl VersionedMpcContract {
                 join_votes: Votes::new(),
                 leave_votes: Votes::new(),
             }),
-            pending_requests: LookupMap::new(b"m"),
+            pending_requests: LookupMap::new(StorageKey::PendingRequests),
             request_counter: 0,
+            yield_resume_requests: LookupMap::new(StorageKey::YieldResumeRequests),
+            next_available_yield_resume_request_index: 0u64,
         })
-    }
-
-    #[private]
-    pub fn sign_helper(
-        &mut self,
-        request: SignatureRequest,
-        depth: usize,
-    ) -> PromiseOrValue<SignatureResponse> {
-        if let Some(signature) = self.sign_result(&request) {
-            match signature {
-                Some(signature) => {
-                    log!(
-                        "sign_helper: signature ready: {:?}, depth: {:?}",
-                        signature,
-                        depth
-                    );
-                    self.remove_sign_request(&request);
-                    PromiseOrValue::Value(signature)
-                }
-                None => {
-                    // Make sure we have enough gas left to do 1 more call and clean up afterwards
-                    // Observationally 30 calls < 300 TGas so 2 calls < 20 TGas
-                    // We keep one call back so we can cleanup then call panic on the next call
-                    // Start cleaning up if there's less than 25 teragas left regardless of how deep you are.
-                    if depth > 30 || env::prepaid_gas() < Gas::from_tgas(25) {
-                        self.remove_sign_request(&request);
-                        let self_id = env::current_account_id();
-                        PromiseOrValue::Promise(Self::ext(self_id).fail_helper(
-                            "Signature was not provided in time. Please, try again.".to_string(),
-                        ))
-                    } else {
-                        log!("sign_helper: signature not ready yet (depth={})", depth);
-                        let account_id = env::current_account_id();
-                        PromiseOrValue::Promise(
-                            Self::ext(account_id).sign_helper(request, depth + 1),
-                        )
-                    }
-                }
-            }
-        } else {
-            env::panic_str("unexpected request")
-        }
-    }
-
-    /// This allows us to return a panic, without rolling back the state from this call
-    #[private]
-    pub fn fail_helper(&mut self, message: String) {
-        env::panic_str(&message);
     }
 
     pub fn state(&self) -> &ProtocolContractState {
@@ -594,6 +657,8 @@ impl VersionedMpcContract {
             protocol_state: ProtocolContractState::NotInitialized,
             pending_requests: LookupMap::new(StorageKey::PendingRequests),
             request_counter: 0,
+            yield_resume_requests: LookupMap::new(StorageKey::YieldResumeRequests),
+            next_available_yield_resume_request_index: 0u64,
         })
     }
 
@@ -606,37 +671,10 @@ impl VersionedMpcContract {
         }
     }
 
-    #[private]
-    #[init(ignore_state)]
-    pub fn migrate_state_old_to_v0() -> Self {
-        let old_contract: MpcContract = env::state_read().expect("Old state doesn't exist");
-        Self::V0(MpcContract {
-            protocol_state: old_contract.protocol_state,
-            pending_requests: old_contract.pending_requests,
-            request_counter: old_contract.request_counter,
-        })
-    }
-
-    fn remove_sign_request(&mut self, request: &SignatureRequest) {
-        match self {
-            Self::V0(mpc_contract) => {
-                mpc_contract.remove_request(request);
-            }
-        }
-    }
-
-    fn add_sign_request(&mut self, request: &SignatureRequest) {
+    fn mark_request_pending(&mut self, request: &SignatureRequest) {
         match self {
             Self::V0(mpc_contract) => {
                 mpc_contract.add_request(request, &None);
-            }
-        }
-    }
-
-    fn add_sign_result(&mut self, request: &SignatureRequest, response: SignatureResponse) {
-        match self {
-            Self::V0(mpc_contract) => {
-                mpc_contract.add_sign_result(request, response);
             }
         }
     }
@@ -647,9 +685,9 @@ impl VersionedMpcContract {
         }
     }
 
-    fn sign_result(&self, request: &SignatureRequest) -> Option<Option<SignatureResponse>> {
+    fn request_already_exists(&self, request: &SignatureRequest) -> bool {
         match self {
-            Self::V0(mpc_contract) => mpc_contract.pending_requests.get(request),
+            Self::V0(mpc_contract) => mpc_contract.pending_requests.contains_key(request),
         }
     }
 

--- a/chain-signatures/contract/src/primitives.rs
+++ b/chain-signatures/contract/src/primitives.rs
@@ -220,3 +220,14 @@ pub struct SignResult {
     pub big_r: String,
     pub s: String,
 }
+
+#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize, Clone, Debug)]
+pub enum SignatureResult<T, E> {
+    Ok(T),
+    Err(E),
+}
+
+#[derive(Serialize, Deserialize, BorshDeserialize, BorshSerialize, Clone, Debug)]
+pub enum SignaturePromiseError {
+    Failed,
+}

--- a/chain-signatures/contract/tests/tests.rs
+++ b/chain-signatures/contract/tests/tests.rs
@@ -1,7 +1,6 @@
-use mpc_contract::{primitives::CandidateInfo, MpcContract, VersionedMpcContract};
-use near_sdk::env;
+use mpc_contract::primitives::CandidateInfo;
 use near_workspaces::AccountId;
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 const CONTRACT_FILE_PATH: &str = "../../target/wasm32-unknown-unknown/release/mpc_contract.wasm";
 
@@ -34,22 +33,6 @@ async fn test_contract_can_not_be_reinitialized() -> anyhow::Result<()> {
         .await?;
 
     assert!(result2.is_failure());
-
-    Ok(())
-}
-
-#[test]
-fn test_old_state_can_be_migrated_to_v0() -> anyhow::Result<()> {
-    let old_contract = MpcContract::init(3, BTreeMap::new());
-    env::state_write(&old_contract);
-
-    let v0_contract = VersionedMpcContract::migrate_state_old_to_v0();
-    let expected_contract = VersionedMpcContract::V0(old_contract);
-
-    assert_eq!(
-        format!("{v0_contract:#?}"),
-        format!("{expected_contract:#?}")
-    );
 
     Ok(())
 }

--- a/infra/scripts/generate_cipher_and_sign_keys/Cargo.toml
+++ b/infra/scripts/generate_cipher_and_sign_keys/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "generate_cipher_keys"
+name = "generate_cipher_and_sign_keys"
 version = "0.1.0"
 edition = "2021"
 

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -3763,6 +3763,7 @@ dependencies = [
  "serde_json",
  "test-log",
  "testcontainers",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -4240,6 +4240,7 @@ dependencies = [
  "borsh",
  "crypto-shared",
  "k256",
+ "near-gas",
  "near-sdk",
  "schemars",
  "serde",

--- a/integration-tests/chain-signatures/Cargo.toml
+++ b/integration-tests/chain-signatures/Cargo.toml
@@ -23,6 +23,7 @@ testcontainers = { version = "0.15", features = ["experimental"] }
 tokio = { version = "1.28", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+thiserror = "1"
 
 # crypto dependencies
 cait-sith = { git = "https://github.com/LIT-Protocol/cait-sith.git", features = [

--- a/integration-tests/chain-signatures/tests/actions/mod.rs
+++ b/integration-tests/chain-signatures/tests/actions/mod.rs
@@ -24,6 +24,7 @@ use near_primitives::transaction::{Action, FunctionCallAction, Transaction};
 use near_workspaces::Account;
 use rand::Rng;
 use secp256k1::XOnlyPublicKey;
+use wait_for::WaitForError;
 
 use std::time::Duration;
 
@@ -212,16 +213,26 @@ pub async fn request_sign_non_random(
     account: Account,
     payload: [u8; 32],
     payload_hashed: [u8; 32],
-) -> anyhow::Result<([u8; 32], [u8; 32], Account, CryptoHash)> {
+) -> Result<([u8; 32], [u8; 32], Account, CryptoHash), WaitForError> {
     let signer = InMemorySigner {
         account_id: account.id().clone(),
-        public_key: account.secret_key().public_key().to_string().parse()?,
-        secret_key: account.secret_key().to_string().parse()?,
+        public_key: account
+            .secret_key()
+            .public_key()
+            .to_string()
+            .parse()
+            .map_err(|_| WaitForError::ParsingError)?,
+        secret_key: account
+            .secret_key()
+            .to_string()
+            .parse()
+            .map_err(|_| WaitForError::ParsingError)?,
     };
     let (nonce, block_hash, _) = ctx
         .rpc_client
         .fetch_nonce(&signer.account_id, &signer.public_key)
-        .await?;
+        .await
+        .map_err(|error| WaitForError::FetchError(format!("{error:?}")))?;
 
     let request = SignRequest {
         payload: payload_hashed,
@@ -242,14 +253,16 @@ pub async fn request_sign_non_random(
                     method_name: "sign".to_string(),
                     args: serde_json::to_vec(&serde_json::json!({
                         "request": request,
-                    }))?,
+                    }))
+                    .map_err(|error| WaitForError::SerdeJsonError(format!("{error:?}")))?,
                     gas: 300_000_000_000_000,
                     deposit: 1,
                 }))],
             }
             .sign(&signer),
         })
-        .await?;
+        .await
+        .map_err(|error| WaitForError::JsonRpcError(format!("{error:?}")))?;
     tokio::time::sleep(Duration::from_secs(1)).await;
     Ok((payload, payload_hashed, account, tx_hash))
 }
@@ -258,10 +271,16 @@ pub async fn single_payload_signature_production(
     ctx: &MultichainTestContext<'_>,
     state: &RunningContractState,
 ) -> anyhow::Result<()> {
-    let (payload, payload_hash, account, _) = request_sign(ctx).await?;
-    let signature =
-        wait_for::signature_payload_responded(ctx, account.clone(), payload, payload_hash).await?;
-
+    let (payload, payload_hash, account, tx_hash) = request_sign(ctx).await?;
+    let first_tx_result = wait_for::signature_responded(ctx, tx_hash).await;
+    let signature = match first_tx_result {
+        Ok(sig) => sig,
+        Err(error) => {
+            println!("single_payload_signature_production: first sign tx err out with {error:?}");
+            wait_for::signature_payload_responded(ctx, account.clone(), payload, payload_hash)
+                .await?
+        }
+    };
     let mut mpc_pk_bytes = vec![0x04];
     mpc_pk_bytes.extend_from_slice(&state.public_key.as_bytes()[1..]);
     assert_signature(

--- a/integration-tests/chain-signatures/tests/actions/mod.rs
+++ b/integration-tests/chain-signatures/tests/actions/mod.rs
@@ -221,18 +221,18 @@ pub async fn request_sign_non_random(
             .public_key()
             .to_string()
             .parse()
-            .map_err(|_| WaitForError::ParsingError)?,
+            .map_err(|_| WaitForError::Parsing)?,
         secret_key: account
             .secret_key()
             .to_string()
             .parse()
-            .map_err(|_| WaitForError::ParsingError)?,
+            .map_err(|_| WaitForError::Parsing)?,
     };
     let (nonce, block_hash, _) = ctx
         .rpc_client
         .fetch_nonce(&signer.account_id, &signer.public_key)
         .await
-        .map_err(|error| WaitForError::FetchError(format!("{error:?}")))?;
+        .map_err(|error| WaitForError::Fetch(format!("{error:?}")))?;
 
     let request = SignRequest {
         payload: payload_hashed,
@@ -254,7 +254,7 @@ pub async fn request_sign_non_random(
                     args: serde_json::to_vec(&serde_json::json!({
                         "request": request,
                     }))
-                    .map_err(|error| WaitForError::SerdeJsonError(format!("{error:?}")))?,
+                    .map_err(|error| WaitForError::SerdeJson(format!("{error:?}")))?,
                     gas: 300_000_000_000_000,
                     deposit: 1,
                 }))],
@@ -262,7 +262,7 @@ pub async fn request_sign_non_random(
             .sign(&signer),
         })
         .await
-        .map_err(|error| WaitForError::JsonRpcError(format!("{error:?}")))?;
+        .map_err(|error| WaitForError::JsonRpc(format!("{error:?}")))?;
     tokio::time::sleep(Duration::from_secs(1)).await;
     Ok((payload, payload_hashed, account, tx_hash))
 }

--- a/integration-tests/chain-signatures/tests/actions/wait_for.rs
+++ b/integration-tests/chain-signatures/tests/actions/wait_for.rs
@@ -4,8 +4,8 @@ use crate::actions;
 use crate::MultichainTestContext;
 
 use anyhow::Context;
-use backon::ExponentialBuilder;
 use backon::Retryable;
+use backon::{ConstantBuilder, ExponentialBuilder};
 use cait_sith::FullSignature;
 use crypto_shared::SignatureResponse;
 use k256::Secp256k1;
@@ -248,17 +248,16 @@ pub async fn signature_responded(
         };
 
         let Some(outcome) = outcome_view.final_execution_outcome else {
-            return Err(WaitForError::Signature(
-                SignatureError::NotYetAvailable,
-            ));
+            return Err(WaitForError::Signature(SignatureError::NotYetAvailable));
         };
 
         let outcome = outcome.into_outcome();
 
         let FinalExecutionStatus::SuccessValue(payload) = outcome.status else {
-            return Err(WaitForError::Signature(SignatureError::Failed(
-                format!("{:?}", outcome.status),
-            )));
+            return Err(WaitForError::Signature(SignatureError::Failed(format!(
+                "{:?}",
+                outcome.status
+            ))));
         };
 
         let result: SignatureResponse = match serde_json::from_slice(&payload) {
@@ -273,29 +272,11 @@ pub async fn signature_responded(
         Ok(signature)
     };
 
-    let mut result: Result<FullSignature<Secp256k1>, WaitForError> = Err(
-        WaitForError::Signature(SignatureError::NotYetAvailable),
-    );
+    let strategy = ConstantBuilder::default()
+        .with_delay(Duration::from_secs(20))
+        .with_max_times(5);
 
-    // retry getting tx status for 5 times
-    let mut retries = 5;
-    while let Err(error) = result {
-        match error {
-            WaitForError::Signature(SignatureError::Failed(_)) => return Err(error),
-            _ => {
-                if retries < 0 {
-                    return Err(error);
-                }
-                if retries < 5 {
-                    tokio::time::sleep(Duration::from_secs(20)).await;
-                }
-                result = is_tx_ready().await;
-            }
-        }
-        retries -= 1;
-    }
-
-    result
+    is_tx_ready.retry(&strategy).await
 }
 
 pub async fn signature_payload_responded(
@@ -310,13 +291,12 @@ pub async fn signature_payload_responded(
         signature_responded(ctx, tx_hash).await
     };
 
-    let mut result: Result<FullSignature<Secp256k1>, WaitForError> = Err(
-        WaitForError::Signature(SignatureError::Failed("Signature timed out".to_string())),
-    );
+    let mut result: Result<FullSignature<Secp256k1>, WaitForError> = Err(WaitForError::Signature(
+        SignatureError::Failed("Signature timed out".to_string()),
+    ));
 
     let mut retries = 3;
-    while let Err(WaitForError::Signature(SignatureError::Failed(ref error_message))) = result
-    {
+    while let Err(WaitForError::Signature(SignatureError::Failed(ref error_message))) = result {
         if retries < 3 {
             println!("single_payload_signature_production: the signature request result is {error_message:?}");
         }

--- a/integration-tests/chain-signatures/tests/actions/wait_for.rs
+++ b/integration-tests/chain-signatures/tests/actions/wait_for.rs
@@ -216,15 +216,15 @@ pub enum SignatureError {
 #[derive(Debug, thiserror::Error)]
 pub enum WaitForError {
     #[error("Json RPC request error: {0}")]
-    JsonRpcError(String),
+    JsonRpc(String),
     #[error("signature tx error: {0}")]
-    SignatureError(SignatureError),
+    Signature(SignatureError),
     #[error("Serde json error: {0}")]
-    SerdeJsonError(String),
+    SerdeJson(String),
     #[error("Parsing error")]
-    ParsingError,
-    #[error("Near fetch error: {0}")]
-    FetchError(String),
+    Parsing,
+    #[error("Near fetch: {0}")]
+    Fetch(String),
 }
 
 pub async fn signature_responded(
@@ -243,12 +243,12 @@ pub async fn signature_responded(
             })
             .await
         {
-            Err(error) => return Err(WaitForError::JsonRpcError(format!("{error:?}"))),
+            Err(error) => return Err(WaitForError::JsonRpc(format!("{error:?}"))),
             Ok(outcome_view) => outcome_view,
         };
 
         let Some(outcome) = outcome_view.final_execution_outcome else {
-            return Err(WaitForError::SignatureError(
+            return Err(WaitForError::Signature(
                 SignatureError::NotYetAvailable,
             ));
         };
@@ -256,13 +256,13 @@ pub async fn signature_responded(
         let outcome = outcome.into_outcome();
 
         let FinalExecutionStatus::SuccessValue(payload) = outcome.status else {
-            return Err(WaitForError::SignatureError(SignatureError::Failed(
+            return Err(WaitForError::Signature(SignatureError::Failed(
                 format!("{:?}", outcome.status),
             )));
         };
 
         let result: SignatureResponse = match serde_json::from_slice(&payload) {
-            Err(error) => return Err(WaitForError::SerdeJsonError(format!("{error:?}"))),
+            Err(error) => return Err(WaitForError::SerdeJson(format!("{error:?}"))),
             Ok(response) => response,
         };
         let signature = cait_sith::FullSignature::<Secp256k1> {
@@ -274,14 +274,14 @@ pub async fn signature_responded(
     };
 
     let mut result: Result<FullSignature<Secp256k1>, WaitForError> = Err(
-        WaitForError::SignatureError(SignatureError::NotYetAvailable),
+        WaitForError::Signature(SignatureError::NotYetAvailable),
     );
 
     // retry getting tx status for 5 times
     let mut retries = 5;
     while let Err(error) = result {
         match error {
-            WaitForError::SignatureError(SignatureError::Failed(_)) => return Err(error),
+            WaitForError::Signature(SignatureError::Failed(_)) => return Err(error),
             _ => {
                 if retries < 0 {
                     return Err(error);
@@ -311,11 +311,11 @@ pub async fn signature_payload_responded(
     };
 
     let mut result: Result<FullSignature<Secp256k1>, WaitForError> = Err(
-        WaitForError::SignatureError(SignatureError::Failed(format!("na"))),
+        WaitForError::Signature(SignatureError::Failed("Signature timed out".to_string())),
     );
 
     let mut retries = 3;
-    while let Err(WaitForError::SignatureError(SignatureError::Failed(ref error_message))) = result
+    while let Err(WaitForError::Signature(SignatureError::Failed(ref error_message))) = result
     {
         if retries < 3 {
             println!("single_payload_signature_production: the signature request result is {error_message:?}");

--- a/integration-tests/chain-signatures/tests/actions/wait_for.rs
+++ b/integration-tests/chain-signatures/tests/actions/wait_for.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::actions;
 use crate::MultichainTestContext;
 
@@ -203,12 +205,34 @@ pub async fn has_at_least_mine_presignatures<'a>(
     Ok(state_views)
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum SignatureError {
+    #[error("tx final outcome not yet available")]
+    NotYetAvailable,
+    #[error("tx was unsuccessful: {0}")]
+    Failed(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum WaitForError {
+    #[error("Json RPC request error: {0}")]
+    JsonRpcError(String),
+    #[error("signature tx error: {0}")]
+    SignatureError(SignatureError),
+    #[error("Serde json error: {0}")]
+    SerdeJsonError(String),
+    #[error("Parsing error")]
+    ParsingError,
+    #[error("Near fetch error: {0}")]
+    FetchError(String),
+}
+
 pub async fn signature_responded(
     ctx: &MultichainTestContext<'_>,
     tx_hash: CryptoHash,
-) -> anyhow::Result<FullSignature<Secp256k1>> {
+) -> Result<FullSignature<Secp256k1>, WaitForError> {
     let is_tx_ready = || async {
-        let outcome_view = ctx
+        let outcome_view = match ctx
             .jsonrpc_client
             .call(RpcTransactionStatusRequest {
                 transaction_info: TransactionInfo::TransactionId {
@@ -217,19 +241,30 @@ pub async fn signature_responded(
                 },
                 wait_until: near_primitives::views::TxExecutionStatus::Final,
             })
-            .await?;
+            .await
+        {
+            Err(error) => return Err(WaitForError::JsonRpcError(format!("{error:?}"))),
+            Ok(outcome_view) => outcome_view,
+        };
 
         let Some(outcome) = outcome_view.final_execution_outcome else {
-            anyhow::bail!("final execution outcome not available");
+            return Err(WaitForError::SignatureError(
+                SignatureError::NotYetAvailable,
+            ));
         };
 
         let outcome = outcome.into_outcome();
 
         let FinalExecutionStatus::SuccessValue(payload) = outcome.status else {
-            anyhow::bail!("tx finished unsuccessfully: {:?}", outcome.status);
+            return Err(WaitForError::SignatureError(SignatureError::Failed(
+                format!("{:?}", outcome.status),
+            )));
         };
 
-        let result: SignatureResponse = serde_json::from_slice(&payload)?;
+        let result: SignatureResponse = match serde_json::from_slice(&payload) {
+            Err(error) => return Err(WaitForError::SerdeJsonError(format!("{error:?}"))),
+            Ok(response) => response,
+        };
         let signature = cait_sith::FullSignature::<Secp256k1> {
             big_r: result.big_r.affine_point,
             s: result.s.scalar,
@@ -238,11 +273,29 @@ pub async fn signature_responded(
         Ok(signature)
     };
 
-    let signature = is_tx_ready
-        .retry(&ExponentialBuilder::default().with_max_times(6))
-        .await
-        .with_context(|| "failed to wait for signature response")?;
-    Ok(signature)
+    let mut result: Result<FullSignature<Secp256k1>, WaitForError> = Err(
+        WaitForError::SignatureError(SignatureError::NotYetAvailable),
+    );
+
+    // retry getting tx status for 5 times
+    let mut retries = 5;
+    while let Err(error) = result {
+        match error {
+            WaitForError::SignatureError(SignatureError::Failed(_)) => return Err(error),
+            _ => {
+                if retries < 0 {
+                    return Err(error);
+                }
+                if retries < 5 {
+                    tokio::time::sleep(Duration::from_secs(20)).await;
+                }
+                result = is_tx_ready().await;
+            }
+        }
+        retries -= 1;
+    }
+
+    result
 }
 
 pub async fn signature_payload_responded(
@@ -250,18 +303,33 @@ pub async fn signature_payload_responded(
     account: Account,
     payload: [u8; 32],
     payload_hashed: [u8; 32],
-) -> anyhow::Result<FullSignature<Secp256k1>> {
+) -> Result<FullSignature<Secp256k1>, WaitForError> {
     let is_signature_ready = || async {
         let (_, _, _, tx_hash) =
             actions::request_sign_non_random(ctx, account.clone(), payload, payload_hashed).await?;
         signature_responded(ctx, tx_hash).await
     };
 
-    let signature = is_signature_ready
-        .retry(&ExponentialBuilder::default().with_max_times(6))
-        .await
-        .with_context(|| "failed to wait for signature response")?;
-    Ok(signature)
+    let mut result: Result<FullSignature<Secp256k1>, WaitForError> = Err(
+        WaitForError::SignatureError(SignatureError::Failed(format!("na"))),
+    );
+
+    let mut retries = 3;
+    while let Err(WaitForError::SignatureError(SignatureError::Failed(ref error_message))) = result
+    {
+        if retries < 3 {
+            println!("single_payload_signature_production: the signature request result is {error_message:?}");
+        }
+        if retries <= 0 {
+            break;
+        }
+        println!("single_payload_signature_production: issuing a new signature request with same payload");
+        result = is_signature_ready().await;
+
+        retries -= 1;
+    }
+
+    result
 }
 
 // Check that the rogue message failed

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -281,8 +281,7 @@ async fn test_signature_offline_node_back_online() -> anyhow::Result<()> {
             wait_for::has_at_least_mine_triples(&ctx, 2).await?;
             wait_for::has_at_least_mine_presignatures(&ctx, 1).await?;
 
-            // Kill the node then have presignature and signature generation only use the active set of nodes
-            // to start generating presignatures and signatures.
+            // Kill node 2
             let account_id = near_workspaces::types::AccountId::from_str(
                 state_0.participants.keys().last().unwrap().clone().as_ref(),
             )

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -279,6 +279,7 @@ async fn test_signature_offline_node_back_online() -> anyhow::Result<()> {
             assert_eq!(state_0.participants.len(), 3);
             wait_for::has_at_least_triples(&ctx, 6).await?;
             wait_for::has_at_least_mine_triples(&ctx, 2).await?;
+            wait_for::has_at_least_mine_presignatures(&ctx, 1).await?;
 
             // Kill the node then have presignature and signature generation only use the active set of nodes
             // to start generating presignatures and signatures.
@@ -288,26 +289,16 @@ async fn test_signature_offline_node_back_online() -> anyhow::Result<()> {
             .unwrap();
             let killed_node_config = ctx.nodes.kill_node(&account_id).await?;
 
-            // This could potentially fail and timeout the first time if the participant set picked up is the
-            // one with the offline node. This is expected behavior for now if a user submits a request in between
-            // a node going offline and the system hasn't detected it yet.
-            let presig_res = wait_for::has_at_least_mine_presignatures(&ctx, 1).await;
-            let sig_res = actions::single_signature_production(&ctx, &state_0).await;
-
-            // Try again if the first attempt failed. This second portion should not be needed when the NEP
-            // comes in for resumeable MPC.
-            if presig_res.is_err() || sig_res.is_err() {
-                // Retry if the first attempt failed.
-                wait_for::has_at_least_mine_presignatures(&ctx, 1).await?;
-                actions::single_signature_production(&ctx, &state_0).await?;
-            }
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
 
             // Start the killed node again
             ctx.nodes.restart_node(killed_node_config).await?;
 
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
             wait_for::has_at_least_mine_triples(&ctx, 2).await?;
             wait_for::has_at_least_mine_presignatures(&ctx, 1).await?;
-            // retry the same payload multiple times because we might pick a presignature that is not present in node 2 initially
+            // retry the same payload multiple times because we might pick many presignatures not present in node 2 repeatedly until yield/resume time out
             actions::single_payload_signature_production(&ctx, &state_0).await?;
 
             Ok(())


### PR DESCRIPTION
in this new design, we don't store the SignatureResponse in contract state. We still 1) won't allow repeated request if it was already requested and not completed; 2) only allow 8 requests concurrently

Note this new sign fn will return nothing, but you could still use it as if it returns Promise in any cross contract calls. 