### PR TITLE
Include tracing_stackdriver layer to format logs for GCP

### DIFF
--- a/chain-signatures/Cargo.lock
+++ b/chain-signatures/Cargo.lock
@@ -3837,6 +3837,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
+ "tracing-stackdriver",
  "tracing-subscriber",
  "url 2.5.2",
 ]
@@ -7594,6 +7595,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-stackdriver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80048836e000e1f058562f01d69cc46f476955bf389c0dc2d2d7edb98ca63ac1"
+dependencies = [
+ "Inflector",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7603,12 +7629,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]

--- a/chain-signatures/node/Cargo.toml
+++ b/chain-signatures/node/Cargo.toml
@@ -41,6 +41,7 @@ tokio = { version = "1.28", features = ["full"] }
 tokio-retry = "0.3"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-stackdriver = "0.10.0"
 url = { version = "2.4.0", features = ["serde"] }
 
 near-account-id = "1.0.0"

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -145,7 +145,7 @@ fn is_running_on_gcp() -> bool {
 
 pub fn run(cmd: Cli) -> anyhow::Result<()> {
     // Install global collector configured based on RUST_LOG env var.
-    let stackdriver = stackdriver_layer().with_writer(|| std::io::stderr());
+    let stackdriver = stackdriver_layer().with_writer(std::io::stderr);
 
     let mut fmt_layer = tracing_subscriber::fmt::layer().with_thread_ids(true);
 

--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -9,7 +9,8 @@ use near_account_id::AccountId;
 use near_crypto::{InMemorySigner, SecretKey};
 use std::sync::Arc;
 use tokio::sync::{mpsc, RwLock};
-use tracing_subscriber::EnvFilter;
+use tracing_stackdriver::layer as stackdriver_layer;
+use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Registry};
 use url::Url;
 
 use mpc_keys::hpke;
@@ -144,14 +145,22 @@ fn is_running_on_gcp() -> bool {
 
 pub fn run(cmd: Cli) -> anyhow::Result<()> {
     // Install global collector configured based on RUST_LOG env var.
-    let mut subscriber = tracing_subscriber::fmt()
-        .with_thread_ids(true)
-        .with_env_filter(EnvFilter::from_default_env());
+    let stackdriver = stackdriver_layer().with_writer(|| std::io::stderr());
+
+    let mut fmt_layer = tracing_subscriber::fmt::layer().with_thread_ids(true);
+
     if is_running_on_gcp() {
         // Disable colored logging as it messes up GCP's log formatting
-        subscriber = subscriber.with_ansi(false);
+        fmt_layer = fmt_layer.with_ansi(false);
     }
-    subscriber.init();
+
+    let subscriber = Registry::default()
+        .with(EnvFilter::from_default_env())
+        .with(fmt_layer)
+        .with(stackdriver);
+
+    tracing::subscriber::set_global_default(subscriber).expect("Failed to set subscriber");
+
     let _span = tracing::trace_span!("cli").entered();
 
     match cmd {

--- a/integration-tests/chain-signatures/Cargo.lock
+++ b/integration-tests/chain-signatures/Cargo.lock
@@ -4239,7 +4239,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "borsh",
  "crypto-shared",
@@ -4264,7 +4264,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "1.0.0-rc.2"
+version = "1.0.0-rc.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4310,6 +4310,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tracing",
+ "tracing-stackdriver",
  "tracing-subscriber",
  "url 2.5.1",
 ]
@@ -8453,6 +8454,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-stackdriver"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80048836e000e1f058562f01d69cc46f476955bf389c0dc2d2d7edb98ca63ac1"
+dependencies = [
+ "Inflector",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "time",
+ "tracing-core",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-subscriber"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8462,12 +8488,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
  "tracing-log 0.2.0",
+ "tracing-serde",
 ]
 
 [[package]]


### PR DESCRIPTION
This PR includes the tracing-stackdriver layer to format the logs for GCP so we can apply custom filters on the data. 

Related ticket: https://github.com/near/mpc/issues/795