### PR TITLE
test: multi signature production

### DIFF
--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -127,18 +127,10 @@ impl Pool {
                     .await;
             }
         }
-        tracing::debug!(
-            "Pool.establish_participants set participants to {:?}",
-            self.connections.read().await.clone().keys_vec()
-        );
     }
 
     async fn set_participants(&self, participants: &Participants) {
         *self.connections.write().await = participants.clone();
-        tracing::debug!(
-            "Pool set participants to {:?}",
-            self.connections.read().await.keys_vec()
-        );
     }
 
     async fn set_potential_participants(&self, participants: &Participants) {

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -65,15 +65,17 @@ impl Mesh {
             .establish_participants(contract_state)
             .await;
         self.ping().await;
+
+        tracing::debug!(
+            ?self.active_participants,
+            ?self.active_potential_participants,
+            "mesh participants",
+        );
     }
 
     /// Ping the active participants such that we can see who is alive.
     pub async fn ping(&mut self) {
         self.active_participants = self.connections.ping().await;
-        tracing::debug!(
-            "Mesh.ping set active participants to {:?}",
-            self.active_participants.keys_vec()
-        );
         self.active_potential_participants = self.connections.ping_potential().await;
     }
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -358,12 +358,6 @@ impl CryptographicProtocol for RunningState {
     ) -> Result<NodeState, CryptographicError> {
         let protocol_cfg = &ctx.cfg().protocol;
         let active = ctx.mesh().active_participants();
-        tracing::debug!(
-            "RunningState.progress active participants: {:?} potential participants: {:?} me: {:?}",
-            active.keys_vec(),
-            ctx.mesh().potential_participants().await.keys_vec(),
-            ctx.me().await
-        );
         if active.len() < self.threshold {
             tracing::info!(
                 active = ?active.keys_vec(),

--- a/chain-signatures/node/src/protocol/mod.rs
+++ b/chain-signatures/node/src/protocol/mod.rs
@@ -284,15 +284,10 @@ impl MpcSignProtocol {
             };
 
             let crypto_time = Instant::now();
-            tracing::debug!("State progress. Node state: {}", state);
             let mut state = match state.progress(&mut self).await {
-                Ok(state) => {
-                    tracing::debug!("Progress ok. New state: {}", state);
-                    state
-                }
+                Ok(state) => state,
                 Err(err) => {
-                    tracing::debug!("Progress error. State not changed");
-                    tracing::info!("protocol unable to progress: {err:?}");
+                    tracing::warn!("protocol unable to progress: {err:?}");
                     tokio::time::sleep(Duration::from_millis(100)).await;
                     continue;
                 }
@@ -303,19 +298,14 @@ impl MpcSignProtocol {
 
             let consensus_time = Instant::now();
             if let Some(contract_state) = contract_state {
-                tracing::debug!(
-                    "State advance. Node state: {}, contract state: {:?}",
-                    state,
-                    contract_state
-                );
+                let from_state = format!("{state}");
                 state = match state.advance(&mut self, contract_state).await {
                     Ok(state) => {
-                        tracing::debug!("Advance ok. New node state: {}", state);
+                        tracing::debug!("advance ok: {from_state} => {state}");
                         state
                     }
                     Err(err) => {
-                        tracing::debug!("Advance error. State not changed");
-                        tracing::info!("protocol unable to advance: {err:?}");
+                        tracing::warn!("protocol unable to advance: {err:?}");
                         tokio::time::sleep(Duration::from_millis(100)).await;
                         continue;
                     }
@@ -327,9 +317,7 @@ impl MpcSignProtocol {
 
             let message_time = Instant::now();
             if let Err(err) = state.handle(&self, &mut queue).await {
-                tracing::info!("protocol unable to handle messages: {err:?}");
-                tokio::time::sleep(Duration::from_millis(100)).await;
-                continue;
+                tracing::warn!("protocol unable to handle messages: {err:?}");
             }
             crate::metrics::PROTOCOL_LATENCY_ITER_MESSAGE
                 .with_label_values(&[my_account_id.as_str()])

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -62,7 +62,9 @@ impl PresignatureGenerator {
 
     pub fn poke(&mut self) -> Result<Action<PresignOutput<Secp256k1>>, ProtocolError> {
         if self.timestamp.elapsed() > self.timeout {
-            tracing::info!(
+            let id = hash_as_id(self.triple0, self.triple1);
+            tracing::warn!(
+                presignature_id = id,
                 self.triple0,
                 self.triple1,
                 self.mine,
@@ -392,8 +394,8 @@ impl PresignatureManager {
     }
 
     pub fn take_mine(&mut self) -> Option<Presignature> {
-        tracing::info!(mine = ?self.mine, "my presignatures");
         let my_presignature_id = self.mine.pop_front()?;
+        tracing::debug!(my_presignature_id, "take presignature of mine");
         // SAFETY: This unwrap is safe because taking mine will always succeed since it is only
         // present when generation completes where the determination of ownership is made.
         Some(self.take(my_presignature_id).unwrap())

--- a/integration-tests/chain-signatures/src/lib.rs
+++ b/integration-tests/chain-signatures/src/lib.rs
@@ -38,19 +38,7 @@ impl Default for MultichainConfig {
         Self {
             nodes: 3,
             threshold: 2,
-            protocol: ProtocolConfig {
-                triple: TripleConfig {
-                    min_triples: 8,
-                    max_triples: 80,
-                    ..Default::default()
-                },
-                presignature: PresignatureConfig {
-                    min_presignatures: 2,
-                    max_presignatures: 20,
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
+            protocol: Default::default(),
         }
     }
 }

--- a/integration-tests/chain-signatures/tests/actions/mod.rs
+++ b/integration-tests/chain-signatures/tests/actions/mod.rs
@@ -38,19 +38,25 @@ use k256::{
 };
 use serde_json::json;
 
-pub async fn request_sign(
-    ctx: &MultichainTestContext<'_>,
-) -> anyhow::Result<([u8; 32], [u8; 32], Account, CryptoHash)> {
+pub async fn new_account(ctx: &MultichainTestContext<'_>) -> anyhow::Result<(Account, InMemorySigner)> {
     let worker = &ctx.nodes.ctx().worker;
     let account = worker.dev_create_account().await?;
-    let payload: [u8; 32] = rand::thread_rng().gen();
-    let payload_hashed = web3::signing::keccak256(&payload);
-
     let signer = InMemorySigner {
         account_id: account.id().clone(),
         public_key: account.secret_key().public_key().to_string().parse()?,
         secret_key: account.secret_key().to_string().parse()?,
     };
+
+    Ok((account, signer))
+}
+
+pub async fn request_sign(
+    ctx: &MultichainTestContext<'_>,
+    signer: &InMemorySigner,
+) -> anyhow::Result<([u8; 32], [u8; 32], CryptoHash)> {
+    let payload: [u8; 32] = rand::thread_rng().gen();
+    let payload_hashed = web3::signing::keccak256(&payload);
+
     let (nonce, block_hash, _) = ctx
         .rpc_client
         .fetch_nonce(&signer.account_id, &signer.public_key)
@@ -79,11 +85,24 @@ pub async fn request_sign(
                     deposit: 1,
                 }))],
             }
-            .sign(&signer),
+            .sign(signer),
         })
         .await?;
     tokio::time::sleep(Duration::from_secs(1)).await;
-    Ok((payload, payload_hashed, account, tx_hash))
+    Ok((payload, payload_hashed, tx_hash))
+}
+
+pub async fn request_sign_multiple(
+    ctx: &MultichainTestContext<'_>,
+    signer: &InMemorySigner,
+    amount: usize,
+) -> anyhow::Result<Vec<([u8; 32], CryptoHash)>> {
+    let mut results = Vec::with_capacity(amount);
+    for _ in 0..amount {
+        let (payload, payload_hashed, tx_hash) = request_sign(ctx, &signer).await?;
+        results.push((payload_hashed, tx_hash));
+    }
+    Ok(results)
 }
 
 pub async fn assert_signature(
@@ -104,7 +123,8 @@ pub async fn single_signature_rogue_responder(
     ctx: &MultichainTestContext<'_>,
     state: &RunningContractState,
 ) -> anyhow::Result<()> {
-    let (_, payload_hash, account, tx_hash) = request_sign(ctx).await?;
+    let (account, signer) = new_account(ctx).await?;
+    let (_, payload_hash, tx_hash) = request_sign(ctx, &signer).await?;
 
     // We have to use seperate transactions because one could fail.
     // This leads to a potential race condition where this transaction could get sent after the signature completes, but I think that's unlikely
@@ -135,12 +155,25 @@ pub async fn single_signature_production(
     ctx: &MultichainTestContext<'_>,
     state: &RunningContractState,
 ) -> anyhow::Result<()> {
-    let (_, payload_hash, account, tx_hash) = request_sign(ctx).await?;
+    let (account, signer) = new_account(ctx).await?;
+    let (_, payload_hash, tx_hash) = request_sign(ctx, &signer).await?;
     let signature = wait_for::signature_responded(ctx, tx_hash).await?;
 
     let mut mpc_pk_bytes = vec![0x04];
     mpc_pk_bytes.extend_from_slice(&state.public_key.as_bytes()[1..]);
     assert_signature(account.id(), &mpc_pk_bytes, payload_hash, &signature).await;
+
+    Ok(())
+}
+
+pub async fn signature_production(
+    ctx: &MultichainTestContext<'_>,
+    state: &RunningContractState,
+    amount: usize,
+) -> anyhow::Result<()> {
+    let (_, signer) = new_account(ctx).await?;
+    let (payload_hashes, tx_hashes): (Vec<_>, Vec<_>) = request_sign_multiple(ctx, &signer, amount).await?.into_iter().unzip();
+    let signatures = wait_for::signatures_responded(ctx, &tx_hashes).await?;
 
     Ok(())
 }
@@ -276,7 +309,8 @@ pub async fn single_payload_signature_production(
     ctx: &MultichainTestContext<'_>,
     state: &RunningContractState,
 ) -> anyhow::Result<()> {
-    let (payload, payload_hash, account, tx_hash) = request_sign(ctx).await?;
+    let (account, signer) = new_account(ctx).await?;
+    let (payload, payload_hash, tx_hash) = request_sign(ctx, &signer).await?;
     let first_tx_result = wait_for::signature_responded(ctx, tx_hash).await;
     let signature = match first_tx_result {
         Ok(sig) => sig,

--- a/integration-tests/chain-signatures/tests/cases/nightly.rs
+++ b/integration-tests/chain-signatures/tests/cases/nightly.rs
@@ -1,5 +1,7 @@
 use integration_tests_chain_signatures::MultichainConfig;
 use mpc_contract::config::{ProtocolConfig, TripleConfig};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 use test_log::test;
 
 use crate::actions::{self, wait_for};
@@ -11,41 +13,28 @@ async fn test_nightly_signature_production() -> anyhow::Result<()> {
     const SIGNATURE_AMOUNT: usize = 1000;
     const NODES: usize = 8;
     const THRESHOLD: usize = 4;
-    const MIN_TRIPLES: u32 = 10;
-    const MAX_TRIPLES: u32 = 2 * NODES as u32 * MIN_TRIPLES;
 
     let config = MultichainConfig {
         nodes: NODES,
         threshold: THRESHOLD,
-        protocol: ProtocolConfig {
-            triple: TripleConfig {
-                min_triples: MIN_TRIPLES,
-                max_triples: MAX_TRIPLES,
-                ..Default::default()
-            },
-            ..Default::default()
-        },
+        protocol: ProtocolConfig::default(),
     };
 
     with_multichain_nodes(config, |ctx| {
         Box::pin(async move {
             let state_0 = wait_for::running_mpc(&ctx, Some(0)).await?;
             assert_eq!(state_0.participants.len(), NODES);
+            let mut rng = rand::rngs::StdRng::from_seed([0; 32]);
 
             for i in 0..SIGNATURE_AMOUNT {
-                if let Err(err) = wait_for::has_at_least_mine_triples(&ctx, 4).await {
-                    tracing::error!(?err, "Failed to wait for triples");
-                    continue;
-                }
-
-                if let Err(err) = wait_for::has_at_least_mine_presignatures(&ctx, 2).await {
-                    tracing::error!(?err, "Failed to wait for presignatures");
-                    continue;
-                }
-
-                tracing::info!(at_signature = i, "Producing signature...");
-                if let Err(err) = actions::single_signature_production(&ctx, &state_0).await {
-                    tracing::error!(?err, "Failed to produce signature");
+                let random_secs: u32 = rng.gen_range(1, 40);
+                tokio::time::sleep(std::time::Duration::from_secs(random_secs as u64)).await;
+                let (account, signer) = actions::new_account(&ctx).await.unwrap();
+                let (_, payload_hash, tx_hash) =
+                    actions::request_sign(&ctx, &signer).await.unwrap();
+                match wait_for::signature_responded(&ctx, tx_hash).await {
+                    Ok(sig) => tracing::info!("GOT SIGNATURE"),
+                    Err(err) => tracing::error!("Unable to produce signature in time: {err:?}"),
                 }
             }
 


### PR DESCRIPTION
Adds in test for doing signature production chaotically throughout a whole entire test

- Also reduces the number of debug logs that were redundant where other logs already log that info