### PR TITLE
feat: contract is now upgradeable through participants voting for updates

### DIFF
--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -3756,6 +3756,7 @@ dependencies = [
  "k256",
  "near-crypto 0.23.0",
  "near-gas",
+ "near-rng",
  "near-sdk",
  "near-workspaces",
  "rand 0.8.5",
@@ -4539,6 +4540,12 @@ dependencies = [
  "sha2 0.10.8",
  "thiserror",
 ]
+
+[[package]]
+name = "near-rng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efd376ff92ef9c5ef550f808406056854815f10e046703ae97f61946ef53a12"
 
 [[package]]
 name = "near-rpc-error-core"

--- a/chain-signatures/contract/Cargo.toml
+++ b/chain-signatures/contract/Cargo.toml
@@ -15,6 +15,7 @@ schemars = "0.8"
 k256 = { version = "0.13.1", features = ["sha256", "ecdsa", "serde", "arithmetic", "expose-field"] }
 crypto-shared = { path = "../crypto-shared" }
 near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }
+near-rng = "0.1.1"
 thiserror = "1"
 
 [dev-dependencies]

--- a/chain-signatures/contract/src/config.rs
+++ b/chain-signatures/contract/src/config.rs
@@ -1,0 +1,30 @@
+use borsh::{self, BorshDeserialize, BorshSerialize};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
+pub struct Config {
+    /// Timeout for triple generation in milliseconds.
+    pub triple_timeout: u64,
+    /// Timeout for presignature generation in milliseconds.
+    pub presignature_timeout: u64,
+    /// Timeout for signature generation in milliseconds.
+    pub signature_timeout: u64,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            triple_timeout: min_to_ms(20),
+            presignature_timeout: secs_to_ms(30),
+            signature_timeout: secs_to_ms(30),
+        }
+    }
+}
+
+pub const fn secs_to_ms(secs: u64) -> u64 {
+    secs * 1000
+}
+
+pub const fn min_to_ms(min: u64) -> u64 {
+    min * 60 * 1000
+}

--- a/chain-signatures/contract/src/errors.rs
+++ b/chain-signatures/contract/src/errors.rs
@@ -66,8 +66,18 @@ pub enum VoteError {
     EpochMismatch,
     #[error("Number of participants cannot go below threshold.")]
     ParticipantsBelowThreshold,
+    #[error("Update not found.")]
+    UpdateNotFound,
     #[error("Unexpected protocol state: {0}")]
     UnexpectedProtocolState(String),
+    #[error("Unexpected: {0}")]
+    Unexpected(String),
+}
+
+impl near_sdk::FunctionError for VoteError {
+    fn panic(&self) -> ! {
+        crate::env::panic_str(&self.to_string())
+    }
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -77,7 +87,7 @@ pub enum MpcContractError {
     #[error("respond fn error: {0}")]
     RespondError(RespondError),
     #[error("vote_* fn error: {0}")]
-    VoteError(VoteError),
+    VoteError(#[from] VoteError),
     #[error("init fn error: {0}")]
     InitError(InitError),
     #[error("join fn error: {0}")]

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1,29 +1,32 @@
 pub mod errors;
 pub mod primitives;
+pub mod state;
 
 use crypto_shared::{
     derive_epsilon, derive_key, kdf::check_ec_signature, near_public_key_to_affine_point,
     types::SignatureResponse, ScalarExt as _,
 };
+use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::Scalar;
 use near_sdk::borsh::{self, BorshDeserialize, BorshSerialize};
 use near_sdk::collections::LookupMap;
-use near_sdk::serde::{Deserialize, Serialize};
-
 use near_sdk::{
     env, log, near_bindgen, AccountId, CryptoHash, Gas, GasWeight, NearToken, PromiseError,
     PublicKey,
 };
-
-use errors::{
-    InitError, JoinError, MpcContractError, PublicKeyError, RespondError, SignError, VoteError,
-};
-use k256::elliptic_curve::sec1::ToEncodedPoint;
 use primitives::{
     CandidateInfo, Candidates, Participants, PkVotes, SignRequest, SignaturePromiseError,
     SignatureRequest, SignatureResult, StorageKey, Votes, YieldIndex,
 };
 use std::collections::{BTreeMap, HashSet};
+
+use crate::errors::{
+    InitError, JoinError, MpcContractError, PublicKeyError, RespondError, SignError, VoteError,
+};
+
+pub use state::{
+    InitializingContractState, ProtocolContractState, ResharingContractState, RunningContractState,
+};
 
 const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(250);
 
@@ -35,43 +38,6 @@ const CLEAR_STATE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
 
 // Prepaid gas for a `return_signature_on_finish` call
 const RETURN_SIGNATURE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
-
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
-pub struct InitializingContractState {
-    pub candidates: Candidates,
-    pub threshold: usize,
-    pub pk_votes: PkVotes,
-}
-
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
-pub struct RunningContractState {
-    pub epoch: u64,
-    pub participants: Participants,
-    pub threshold: usize,
-    pub public_key: PublicKey,
-    pub candidates: Candidates,
-    pub join_votes: Votes,
-    pub leave_votes: Votes,
-}
-
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
-pub struct ResharingContractState {
-    pub old_epoch: u64,
-    pub old_participants: Participants,
-    // TODO: only store diff to save on storage
-    pub new_participants: Participants,
-    pub threshold: usize,
-    pub public_key: PublicKey,
-    pub finished_votes: HashSet<AccountId>,
-}
-
-#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
-pub enum ProtocolContractState {
-    NotInitialized,
-    Initializing(InitializingContractState),
-    Running(RunningContractState),
-    Resharing(ResharingContractState),
-}
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, Debug)]

--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -1,6 +1,8 @@
+pub mod config;
 pub mod errors;
 pub mod primitives;
 pub mod state;
+pub mod update;
 
 use crypto_shared::{
     derive_epsilon, derive_key, kdf::check_ec_signature, near_public_key_to_affine_point,
@@ -20,9 +22,11 @@ use primitives::{
 };
 use std::collections::{BTreeMap, HashSet};
 
+use crate::config::Config;
 use crate::errors::{
     InitError, JoinError, MpcContractError, PublicKeyError, RespondError, SignError, VoteError,
 };
+use crate::update::{ProposedUpdates, UpdateId};
 
 pub use state::{
     InitializingContractState, ProtocolContractState, ResharingContractState, RunningContractState,
@@ -38,6 +42,9 @@ const CLEAR_STATE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
 
 // Prepaid gas for a `return_signature_on_finish` call
 const RETURN_SIGNATURE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
+
+// Prepaid gas for a `update_config` call
+const UPDATE_CONFIG_GAS: Gas = Gas::from_tgas(5);
 
 #[near_bindgen]
 #[derive(BorshDeserialize, BorshSerialize, Debug)]
@@ -56,6 +63,8 @@ pub struct MpcContract {
     protocol_state: ProtocolContractState,
     pending_requests: LookupMap<SignatureRequest, YieldIndex>,
     request_counter: u32,
+    proposed_updates: ProposedUpdates,
+    config: Config,
 }
 
 impl MpcContract {
@@ -87,6 +96,8 @@ impl MpcContract {
             }),
             pending_requests: LookupMap::new(StorageKey::PendingRequests),
             request_counter: 0,
+            proposed_updates: ProposedUpdates::default(),
+            config: Config::default(),
         }
     }
 }
@@ -313,6 +324,7 @@ impl VersionedMpcContract {
             env::signer_account_id(),
             candidate_account_id
         );
+        let voter = self.voter()?;
         let protocol_state = self.mutable_state();
         match protocol_state {
             ProtocolContractState::Running(RunningContractState {
@@ -324,15 +336,11 @@ impl VersionedMpcContract {
                 join_votes,
                 ..
             }) => {
-                let signer_account_id = env::signer_account_id();
-                if !participants.contains_key(&signer_account_id) {
-                    return Err(MpcContractError::VoteError(VoteError::VoterNotParticipant));
-                }
                 let candidate_info = candidates
                     .get(&candidate_account_id)
                     .ok_or(MpcContractError::VoteError(VoteError::JoinNotCandidate))?;
                 let voted = join_votes.entry(candidate_account_id.clone());
-                voted.insert(signer_account_id);
+                voted.insert(voter);
                 if voted.len() >= *threshold {
                     let mut new_participants = participants.clone();
                     new_participants
@@ -416,6 +424,7 @@ impl VersionedMpcContract {
             env::signer_account_id(),
             public_key
         );
+        let voter = self.voter()?;
         let protocol_state = self.mutable_state();
         match protocol_state {
             ProtocolContractState::Initializing(InitializingContractState {
@@ -423,12 +432,8 @@ impl VersionedMpcContract {
                 threshold,
                 pk_votes,
             }) => {
-                let signer_account_id = env::signer_account_id();
-                if !candidates.contains_key(&signer_account_id) {
-                    return Err(MpcContractError::VoteError(VoteError::VoterNotParticipant));
-                }
                 let voted = pk_votes.entry(public_key.clone());
-                voted.insert(signer_account_id);
+                voted.insert(voter);
                 if voted.len() >= *threshold {
                     *protocol_state = ProtocolContractState::Running(RunningContractState {
                         epoch: 0,
@@ -461,11 +466,12 @@ impl VersionedMpcContract {
             env::signer_account_id(),
             epoch
         );
+        let voter = self.voter()?;
         let protocol_state = self.mutable_state();
         match protocol_state {
             ProtocolContractState::Resharing(ResharingContractState {
                 old_epoch,
-                old_participants,
+                old_participants: _,
                 new_participants,
                 threshold,
                 public_key,
@@ -474,11 +480,7 @@ impl VersionedMpcContract {
                 if *old_epoch + 1 != epoch {
                     return Err(MpcContractError::VoteError(VoteError::EpochMismatch));
                 }
-                let signer_account_id = env::signer_account_id();
-                if !old_participants.contains_key(&signer_account_id) {
-                    return Err(MpcContractError::VoteError(VoteError::VoterNotParticipant));
-                }
-                finished_votes.insert(signer_account_id);
+                finished_votes.insert(voter);
                 if finished_votes.len() >= *threshold {
                     *protocol_state = ProtocolContractState::Running(RunningContractState {
                         epoch: *old_epoch + 1,
@@ -499,14 +501,73 @@ impl VersionedMpcContract {
                     Ok(true)
                 } else {
                     Err(MpcContractError::VoteError(
-                        VoteError::UnexpectedProtocolState("resharing".to_string()),
+                        VoteError::UnexpectedProtocolState("Running".to_string()),
                     ))
                 }
             }
             _ => Err(MpcContractError::VoteError(
-                VoteError::UnexpectedProtocolState("resharing".to_string()),
+                VoteError::UnexpectedProtocolState("Running".to_string()),
             )),
         }
+    }
+
+    /// Propose an update to the contract. [`Update`] are all the possible updates that can be proposed.
+    ///
+    /// returns Some(id) if the proposal was successful, None otherwise
+    #[handle_result]
+    pub fn propose_update(
+        &mut self,
+        code: Option<Vec<u8>>,
+        config: Option<Config>,
+    ) -> Result<UpdateId, VoteError> {
+        // Only voters can propose updates:
+        self.voter()?;
+
+        let Some(id) = self.proposed_updates().propose(code, config) else {
+            return Err(VoteError::Unexpected(
+                "cannot propose update due to incorrect parameters".into(),
+            ));
+        };
+
+        env::log_str(&format!("id={id:?}"));
+        Ok(id)
+    }
+
+    /// Vote for a proposed update given the [`UpdateId`] of the update.
+    ///
+    /// Returns Ok(true) if the amount of participants surpassed the threshold and the update was executed.
+    #[handle_result]
+    pub fn vote_update(&mut self, id: UpdateId) -> Result<bool, MpcContractError> {
+        let threshold = match self {
+            Self::V0(contract) => match &contract.protocol_state {
+                ProtocolContractState::Running(state) => state.threshold,
+                ProtocolContractState::Resharing(state) => state.threshold,
+                _ => {
+                    return Err(MpcContractError::VoteError(
+                        VoteError::UnexpectedProtocolState("Initialized or NotInitialized".into()),
+                    ))
+                }
+            },
+        };
+
+        let voter = self.voter()?;
+        let Some(votes) = self.proposed_updates().vote(&id, voter) else {
+            return Err(MpcContractError::VoteError(VoteError::UpdateNotFound));
+        };
+
+        // Not enough votes, wait for more.
+        if votes.len() < threshold {
+            return Ok(false);
+        }
+
+        let Some(_promise) =
+            self.proposed_updates()
+                .do_update(&id, "update_config", UPDATE_CONFIG_GAS)
+        else {
+            return Err(MpcContractError::VoteError(VoteError::UpdateNotFound));
+        };
+
+        Ok(true)
     }
 }
 
@@ -568,12 +629,20 @@ impl VersionedMpcContract {
             }),
             pending_requests: LookupMap::new(StorageKey::PendingRequests),
             request_counter: 0,
+            proposed_updates: ProposedUpdates::default(),
+            config: Config::default(),
         }))
     }
 
     pub fn state(&self) -> &ProtocolContractState {
         match self {
             Self::V0(mpc_contract) => &mpc_contract.protocol_state,
+        }
+    }
+
+    pub fn config(&self) -> &Config {
+        match self {
+            Self::V0(mpc_contract) => &mpc_contract.config,
         }
     }
 
@@ -653,6 +722,15 @@ impl VersionedMpcContract {
     }
 
     #[private]
+    pub fn update_config(&mut self, config: Config) {
+        match self {
+            Self::V0(mpc_contract) => {
+                mpc_contract.config = config;
+            }
+        }
+    }
+
+    #[private]
     #[init(ignore_state)]
     pub fn clean(keys: Vec<near_sdk::json_types::Base64VecU8>) -> Self {
         log!("clean: keys={:?}", keys);
@@ -663,6 +741,8 @@ impl VersionedMpcContract {
             protocol_state: ProtocolContractState::NotInitialized,
             pending_requests: LookupMap::new(StorageKey::PendingRequests),
             request_counter: 0,
+            proposed_updates: ProposedUpdates::default(),
+            config: Config::default(),
         })
     }
 
@@ -690,5 +770,38 @@ impl VersionedMpcContract {
                     * NearToken::from_millinear(50).as_yoctonear()
             }
         }
+    }
+
+    fn proposed_updates(&mut self) -> &mut ProposedUpdates {
+        match self {
+            Self::V0(contract) => &mut contract.proposed_updates,
+        }
+    }
+
+    fn voter(&self) -> Result<AccountId, VoteError> {
+        let voter = env::signer_account_id();
+        match self {
+            Self::V0(contract) => match &contract.protocol_state {
+                ProtocolContractState::Initializing(state) => {
+                    if !state.candidates.contains_key(&voter) {
+                        return Err(VoteError::VoterNotParticipant);
+                    }
+                }
+                ProtocolContractState::Running(state) => {
+                    if !state.participants.contains_key(&voter) {
+                        return Err(VoteError::VoterNotParticipant);
+                    }
+                }
+                ProtocolContractState::Resharing(state) => {
+                    if !state.old_participants.contains_key(&voter) {
+                        return Err(VoteError::VoterNotParticipant);
+                    }
+                }
+                ProtocolContractState::NotInitialized => {
+                    return Err(VoteError::UnexpectedProtocolState("NotInitialized".into()))
+                }
+            },
+        }
+        Ok(voter)
     }
 }

--- a/chain-signatures/contract/src/state.rs
+++ b/chain-signatures/contract/src/state.rs
@@ -1,0 +1,44 @@
+use std::collections::HashSet;
+
+use borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::{AccountId, PublicKey};
+use serde::{Deserialize, Serialize};
+
+use crate::primitives::{Candidates, Participants, PkVotes, Votes};
+
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
+pub struct InitializingContractState {
+    pub candidates: Candidates,
+    pub threshold: usize,
+    pub pk_votes: PkVotes,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
+pub struct RunningContractState {
+    pub epoch: u64,
+    pub participants: Participants,
+    pub threshold: usize,
+    pub public_key: PublicKey,
+    pub candidates: Candidates,
+    pub join_votes: Votes,
+    pub leave_votes: Votes,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
+pub struct ResharingContractState {
+    pub old_epoch: u64,
+    pub old_participants: Participants,
+    // TODO: only store diff to save on storage
+    pub new_participants: Participants,
+    pub threshold: usize,
+    pub public_key: PublicKey,
+    pub finished_votes: HashSet<AccountId>,
+}
+
+#[derive(BorshDeserialize, BorshSerialize, Serialize, Deserialize, Debug)]
+pub enum ProtocolContractState {
+    NotInitialized,
+    Initializing(InitializingContractState),
+    Running(RunningContractState),
+    Resharing(ResharingContractState),
+}

--- a/chain-signatures/contract/src/update.rs
+++ b/chain-signatures/contract/src/update.rs
@@ -1,0 +1,101 @@
+use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+
+use crate::config::Config;
+
+use borsh::{self, BorshDeserialize, BorshSerialize};
+use near_sdk::serde::{Deserialize, Serialize};
+use near_sdk::{env, AccountId, Gas, NearToken, Promise};
+
+#[derive(
+    Copy,
+    Clone,
+    Debug,
+    BorshDeserialize,
+    BorshSerialize,
+    Serialize,
+    Deserialize,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+)]
+pub struct UpdateId(pub(crate) u64);
+
+impl From<u64> for UpdateId {
+    fn from(id: u64) -> Self {
+        Self(id)
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+pub enum Update {
+    Config(Config),
+    Contract(Vec<u8>),
+}
+
+#[derive(Default, Debug, BorshSerialize, BorshDeserialize)]
+pub struct ProposedUpdates {
+    updates: HashMap<UpdateId, Vec<Update>>,
+    votes: HashMap<UpdateId, HashSet<AccountId>>,
+    next_id: u64,
+}
+
+impl ProposedUpdates {
+    /// Propose an update given the new contract code and/or config.
+    ///
+    /// Returns Some(UpdateId) if the update was successfully proposed, otherwise None.
+    pub fn propose(&mut self, code: Option<Vec<u8>>, config: Option<Config>) -> Option<UpdateId> {
+        let updates = match (code, config) {
+            (Some(contract), Some(config)) => {
+                vec![Update::Contract(contract), Update::Config(config)]
+            }
+            (Some(contract), None) => vec![Update::Contract(contract)],
+            (None, Some(config)) => vec![Update::Config(config)],
+            (None, None) => return None,
+        };
+
+        let id = UpdateId::from(self.next_id);
+        self.next_id += 1;
+
+        self.updates.insert(id, updates);
+        self.votes.insert(id, HashSet::new());
+
+        Some(id)
+    }
+
+    /// Vote for the update with the given id.
+    ///
+    /// Returns Some(votes) if the given [`UpdateId`] exists, otherwise None.
+    pub fn vote(&mut self, id: &UpdateId, voter: AccountId) -> Option<&HashSet<AccountId>> {
+        let votes = self.votes.get_mut(id)?;
+        votes.insert(voter);
+        Some(votes)
+    }
+
+    pub fn remove(&mut self, id: &UpdateId) -> Option<Vec<Update>> {
+        self.votes.remove(id);
+        self.updates.remove(id)
+    }
+
+    pub fn do_update(&mut self, id: &UpdateId, config_callback: &str, gas: Gas) -> Option<Promise> {
+        let updates = self.remove(id)?;
+
+        let mut promise = Promise::new(env::current_account_id());
+        for update in updates {
+            match update {
+                Update::Config(config) => {
+                    promise = promise.function_call(
+                        config_callback.into(),
+                        serde_json::to_vec(&(&config,)).unwrap(),
+                        NearToken::from_near(0),
+                        gas,
+                    );
+                }
+                Update::Contract(code) => promise = promise.deploy_contract(code),
+            }
+        }
+        Some(promise)
+    }
+}


### PR DESCRIPTION
The contract can now be upgraded or config updated through calling into:
- `propose_update: (config | wasm) -> UpdateId`
- `vote_update: (UpdateId) -> bool`

Only participants from the contract are able to partake. Added config here just to test it can work there too.
