### PR TITLE
chore: reduce unnecessary logs

### DIFF
--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -135,10 +135,6 @@ impl Pool {
 
     async fn set_participants(&self, participants: &Participants) {
         *self.connections.write().await = participants.clone();
-        tracing::debug!(
-            "Pool set participants to {:?}",
-            self.connections.read().await.keys_vec()
-        );
     }
 
     async fn set_potential_participants(&self, participants: &Participants) {

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -65,15 +65,17 @@ impl Mesh {
             .establish_participants(contract_state)
             .await;
         self.ping().await;
+
+        tracing::debug!(
+            active = ?self.active_participants.keys_vec(),
+            active_potential = ?self.active_potential_participants.keys_vec(),
+            "mesh pinging",
+        );
     }
 
     /// Ping the active participants such that we can see who is alive.
     pub async fn ping(&mut self) {
         self.active_participants = self.connections.ping().await;
-        tracing::debug!(
-            "Mesh.ping set active participants to {:?}",
-            self.active_participants.keys_vec()
-        );
         self.active_potential_participants = self.connections.ping_potential().await;
     }
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -358,12 +358,6 @@ impl CryptographicProtocol for RunningState {
     ) -> Result<NodeState, CryptographicError> {
         let protocol_cfg = &ctx.cfg().protocol;
         let active = ctx.mesh().active_participants();
-        tracing::debug!(
-            "RunningState.progress active participants: {:?} potential participants: {:?} me: {:?}",
-            active.keys_vec(),
-            ctx.mesh().potential_participants().await.keys_vec(),
-            ctx.me().await
-        );
         if active.len() < self.threshold {
             tracing::info!(
                 active = ?active.keys_vec(),

--- a/chain-signatures/node/src/protocol/presignature.rs
+++ b/chain-signatures/node/src/protocol/presignature.rs
@@ -62,7 +62,9 @@ impl PresignatureGenerator {
 
     pub fn poke(&mut self) -> Result<Action<PresignOutput<Secp256k1>>, ProtocolError> {
         if self.timestamp.elapsed() > self.timeout {
-            tracing::info!(
+            let id = hash_as_id(self.triple0, self.triple1);
+            tracing::warn!(
+                presignature_id = id,
                 self.triple0,
                 self.triple1,
                 self.mine,
@@ -392,8 +394,8 @@ impl PresignatureManager {
     }
 
     pub fn take_mine(&mut self) -> Option<Presignature> {
-        tracing::info!(mine = ?self.mine, "my presignatures");
         let my_presignature_id = self.mine.pop_front()?;
+        tracing::debug!(my_presignature_id, "take presignature of mine");
         // SAFETY: This unwrap is safe because taking mine will always succeed since it is only
         // present when generation completes where the determination of ownership is made.
         Some(self.take(my_presignature_id).unwrap())


### PR DESCRIPTION
pulled these out of the multi signature production test I had since I won't have time to get that in before mainnet. This reduces all the unnecessary logging of participants and protocol due to how spammy it is and much the information repeats