### PR TITLE
fix: Added retrying on indexer failures

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -182,10 +182,15 @@ fn spinup_indexer(
             let sign_queue = sign_queue.clone();
             let gcp = gcp.clone();
 
-            if let Err(err) = indexer::run(options, mpc_contract_id, account_id, sign_queue, gcp) {
-                tracing::error!(%err, "indexer failed");
-                std::thread::sleep(std::time::Duration::from_secs(2u64.pow(i)));
-            }
+            // TODO/NOTE: currently indexer does not have any interrupt handlers and will never yield back
+            // as successful. We can add interrupt handlers in the future but this is not important right
+            // now since we managing nodes through integration tests that can kill it or through docker.
+            let Err(err) = indexer::run(options, mpc_contract_id, account_id, sign_queue, gcp)
+            else {
+                break;
+            };
+            tracing::error!(%err, "indexer failed");
+            std::thread::sleep(std::time::Duration::from_secs(2u64.pow(i)));
         }
     })
 }


### PR DESCRIPTION
Noticed that indexer can potentially fail but won't report the error until we go to join the handle much later. This is due to the fact that panics are per thread here and would require getting the panic hook to truly handle it. Which is quite a hassle to deal with for now.

There's one minor thing this doesn't address is the cancellation of threads, which means that the when we go to join the thread handle at the end of the run call, it will potentially not join due to indexer being alive still. We would need to add some cancellation mechanisms such as sending over a message to kill the indexer loop, but that's too much work right now for this simple fix.