### PR TITLE
feat: make PresignatureId be generated and reproducible from triple ids

### DIFF
--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -3820,6 +3820,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "sha3",
  "thiserror",
  "tokio",
  "tokio-retry",

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -33,6 +33,7 @@ rand = "0.8"
 reqwest = { version = "0.11.16", features = ["blocking", "json"] }
 semver = "1.0.23"
 sha2 = "0.10.8"
+sha3 = "0.10.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1"

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -1,11 +1,11 @@
 mod cryptography;
-mod signature;
 
 pub mod consensus;
 pub mod contract;
 pub mod message;
 pub mod monitor;
 pub mod presignature;
+pub mod signature;
 pub mod state;
 pub mod triple;
 

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -10,6 +10,8 @@ use chrono::Utc;
 use crypto_shared::PublicKey;
 use k256::Secp256k1;
 use mpc_contract::config::ProtocolConfig;
+use rand::rngs::StdRng;
+use rand::{Rng as _, SeedableRng as _};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
@@ -213,7 +215,7 @@ impl PresignatureManager {
         private_share: &SecretKeyShare,
         timeout: u64,
     ) -> Result<(), InitializationError> {
-        let id = rand::random();
+        let id = hash_as_id(triple0.id, triple1.id);
 
         // Check if the `id` is already in the system. Error out and have the next cycle try again.
         if self.generators.contains_key(&id)
@@ -515,4 +517,16 @@ impl PresignatureManager {
 
         messages
     }
+}
+
+pub fn hash_as_id(triple0: TripleId, triple1: TripleId) -> PresignatureId {
+    use sha3::{Digest, Sha3_256};
+    let mut hasher = Sha3_256::new();
+    hasher.update(triple0.to_le_bytes());
+    hasher.update(triple1.to_le_bytes());
+    let seed: [u8; 32] = hasher.finalize().into();
+    let mut rng = StdRng::from_seed(seed);
+    let id = rng.gen::<u64>();
+
+    PresignatureId::from(id)
 }

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -10,8 +10,7 @@ use chrono::Utc;
 use crypto_shared::PublicKey;
 use k256::Secp256k1;
 use mpc_contract::config::ProtocolConfig;
-use rand::rngs::StdRng;
-use rand::{Rng as _, SeedableRng as _};
+use sha3::{Digest, Sha3_256};
 use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::time::{Duration, Instant};
@@ -520,13 +519,21 @@ impl PresignatureManager {
 }
 
 pub fn hash_as_id(triple0: TripleId, triple1: TripleId) -> PresignatureId {
-    use sha3::{Digest, Sha3_256};
     let mut hasher = Sha3_256::new();
     hasher.update(triple0.to_le_bytes());
     hasher.update(triple1.to_le_bytes());
-    let seed: [u8; 32] = hasher.finalize().into();
-    let mut rng = StdRng::from_seed(seed);
-    let id = rng.gen::<u64>();
+    let id: [u8; 32] = hasher.finalize().into();
+    let id = u64::from_le_bytes(first_8_bytes(id));
 
     PresignatureId::from(id)
+}
+
+const fn first_8_bytes(input: [u8; 32]) -> [u8; 8] {
+    let mut output = [0u8; 8];
+    let mut i = 0;
+    while i < 8 {
+        output[i] = input[i];
+        i += 1;
+    }
+    output
 }


### PR DESCRIPTION
This is better to have now than later, as we won't break the presignature id guarantees later if we add it later.

This will allow us to validate `Presignature` generation messages a lit bit more easily by verifying that the presignature id is correct in the future