### PR TITLE
Fail on bad scalar conversions

### DIFF
--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -1753,7 +1753,7 @@ dependencies = [
  "near-sdk",
  "serde",
  "serde_json",
- "sha3",
+ "subtle",
 ]
 
 [[package]]

--- a/chain-signatures/contract/tests/tests.rs
+++ b/chain-signatures/contract/tests/tests.rs
@@ -1,12 +1,13 @@
 use crypto_shared::kdf::{check_ec_signature, derive_secret_key};
 use crypto_shared::{
-    derive_epsilon, derive_key, SerializableAffinePoint, SerializableScalar, SignatureResponse,
+    derive_epsilon, derive_key, ScalarExt as _, SerializableAffinePoint, SerializableScalar,
+    SignatureResponse,
 };
 use ecdsa::signature::Verifier;
 use k256::elliptic_curve::ops::Reduce;
 use k256::elliptic_curve::point::DecompressPoint;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
-use k256::{AffinePoint, FieldBytes, Secp256k1};
+use k256::{AffinePoint, FieldBytes, Scalar, Secp256k1};
 use mpc_contract::primitives::{CandidateInfo, ParticipantInfo, SignRequest};
 use mpc_contract::SignatureRequest;
 use near_sdk::NearToken;
@@ -135,8 +136,8 @@ async fn create_response(
 
     let s = signature.s();
     let (r_bytes, _s_bytes) = signature.split_bytes();
-
-    let respond_req = SignatureRequest::new(payload_hash, predecessor_id, path);
+    let payload_hash_s = Scalar::from_bytes(payload_hash).unwrap();
+    let respond_req = SignatureRequest::new(payload_hash_s, predecessor_id, path);
     let big_r =
         AffinePoint::decompress(&r_bytes, k256::elliptic_curve::subtle::Choice::from(0)).unwrap();
     let s: k256::Scalar = *s.as_ref();

--- a/chain-signatures/crypto-shared/Cargo.toml
+++ b/chain-signatures/crypto-shared/Cargo.toml
@@ -18,6 +18,7 @@ near-account-id = "1"
 serde_json = "1"
 near-sdk = { version = "5.2.1", features = ["unstable"] }
 sha3 = "0.10.8"
+subtle = "2.6.1"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { version = "0.2.12", features = ["custom"] }

--- a/chain-signatures/crypto-shared/src/kdf.rs
+++ b/chain-signatures/crypto-shared/src/kdf.rs
@@ -22,7 +22,8 @@ pub fn derive_epsilon(predecessor_id: &AccountId, path: &str) -> Scalar {
     let derivation_path = format!("{EPSILON_DERIVATION_PREFIX}{},{}", predecessor_id, path);
     let mut hasher = Sha3_256::new();
     hasher.update(derivation_path);
-    Scalar::from_bytes(&hasher.finalize())
+    let hash: [u8; 32] = hasher.finalize().into();
+    Scalar::from_non_biased(hash)
 }
 
 pub fn derive_key(public_key: PublicKey, epsilon: Scalar) -> PublicKey {

--- a/chain-signatures/crypto-shared/src/types.rs
+++ b/chain-signatures/crypto-shared/src/types.rs
@@ -11,7 +11,6 @@ pub trait ScalarExt {
     fn from_bytes(bytes: &[u8]) -> Self;
 }
 
-// TODO prevent bad scalars from beind sent
 impl ScalarExt for Scalar {
     fn from_bytes(bytes: &[u8]) -> Self {
         let bytes = U256::from_be_slice(bytes);

--- a/chain-signatures/crypto-shared/src/types.rs
+++ b/chain-signatures/crypto-shared/src/types.rs
@@ -7,21 +7,49 @@ use serde::{Deserialize, Serialize};
 
 pub type PublicKey = <Secp256k1 as CurveArithmetic>::AffinePoint;
 
-pub trait ScalarExt {
-    fn from_bytes(bytes: &[u8]) -> Self;
+pub trait ScalarExt: Sized {
+    fn from_bytes(bytes: [u8; 32]) -> Option<Self>;
+    fn from_non_biased(bytes: [u8; 32]) -> Self;
 }
 
 impl ScalarExt for Scalar {
-    fn from_bytes(bytes: &[u8]) -> Self {
-        let bytes = U256::from_be_slice(bytes);
-        Scalar::from_repr(bytes.to_be_byte_array()).expect("Byte conversion to scalar failed")
+    /// Returns nothing if the bytes are greater than the field size of Secp256k1.
+    /// This will be very rare with random bytes as the field size is 2^256 - 2^32 - 2^9 - 2^8 - 2^7 - 2^6 - 2^4 - 1
+    fn from_bytes(bytes: [u8; 32]) -> Option<Self> {
+        let bytes = U256::from_be_slice(bytes.as_slice());
+        Scalar::from_repr(bytes.to_be_byte_array()).into_option()
     }
+
+    /// When the user can't directly select the value, this will always work
+    /// Use cases are things that we know have been hashed
+    fn from_non_biased(hash: [u8; 32]) -> Self {
+        // This should never happen.
+        // The space of inputs is 2^256, the space of the field is ~2^256 - 2^32.
+        // This mean that you'd have to run 2^224 hashes to find a value that causes this to fail.
+        Scalar::from_bytes(hash).expect("Derived epsilon value falls outside of the field")
+    }
+}
+
+#[test]
+fn scalar_fails_as_expected() {
+    let too_high = [0xFF; 32];
+    assert!(Scalar::from_bytes(too_high).is_none());
+
+    let mut not_too_high = [0xFF; 32];
+    not_too_high[27] = 0xFD;
+    assert!(Scalar::from_bytes(not_too_high).is_some());
 }
 
 // Is there a better way to force a borsh serialization?
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
 pub struct SerializableScalar {
     pub scalar: Scalar,
+}
+
+impl From<Scalar> for SerializableScalar {
+    fn from(scalar: Scalar) -> Self {
+        SerializableScalar { scalar }
+    }
 }
 
 impl BorshSerialize for SerializableScalar {
@@ -34,7 +62,10 @@ impl BorshSerialize for SerializableScalar {
 impl BorshDeserialize for SerializableScalar {
     fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
         let from_ser: [u8; 32] = BorshDeserialize::deserialize_reader(reader)?;
-        let scalar = Scalar::from_bytes(&from_ser[..]);
+        let scalar = Scalar::from_bytes(from_ser).ok_or(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "Scalar bytes are not in the k256 field",
+        ))?;
         Ok(SerializableScalar { scalar })
     }
 }
@@ -67,7 +98,7 @@ fn serializeable_scalar_roundtrip() {
         Scalar::ZERO,
         Scalar::ONE,
         Scalar::from_u128(u128::MAX),
-        Scalar::from_bytes(&[3; 32]),
+        Scalar::from_bytes([3; 32]).unwrap(),
     ];
 
     for scalar in test_vec.into_iter() {

--- a/chain-signatures/crypto-shared/src/types.rs
+++ b/chain-signatures/crypto-shared/src/types.rs
@@ -1,6 +1,6 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use k256::{
-    elliptic_curve::{scalar::FromUintUnchecked, CurveArithmetic},
+    elliptic_curve::{bigint::ArrayEncoding, CurveArithmetic, PrimeField},
     AffinePoint, Scalar, Secp256k1, U256,
 };
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,8 @@ pub trait ScalarExt {
 // TODO prevent bad scalars from beind sent
 impl ScalarExt for Scalar {
     fn from_bytes(bytes: &[u8]) -> Self {
-        Scalar::from_uint_unchecked(U256::from_be_slice(bytes))
+        let bytes = U256::from_be_slice(bytes);
+        Scalar::from_repr(bytes.to_be_byte_array()).expect("Byte conversion to scalar failed")
     }
 }
 

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -2,7 +2,9 @@ use crate::gcp::GcpService;
 use crate::kdf;
 use crate::protocol::{SignQueue, SignRequest};
 use crate::types::LatestBlockHeight;
-use crypto_shared::derive_epsilon;
+use anyhow::Context as _;
+use crypto_shared::{derive_epsilon, ScalarExt};
+use k256::Scalar;
 use near_account_id::AccountId;
 use near_lake_framework::{LakeBuilder, LakeContext};
 use near_lake_primitives::actions::ActionMetaDataExt;
@@ -67,13 +69,22 @@ impl Options {
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
-pub struct SignArguments {
-    pub request: ContractSignRequest,
+struct SignArguments {
+    request: UnvalidatedContractSignRequest,
 }
 
+/// What is recieved when sign is called
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
+struct UnvalidatedContractSignRequest {
+    pub payload: [u8; 32],
+    pub path: String,
+    pub key_version: u32,
+}
+
+/// A validated version of the sign request
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct ContractSignRequest {
-    pub payload: [u8; 32],
+    pub payload: Scalar,
     pub path: String,
     pub key_version: u32,
 }
@@ -113,6 +124,8 @@ async fn handle_block(
                             tracing::warn!("`sign` did not produce entropy");
                             continue;
                         }
+                        let payload = Scalar::from_bytes(arguments.request.payload)
+                            .context("Payload cannot be converted to scalar, not in k256 field")?;
                         let Ok(entropy) = serde_json::from_str::<'_, [u8; 32]>(&receipt.logs()[1])
                         else {
                             tracing::warn!(
@@ -133,9 +146,14 @@ async fn handle_block(
                             entropy = hex::encode(entropy),
                             "indexed new `sign` function call"
                         );
+                        let request = ContractSignRequest {
+                            payload,
+                            path: arguments.request.path,
+                            key_version: arguments.request.key_version,
+                        };
                         pending_requests.push(SignRequest {
                             receipt_id,
-                            request: arguments.request,
+                            request,
                             epsilon,
                             delta,
                             entropy,

--- a/chain-signatures/node/src/kdf.rs
+++ b/chain-signatures/node/src/kdf.rs
@@ -13,7 +13,7 @@ pub fn derive_delta(receipt_id: CryptoHash, entropy: [u8; 32]) -> Scalar {
     let info = format!("{DELTA_DERIVATION_PREFIX}:{}", receipt_id);
     let mut okm = [0u8; 32];
     hk.expand(info.as_bytes(), &mut okm).unwrap();
-    Scalar::from_bytes(&okm)
+    Scalar::from_non_biased(okm)
 }
 
 // Constant prefix that ensures delta derivation values are used specifically for

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -1837,7 +1837,7 @@ dependencies = [
  "near-sdk",
  "serde",
  "serde_json",
- "sha3",
+ "subtle",
 ]
 
 [[package]]
@@ -7688,9 +7688,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.5.0"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "symbolic-common"

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "near-sdk",
  "serde",
  "serde_json",
+ "sha3",
  "subtle",
 ]
 

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -124,7 +124,7 @@ async fn test_key_derivation() -> anyhow::Result<()> {
                     &user_pk,
                     &sig.big_r,
                     &sig.s,
-                    k256::Scalar::from_bytes(&payload_hashed),
+                    k256::Scalar::from_bytes(payload_hashed).unwrap(),
                 )
                 .unwrap();
 


### PR DESCRIPTION
Previously we'd allow bad scalars to be converted too and from bytes. This should be impossible since all conversions are done internally, but it's good to check.

Closes #702