### PR TITLE
feat: stuck protocol monitor

### DIFF
--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -465,7 +465,7 @@ impl CryptographicProtocol for RunningState {
         }
         drop(messages);
 
-        self.stuck_monitor.write().await.advance_then_check().await;
+        self.stuck_monitor.write().await.check().await;
         Ok(NodeState::Running(self))
     }
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -465,6 +465,7 @@ impl CryptographicProtocol for RunningState {
         }
         drop(messages);
 
+        self.stuck_monitor.write().await.advance_then_check().await;
         Ok(NodeState::Running(self))
     }
 }

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -1,12 +1,13 @@
-pub mod contract;
 mod cryptography;
-pub mod presignature;
 mod signature;
-pub mod triple;
 
 pub mod consensus;
+pub mod contract;
 pub mod message;
+pub mod monitor;
+pub mod presignature;
 pub mod state;
+pub mod triple;
 
 pub use consensus::ConsensusError;
 pub use contract::primitives::ParticipantInfo;

--- a/chain-signatures/node/src/protocol/monitor.rs
+++ b/chain-signatures/node/src/protocol/monitor.rs
@@ -1,0 +1,74 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+use super::triple::{TripleId, TripleManager};
+
+/// Amount of iterations before we can say that the protocol is stuck.
+const ADVANCEMENT_THRESHOLD: usize = 20;
+
+pub struct StuckMonitor {
+    triple_manager: Arc<RwLock<TripleManager>>,
+    last_checked_triples: HashSet<TripleId>,
+    last_changed_count: usize,
+}
+
+impl StuckMonitor {
+    pub async fn new(triple_manager: &Arc<RwLock<TripleManager>>) -> Self {
+        Self {
+            triple_manager: triple_manager.clone(),
+            last_checked_triples: triple_manager
+                .read()
+                .await
+                .triples
+                .keys()
+                .cloned()
+                .collect(),
+            last_changed_count: 0,
+        }
+    }
+
+    pub async fn advance_then_check(&mut self) {
+        let triple_manager = self.triple_manager.read().await;
+        let latest_triples: HashSet<_> = triple_manager.triples.keys().cloned().collect();
+        if triple_manager.has_min_triples() {
+            drop(triple_manager);
+            self.reset(latest_triples);
+            return;
+        }
+
+        let diff = latest_triples
+            .difference(&self.last_checked_triples)
+            .collect::<HashSet<_>>();
+        if diff.len() > 0 {
+            drop(triple_manager);
+            self.reset(latest_triples);
+            return;
+        }
+
+        self.last_changed_count += 1;
+        if self.last_changed_count == ADVANCEMENT_THRESHOLD {
+            tracing::warn!(
+                // ?latest_triples,
+                // generators = ?triple_manager.generators.keys().collect::<Vec<_>>(),
+                // queued = ?triple_manager.queued,
+                // ongoing = ?triple_manager.ongoing,
+                ?diff,
+                ?triple_manager,
+                "protocol is stuck for the last {} iterations",
+                self.last_changed_count
+            );
+        } else if self.last_changed_count > ADVANCEMENT_THRESHOLD {
+            tracing::error!(
+                ?diff,
+                "protocol is stuck for the last {} iterations",
+                self.last_changed_count
+            );
+        }
+    }
+
+    fn reset(&mut self, latest_triples: HashSet<TripleId>) {
+        self.last_checked_triples = latest_triples;
+        self.last_changed_count = 0;
+    }
+}

--- a/chain-signatures/node/src/protocol/state.rs
+++ b/chain-signatures/node/src/protocol/state.rs
@@ -1,5 +1,6 @@
 use super::contract::primitives::{ParticipantInfo, Participants};
 use super::cryptography::CryptographicError;
+use super::monitor::StuckMonitor;
 use super::presignature::PresignatureManager;
 use super::signature::SignatureManager;
 use super::triple::TripleManager;
@@ -7,6 +8,7 @@ use super::SignQueue;
 use crate::http_client::MessageQueue;
 use crate::storage::triple_storage::TripleData;
 use crate::types::{KeygenProtocol, ReshareProtocol, SecretKeyShare};
+
 use cait_sith::protocol::Participant;
 use crypto_shared::PublicKey;
 use near_account_id::AccountId;
@@ -92,6 +94,7 @@ pub struct RunningState {
     pub private_share: SecretKeyShare,
     pub public_key: PublicKey,
     pub sign_queue: Arc<RwLock<SignQueue>>,
+    pub stuck_monitor: Arc<RwLock<StuckMonitor>>,
     pub triple_manager: Arc<RwLock<TripleManager>>,
     pub presignature_manager: Arc<RwLock<PresignatureManager>>,
     pub signature_manager: Arc<RwLock<SignatureManager>>,

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -16,6 +16,7 @@ use k256::Secp256k1;
 use serde::{Deserialize, Serialize};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::fmt;
 use std::time::{Duration, Instant};
 
 use near_account_id::AccountId;
@@ -117,6 +118,29 @@ pub struct TripleManager {
     pub my_account_id: AccountId,
 }
 
+impl fmt::Debug for TripleManager {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("TripleManager")
+            .field("triples", &self.triples.keys().collect::<Vec<_>>())
+            .field("generators", &self.generators.keys().collect::<Vec<_>>())
+            .field("queued", &self.queued)
+            .field("ongoing", &self.ongoing)
+            .field("introduced", &self.introduced)
+            .field("taken", &self.taken.keys().collect::<Vec<_>>())
+            .field(
+                "failed_triples",
+                &self.failed_triples.keys().collect::<Vec<_>>(),
+            )
+            .field("mine", &self.mine)
+            .field("me", &self.me)
+            .field("threshold", &self.threshold)
+            .field("epoch", &self.epoch)
+            .field("my_account_id", &self.my_account_id)
+            .field("triple_cfg", &self.triple_cfg)
+            .finish()
+    }
+}
+
 impl TripleManager {
     pub fn new(
         me: Participant,
@@ -174,6 +198,10 @@ impl TripleManager {
     /// all ongoing generation protocols complete.
     pub fn potential_len(&self) -> usize {
         self.len() + self.generators.len()
+    }
+
+    pub fn has_min_triples(&self) -> bool {
+        self.my_len() >= self.triple_cfg.min_triples
     }
 
     /// Clears an entry from failed triples if that triple protocol was created more than 2 hrs ago


### PR DESCRIPTION
This will allow to keep tabs on whether our triple protocols are stuck or not while testing. This will be vital for monitoring if there is something going wrong or not. By default, we will report that the protocol is stuck if the amount of triples remain the same `STUCK_TIMEOUT_THRESHOLD` seconds. There's a `STUCK_COUNT_REPORT_INTERVAL` that will report the stuckness of the system every so often just to not spam the logs.

Ideally should make it into grafana metrics later