### PR TITLE
fix: contract init stuck because of secret storage loading

### DIFF
--- a/chain-signatures/node/src/storage/secret_storage.rs
+++ b/chain-signatures/node/src/storage/secret_storage.rs
@@ -65,7 +65,14 @@ impl SecretNodeStorage for SecretManagerNodeStorage {
             .load_secret(&self.sk_share_secret_id)
             .await?;
         match raw_data {
-            Some(data) if data.len() > 1 => Ok(Some(serde_json::from_slice(&data)?)),
+            Some(data) if data.len() > 1 => {
+                if let Ok(persistent_node_data) = serde_json::from_slice(&data) {
+                    Ok(Some(persistent_node_data))
+                } else {
+                    tracing::info!("failed to convert stored data to key share, presuming it is missing");
+                    Ok(None)
+                }
+            },
             _ => {
                 tracing::info!("failed to load existing key share, presuming it is missing");
                 Ok(None)


### PR DESCRIPTION
secret storage loading value `1`, which is the initial value, returns error instead of None, thus state progression is stuck