### PR TITLE
fix: dockerfile multichain

### DIFF
--- a/Dockerfile.multichain
+++ b/Dockerfile.multichain
@@ -12,12 +12,9 @@ RUN sed -i 's#mpc-keys = { path = "../keys" }##' Cargo.toml
 RUN sed -i 's#mpc-contract = { path = "../contract" }##' Cargo.toml
 RUN sed -i 's#crypto-shared = { path = "../crypto-shared" }##' Cargo.toml
 RUN cargo build --release
-COPY . .
-RUN sed -i 's#"mpc-recovery",##' Cargo.toml
-RUN sed -i 's#"integration-tests",##' Cargo.toml
-RUN sed -i 's#"load-tests",##' Cargo.toml
+COPY chain-signatures/Cargo.toml Cargo.toml
+RUN sed -i 's#"contract",##' Cargo.toml
 RUN sed -i 's#"keys",##' Cargo.toml
-RUN sed -i 's#"crypto-shared",##' Cargo.toml
 RUN cargo build --release --package mpc-recovery-node
 
 FROM debian:stable-slim as runtime

--- a/Dockerfile.multichain
+++ b/Dockerfile.multichain
@@ -12,9 +12,10 @@ RUN sed -i 's#mpc-keys = { path = "../keys" }##' Cargo.toml
 RUN sed -i 's#mpc-contract = { path = "../contract" }##' Cargo.toml
 RUN sed -i 's#crypto-shared = { path = "../crypto-shared" }##' Cargo.toml
 RUN cargo build --release
-COPY chain-signatures/Cargo.toml Cargo.toml
-RUN sed -i 's#"contract",##' Cargo.toml
+COPY chain-signatures/. .
 RUN sed -i 's#"keys",##' Cargo.toml
+RUN sed -i 's#"contract",##' Cargo.toml
+RUN sed -i 's#target-dir = "../target"#target-dir = "target"#' .cargo/config.toml
 RUN cargo build --release --package mpc-recovery-node
 
 FROM debian:stable-slim as runtime

--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -4652,7 +4652,7 @@ dependencies = [
 [[package]]
 name = "near-lake-context-derive"
 version = "0.8.0-beta.3"
-source = "git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies#e4eaa0c1b1c1d63c45963474db7ee82c38557d54"
+source = "git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e#e0b28590ffe6b6441987d302843d45bef55ef50e"
 dependencies = [
  "quote",
  "syn 2.0.66",
@@ -4661,7 +4661,7 @@ dependencies = [
 [[package]]
 name = "near-lake-framework"
 version = "0.8.0-beta.3"
-source = "git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies#e4eaa0c1b1c1d63c45963474db7ee82c38557d54"
+source = "git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e#e0b28590ffe6b6441987d302843d45bef55ef50e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4684,7 +4684,7 @@ dependencies = [
 [[package]]
 name = "near-lake-primitives"
 version = "0.8.0-beta.3"
-source = "git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies#e4eaa0c1b1c1d63c45963474db7ee82c38557d54"
+source = "git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e#e0b28590ffe6b6441987d302843d45bef55ef50e"
 dependencies = [
  "anyhow",
  "near-crypto 0.21.2",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -44,8 +44,8 @@ url = { version = "2.4.0", features = ["serde"] }
 near-account-id = "1.0.0"
 near-crypto = "0.21.2"
 near-fetch = "0.3.1"
-near-lake-framework = { git = "https://github.com/near/near-lake-framework-rs", branch = "dmd/bump-dependencies" }
-near-lake-primitives = { git = "https://github.com/near/near-lake-framework-rs", branch = "dmd/bump-dependencies" }
+near-lake-framework = { git = "https://github.com/near/near-lake-framework-rs", rev = "e0b28590ffe6b6441987d302843d45bef55ef50e" }
+near-lake-primitives = { git = "https://github.com/near/near-lake-framework-rs", rev = "e0b28590ffe6b6441987d302843d45bef55ef50e" }
 near-primitives = "0.21.2"
 near-sdk = { git = "https://github.com/near/near-sdk-rs.git", rev = "5a9acaedc95c5721d2088f263bc99e3de574decf", features = ["legacy", "unit-testing"] }
 

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -3995,8 +3995,8 @@ dependencies = [
  "near-crypto 0.21.2",
  "near-fetch",
  "near-jsonrpc-client 0.9.0",
- "near-lake-framework",
- "near-lake-primitives",
+ "near-lake-framework 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies)",
+ "near-lake-primitives 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies)",
  "near-primitives 0.21.2",
  "near-workspaces",
  "once_cell",
@@ -4611,8 +4611,8 @@ dependencies = [
  "near-account-id",
  "near-crypto 0.21.2",
  "near-fetch",
- "near-lake-framework",
- "near-lake-primitives",
+ "near-lake-framework 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e)",
+ "near-lake-primitives 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e)",
  "near-primitives 0.21.2",
  "near-sdk",
  "once_cell",
@@ -5048,6 +5048,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "near-lake-context-derive"
+version = "0.8.0-beta.3"
+source = "git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e#e0b28590ffe6b6441987d302843d45bef55ef50e"
+dependencies = [
+ "quote",
+ "syn 2.0.65",
+]
+
+[[package]]
 name = "near-lake-framework"
 version = "0.8.0-beta.3"
 source = "git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies#e4eaa0c1b1c1d63c45963474db7ee82c38557d54"
@@ -5060,8 +5069,31 @@ dependencies = [
  "aws-types",
  "derive_builder",
  "futures",
- "near-lake-context-derive",
- "near-lake-primitives",
+ "near-lake-context-derive 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies)",
+ "near-lake-primitives 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies)",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+]
+
+[[package]]
+name = "near-lake-framework"
+version = "0.8.0-beta.3"
+source = "git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e#e0b28590ffe6b6441987d302843d45bef55ef50e"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "aws-config",
+ "aws-credential-types",
+ "aws-sdk-s3",
+ "aws-types",
+ "derive_builder",
+ "futures",
+ "near-lake-context-derive 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e)",
+ "near-lake-primitives 0.8.0-beta.3 (git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e)",
  "serde",
  "serde_json",
  "thiserror",
@@ -5074,6 +5106,22 @@ dependencies = [
 name = "near-lake-primitives"
 version = "0.8.0-beta.3"
 source = "git+https://github.com/near/near-lake-framework-rs?branch=dmd/bump-dependencies#e4eaa0c1b1c1d63c45963474db7ee82c38557d54"
+dependencies = [
+ "anyhow",
+ "near-crypto 0.21.2",
+ "near-indexer-primitives",
+ "near-primitives 0.21.2",
+ "near-primitives-core 0.21.2",
+ "paste",
+ "serde",
+ "serde_json",
+ "thiserror",
+]
+
+[[package]]
+name = "near-lake-primitives"
+version = "0.8.0-beta.3"
+source = "git+https://github.com/near/near-lake-framework-rs?rev=e0b28590ffe6b6441987d302843d45bef55ef50e#e0b28590ffe6b6441987d302843d45bef55ef50e"
 dependencies = [
  "anyhow",
  "near-crypto 0.21.2",


### PR DESCRIPTION
Has been broken since we change folder structure. already tested on develop this works.
This will fix the down dev env.

There were 2 bugs with the Dockerfile.multichain:
1) we copied whole mpc folder instead of `chain-signatures/` folder. the issue there is the top level mpc folder has no `Cargo.toml` file, nothing will be built; 
2) after fixing 1), I find that https://github.com/near/mpc/blob/develop/chain-signatures/.cargo/config.toml#L2 actually ask to put the built binary to `../target`, instead of `target`. But later when we do
`COPY --from=builder /usr/src/app/target/release/mpc-recovery-node /usr/local/bin/mpc-recovery-node`
it is copying from `target` instead of `../target`. Which will copy nothing

This can be verified by built artifact size. If you look at artifacts size: [correct](https://console.cloud.google.com/artifacts/docker/pagoda-discovery-platform-dev/us-east1/multichain-public/multichain-dev/sha256:e1c97663fe2de5e6fe3b3e128ef462e6cca44a444c6e5d135615bb2274b7f5c6?project=pagoda-discovery-platform-dev) ones are 60+mb, [incorrect](https://console.cloud.google.com/artifacts/docker/pagoda-discovery-platform-dev/us-east1/multichain-public/multichain-dev/sha256:ea2a84fe2846009f42f9b0e35cad5405a3e3beb48d605fc341fd669603387679?project=pagoda-discovery-platform-dev) ones are only 50+ mb. I think reflects the fact that actually nothing is built.

Also included a dependency fix. Because the dmd/bump-dependencies branch has been deleted, I updated to a commit hash that merged.