### PR TITLE
fix: make manager reject messages for already completed sigs

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -66,6 +66,7 @@ impl Default for SignatureConfig {
     fn default() -> Self {
         Self {
             generation_timeout: secs_to_ms(60),
+            garbage_timeout: hours_to_ms(24),
 
             other: Default::default(),
         }

--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -83,6 +83,8 @@ pub struct PresignatureConfig {
 pub struct SignatureConfig {
     /// Timeout for signature generation in milliseconds.
     pub generation_timeout: u64,
+    /// Garbage collection timeout in milliseconds for signatures generated.
+    pub garbage_timeout: u64,
 
     /// The remaining entries that can be present in future forms of the configuration.
     #[serde(flatten)]

--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -97,35 +97,6 @@ mod tests {
 
     #[test]
     fn test_load_config() {
-        let config_str: serde_json::Value = serde_json::from_str(
-            r#"{
-                "protocol": {
-                    "message_timeout": 10000,
-                    "garbage_timeout": 20000,
-                    "max_concurrent_introduction": 10,
-                    "max_concurrent_generation": 10,
-                    "triple": {
-                        "min_triples": 10,
-                        "max_triples": 100,
-                        "generation_timeout": 10000
-                    },
-                    "presignature": {
-                        "min_presignatures": 10,
-                        "max_presignatures": 100,
-                        "generation_timeout": 10000
-                    },
-                    "signature": {
-                        "generation_timeout": 10000
-                    },
-                    "string": "value",
-                    "integer": 1000
-                },
-                "string": "value2",
-                "integer": 20
-            }"#,
-        )
-        .unwrap();
-
         let config_macro = serde_json::json!({
             "protocol": {
                 "message_timeout": 10000,
@@ -143,7 +114,8 @@ mod tests {
                     "generation_timeout": 10000
                 },
                 "signature": {
-                    "generation_timeout": 10000
+                    "generation_timeout": 10000,
+                    "garbage_timeout": 10000000
                 },
                 "string": "value",
                 "integer": 1000
@@ -151,8 +123,6 @@ mod tests {
             "string": "value2",
             "integer": 20
         });
-
-        assert_eq!(config_str, config_macro);
 
         let config: Config = serde_json::from_value(config_macro).unwrap();
         assert_eq!(config.protocol.message_timeout, 10000);

--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -365,7 +365,7 @@ impl MessageHandler for RunningState {
 
         let mut signature_manager = self.signature_manager.write().await;
         let signature_messages = queue.signature_bins.entry(self.epoch).or_default();
-        signature_messages.retain(|_, queue| {
+        signature_messages.retain(|receipt_id, queue| {
             // Skip message if it already timed out
             if queue.is_empty()
                 || queue.iter().any(|msg| {
@@ -377,7 +377,8 @@ impl MessageHandler for RunningState {
             {
                 return false;
             }
-            true
+
+            !signature_manager.refresh_gc(receipt_id)
         });
         for (receipt_id, queue) in signature_messages {
             // SAFETY: this unwrap() is safe since we have already checked that the queue is not empty.


### PR DESCRIPTION
Noticed this wasn't handled quite yet. This would be the case where a node's indexer is behind but slowly catches up and tries to do signature request, but it has already been completed for other nodes