### PR TITLE
feat: precheck triple and presigs

### DIFF
--- a/chain-signatures/contract/src/config/impls.rs
+++ b/chain-signatures/contract/src/config/impls.rs
@@ -46,6 +46,7 @@ impl Default for TripleConfig {
             min_triples: 1024,
             max_triples: 1024 * MAX_EXPECTED_PARTICIPANTS * NETWORK_MULTIPLIER,
             generation_timeout: min_to_ms(10),
+            preview_limit: 128,
 
             other: Default::default(),
         }
@@ -58,6 +59,7 @@ impl Default for PresignatureConfig {
             min_presignatures: 512,
             max_presignatures: 512 * MAX_EXPECTED_PARTICIPANTS * NETWORK_MULTIPLIER,
             generation_timeout: secs_to_ms(45),
+            preview_limit: 128,
 
             other: Default::default(),
         }

--- a/chain-signatures/contract/src/config/mod.rs
+++ b/chain-signatures/contract/src/config/mod.rs
@@ -59,6 +59,8 @@ pub struct TripleConfig {
     pub max_triples: u32,
     /// Timeout for triple generation in milliseconds.
     pub generation_timeout: u64,
+    /// Max amount of Triple IDs allowed to be previewed in state.
+    pub preview_limit: u32,
 
     /// The remaining entries that can be present in future forms of the configuration.
     #[serde(flatten)]
@@ -73,6 +75,8 @@ pub struct PresignatureConfig {
     pub max_presignatures: u32,
     /// Timeout for presignature generation in milliseconds.
     pub generation_timeout: u64,
+    /// Max amount of Presignature IDs allowed to be previewed in state.
+    pub preview_limit: u32,
 
     /// The remaining entries that can be present in future forms of the configuration.
     #[serde(flatten)]

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -211,6 +211,14 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 client_headers.insert(http::header::REFERER, referer_param.parse().unwrap());
             }
 
+            let config = Arc::new(RwLock::new(Config::new(LocalConfig {
+                over: override_config.unwrap_or_else(Default::default),
+                network: NetworkConfig {
+                    cipher_pk: hpke::PublicKey::try_from_bytes(&hex::decode(cipher_pk)?)?,
+                    sign_sk,
+                },
+            })));
+
             tracing::debug!(rpc_addr = rpc_client.rpc_addr(), "rpc client initialized");
             let signer = InMemorySigner::from_secret_key(account_id.clone(), account_sk);
             let (protocol, protocol_state) = MpcSignProtocol::init(
@@ -223,13 +231,7 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 sign_queue,
                 key_storage,
                 triple_storage,
-                Config::new(LocalConfig {
-                    over: override_config.unwrap_or_else(Default::default),
-                    network: NetworkConfig {
-                        cipher_pk: hpke::PublicKey::try_from_bytes(&hex::decode(cipher_pk)?)?,
-                        sign_sk,
-                    },
-                }),
+                config.clone(),
             );
 
             rt.block_on(async {
@@ -238,7 +240,7 @@ pub fn run(cmd: Cli) -> anyhow::Result<()> {
                 tracing::debug!("protocol thread spawned");
                 let cipher_sk = hpke::SecretKey::try_from_bytes(&hex::decode(cipher_sk)?)?;
                 let web_handle = tokio::spawn(async move {
-                    web::run(web_port, sender, cipher_sk, protocol_state, indexer).await
+                    web::run(web_port, sender, cipher_sk, protocol_state, indexer, config).await
                 });
                 tracing::debug!("protocol http server spawned");
 

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -75,6 +75,7 @@ impl Mesh {
 
     /// Ping the active participants such that we can see who is alive.
     pub async fn ping(&mut self, previews: Option<(HashSet<TripleId>, HashSet<PresignatureId>)>) {
+        self.connections.clear_status().await;
         self.active_participants = self.connections.ping(previews).await;
         tracing::debug!(
             "Mesh.ping set active participants to {:?}",

--- a/chain-signatures/node/src/mesh/mod.rs
+++ b/chain-signatures/node/src/mesh/mod.rs
@@ -1,5 +1,12 @@
+use std::collections::{HashMap, HashSet};
+
+use cait_sith::protocol::Participant;
+
 use crate::protocol::contract::primitives::Participants;
+use crate::protocol::presignature::PresignatureId;
+use crate::protocol::triple::TripleId;
 use crate::protocol::ProtocolState;
+use crate::web::StateView;
 
 pub mod connection;
 
@@ -64,16 +71,19 @@ impl Mesh {
         self.connections
             .establish_participants(contract_state)
             .await;
-        self.ping().await;
     }
 
     /// Ping the active participants such that we can see who is alive.
-    pub async fn ping(&mut self) {
-        self.active_participants = self.connections.ping().await;
+    pub async fn ping(&mut self, previews: Option<(HashSet<TripleId>, HashSet<PresignatureId>)>) {
+        self.active_participants = self.connections.ping(previews).await;
         tracing::debug!(
             "Mesh.ping set active participants to {:?}",
             self.active_participants.keys_vec()
         );
         self.active_potential_participants = self.connections.ping_potential().await;
+    }
+
+    pub async fn state_views(&self) -> HashMap<Participant, StateView> {
+        self.connections.status.read().await.clone()
     }
 }

--- a/chain-signatures/node/src/protocol/cryptography.rs
+++ b/chain-signatures/node/src/protocol/cryptography.rs
@@ -23,7 +23,7 @@ pub trait CryptographicCtx {
     fn signer(&self) -> &InMemorySigner;
     fn mpc_contract_id(&self) -> &AccountId;
     fn secret_storage(&mut self) -> &mut SecretNodeStorageBox;
-    fn cfg(&self) -> &Config;
+    async fn cfg(&self) -> Config;
 
     /// Active participants is the active participants at the beginning of each protocol loop.
     fn mesh(&self) -> &Mesh;
@@ -74,6 +74,7 @@ impl CryptographicProtocol for GeneratingState {
         mut self,
         mut ctx: C,
     ) -> Result<NodeState, CryptographicError> {
+        let cfg = ctx.cfg().await;
         tracing::info!(active = ?ctx.mesh().active_participants().keys_vec(), "generating: progressing key generation");
         let mut protocol = self.protocol.write().await;
         loop {
@@ -97,10 +98,10 @@ impl CryptographicProtocol for GeneratingState {
                         .await
                         .send_encrypted(
                             ctx.me().await,
-                            &ctx.cfg().local.network.sign_sk,
+                            &cfg.local.network.sign_sk,
                             ctx.http_client(),
                             ctx.mesh().active_participants(),
-                            &ctx.cfg().protocol,
+                            &cfg.protocol,
                         )
                         .await;
                     if !failures.is_empty() {
@@ -159,10 +160,10 @@ impl CryptographicProtocol for GeneratingState {
                         .await
                         .send_encrypted(
                             ctx.me().await,
-                            &ctx.cfg().local.network.sign_sk,
+                            &cfg.local.network.sign_sk,
                             ctx.http_client(),
                             ctx.mesh().active_participants(),
-                            &ctx.cfg().protocol,
+                            &cfg.protocol,
                         )
                         .await;
                     if !failures.is_empty() {
@@ -191,16 +192,17 @@ impl CryptographicProtocol for WaitingForConsensusState {
         mut self,
         ctx: C,
     ) -> Result<NodeState, CryptographicError> {
+        let cfg = ctx.cfg().await;
         let failures = self
             .messages
             .write()
             .await
             .send_encrypted(
                 ctx.me().await,
-                &ctx.cfg().local.network.sign_sk,
+                &cfg.local.network.sign_sk,
                 ctx.http_client(),
                 ctx.mesh().active_participants(),
-                &ctx.cfg().protocol,
+                &cfg.protocol,
             )
             .await;
         if !failures.is_empty() {
@@ -221,6 +223,8 @@ impl CryptographicProtocol for ResharingState {
         mut self,
         mut ctx: C,
     ) -> Result<NodeState, CryptographicError> {
+        let cfg = ctx.cfg().await;
+
         // TODO: we are not using active potential participants here, but we should in the future.
         // Currently resharing protocol does not timeout and restart with new set of participants.
         // So if it picks up a participant that is not active, it will never be able to send a message to it.
@@ -253,10 +257,10 @@ impl CryptographicProtocol for ResharingState {
                         .await
                         .send_encrypted(
                             ctx.me().await,
-                            &ctx.cfg().local.network.sign_sk,
+                            &cfg.local.network.sign_sk,
                             ctx.http_client(),
                             &active,
-                            &ctx.cfg().protocol,
+                            &cfg.protocol,
                         )
                         .await;
                     if !failures.is_empty() {
@@ -321,10 +325,10 @@ impl CryptographicProtocol for ResharingState {
                         .await
                         .send_encrypted(
                             ctx.me().await,
-                            &ctx.cfg().local.network.sign_sk,
+                            &cfg.local.network.sign_sk,
                             ctx.http_client(),
                             &active,
-                            &ctx.cfg().protocol,
+                            &cfg.protocol,
                         )
                         .await;
                     if !failures.is_empty() {
@@ -356,8 +360,10 @@ impl CryptographicProtocol for RunningState {
         mut self,
         ctx: C,
     ) -> Result<NodeState, CryptographicError> {
-        let protocol_cfg = &ctx.cfg().protocol;
+        let cfg = ctx.cfg().await;
+        let protocol_cfg = &cfg.protocol;
         let active = ctx.mesh().active_participants();
+        let state_views = ctx.mesh().state_views().await;
         tracing::debug!(
             "RunningState.progress active participants: {:?} potential participants: {:?} me: {:?}",
             active.keys_vec(),
@@ -403,6 +409,7 @@ impl CryptographicProtocol for RunningState {
         if let Err(err) = presignature_manager
             .stockpile(
                 active,
+                &state_views,
                 &self.public_key,
                 &self.private_share,
                 &mut triple_manager,
@@ -450,6 +457,7 @@ impl CryptographicProtocol for RunningState {
         signature_manager.handle_requests(
             self.threshold,
             &stable,
+            &state_views,
             my_requests,
             &mut presignature_manager,
             protocol_cfg,
@@ -473,7 +481,7 @@ impl CryptographicProtocol for RunningState {
         let failures = messages
             .send_encrypted(
                 ctx.me().await,
-                &ctx.cfg().local.network.sign_sk,
+                &cfg.local.network.sign_sk,
                 ctx.http_client(),
                 active,
                 protocol_cfg,

--- a/chain-signatures/node/src/protocol/message.rs
+++ b/chain-signatures/node/src/protocol/message.rs
@@ -23,7 +23,7 @@ use tokio::sync::RwLock;
 pub trait MessageCtx {
     async fn me(&self) -> Participant;
     fn mesh(&self) -> &Mesh;
-    fn cfg(&self) -> &crate::config::Config;
+    async fn cfg(&self) -> crate::config::Config;
 }
 
 #[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
@@ -231,7 +231,7 @@ impl MessageHandler for RunningState {
         ctx: C,
         queue: &mut MpcMessageQueue,
     ) -> Result<(), MessageHandleError> {
-        let protocol_cfg = &ctx.cfg().protocol;
+        let protocol_cfg = &ctx.cfg().await.protocol;
         let participants = ctx.mesh().active_participants();
         let mut triple_manager = self.triple_manager.write().await;
 

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -656,8 +656,7 @@ impl SignatureManager {
                     failed_presigs.push(presignature);
                     tracing::warn!(%receipt_id, id, ?err, "failed to retry signature generation: trashing presignature");
                 }
-            }
-            else {
+            } else {
                 let Some((receipt_id, my_request)) = my_requests.pop_front() else {
                     failed_presigs.push(presignature);
                     continue;

--- a/chain-signatures/node/src/protocol/triple.rs
+++ b/chain-signatures/node/src/protocol/triple.rs
@@ -346,8 +346,7 @@ impl TripleManager {
         let id1 = self.mine.pop_front()?;
         tracing::info!(id0, id1, me = ?self.me, "trying to take two triples");
 
-        let take_two_result = self.take_two(id0, id1).await;
-        match take_two_result {
+        match self.take_two(id0, id1).await {
             Err(error)
                 if matches!(
                     error,
@@ -375,6 +374,17 @@ impl TripleManager {
             }
             Ok(val) => Some(val),
         }
+    }
+
+    pub fn peek_two_mine(&self) -> Option<(&Triple, &Triple)> {
+        if self.mine.len() < 2 {
+            return None;
+        }
+        let id0 = self.mine.get(0)?;
+        let id1 = self.mine.get(1)?;
+        let triple0 = self.triples.get(id0)?;
+        let triple1 = self.triples.get(id1)?;
+        Some((triple0, triple1))
     }
 
     pub async fn insert_mine(&mut self, triple: Triple) {
@@ -590,6 +600,16 @@ impl TripleManager {
             let retry_strategy = std::iter::repeat_with(|| Duration::from_millis(500)).take(3);
             let _ = tokio_retry::Retry::spawn(retry_strategy, action).await;
         }
+    }
+
+    pub fn preview(&self, triples: &HashSet<TripleId>) -> HashSet<TripleId> {
+        let triples = triples
+            .into_iter()
+            .filter(|id| self.triples.contains_key(id))
+            .cloned()
+            .collect();
+
+        triples
     }
 }
 

--- a/chain-signatures/node/src/web/mod.rs
+++ b/chain-signatures/node/src/web/mod.rs
@@ -9,7 +9,6 @@ use crate::protocol::triple::TripleId;
 use crate::protocol::{MpcMessage, NodeState};
 use crate::web::error::Result;
 use anyhow::Context;
-use axum::extract::Query;
 use axum::http::StatusCode;
 use axum::routing::{get, post};
 use axum::{Extension, Json, Router};
@@ -19,7 +18,7 @@ use mpc_keys::hpke::{self, Ciphered};
 use near_primitives::types::BlockHeight;
 use prometheus::{Encoder, TextEncoder};
 use serde::{Deserialize, Serialize};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::{net::SocketAddr, sync::Arc};
 use tokio::sync::{mpsc::Sender, RwLock};
 
@@ -171,14 +170,16 @@ async fn state(
             let participants = state.participants.keys_vec();
 
             let (triple_postview, presignature_postview) = if let Some(params) = params {
-                let triple_preview = params.triple_preview
+                let triple_preview = params
+                    .triple_preview
                     .iter()
                     .take(config.protocol.triple.preview_limit as usize)
                     .cloned()
                     .collect();
                 let triple_manager = state.triple_manager.read().await;
                 let triple_postview = triple_manager.preview(&triple_preview);
-                let presignature_preview = params.presignature_preview
+                let presignature_preview = params
+                    .presignature_preview
                     .iter()
                     .take(config.protocol.presignature.preview_limit as usize)
                     .cloned()

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "borsh",
  "crypto-shared",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",


### PR DESCRIPTION
This adds previewing whether a node has a triple id or presignature id. This also has a limit so that the amount of previews should not be overwhelming and require large responses. The current limit is 128 which allows us to view our most recently completed owned triples and presignatures.

Note that with this change, all nodes need to be updated before being able to generate presignatures and consequently signatures again because there's a filtering that happens. Old nodes may not return anything or error out on this new `/state` function