### PR TITLE
We should not check if caller of "respond" is a participant

### DIFF
--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -316,8 +316,6 @@ impl VersionedMpcContract {
         let protocol_state = self.mutable_state();
         if let ProtocolContractState::Running(_) = protocol_state {
             let signer = env::signer_account_id();
-            // TODO add back in a check to see that the caller is a participant (it's horrible to test atm)
-            // It's not strictly necessary, since we verify the payload is correct
             log!(
                 "respond: signer={}, request={:?} big_r={:?} s={:?}",
                 &signer,


### PR DESCRIPTION
We should not check if the caller of the “respond” function is a participant.
We agreed that we would use a locked contract and move from `v1.mpc.near` to `v2.mpc.near` in case of an upgrade. We plan to index both `v1` and `v2`, but the participant list will be updated only on the latest contract.

I do not see any security risks in this, since we are checking that the provided signature is valid.