### PR TITLE
fix: make override default impl return empty map and use u32 instead of usize

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -4,11 +4,11 @@ use super::{
     Config, DynamicValue, PresignatureConfig, ProtocolConfig, SignatureConfig, TripleConfig,
 };
 
-const MAX_EXPECTED_PARTICIPANTS: usize = 32;
+const MAX_EXPECTED_PARTICIPANTS: u32 = 32;
 
 // The network multiplier is used to calculate the maximum amount of protocols in totality
 // that should be in the network.
-const NETWORK_MULTIPLIER: usize = 128;
+const NETWORK_MULTIPLIER: u32 = 128;
 
 impl Config {
     pub fn get(&self, key: &str) -> Option<serde_json::Value> {

--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -35,10 +35,10 @@ pub struct ProtocolConfig {
     pub garbage_timeout: u64,
     /// Maximum amount of concurrent protocol generation that can be introduced by this node.
     /// This only includes protocols that generate triples and presignatures.
-    pub max_concurrent_introduction: usize,
+    pub max_concurrent_introduction: u32,
     /// Maximum amount of concurrent protocol generation that can be done per node.
     /// This only includes protocols that generate triples and presignatures.
-    pub max_concurrent_generation: usize,
+    pub max_concurrent_generation: u32,
     /// Configuration for triple generation.
     pub triple: TripleConfig,
     /// Configuration for presignature generation.
@@ -54,9 +54,9 @@ pub struct ProtocolConfig {
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct TripleConfig {
     /// Minimum amount of triples that is owned by each node.
-    pub min_triples: usize,
+    pub min_triples: u32,
     /// Maximum amount of triples that is in the whole network.
-    pub max_triples: usize,
+    pub max_triples: u32,
     /// Timeout for triple generation in milliseconds.
     pub generation_timeout: u64,
 
@@ -68,9 +68,9 @@ pub struct TripleConfig {
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize, PartialEq, Eq)]
 pub struct PresignatureConfig {
     /// Minimum amount of presignatures that is owned by each node.
-    pub min_presignatures: usize,
+    pub min_presignatures: u32,
     /// Maximum amount of presignatures that is in the whole network.
-    pub max_presignatures: usize,
+    pub max_presignatures: u32,
     /// Timeout for presignature generation in milliseconds.
     pub generation_timeout: u64,
 

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -202,7 +202,7 @@ impl MpcSignProtocol {
         let mut last_pinged = Instant::now();
         loop {
             let protocol_time = Instant::now();
-            tracing::debug!("trying to advance mpc recovery protocol");
+            tracing::debug!("trying to advance chain signatures protocol");
             loop {
                 let msg_result = self.receiver.try_recv();
                 match msg_result {

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -261,12 +261,12 @@ impl PresignatureManager {
             // Stopgap to prevent too many presignatures in the system. This should be around min_presig*nodes*2
             // for good measure so that we have enough presignatures to do sig generation while also maintain
             // the minimum number of presignature where a single node can't flood the system.
-            if self.potential_len() >= cfg.presignature.max_presignatures {
+            if self.potential_len() >= cfg.presignature.max_presignatures as usize {
                 false
             } else {
                 // We will always try to generate a new triple if we have less than the minimum
-                self.my_len() < cfg.presignature.min_presignatures
-                    && self.introduced.len() < cfg.max_concurrent_introduction
+                self.my_len() < cfg.presignature.min_presignatures as usize
+                    && self.introduced.len() < cfg.max_concurrent_introduction as usize
             }
         };
 

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -185,7 +185,7 @@ impl TripleManager {
     }
 
     pub fn has_min_triples(&self, cfg: &ProtocolConfig) -> bool {
-        self.my_len() >= cfg.triple.min_triples
+        self.my_len() >= cfg.triple.min_triples as usize
     }
 
     /// Clears an entry from failed triples if that triple protocol was created more than 2 hrs ago
@@ -250,13 +250,13 @@ impl TripleManager {
             // Stopgap to prevent too many triples in the system. This should be around min_triple*nodes*2
             // for good measure so that we have enough triples to do presig generation while also maintain
             // the minimum number of triples where a single node can't flood the system.
-            if self.potential_len() >= cfg.triple.max_triples {
+            if self.potential_len() >= cfg.triple.max_triples as usize {
                 false
             } else {
                 // We will always try to generate a new triple if we have less than the minimum
-                self.my_len() < cfg.triple.min_triples
-                    && self.introduced.len() < cfg.max_concurrent_introduction
-                    && self.generators.len() < cfg.max_concurrent_generation
+                self.my_len() < cfg.triple.min_triples as usize
+                    && self.introduced.len() < cfg.max_concurrent_introduction as usize
+                    && self.generators.len() < cfg.max_concurrent_generation as usize
             }
         };
 
@@ -401,7 +401,7 @@ impl TripleManager {
             let potential_len = self.potential_len();
             match self.generators.entry(id) {
                 Entry::Vacant(e) => {
-                    if potential_len >= cfg.triple.max_triples {
+                    if potential_len >= cfg.triple.max_triples as usize {
                         // We are at the maximum amount of triples, we cannot generate more. So just in case a node
                         // sends more triple generation requests, reject them and have them tiemout.
                         return Ok(None);
@@ -437,7 +437,7 @@ impl TripleManager {
     /// An empty vector means we cannot progress until we receive a new message.
     pub async fn poke(&mut self, cfg: &ProtocolConfig) -> Vec<(Participant, TripleMessage)> {
         // Add more protocols to the ongoing pool if there is space.
-        let to_generate_len = cfg.max_concurrent_generation - self.ongoing.len();
+        let to_generate_len = cfg.max_concurrent_generation as usize - self.ongoing.len();
         if !self.queued.is_empty() && to_generate_len > 0 {
             for _ in 0..to_generate_len {
                 self.queued.pop_front().map(|id| self.ongoing.insert(id));

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -4304,6 +4304,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.8",
+ "sha3",
  "thiserror",
  "tokio",
  "tokio-retry",

--- a/integration-tests/chain-signatures/tests/cases/nightly.rs
+++ b/integration-tests/chain-signatures/tests/cases/nightly.rs
@@ -11,8 +11,8 @@ async fn test_nightly_signature_production() -> anyhow::Result<()> {
     const SIGNATURE_AMOUNT: usize = 1000;
     const NODES: usize = 8;
     const THRESHOLD: usize = 4;
-    const MIN_TRIPLES: usize = 10;
-    const MAX_TRIPLES: usize = 2 * NODES * MIN_TRIPLES;
+    const MIN_TRIPLES: u32 = 10;
+    const MAX_TRIPLES: u32 = 2 * NODES as u32 * MIN_TRIPLES;
 
     let config = MultichainConfig {
         nodes: NODES,


### PR DESCRIPTION
fixes:
- make override default have empty map instead of null
- make all usize in contract/ code use u32 instead due to architectural differences