### PR TITLE
fix: signature request order and retrying

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -68,6 +68,7 @@ impl Default for SignatureConfig {
     fn default() -> Self {
         Self {
             generation_timeout: secs_to_ms(45),
+            generation_timeout_total: secs_to_ms(200),
             garbage_timeout: hours_to_ms(24),
 
             other: Default::default(),

--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -119,6 +119,7 @@ mod tests {
                 },
                 "signature": {
                     "generation_timeout": 10000,
+                    "generation_timeout_total": 1000000,
                     "garbage_timeout": 10000000
                 },
                 "string": "value",

--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -83,6 +83,10 @@ pub struct PresignatureConfig {
 pub struct SignatureConfig {
     /// Timeout for signature generation in milliseconds.
     pub generation_timeout: u64,
+    /// Timeout for signature generation in milliseconds. This is the total timeout for
+    /// the signature generation process. Mainly used to include the whole generation of
+    /// signatures including their retries up till this timeout.
+    pub generation_timeout_total: u64,
     /// Garbage collection timeout in milliseconds for signatures generated.
     pub garbage_timeout: u64,
 

--- a/chain-signatures/node/src/indexer.rs
+++ b/chain-signatures/node/src/indexer.rs
@@ -3,7 +3,6 @@ use crate::gcp::GcpService;
 use crate::kdf;
 use crate::protocol::{SignQueue, SignRequest};
 use crate::types::LatestBlockHeight;
-use anyhow::Context as _;
 use crypto_shared::{derive_epsilon, ScalarExt};
 use k256::Scalar;
 use near_account_id::AccountId;
@@ -150,62 +149,75 @@ async fn handle_block(
     let mut pending_requests = Vec::new();
     for action in block.actions().cloned().collect::<Vec<_>>() {
         if action.receiver_id() == ctx.mpc_contract_id {
-            let receipt =
-                anyhow::Context::with_context(block.receipt_by_id(&action.receipt_id()), || {
-                    format!(
-                        "indexer unable to find block for receipt_id={}",
-                        action.receipt_id()
-                    )
-                })?;
+            let Some(receipt) = block.receipt_by_id(&action.receipt_id()) else {
+                let err = format!(
+                    "indexer unable to find block for receipt_id={}",
+                    action.receipt_id()
+                );
+                tracing::warn!("{err}");
+                anyhow::bail!(err);
+            };
             let ExecutionStatus::SuccessReceiptId(receipt_id) = receipt.status() else {
                 continue;
             };
-            if let Some(function_call) = action.as_function_call() {
-                if function_call.method_name() == "sign" {
-                    if let Ok(arguments) =
-                        serde_json::from_slice::<'_, SignArguments>(function_call.args())
-                    {
-                        if receipt.logs().is_empty() {
-                            tracing::warn!("`sign` did not produce entropy");
+            let Some(function_call) = action.as_function_call() else {
+                continue;
+            };
+            if function_call.method_name() == "sign" {
+                let arguments =
+                    match serde_json::from_slice::<'_, SignArguments>(function_call.args()) {
+                        Ok(arguments) => arguments,
+                        Err(err) => {
+                            tracing::warn!(%err, "failed to parse `sign` arguments");
                             continue;
                         }
-                        let payload = Scalar::from_bytes(arguments.request.payload)
-                            .context("Payload cannot be converted to scalar, not in k256 field")?;
-                        let Ok(entropy) = serde_json::from_str::<'_, [u8; 32]>(&receipt.logs()[1])
-                        else {
-                            tracing::warn!(
-                                "`sign` did not produce entropy correctly: {:?}",
-                                receipt.logs()[0]
-                            );
-                            continue;
-                        };
-                        let epsilon =
-                            derive_epsilon(&action.predecessor_id(), &arguments.request.path);
-                        let delta = kdf::derive_delta(receipt_id, entropy);
-                        tracing::info!(
-                            receipt_id = %receipt_id,
-                            caller_id = receipt.predecessor_id().to_string(),
-                            our_account = ctx.node_account_id.to_string(),
-                            payload = hex::encode(arguments.request.payload),
-                            key_version = arguments.request.key_version,
-                            entropy = hex::encode(entropy),
-                            "indexed new `sign` function call"
-                        );
-                        let request = ContractSignRequest {
-                            payload,
-                            path: arguments.request.path,
-                            key_version: arguments.request.key_version,
-                        };
-                        pending_requests.push(SignRequest {
-                            receipt_id,
-                            request,
-                            epsilon,
-                            delta,
-                            entropy,
-                            time_added: Instant::now(),
-                        });
-                    }
+                    };
+
+                if receipt.logs().is_empty() {
+                    tracing::warn!("`sign` did not produce entropy");
+                    continue;
                 }
+
+                let Some(payload) = Scalar::from_bytes(arguments.request.payload) else {
+                    tracing::warn!(
+                        "`sign` did not produce payload correctly: {:?}",
+                        arguments.request.payload,
+                    );
+                    continue;
+                };
+
+                let Ok(entropy) = serde_json::from_str::<'_, [u8; 32]>(&receipt.logs()[1]) else {
+                    tracing::warn!(
+                        "`sign` did not produce entropy correctly: {:?}",
+                        receipt.logs()[0]
+                    );
+                    continue;
+                };
+                let epsilon = derive_epsilon(&action.predecessor_id(), &arguments.request.path);
+                let delta = kdf::derive_delta(receipt_id, entropy);
+                tracing::info!(
+                    receipt_id = %receipt_id,
+                    caller_id = receipt.predecessor_id().to_string(),
+                    our_account = ctx.node_account_id.to_string(),
+                    payload = hex::encode(arguments.request.payload),
+                    key_version = arguments.request.key_version,
+                    entropy = hex::encode(entropy),
+                    "indexed new `sign` function call"
+                );
+                let request = ContractSignRequest {
+                    payload,
+                    path: arguments.request.path,
+                    key_version: arguments.request.key_version,
+                };
+                pending_requests.push(SignRequest {
+                    receipt_id,
+                    request,
+                    epsilon,
+                    delta,
+                    entropy,
+                    // TODO: use indexer timestamp instead.
+                    time_added: Instant::now(),
+                });
             }
         }
     }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -438,8 +438,10 @@ impl CryptographicProtocol for RunningState {
         crate::metrics::SIGN_QUEUE_SIZE
             .with_label_values(&[my_account_id.as_str()])
             .set(sign_queue.len() as i64);
-        sign_queue.organize(self.threshold, &stable, ctx.me().await, &my_account_id);
-        let my_requests = sign_queue.my_requests(ctx.me().await);
+        let me = ctx.me().await;
+        sign_queue.organize(self.threshold, &stable, me, &my_account_id);
+
+        let my_requests = sign_queue.my_requests(me);
         crate::metrics::SIGN_QUEUE_MINE_SIZE
             .with_label_values(&[my_account_id.as_str()])
             .set(my_requests.len() as i64);

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -288,6 +288,7 @@ impl SignatureManager {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::result_large_err)]
     fn generate_internal(
         participants: &Participants,
         me: Participant,
@@ -335,6 +336,7 @@ impl SignatureManager {
         ))
     }
 
+    #[allow(clippy::result_large_err)]
     fn retry_failed_generation(
         &mut self,
         receipt_id: ReceiptId,
@@ -358,6 +360,7 @@ impl SignatureManager {
 
     /// Starts a new presignature generation protocol.
     #[allow(clippy::too_many_arguments)]
+    #[allow(clippy::result_large_err)]
     pub fn generate(
         &mut self,
         participants: &Participants,


### PR DESCRIPTION
This fixes:
- signature retrying constantly even after request has fully timeout on contract. This adds in total generation timeout to alleviate that.
- signature request ordering is very arbitrary. Could likely go into a case where we don't pick the signature request and it starves. This fixes that by adding insertion order into the requests as one of the metrics for choice.