### PR TITLE
chore: update naming of env vars and binary (MPC_RECOVERY_* is now MPC_*)

### DIFF
--- a/.github/workflows/multichain-integration.yml
+++ b/.github/workflows/multichain-integration.yml
@@ -86,7 +86,7 @@ jobs:
 
       - name: Build Chain-Signatures Node
         working-directory: ./chain-signatures
-        run: cargo build -p mpc-recovery-node --release
+        run: cargo build -p mpc-node --release
 
       # Build the tests before actually running them to see how long the tests take to run by itself
       # instead of including the build time in the test time report on Github.

--- a/.github/workflows/multichain-nightly.yml
+++ b/.github/workflows/multichain-nightly.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Build Chain-Signatures Node
         working-directory: ./chain-signatures
-        run: cargo build -p mpc-recovery-node --release
+        run: cargo build -p mpc-node --release
 
       - name: Build Chain-Signatures Integration Tests
         working-directory: ./integration-tests/chain-signatures

--- a/Dockerfile.multichain
+++ b/Dockerfile.multichain
@@ -16,12 +16,12 @@ COPY chain-signatures/. .
 RUN sed -i 's#"keys",##' Cargo.toml
 RUN sed -i 's#"contract",##' Cargo.toml
 RUN sed -i 's#target-dir = "../target"#target-dir = "target"#' .cargo/config.toml
-RUN cargo build --release --package mpc-recovery-node
+RUN cargo build --release --package mpc-node
 
 FROM debian:stable-slim as runtime
 RUN apt-get update && apt-get install --assume-yes libssl-dev ca-certificates curl
 RUN update-ca-certificates
-COPY --from=builder /usr/src/app/target/release/mpc-recovery-node /usr/local/bin/mpc-recovery-node
+COPY --from=builder /usr/src/app/target/release/mpc-node /usr/local/bin/mpc-node
 WORKDIR /usr/local/bin
 
-ENTRYPOINT [ "mpc-recovery-node" ]
+ENTRYPOINT [ "mpc-node" ]

--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -3780,7 +3780,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mpc-recovery-node"
+name = "mpc-node"
 version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "mpc-recovery-node"
+name = "mpc-node"
 version = "1.0.0-rc.1"
 edition = "2021"
 
 [[bin]]
-name = "mpc-recovery-node"
+name = "mpc-node"
 path = "src/main.rs"
 
 [dependencies]

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -70,20 +70,12 @@ pub enum Cli {
 
         /// At maximum, how many triple protocols can this current node introduce
         /// at the same time. This should be something like `max_concurrent_gen / num_nodes`
-        #[arg(
-            long,
-            env("MPC_MAX_CONCURRENT_INTRODUCTION"),
-            default_value("2")
-        )]
+        #[arg(long, env("MPC_MAX_CONCURRENT_INTRODUCTION"), default_value("2"))]
         max_concurrent_introduction: usize,
 
         /// At maximum, how many ongoing protocols for triples to be running
         /// at the same time. The rest will be queued up.
-        #[arg(
-            long,
-            env("MPC_MAX_CONCURRENT_GENERATION"),
-            default_value("16")
-        )]
+        #[arg(long, env("MPC_MAX_CONCURRENT_GENERATION"), default_value("16"))]
         max_concurrent_generation: usize,
 
         /// At minimum, how many presignatures to stockpile on this node.

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -22,57 +22,57 @@ pub enum Cli {
         /// NEAR RPC address
         #[arg(
             long,
-            env("MPC_RECOVERY_NEAR_RPC"),
+            env("MPC_NEAR_RPC"),
             default_value("https://rpc.testnet.near.org")
         )]
         near_rpc: String,
         /// MPC contract id
         #[arg(
             long,
-            env("MPC_RECOVERY_CONTRACT_ID"),
+            env("MPC_CONTRACT_ID"),
             default_value("v5.multichain-mpc-dev.testnet")
         )]
         mpc_contract_id: AccountId,
         /// This node's account id
-        #[arg(long, env("MPC_RECOVERY_ACCOUNT_ID"))]
+        #[arg(long, env("MPC_ACCOUNT_ID"))]
         account_id: AccountId,
         /// This node's account ed25519 secret key
-        #[arg(long, env("MPC_RECOVERY_ACCOUNT_SK"))]
+        #[arg(long, env("MPC_ACCOUNT_SK"))]
         account_sk: SecretKey,
         /// The web port for this server
-        #[arg(long, env("MPC_RECOVERY_WEB_PORT"))]
+        #[arg(long, env("MPC_WEB_PORT"))]
         web_port: u16,
         // TODO: need to add in CipherPK type for parsing.
         /// The cipher public key used to encrypt messages between nodes.
-        #[arg(long, env("MPC_RECOVERY_CIPHER_PK"))]
+        #[arg(long, env("MPC_CIPHER_PK"))]
         cipher_pk: String,
         /// The cipher secret key used to decrypt messages between nodes.
-        #[arg(long, env("MPC_RECOVERY_CIPHER_SK"))]
+        #[arg(long, env("MPC_CIPHER_SK"))]
         cipher_sk: String,
         /// The secret key used to sign messages to be sent between nodes.
-        #[arg(long, env("MPC_RECOVERY_SIGN_SK"))]
+        #[arg(long, env("MPC_SIGN_SK"))]
         sign_sk: Option<SecretKey>,
         /// NEAR Lake Indexer options
         #[clap(flatten)]
         indexer_options: indexer::Options,
         /// Local address that other peers can use to message this node.
-        #[arg(long, env("MPC_RECOVERY_LOCAL_ADDRESS"))]
+        #[arg(long, env("MPC_LOCAL_ADDRESS"))]
         my_address: Option<Url>,
         /// Storage options
         #[clap(flatten)]
         storage_options: storage::Options,
         /// At minimum, how many triples to stockpile on this node.
-        #[arg(long, env("MPC_RECOVERY_MIN_TRIPLES"), default_value("20"))]
+        #[arg(long, env("MPC_MIN_TRIPLES"), default_value("20"))]
         min_triples: usize,
         /// At maximum, how many triples to stockpile on this node.
-        #[arg(long, env("MPC_RECOVERY_MAX_TRIPLES"), default_value("640"))]
+        #[arg(long, env("MPC_MAX_TRIPLES"), default_value("640"))]
         max_triples: usize,
 
         /// At maximum, how many triple protocols can this current node introduce
         /// at the same time. This should be something like `max_concurrent_gen / num_nodes`
         #[arg(
             long,
-            env("MPC_RECOVERY_MAX_CONCURRENT_INTRODUCTION"),
+            env("MPC_MAX_CONCURRENT_INTRODUCTION"),
             default_value("2")
         )]
         max_concurrent_introduction: usize,
@@ -81,17 +81,17 @@ pub enum Cli {
         /// at the same time. The rest will be queued up.
         #[arg(
             long,
-            env("MPC_RECOVERY_MAX_CONCURRENT_GENERATION"),
+            env("MPC_MAX_CONCURRENT_GENERATION"),
             default_value("16")
         )]
         max_concurrent_generation: usize,
 
         /// At minimum, how many presignatures to stockpile on this node.
-        #[arg(long, env("MPC_RECOVERY_MIN_PRESIGNATURES"), default_value("10"))]
+        #[arg(long, env("MPC_MIN_PRESIGNATURES"), default_value("10"))]
         min_presignatures: usize,
 
         /// At maximum, how many presignatures to stockpile on the network.
-        #[arg(long, env("MPC_RECOVERY_MAX_PRESIGNATURES"), default_value("320"))]
+        #[arg(long, env("MPC_MAX_PRESIGNATURES"), default_value("320"))]
         max_presignatures: usize,
     },
 }

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -25,7 +25,7 @@ pub struct Options {
     /// AWS S3 bucket name for NEAR Lake Indexer
     #[clap(
         long,
-        env("MPC_RECOVERY_INDEXER_S3_BUCKET"),
+        env("MPC_INDEXER_S3_BUCKET"),
         default_value = "near-lake-data-testnet"
     )]
     pub s3_bucket: String,
@@ -33,20 +33,20 @@ pub struct Options {
     /// AWS S3 region name for NEAR Lake Indexer
     #[clap(
         long,
-        env("MPC_RECOVERY_INDEXER_S3_REGION"),
+        env("MPC_INDEXER_S3_REGION"),
         default_value = "eu-central-1"
     )]
     pub s3_region: String,
 
     /// AWS S3 URL for NEAR Lake Indexer (can be used to point to LocalStack)
-    #[clap(long, env("MPC_RECOVERY_INDEXER_S3_URL"))]
+    #[clap(long, env("MPC_INDEXER_S3_URL"))]
     pub s3_url: Option<String>,
 
     /// The block height to start indexing from.
     // Defaults to the latest block on 2023-11-14 07:40:22 AM UTC
     #[clap(
         long,
-        env("MPC_RECOVERY_INDEXER_START_BLOCK_HEIGHT"),
+        env("MPC_INDEXER_START_BLOCK_HEIGHT"),
         default_value = "145964826"
     )]
     pub start_block_height: u64,

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -31,11 +31,7 @@ pub struct Options {
     pub s3_bucket: String,
 
     /// AWS S3 region name for NEAR Lake Indexer
-    #[clap(
-        long,
-        env("MPC_INDEXER_S3_REGION"),
-        default_value = "eu-central-1"
-    )]
+    #[clap(long, env("MPC_INDEXER_S3_REGION"), default_value = "eu-central-1")]
     pub s3_region: String,
 
     /// AWS S3 URL for NEAR Lake Indexer (can be used to point to LocalStack)

--- a/chain-signatures/node/src/main.rs
+++ b/chain-signatures/node/src/main.rs
@@ -1,6 +1,6 @@
 use clap::Parser;
-use mpc_recovery_node::cli::Cli;
+use mpc_node::cli::Cli;
 
 fn main() -> anyhow::Result<()> {
-    mpc_recovery_node::cli::run(Cli::parse())
+    mpc_node::cli::run(Cli::parse())
 }

--- a/chain-signatures/node/src/storage/mod.rs
+++ b/chain-signatures/node/src/storage/mod.rs
@@ -6,19 +6,19 @@ pub mod triple_storage;
 #[group(id = "storage_options")]
 pub struct Options {
     /// env used to suffix datastore table names to differentiate among environments.
-    #[clap(long, env("MPC_RECOVERY_ENV"))]
+    #[clap(long, env("MPC_ENV"))]
     pub env: String,
     /// GCP project ID.
-    #[clap(long, env("MPC_RECOVERY_GCP_PROJECT_ID"))]
+    #[clap(long, env("MPC_GCP_PROJECT_ID"))]
     pub gcp_project_id: String,
     /// GCP Secret Manager ID that will be used to load/store the node's secret key share.
-    #[clap(long, env("MPC_RECOVERY_SK_SHARE_SECRET_ID"), requires_all=["gcp_project_id"])]
+    #[clap(long, env("MPC_SK_SHARE_SECRET_ID"), requires_all=["gcp_project_id"])]
     pub sk_share_secret_id: Option<String>,
     /// Mostly for integration tests.
     /// GCP Datastore URL that will be used to load/store the node's triples and presignatures.
-    #[arg(long, env("MPC_RECOVERY_GCP_DATASTORE_URL"))]
+    #[arg(long, env("MPC_GCP_DATASTORE_URL"))]
     pub gcp_datastore_url: Option<String>,
-    #[arg(long, env("MPC_RECOVERY_SK_SHARE_LOCAL_PATH"))]
+    #[arg(long, env("MPC_SK_SHARE_LOCAL_PATH"))]
     pub sk_share_local_path: Option<String>,
 }
 

--- a/chain-signatures/node/src/util.rs
+++ b/chain-signatures/node/src/util.rs
@@ -65,7 +65,7 @@ impl AffinePointExt for AffinePoint {
 }
 
 pub fn get_triple_timeout() -> Duration {
-    env::var("MPC_RECOVERY_TRIPLE_TIMEOUT_SEC")
+    env::var("MPC_TRIPLE_TIMEOUT_SEC")
         .map(|val| val.parse::<u64>().ok().map(Duration::from_secs))
         .unwrap_or_default()
         .unwrap_or(crate::types::PROTOCOL_TRIPLE_TIMEOUT)

--- a/infra/modules/multichain/main.tf
+++ b/infra/modules/multichain/main.tf
@@ -132,7 +132,7 @@ resource "google_cloud_run_v2_service" "node" {
       }
       env {
         name  = "RUST_LOG"
-        value = "mpc_recovery_node=debug"
+        value = "mpc_node=debug"
       }
 
       ports {

--- a/infra/modules/multichain/main.tf
+++ b/infra/modules/multichain/main.tf
@@ -18,51 +18,51 @@ resource "google_cloud_run_v2_service" "node" {
       args  = ["start"]
 
       env {
-        name  = "MPC_RECOVERY_NODE_ID"
+        name  = "MPC_NODE_ID"
         value = var.node_id
       }
       env {
-        name  = "MPC_RECOVERY_NEAR_RPC"
+        name  = "MPC_NEAR_RPC"
         value = var.near_rpc
       }
       env {
-        name  = "MPC_RECOVERY_CONTRACT_ID"
+        name  = "MPC_CONTRACT_ID"
         value = var.mpc_contract_id
       }
       env {
-        name  = "MPC_RECOVERY_ACCOUNT_ID"
+        name  = "MPC_ACCOUNT_ID"
         value = var.account_id
       }
       env {
-        name  = "MPC_RECOVERY_CIPHER_PK"
+        name  = "MPC_CIPHER_PK"
         value = var.cipher_pk
       }
       env {
-        name  = "MPC_RECOVERY_LOCAL_ADDRESS"
+        name  = "MPC_LOCAL_ADDRESS"
         value = var.my_address
       }
       env {
-        name  = "MPC_RECOVERY_INDEXER_S3_BUCKET"
+        name  = "MPC_INDEXER_S3_BUCKET"
         value = var.indexer_options.s3_bucket
       }
       env {
-        name  = "MPC_RECOVERY_INDEXER_S3_REGION"
+        name  = "MPC_INDEXER_S3_REGION"
         value = var.indexer_options.s3_region
       }
       // Conditional block in case s3_url is present. See https://stackoverflow.com/a/69891235
       dynamic "env" {
         for_each = var.indexer_options.s3_url == null ? [] : [1]
         content {
-          name  = "MPC_RECOVERY_INDEXER_S3_URL"
+          name  = "MPC_INDEXER_S3_URL"
           value = var.indexer_options.s3_url
         }
       }
       env {
-        name  = "MPC_RECOVERY_INDEXER_START_BLOCK_HEIGHT"
+        name  = "MPC_INDEXER_START_BLOCK_HEIGHT"
         value = var.indexer_options.start_block_height
       }
       env {
-        name = "MPC_RECOVERY_ACCOUNT_SK"
+        name = "MPC_ACCOUNT_SK"
         value_source {
           secret_key_ref {
             secret  = var.account_sk_secret_id
@@ -71,7 +71,7 @@ resource "google_cloud_run_v2_service" "node" {
         }
       }
       env {
-        name = "MPC_RECOVERY_CIPHER_SK"
+        name = "MPC_CIPHER_SK"
         value_source {
           secret_key_ref {
             secret  = var.cipher_sk_secret_id
@@ -83,7 +83,7 @@ resource "google_cloud_run_v2_service" "node" {
       dynamic "env" {
         for_each = var.sign_sk_secret_id == null ? [] : [1]
         content {
-          name = "MPC_RECOVERY_SIGN_SK"
+          name = "MPC_SIGN_SK"
           value_source {
             secret_key_ref {
               secret  = var.sign_sk_secret_id
@@ -115,19 +115,19 @@ resource "google_cloud_run_v2_service" "node" {
         value = var.indexer_options.s3_region
       }
       env {
-        name  = "MPC_RECOVERY_GCP_PROJECT_ID"
+        name  = "MPC_GCP_PROJECT_ID"
         value = var.project
       }
       env {
-        name  = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_SK_SHARE_SECRET_ID"
         value = var.sk_share_secret_id
       }
       env {
-        name  = "MPC_RECOVERY_ENV"
+        name  = "MPC_ENV"
         value = var.env
       }
       env {
-        name  = "MPC_RECOVERY_WEB_PORT"
+        name  = "MPC_WEB_PORT"
         value = "3000"
       }
       env {

--- a/infra/multichain-dev/main.tf
+++ b/infra/multichain-dev/main.tf
@@ -16,27 +16,27 @@ module "gce-container" {
 
     env = concat(var.static_env, [
       {
-        name  = "MPC_RECOVERY_NODE_ID"
+        name  = "MPC_NODE_ID"
         value = "${count.index}"
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_ID"
+        name  = "MPC_ACCOUNT_ID"
         value = var.node_configs["${count.index}"].account
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_PK"
+        name  = "MPC_CIPHER_PK"
         value = var.node_configs["${count.index}"].cipher_pk
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_SK"
+        name  = "MPC_ACCOUNT_SK"
         value = data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_SK"
+        name  = "MPC_CIPHER_SK"
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_SIGN_SK"
+        name  = "MPC_SIGN_SK"
         value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index] != null ? data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data : data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
@@ -48,15 +48,15 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.aws_secret_key_secret_id.secret_data
       },
       {
-        name  = "MPC_RECOVERY_LOCAL_ADDRESS"
+        name  = "MPC_LOCAL_ADDRESS"
         value = "http://${google_compute_address.internal_ips[count.index].address}"
       },
       {
-        name  = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_SK_SHARE_SECRET_ID"
         value = var.node_configs["${count.index}"].sk_share_secret_id
       },
       {
-        name  = "MPC_RECOVERY_ENV",
+        name  = "MPC_ENV",
         value = var.env
       }
     ])

--- a/infra/multichain-dev/variables.tf
+++ b/infra/multichain-dev/variables.tf
@@ -115,7 +115,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_recovery_node=debug"
+      value = "mpc_node=debug"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"

--- a/infra/multichain-dev/variables.tf
+++ b/infra/multichain-dev/variables.tf
@@ -75,7 +75,7 @@ variable "node_configs" {
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "dev"
 }
 
@@ -86,19 +86,19 @@ variable "static_env" {
   }))
   default = [
     {
-      name  = "MPC_RECOVERY_NEAR_RPC"
+      name  = "MPC_NEAR_RPC"
       value = "https://rpc.testnet.near.org"
     },
     {
-      name  = "MPC_RECOVERY_CONTRACT_ID"
+      name  = "MPC_CONTRACT_ID"
       value = "v5.multichain-mpc-dev.testnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_BUCKET"
+      name  = "MPC_INDEXER_S3_BUCKET"
       value = "near-lake-data-testnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_START_BLOCK_HEIGHT"
+      name  = "MPC_INDEXER_START_BLOCK_HEIGHT"
       value = 159307004
     },
     {
@@ -106,11 +106,11 @@ variable "static_env" {
       value = "eu-central-1"
     },
     {
-      name  = "MPC_RECOVERY_GCP_PROJECT_ID"
+      name  = "MPC_GCP_PROJECT_ID"
       value = "pagoda-discovery-platform-dev"
     },
     {
-      name  = "MPC_RECOVERY_WEB_PORT"
+      name  = "MPC_WEB_PORT"
       value = "3000"
     },
     {
@@ -118,35 +118,35 @@ variable "static_env" {
       value = "mpc_recovery_node=debug"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_REGION"
+      name  = "MPC_INDEXER_S3_REGION"
       value = "eu-central-1"
     },
     {
-      name  = "MPC_RECOVERY_MIN_TRIPLES"
+      name  = "MPC_MIN_TRIPLES"
       value = 20
     },
     {
-      name  = "MPC_RECOVERY_MAX_TRIPLES"
+      name  = "MPC_MAX_TRIPLES"
       value = 640
     },
     {
-      name  = "MPC_RECOVERY_MIN_PRESIGNATURES"
+      name  = "MPC_MIN_PRESIGNATURES"
       value = 10
     },
     {
-      name  = "MPC_RECOVERY_MAX_PRESIGNATURES"
+      name  = "MPC_MAX_PRESIGNATURES"
       value = 320
     },
     {
-      name  = "MPC_RECOVERY_MAX_CONCURRENT_INTRODUCTION"
+      name  = "MPC_MAX_CONCURRENT_INTRODUCTION"
       value = 2
     },
     {
-      name  = "MPC_RECOVERY_MAX_CONCURRENT_GENERATION"
+      name  = "MPC_MAX_CONCURRENT_GENERATION"
       value = 16
     },
     {
-      name  = "MPC_RECOVERY_TRIPLE_TIMEOUT_SEC"
+      name  = "MPC_TRIPLE_TIMEOUT_SEC"
       value = 1200
     }
   ]

--- a/infra/multichain-mainnet-dev/main.tf
+++ b/infra/multichain-mainnet-dev/main.tf
@@ -16,28 +16,28 @@ module "gce-container" {
 
     env = concat(var.static_env, [
       {
-        name  = "MPC_RECOVERY_NODE_ID"
+        name  = "MPC_NODE_ID"
         value = "${count.index}"
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_ID"
+        name  = "MPC_ACCOUNT_ID"
         value = var.node_configs["${count.index}"].account
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_PK"
+        name  = "MPC_CIPHER_PK"
         value = var.node_configs["${count.index}"].cipher_pk
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_SK"
+        name  = "MPC_ACCOUNT_SK"
         value = data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_SK"
+        name  = "MPC_CIPHER_SK"
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_SIGN_SK"
-        value =  data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data
+        name  = "MPC_SIGN_SK"
+        value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data
       },
       {
         name  = "AWS_ACCESS_KEY_ID"
@@ -48,15 +48,15 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.aws_secret_key_secret_id.secret_data
       },
       {
-        name  = "MPC_RECOVERY_LOCAL_ADDRESS"
+        name  = "MPC_LOCAL_ADDRESS"
         value = "https://${var.node_configs[count.index].domain}"
       },
       {
-        name  = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_SK_SHARE_SECRET_ID"
         value = var.node_configs["${count.index}"].sk_share_secret_id
       },
       {
-        name  = "MPC_RECOVERY_ENV",
+        name  = "MPC_ENV",
         value = var.env
       }
     ])
@@ -72,7 +72,7 @@ resource "google_compute_global_address" "external_ips" {
 
 resource "google_compute_managed_ssl_certificate" "mainnet_dev_ssl" {
   count = length(var.node_configs)
-  name = "multichain-mainnet-dev-ssl-${count.index}"
+  name  = "multichain-mainnet-dev-ssl-${count.index}"
 
   managed {
     domains = [var.node_configs["${count.index}"].domain]
@@ -142,13 +142,13 @@ resource "google_compute_global_forwarding_rule" "default" {
 }
 
 resource "google_compute_global_forwarding_rule" "https_fw" {
-  count      = length(var.node_configs)
-  name       = "multichain-mainnet-dev-https-rule-${count.index}"
-  target     = google_compute_target_https_proxy.default_https[count.index].id
-  port_range = "443"
-  ip_protocol = "TCP"
+  count                 = length(var.node_configs)
+  name                  = "multichain-mainnet-dev-https-rule-${count.index}"
+  target                = google_compute_target_https_proxy.default_https[count.index].id
+  port_range            = "443"
+  ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
-  ip_address = google_compute_global_address.external_ips[count.index].address
+  ip_address            = google_compute_global_address.external_ips[count.index].address
 }
 
 resource "google_compute_target_http_proxy" "default" {
@@ -159,11 +159,11 @@ resource "google_compute_target_http_proxy" "default" {
 }
 
 resource "google_compute_target_https_proxy" "default_https" {
-  count      = length(var.node_configs)
-  name        = "multichain-mainnet-dev-target-https-proxy-${count.index}"
-  description = "a description"
-  ssl_certificates = [ google_compute_managed_ssl_certificate.mainnet_dev_ssl[count.index].self_link ]
-  url_map     = google_compute_url_map.default[count.index].id
+  count            = length(var.node_configs)
+  name             = "multichain-mainnet-dev-target-https-proxy-${count.index}"
+  description      = "a description"
+  ssl_certificates = [google_compute_managed_ssl_certificate.mainnet_dev_ssl[count.index].self_link]
+  url_map          = google_compute_url_map.default[count.index].id
 }
 
 resource "google_compute_url_map" "default" {
@@ -173,8 +173,8 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_url_map" "default_redirect" {
-  count           = length(var.node_configs)
-  name            = "multichain-mainnet-dev-redirect-url-map-${count.index}"
+  count = length(var.node_configs)
+  name  = "multichain-mainnet-dev-redirect-url-map-${count.index}"
 
   default_url_redirect {
     strip_query    = false

--- a/infra/multichain-mainnet-dev/variables.tf
+++ b/infra/multichain-mainnet-dev/variables.tf
@@ -116,7 +116,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_recovery_node=debug"
+      value = "mpc_node=debug"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"

--- a/infra/multichain-mainnet-dev/variables.tf
+++ b/infra/multichain-mainnet-dev/variables.tf
@@ -76,7 +76,7 @@ variable "node_configs" {
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "dev"
 }
 
@@ -87,19 +87,19 @@ variable "static_env" {
   }))
   default = [
     {
-      name  = "MPC_RECOVERY_NEAR_RPC"
+      name  = "MPC_NEAR_RPC"
       value = "https://rpc.mainnet.near.org"
     },
     {
-      name  = "MPC_RECOVERY_CONTRACT_ID"
+      name  = "MPC_CONTRACT_ID"
       value = "multichain-mpc-dev.near"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_BUCKET"
+      name  = "MPC_INDEXER_S3_BUCKET"
       value = "near-lake-data-mainnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_START_BLOCK_HEIGHT"
+      name  = "MPC_INDEXER_START_BLOCK_HEIGHT"
       value = 122414750
     },
     {
@@ -107,11 +107,11 @@ variable "static_env" {
       value = "eu-central-1"
     },
     {
-      name  = "MPC_RECOVERY_GCP_PROJECT_ID"
+      name  = "MPC_GCP_PROJECT_ID"
       value = "pagoda-discovery-platform-dev"
     },
     {
-      name  = "MPC_RECOVERY_WEB_PORT"
+      name  = "MPC_WEB_PORT"
       value = "3000"
     },
     {
@@ -119,35 +119,35 @@ variable "static_env" {
       value = "mpc_recovery_node=debug"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_REGION"
+      name  = "MPC_INDEXER_S3_REGION"
       value = "eu-central-1"
     },
     {
-      name  = "MPC_RECOVERY_MIN_TRIPLES"
+      name  = "MPC_MIN_TRIPLES"
       value = 20
     },
     {
-      name  = "MPC_RECOVERY_MAX_TRIPLES"
+      name  = "MPC_MAX_TRIPLES"
       value = 640
     },
     {
-      name  = "MPC_RECOVERY_MIN_PRESIGNATURES"
+      name  = "MPC_MIN_PRESIGNATURES"
       value = 10
     },
     {
-      name  = "MPC_RECOVERY_MAX_PRESIGNATURES"
+      name  = "MPC_MAX_PRESIGNATURES"
       value = 320
     },
     {
-      name  = "MPC_RECOVERY_MAX_CONCURRENT_INTRODUCTION"
+      name  = "MPC_MAX_CONCURRENT_INTRODUCTION"
       value = 2
     },
     {
-      name  = "MPC_RECOVERY_MAX_CONCURRENT_GENERATION"
+      name  = "MPC_MAX_CONCURRENT_GENERATION"
       value = 16
     },
     {
-      name  = "MPC_RECOVERY_TRIPLE_TIMEOUT_SEC"
+      name  = "MPC_TRIPLE_TIMEOUT_SEC"
       value = 1200
     }
   ]
@@ -155,5 +155,5 @@ variable "static_env" {
 
 variable "domain" {
   description = "DNS name of the node"
-  default = ""
+  default     = ""
 }

--- a/infra/multichain-testnet/main.tf
+++ b/infra/multichain-testnet/main.tf
@@ -16,27 +16,27 @@ module "gce-container" {
 
     env = concat(var.static_env, [
       {
-        name  = "MPC_RECOVERY_NODE_ID"
+        name  = "MPC_NODE_ID"
         value = "${count.index}"
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_ID"
+        name  = "MPC_ACCOUNT_ID"
         value = var.node_configs["${count.index}"].account
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_PK"
+        name  = "MPC_CIPHER_PK"
         value = var.node_configs["${count.index}"].cipher_pk
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_SK"
+        name  = "MPC_ACCOUNT_SK"
         value = data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_SK"
+        name  = "MPC_CIPHER_SK"
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_SIGN_SK"
+        name  = "MPC_SIGN_SK"
         value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index] != null ? data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data : data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
@@ -48,19 +48,19 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.aws_secret_key_secret_id.secret_data
       },
       {
-        name  = "MPC_RECOVERY_LOCAL_ADDRESS"
+        name  = "MPC_LOCAL_ADDRESS"
         value = "http://${google_compute_global_address.external_ips[count.index].address}"
       },
       {
-        name  = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_SK_SHARE_SECRET_ID"
         value = var.node_configs["${count.index}"].sk_share_secret_id
       },
       {
-        name  = "MPC_RECOVERY_ENV",
+        name  = "MPC_ENV",
         value = var.env
       },
       {
-        name  = "MPC_RECOVERY_GCP_PROJECT_ID"
+        name  = "MPC_GCP_PROJECT_ID"
         value = var.project_id
       },
     ])

--- a/infra/multichain-testnet/variables.tf
+++ b/infra/multichain-testnet/variables.tf
@@ -110,7 +110,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_recovery_node=debug"
+      value = "mpc_node=debug"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"

--- a/infra/multichain-testnet/variables.tf
+++ b/infra/multichain-testnet/variables.tf
@@ -85,19 +85,19 @@ variable "static_env" {
   }))
   default = [
     {
-      name  = "MPC_RECOVERY_NEAR_RPC"
+      name  = "MPC_NEAR_RPC"
       value = "https://rpc.testnet.near.org"
     },
     {
-      name  = "MPC_RECOVERY_CONTRACT_ID"
+      name  = "MPC_CONTRACT_ID"
       value = "v2.multichain-mpc.testnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_BUCKET"
+      name  = "MPC_INDEXER_S3_BUCKET"
       value = "near-lake-data-testnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_START_BLOCK_HEIGHT"
+      name  = "MPC_INDEXER_START_BLOCK_HEIGHT"
       value = 158767549
     },
     {
@@ -105,7 +105,7 @@ variable "static_env" {
       value = "eu-central-1"
     },
     {
-      name  = "MPC_RECOVERY_WEB_PORT"
+      name  = "MPC_WEB_PORT"
       value = "3000"
     },
     {
@@ -113,7 +113,7 @@ variable "static_env" {
       value = "mpc_recovery_node=debug"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_REGION"
+      name  = "MPC_INDEXER_S3_REGION"
       value = "eu-central-1"
     }
   ]

--- a/infra/partner-mainnet/main.tf
+++ b/infra/partner-mainnet/main.tf
@@ -16,27 +16,27 @@ module "gce-container" {
 
     env = concat(var.static_env, [
       {
-        name  = "MPC_RECOVERY_NODE_ID"
+        name  = "MPC_NODE_ID"
         value = "${count.index}"
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_ID"
+        name  = "MPC_ACCOUNT_ID"
         value = var.node_configs["${count.index}"].account
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_PK"
+        name  = "MPC_CIPHER_PK"
         value = var.node_configs["${count.index}"].cipher_pk
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_SK"
+        name  = "MPC_ACCOUNT_SK"
         value = data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_SK"
+        name  = "MPC_CIPHER_SK"
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_SIGN_SK"
+        name  = "MPC_SIGN_SK"
         value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index] != null ? data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data : data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
@@ -48,15 +48,15 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.aws_secret_key_secret_id.secret_data
       },
       {
-        name  = "MPC_RECOVERY_LOCAL_ADDRESS"
+        name  = "MPC_LOCAL_ADDRESS"
         value = "https://${var.node_configs[count.index].domain}"
       },
       {
-        name = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_SK_SHARE_SECRET_ID"
         value = var.node_configs["${count.index}"].sk_share_secret_id
       },
       {
-        name = "MPC_RECOVERY_ENV",
+        name  = "MPC_ENV",
         value = var.env
       }
     ])
@@ -70,17 +70,17 @@ resource "google_service_account" "service_account" {
 
 resource "google_project_iam_binding" "sa-roles" {
   for_each = toset([
-      "roles/datastore.user",
-      "roles/secretmanager.admin",
-      "roles/storage.objectAdmin",
-      "roles/iam.serviceAccountAdmin",
+    "roles/datastore.user",
+    "roles/secretmanager.admin",
+    "roles/storage.objectAdmin",
+    "roles/iam.serviceAccountAdmin",
   ])
 
   role = each.key
   members = [
     "serviceAccount:${google_service_account.service_account.email}"
-   ]
-   project = var.project_id
+  ]
+  project = var.project_id
 }
 
 resource "google_compute_global_address" "external_ips" {
@@ -95,7 +95,7 @@ resource "google_compute_global_address" "external_ips" {
 
 resource "google_compute_managed_ssl_certificate" "mainnet_ssl" {
   count = length(var.node_configs)
-  name = "multichain-partner-mainnet-ssl-${count.index}"
+  name  = "multichain-partner-mainnet-ssl-${count.index}"
 
   managed {
     domains = [var.node_configs[count.index].domain]
@@ -157,38 +157,38 @@ resource "google_compute_health_check" "multichain_healthcheck" {
 }
 
 resource "google_compute_global_forwarding_rule" "http_fw" {
-  count      = length(var.node_configs)
-  name       = "multichain-partner-mainnet-http-rule-${count.index}"
-  target     = google_compute_target_http_proxy.default[count.index].id
-  port_range = "80"
-  ip_protocol = "TCP"
+  count                 = length(var.node_configs)
+  name                  = "multichain-partner-mainnet-http-rule-${count.index}"
+  target                = google_compute_target_http_proxy.default[count.index].id
+  port_range            = "80"
+  ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
-  ip_address = google_compute_global_address.external_ips[count.index].address
+  ip_address            = google_compute_global_address.external_ips[count.index].address
 }
 
 resource "google_compute_global_forwarding_rule" "https_fw" {
-  count      = length(var.node_configs)
-  name       = "multichain-partner-mainnet-https-rule-${count.index}"
-  target     = google_compute_target_https_proxy.default_https[count.index].id
-  port_range = "443"
-  ip_protocol = "TCP"
+  count                 = length(var.node_configs)
+  name                  = "multichain-partner-mainnet-https-rule-${count.index}"
+  target                = google_compute_target_https_proxy.default_https[count.index].id
+  port_range            = "443"
+  ip_protocol           = "TCP"
   load_balancing_scheme = "EXTERNAL"
-  ip_address = google_compute_global_address.external_ips[count.index].address
+  ip_address            = google_compute_global_address.external_ips[count.index].address
 }
 
 resource "google_compute_target_http_proxy" "default" {
-  count      = length(var.node_configs)
+  count       = length(var.node_configs)
   name        = "multichain-partner-mainnet-http-target-proxy-${count.index}"
   description = "a description"
   url_map     = google_compute_url_map.redirect_default[count.index].id
 }
 
 resource "google_compute_target_https_proxy" "default_https" {
-  count      = length(var.node_configs)
-  name        = "multichain-partner-mainnet-https-target-proxy-${count.index}"
-  description = "a description"
-  ssl_certificates = [ google_compute_managed_ssl_certificate.mainnet_ssl[count.index].self_link ]
-  url_map     = google_compute_url_map.default[count.index].id
+  count            = length(var.node_configs)
+  name             = "multichain-partner-mainnet-https-target-proxy-${count.index}"
+  description      = "a description"
+  ssl_certificates = [google_compute_managed_ssl_certificate.mainnet_ssl[count.index].self_link]
+  url_map          = google_compute_url_map.default[count.index].id
 }
 
 resource "google_compute_url_map" "default" {
@@ -198,8 +198,8 @@ resource "google_compute_url_map" "default" {
 }
 
 resource "google_compute_url_map" "redirect_default" {
-  count           = length(var.node_configs)
-  name            = "multichain-partner-mainnet-redirect-url-map-${count.index}"
+  count = length(var.node_configs)
+  name  = "multichain-partner-mainnet-redirect-url-map-${count.index}"
   default_url_redirect {
     strip_query    = false
     https_redirect = true
@@ -230,15 +230,15 @@ resource "google_compute_instance_group" "multichain_group" {
 }
 
 resource "google_compute_firewall" "app_port" {
-  name = "allow-multichain-healthcheck-access"
+  name    = "allow-multichain-healthcheck-access"
   network = var.network
 
-  source_ranges = [ "130.211.0.0/22", "35.191.0.0/16" ]
-  source_tags = [ "multichain" ]
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  source_tags   = ["multichain"]
 
   allow {
     protocol = "tcp"
-    ports = [ "80", "3000" ]
+    ports    = ["80", "3000"]
   }
 
 }

--- a/infra/partner-mainnet/variables.tf
+++ b/infra/partner-mainnet/variables.tf
@@ -117,7 +117,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_recovery_node=debug"
+      value = "mpc_node=debug"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"

--- a/infra/partner-mainnet/variables.tf
+++ b/infra/partner-mainnet/variables.tf
@@ -43,8 +43,8 @@ variable "network" {
 variable "additional_metadata" {
   type        = map(any)
   description = "Additional metadata to attach to the instance"
-  default     = {
-    cos-update-strategy:	"update_enabled"
+  default = {
+    cos-update-strategy : "update_enabled"
   }
 }
 
@@ -77,7 +77,7 @@ variable "node_configs" {
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "mainnet"
 }
 
@@ -88,19 +88,19 @@ variable "static_env" {
   }))
   default = [
     {
-      name  = "MPC_RECOVERY_NEAR_RPC"
+      name  = "MPC_NEAR_RPC"
       value = "https://rpc.mainnet.near.org"
     },
     {
-      name  = "MPC_RECOVERY_CONTRACT_ID"
+      name  = "MPC_CONTRACT_ID"
       value = "v2.multichain-mpc.testnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_BUCKET"
+      name  = "MPC_INDEXER_S3_BUCKET"
       value = "near-lake-data-mainnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_START_BLOCK_HEIGHT"
+      name  = "MPC_INDEXER_START_BLOCK_HEIGHT"
       value = 124092099
     },
     {
@@ -108,11 +108,11 @@ variable "static_env" {
       value = "eu-central-1"
     },
     {
-      name  = "MPC_RECOVERY_GCP_PROJECT_ID"
+      name  = "MPC_GCP_PROJECT_ID"
       value = "<your-project-id>"
     },
     {
-      name  = "MPC_RECOVERY_WEB_PORT"
+      name  = "MPC_WEB_PORT"
       value = "3000"
     },
     {
@@ -120,14 +120,14 @@ variable "static_env" {
       value = "mpc_recovery_node=debug"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_REGION"
+      name  = "MPC_INDEXER_S3_REGION"
       value = "eu-central-1"
     }
   ]
 }
 
 variable "create_network" {
-  default = false
+  default     = false
   description = "Do you want to create a new VPC network (true) or use default GCP network (false)?"
 }
 

--- a/infra/partner-testnet/main.tf
+++ b/infra/partner-testnet/main.tf
@@ -16,27 +16,27 @@ module "gce-container" {
 
     env = concat(var.static_env, [
       {
-        name  = "MPC_RECOVERY_NODE_ID"
+        name  = "MPC_NODE_ID"
         value = "${count.index}"
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_ID"
+        name  = "MPC_ACCOUNT_ID"
         value = var.node_configs["${count.index}"].account
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_PK"
+        name  = "MPC_CIPHER_PK"
         value = var.node_configs["${count.index}"].cipher_pk
       },
       {
-        name  = "MPC_RECOVERY_ACCOUNT_SK"
+        name  = "MPC_ACCOUNT_SK"
         value = data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_CIPHER_SK"
+        name  = "MPC_CIPHER_SK"
         value = data.google_secret_manager_secret_version.cipher_sk_secret_id[count.index].secret_data
       },
       {
-        name  = "MPC_RECOVERY_SIGN_SK"
+        name  = "MPC_SIGN_SK"
         value = data.google_secret_manager_secret_version.sign_sk_secret_id[count.index] != null ? data.google_secret_manager_secret_version.sign_sk_secret_id[count.index].secret_data : data.google_secret_manager_secret_version.account_sk_secret_id[count.index].secret_data
       },
       {
@@ -48,15 +48,15 @@ module "gce-container" {
         value = data.google_secret_manager_secret_version.aws_secret_key_secret_id.secret_data
       },
       {
-        name  = "MPC_RECOVERY_LOCAL_ADDRESS"
+        name  = "MPC_LOCAL_ADDRESS"
         value = "http://${google_compute_global_address.external_ips[count.index].address}"
       },
       {
-        name = "MPC_RECOVERY_SK_SHARE_SECRET_ID"
+        name  = "MPC_SK_SHARE_SECRET_ID"
         value = var.node_configs["${count.index}"].sk_share_secret_id
       },
       {
-        name = "MPC_RECOVERY_ENV",
+        name  = "MPC_ENV",
         value = var.env
       }
     ])
@@ -70,17 +70,17 @@ resource "google_service_account" "service_account" {
 
 resource "google_project_iam_binding" "sa-roles" {
   for_each = toset([
-      "roles/datastore.user",
-      "roles/secretmanager.admin",
-      "roles/storage.objectAdmin",
-      "roles/iam.serviceAccountAdmin",
+    "roles/datastore.user",
+    "roles/secretmanager.admin",
+    "roles/storage.objectAdmin",
+    "roles/iam.serviceAccountAdmin",
   ])
 
   role = each.key
   members = [
     "serviceAccount:${google_service_account.service_account.email}"
-   ]
-   project = var.project_id
+  ]
+  project = var.project_id
 }
 
 resource "google_compute_global_address" "external_ips" {
@@ -144,16 +144,16 @@ resource "google_compute_health_check" "multichain_healthcheck" {
 }
 
 resource "google_compute_global_forwarding_rule" "default" {
-  count      = length(var.node_configs)
-  name       = "multichain-partner-rule-${count.index}"
-  target     = google_compute_target_http_proxy.default[count.index].id
-  port_range = "80"
+  count                 = length(var.node_configs)
+  name                  = "multichain-partner-rule-${count.index}"
+  target                = google_compute_target_http_proxy.default[count.index].id
+  port_range            = "80"
   load_balancing_scheme = "EXTERNAL"
-  ip_address = google_compute_global_address.external_ips[count.index].address
+  ip_address            = google_compute_global_address.external_ips[count.index].address
 }
 
 resource "google_compute_target_http_proxy" "default" {
-  count      = length(var.node_configs)
+  count       = length(var.node_configs)
   name        = "multichain-partner-target-proxy-${count.index}"
   description = "a description"
   url_map     = google_compute_url_map.default[count.index].id
@@ -188,15 +188,15 @@ resource "google_compute_instance_group" "multichain_group" {
 }
 
 resource "google_compute_firewall" "app_port" {
-  name = "allow-multichain-healthcheck-access"
+  name    = "allow-multichain-healthcheck-access"
   network = var.network
 
-  source_ranges = [ "130.211.0.0/22", "35.191.0.0/16" ]
-  source_tags = [ "multichain" ]
+  source_ranges = ["130.211.0.0/22", "35.191.0.0/16"]
+  source_tags   = ["multichain"]
 
   allow {
     protocol = "tcp"
-    ports = [ "80", "3000" ]
+    ports    = ["80", "3000"]
   }
 
 }

--- a/infra/partner-testnet/variables.tf
+++ b/infra/partner-testnet/variables.tf
@@ -74,7 +74,7 @@ variable "node_configs" {
 }
 
 variable "env" {
-  type = string
+  type    = string
   default = "dev"
 }
 
@@ -85,19 +85,19 @@ variable "static_env" {
   }))
   default = [
     {
-      name  = "MPC_RECOVERY_NEAR_RPC"
+      name  = "MPC_NEAR_RPC"
       value = "https://rpc.testnet.near.org"
     },
     {
-      name  = "MPC_RECOVERY_CONTRACT_ID"
+      name  = "MPC_CONTRACT_ID"
       value = "v2.multichain-mpc.testnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_BUCKET"
+      name  = "MPC_INDEXER_S3_BUCKET"
       value = "near-lake-data-testnet"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_START_BLOCK_HEIGHT"
+      name  = "MPC_INDEXER_START_BLOCK_HEIGHT"
       value = 158767549
     },
     {
@@ -105,11 +105,11 @@ variable "static_env" {
       value = "eu-central-1"
     },
     {
-      name  = "MPC_RECOVERY_GCP_PROJECT_ID"
+      name  = "MPC_GCP_PROJECT_ID"
       value = "<your-project-id>"
     },
     {
-      name  = "MPC_RECOVERY_WEB_PORT"
+      name  = "MPC_WEB_PORT"
       value = "3000"
     },
     {
@@ -117,13 +117,13 @@ variable "static_env" {
       value = "mpc_recovery_node=debug"
     },
     {
-      name  = "MPC_RECOVERY_INDEXER_S3_REGION"
+      name  = "MPC_INDEXER_S3_REGION"
       value = "eu-central-1"
     }
   ]
 }
 
 variable "create_network" {
-  default = false
+  default     = false
   description = "Do you want to create a new VPC network (true) or use default GCP network (false)?"
 }

--- a/infra/partner-testnet/variables.tf
+++ b/infra/partner-testnet/variables.tf
@@ -114,7 +114,7 @@ variable "static_env" {
     },
     {
       name  = "RUST_LOG"
-      value = "mpc_recovery_node=debug"
+      value = "mpc_node=debug"
     },
     {
       name  = "MPC_INDEXER_S3_REGION"

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -3748,7 +3748,7 @@ dependencies = [
  "lazy_static",
  "mpc-contract",
  "mpc-keys",
- "mpc-recovery-node",
+ "mpc-node",
  "near-account-id",
  "near-crypto 0.23.0",
  "near-fetch",
@@ -4263,7 +4263,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "mpc-recovery-node"
+name = "mpc-node"
 version = "1.0.0-rc.1"
 dependencies = [
  "anyhow",

--- a/integration-tests/chain-signatures/Cargo.toml
+++ b/integration-tests/chain-signatures/Cargo.toml
@@ -46,7 +46,7 @@ near-workspaces = { git = "https://github.com/near/near-workspaces-rs", branch =
 crypto-shared = { path = "../../chain-signatures/crypto-shared" }
 mpc-contract = { path = "../../chain-signatures/contract" }
 mpc-keys = { path = "../../chain-signatures/keys" }
-mpc-recovery-node = { path = "../../chain-signatures/node" }
+mpc-node = { path = "../../chain-signatures/node" }
 clap = { version = "4.5.4", features = ["derive"] }
 lazy_static = "1.4.0"
 

--- a/integration-tests/chain-signatures/build.rs
+++ b/integration-tests/chain-signatures/build.rs
@@ -4,7 +4,7 @@ use std::{env, fs, io};
 use anyhow::Context;
 use async_process::{Command, ExitStatus, Stdio};
 
-const PACKAGE_MULTICHAIN: &str = "mpc-recovery-node";
+const PACKAGE_MULTICHAIN: &str = "mpc-node";
 const PACKAGE_CONTRACT: &str = "mpc-contract";
 const TARGET_CONTRACT: &str = "wasm32-unknown-unknown";
 const TARGET_FOLDER: &str = "target";

--- a/integration-tests/chain-signatures/src/containers.rs
+++ b/integration-tests/chain-signatures/src/containers.rs
@@ -180,7 +180,7 @@ impl<'a> Node<'a> {
             sign_sk: Some(sign_sk),
         }
         .into_str_args();
-        let image: GenericImage = GenericImage::new("near/mpc-recovery-node", "latest")
+        let image: GenericImage = GenericImage::new("near/mpc-node", "latest")
             .with_wait_for(WaitFor::Nothing)
             .with_exposed_port(Self::CONTAINER_PORT)
             .with_env_var("RUST_LOG", "mpc_node=DEBUG")

--- a/integration-tests/chain-signatures/src/containers.rs
+++ b/integration-tests/chain-signatures/src/containers.rs
@@ -65,13 +65,13 @@ impl<'a> Node<'a> {
         );
         LakeIndexer::populate_proxy(&proxy_name, true, &rpc_address_proxied, &near_rpc).await?;
 
-        let indexer_options = mpc_recovery_node::indexer::Options {
+        let indexer_options = mpc_node::indexer::Options {
             s3_bucket: ctx.localstack.s3_bucket.clone(),
             s3_region: ctx.localstack.s3_region.clone(),
             s3_url: Some(ctx.localstack.s3_host_address.clone()),
             start_block_height: 0,
         };
-        let args = mpc_recovery_node::cli::Cli::Start {
+        let args = mpc_node::cli::Cli::Start {
             near_rpc: rpc_address_proxied.clone(),
             mpc_contract_id: ctx.mpc_contract.id().clone(),
             account_id: account_id.clone(),
@@ -91,10 +91,10 @@ impl<'a> Node<'a> {
             max_presignatures: cfg.presig_cfg.max_presignatures,
         }
         .into_str_args();
-        let image: GenericImage = GenericImage::new("near/mpc-recovery-node", "latest")
+        let image: GenericImage = GenericImage::new("near/mpc-node", "latest")
             .with_wait_for(WaitFor::Nothing)
             .with_exposed_port(Self::CONTAINER_PORT)
-            .with_env_var("RUST_LOG", "mpc_recovery_node=DEBUG")
+            .with_env_var("RUST_LOG", "mpc_node=DEBUG")
             .with_env_var("RUST_BACKTRACE", "1");
         let image: RunnableImage<GenericImage> = (image, args).into();
         let image = image.with_network(&ctx.docker_network);
@@ -152,7 +152,7 @@ impl<'a> Node<'a> {
         let storage_options = ctx.storage_options.clone();
         let near_rpc = config.near_rpc;
         let mpc_contract_id = ctx.mpc_contract.id().clone();
-        let indexer_options = mpc_recovery_node::indexer::Options {
+        let indexer_options = mpc_node::indexer::Options {
             s3_bucket: ctx.localstack.s3_bucket.clone(),
             s3_region: ctx.localstack.s3_region.clone(),
             s3_url: Some(ctx.localstack.s3_host_address.clone()),
@@ -160,7 +160,7 @@ impl<'a> Node<'a> {
         };
         let sign_sk =
             near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "integration-test");
-        let args = mpc_recovery_node::cli::Cli::Start {
+        let args = mpc_node::cli::Cli::Start {
             near_rpc: near_rpc.clone(),
             mpc_contract_id: mpc_contract_id.clone(),
             account_id: account_id.clone(),
@@ -183,7 +183,7 @@ impl<'a> Node<'a> {
         let image: GenericImage = GenericImage::new("near/mpc-recovery-node", "latest")
             .with_wait_for(WaitFor::Nothing)
             .with_exposed_port(Self::CONTAINER_PORT)
-            .with_env_var("RUST_LOG", "mpc_recovery_node=DEBUG")
+            .with_env_var("RUST_LOG", "mpc_node=DEBUG")
             .with_env_var("RUST_BACKTRACE", "1");
         let image: RunnableImage<GenericImage> = (image, args).into();
         let image = image.with_network(&ctx.docker_network);

--- a/integration-tests/chain-signatures/src/execute.rs
+++ b/integration-tests/chain-signatures/src/execute.rs
@@ -27,14 +27,14 @@ pub fn executable(release: bool, executable: &str) -> Option<std::path::PathBuf>
 pub fn spawn_multichain(
     release: bool,
     node: &str,
-    cli: mpc_recovery_node::cli::Cli,
+    cli: mpc_node::cli::Cli,
 ) -> anyhow::Result<Child> {
     let executable = executable(release, PACKAGE_MULTICHAIN)
         .with_context(|| format!("could not find target dir while starting {node} node"))?;
 
     async_process::Command::new(&executable)
         .args(cli.into_str_args())
-        .env("RUST_LOG", "mpc_recovery_node=INFO")
+        .env("RUST_LOG", "mpc_node=INFO")
         .envs(std::env::vars())
         .stdout(async_process::Stdio::inherit())
         .stderr(async_process::Stdio::inherit())

--- a/integration-tests/chain-signatures/src/execute.rs
+++ b/integration-tests/chain-signatures/src/execute.rs
@@ -1,7 +1,7 @@
 use anyhow::Context;
 use async_process::Child;
 
-const PACKAGE_MULTICHAIN: &str = "mpc-recovery-node";
+const PACKAGE_MULTICHAIN: &str = "mpc-node";
 
 pub fn target_dir() -> Option<std::path::PathBuf> {
     let mut out_dir = std::path::Path::new(std::env!("OUT_DIR"));

--- a/integration-tests/chain-signatures/src/lib.rs
+++ b/integration-tests/chain-signatures/src/lib.rs
@@ -13,11 +13,11 @@ use anyhow::Context as _;
 use bollard::exec::{CreateExecOptions, StartExecResults};
 use futures::StreamExt;
 use mpc_contract::primitives::CandidateInfo;
-use mpc_recovery_node::gcp::GcpService;
-use mpc_recovery_node::protocol::presignature::PresignatureConfig;
-use mpc_recovery_node::protocol::triple::TripleConfig;
-use mpc_recovery_node::storage;
-use mpc_recovery_node::storage::triple_storage::TripleNodeStorageBox;
+use mpc_node::gcp::GcpService;
+use mpc_node::protocol::presignature::PresignatureConfig;
+use mpc_node::protocol::triple::TripleConfig;
+use mpc_node::storage;
+use mpc_node::storage::triple_storage::TripleNodeStorageBox;
 use near_crypto::KeyFile;
 use near_workspaces::network::{Sandbox, ValidatorKey};
 use near_workspaces::types::SecretKey;
@@ -278,7 +278,7 @@ pub async fn setup(docker_client: &DockerClient) -> anyhow::Result<Context<'_>> 
         crate::containers::Datastore::run(docker_client, docker_network, gcp_project_id).await?;
 
     let sk_share_local_path = "multichain-integration-secret-manager".to_string();
-    let storage_options = mpc_recovery_node::storage::Options {
+    let storage_options = mpc_node::storage::Options {
         env: "local-test".to_string(),
         gcp_project_id: "multichain-integration".to_string(),
         sk_share_secret_id: None,

--- a/integration-tests/chain-signatures/src/local.rs
+++ b/integration-tests/chain-signatures/src/local.rs
@@ -44,7 +44,7 @@ impl Node {
         let sign_sk =
             near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "integration-test");
 
-        let indexer_options = mpc_recovery_node::indexer::Options {
+        let indexer_options = mpc_node::indexer::Options {
             s3_bucket: ctx.localstack.s3_bucket.clone(),
             s3_region: ctx.localstack.s3_region.clone(),
             s3_url: Some(ctx.localstack.s3_host_address.clone()),
@@ -65,7 +65,7 @@ impl Node {
         LakeIndexer::populate_proxy(&proxy_name, true, &rpc_address_proxied, &near_rpc).await?;
 
         let mpc_contract_id = ctx.mpc_contract.id().clone();
-        let cli = mpc_recovery_node::cli::Cli::Start {
+        let cli = mpc_node::cli::Cli::Start {
             near_rpc: rpc_address_proxied.clone(),
             mpc_contract_id: mpc_contract_id.clone(),
             account_id: account_id.clone(),
@@ -113,7 +113,7 @@ impl Node {
         let account_id = config.account_id;
         let account_sk = config.account_sk;
         let storage_options = ctx.storage_options.clone();
-        let indexer_options = mpc_recovery_node::indexer::Options {
+        let indexer_options = mpc_node::indexer::Options {
             s3_bucket: ctx.localstack.s3_bucket.clone(),
             s3_region: ctx.localstack.s3_region.clone(),
             s3_url: Some(ctx.localstack.s3_host_address.clone()),
@@ -123,7 +123,7 @@ impl Node {
             near_crypto::SecretKey::from_seed(near_crypto::KeyType::ED25519, "integration-test");
         let near_rpc = config.near_rpc;
         let mpc_contract_id = ctx.mpc_contract.id().clone();
-        let cli = mpc_recovery_node::cli::Cli::Start {
+        let cli = mpc_node::cli::Cli::Start {
             near_rpc: near_rpc.clone(),
             mpc_contract_id: mpc_contract_id.clone(),
             account_id: account_id.clone(),

--- a/integration-tests/chain-signatures/tests/actions/mod.rs
+++ b/integration-tests/chain-signatures/tests/actions/mod.rs
@@ -17,7 +17,7 @@ use mpc_contract::errors;
 use mpc_contract::primitives::SignRequest;
 use mpc_contract::primitives::SignatureRequest;
 use mpc_contract::RunningContractState;
-use mpc_recovery_node::kdf::into_eth_sig;
+use mpc_node::kdf::into_eth_sig;
 use near_crypto::InMemorySigner;
 use near_jsonrpc_client::methods::broadcast_tx_async::RpcBroadcastTxAsyncRequest;
 use near_lake_primitives::CryptoHash;

--- a/integration-tests/chain-signatures/tests/actions/wait_for.rs
+++ b/integration-tests/chain-signatures/tests/actions/wait_for.rs
@@ -11,7 +11,7 @@ use crypto_shared::SignatureResponse;
 use k256::Secp256k1;
 use mpc_contract::ProtocolContractState;
 use mpc_contract::RunningContractState;
-use mpc_recovery_node::web::StateView;
+use mpc_node::web::StateView;
 use near_jsonrpc_client::methods::tx::RpcTransactionStatusRequest;
 use near_jsonrpc_client::methods::tx::TransactionInfo;
 use near_lake_primitives::CryptoHash;

--- a/integration-tests/chain-signatures/tests/cases/mod.rs
+++ b/integration-tests/chain-signatures/tests/cases/mod.rs
@@ -7,10 +7,10 @@ use crypto_shared::{self, derive_epsilon, derive_key, x_coordinate, ScalarExt};
 use integration_tests_chain_signatures::containers::{self, DockerClient};
 use integration_tests_chain_signatures::MultichainConfig;
 use k256::elliptic_curve::point::AffineCoordinates;
-use mpc_recovery_node::kdf::into_eth_sig;
-use mpc_recovery_node::test_utils;
-use mpc_recovery_node::types::LatestBlockHeight;
-use mpc_recovery_node::util::NearPublicKeyExt;
+use mpc_node::kdf::into_eth_sig;
+use mpc_node::test_utils;
+use mpc_node::types::LatestBlockHeight;
+use mpc_node::util::NearPublicKeyExt;
 use test_log::test;
 
 pub mod nightly;

--- a/integration-tests/chain-signatures/tests/cases/nightly.rs
+++ b/integration-tests/chain-signatures/tests/cases/nightly.rs
@@ -1,6 +1,6 @@
 use integration_tests_chain_signatures::MultichainConfig;
-use mpc_recovery_node::protocol::presignature::PresignatureConfig;
-use mpc_recovery_node::protocol::triple::TripleConfig;
+use mpc_node::protocol::presignature::PresignatureConfig;
+use mpc_node::protocol::triple::TripleConfig;
 use test_log::test;
 
 use crate::actions::{self, wait_for};


### PR DESCRIPTION
Been meaning to do this for a while. Let me know if this is too big of a change for our upgrade of partner testnet

renames:
- `MPC_RECOVERY_*` env variables to `MPC_*`
- `mpc-recovery-node`/`mpc_recovery_node` library/binary to `mpc-node`/`mpc_node`

This would be nice to have as we do not have the confusion of MPC_RECOVERY anymore. I'll also be getting rid of some these env variables in favor of the contract configurations.