### PR TITLE
fix: potential panics when calling into contract

### DIFF
--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -4519,8 +4519,9 @@ dependencies = [
 
 [[package]]
 name = "near-fetch"
-version = "0.2.0"
-source = "git+https://github.com/ChaoticTempest/fetch.git#20c8825f47cb88b61a961be3ccbfc262bff45db9"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc473b6bf35836eebc23457fb1a3747ab956022e04a9238fcb510b5912a9f0fe"
 dependencies = [
  "base64 0.22.1",
  "near-account-id",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -43,7 +43,7 @@ url = { version = "2.4.0", features = ["serde"] }
 
 near-account-id = "1.0.0"
 near-crypto = "0.21.2"
-near-fetch = { git = "https://github.com/ChaoticTempest/fetch.git" }
+near-fetch = "0.3.1"
 near-lake-framework = { git = "https://github.com/near/near-lake-framework-rs", branch = "dmd/bump-dependencies" }
 near-lake-primitives = { git = "https://github.com/near/near-lake-framework-rs", branch = "dmd/bump-dependencies" }
 near-primitives = "0.21.2"

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -236,12 +236,12 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                     let signer = InMemorySigner::from_secret_key(account_id.clone(), account_sk);
                     let (protocol, protocol_state) = MpcSignProtocol::init(
                         my_address,
-                        mpc_contract_id.clone(),
+                        mpc_contract_id,
                         account_id,
-                        rpc_client.clone(),
-                        signer.clone(),
+                        rpc_client,
+                        signer,
                         receiver,
-                        sign_queue.clone(),
+                        sign_queue,
                         key_storage,
                         triple_storage,
                         Config {

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -59,6 +59,8 @@ pub enum ConsensusError {
     HasBeenKicked,
     #[error("this node errored out during the join process: {0}")]
     CannotJoin(String),
+    #[error("this node errored out while trying to vote: {0}")]
+    CannotVote(String),
     #[error("cait-sith initialization error: {0}")]
     CaitSithInitializationError(#[from] InitializationError),
     #[error("secret storage error: {0}")]
@@ -314,7 +316,14 @@ impl ConsensusProtocol for WaitingForConsensusState {
                         &public_key,
                     )
                     .await
-                    .unwrap();
+                    .map_err(|err| {
+                        tracing::error!(
+                            ?public_key,
+                            ?err,
+                            "failed to vote for the generated public key"
+                        );
+                        ConsensusError::CannotVote(format!("{err:?}"))
+                    })?;
                 }
                 Ok(NodeState::WaitingForConsensus(self))
             }
@@ -433,7 +442,14 @@ impl ConsensusProtocol for WaitingForConsensusState {
                                         self.epoch,
                                     )
                                     .await
-                                    .unwrap();
+                                    .map_err(|err| {
+                                        tracing::error!(
+                                            epoch = self.epoch,
+                                            ?err,
+                                            "failed to vote for resharing"
+                                        );
+                                        ConsensusError::CannotVote(format!("{err:?}"))
+                                    })?;
                                 } else {
                                     tracing::info!(
                                         epoch = self.epoch,

--- a/chain-signatures/node/src/protocol/consensus.rs
+++ b/chain-signatures/node/src/protocol/consensus.rs
@@ -665,6 +665,7 @@ impl ConsensusProtocol for JoiningState {
                                 "sign_pk": ctx.cfg().network_cfg.sign_sk.public_key(),
                             }))
                             .max_gas()
+                            .retry_exponential(10, 3)
                             .transact()
                             .await
                             .map_err(|err| {

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -26,7 +26,7 @@ use crate::mesh::{Mesh, NetworkConfig};
 use crate::protocol::consensus::ConsensusProtocol;
 use crate::protocol::cryptography::CryptographicProtocol;
 use crate::protocol::message::{MessageHandler, MpcMessageQueue};
-use crate::rpc_client::{self};
+use crate::rpc_client;
 use crate::storage::secret_storage::SecretNodeStorageBox;
 use crate::storage::triple_storage::LockTripleNodeStorageBox;
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -544,6 +544,7 @@ impl SignatureManager {
                     "response": signature,
                 }))
                 .max_gas()
+                .retry_exponential(10, 5)
                 .transact()
                 .await?;
             crate::metrics::NUM_SIGN_SUCCESS

--- a/chain-signatures/node/src/rpc_client.rs
+++ b/chain-signatures/node/src/rpc_client.rs
@@ -2,7 +2,6 @@ use crate::protocol::ProtocolState;
 
 use near_account_id::AccountId;
 use near_crypto::InMemorySigner;
-use near_primitives::views::FinalExecutionStatus;
 
 use serde_json::json;
 
@@ -32,12 +31,10 @@ pub async fn vote_for_public_key(
         .max_gas()
         .retry_exponential(10, 5)
         .transact()
-        .await?;
+        .await?
+        .json()?;
 
-    match result.status() {
-        FinalExecutionStatus::SuccessValue(value) => Ok(serde_json::from_slice(value)?),
-        status => anyhow::bail!("unexpected status: {:?}", status),
-    }
+    Ok(result)
 }
 
 pub async fn vote_reshared(
@@ -54,10 +51,8 @@ pub async fn vote_reshared(
         .max_gas()
         .retry_exponential(10, 5)
         .transact()
-        .await?;
+        .await?
+        .json()?;
 
-    match result.status() {
-        FinalExecutionStatus::SuccessValue(value) => Ok(serde_json::from_slice(value)?),
-        status => anyhow::bail!("unexpected status: {:?}", status),
-    }
+    Ok(result)
 }

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -4908,8 +4908,9 @@ dependencies = [
 
 [[package]]
 name = "near-fetch"
-version = "0.2.0"
-source = "git+https://github.com/ChaoticTempest/fetch.git#20c8825f47cb88b61a961be3ccbfc262bff45db9"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc473b6bf35836eebc23457fb1a3747ab956022e04a9238fcb510b5912a9f0fe"
 dependencies = [
  "base64 0.22.1",
  "near-account-id",

--- a/integration-tests/chain-signatures/Cargo.toml
+++ b/integration-tests/chain-signatures/Cargo.toml
@@ -33,7 +33,7 @@ k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde"] }
 # near dependencies
 near-account-id = "1"
 near-crypto = "0.21"
-near-fetch = { git = "https://github.com/ChaoticTempest/fetch.git" }
+near-fetch = "0.3.1"
 near-jsonrpc-client = "0.9"
 near-primitives = "0.21"
 near-lake-framework = { git = "https://github.com/near/near-lake-framework-rs", branch = "dmd/bump-dependencies" }

--- a/integration-tests/chain-signatures/tests/actions/wait_for.rs
+++ b/integration-tests/chain-signatures/tests/actions/wait_for.rs
@@ -218,9 +218,7 @@ pub async fn signature_responded(
                 wait_until: near_primitives::views::TxExecutionStatus::Final,
             })
             .await?;
-        // let FinalExecutionStatus::SuccessValue(payload) = outcome_view.status else {
-        //     anyhow::bail!("tx finished unsuccessfully: {:?}", outcome_view.status);
-        // };
+
         let Some(outcome) = outcome_view.final_execution_outcome else {
             anyhow::bail!("final execution outcome not available");
         };


### PR DESCRIPTION
This fixes a couple `unwrap`s that happen when voting. This can cause some errors to happen when the chain is slow. Also no longer using the near-fetch git repo