### PR TITLE
Fixed a test

### DIFF
--- a/chain-signatures/crypto-shared/src/types.rs
+++ b/chain-signatures/crypto-shared/src/types.rs
@@ -37,6 +37,7 @@ fn scalar_fails_as_expected() {
 
     let mut not_too_high = [0xFF; 32];
     // Order is of k256 is FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+    //                                                  [15]
     not_too_high[15] = 0xFD;
     assert!(Scalar::from_bytes(not_too_high).is_some());
 }

--- a/chain-signatures/crypto-shared/src/types.rs
+++ b/chain-signatures/crypto-shared/src/types.rs
@@ -24,8 +24,8 @@ impl ScalarExt for Scalar {
     /// Use cases are things that we know have been hashed
     fn from_non_biased(hash: [u8; 32]) -> Self {
         // This should never happen.
-        // The space of inputs is 2^256, the space of the field is ~2^256 - 2^32.
-        // This mean that you'd have to run 2^224 hashes to find a value that causes this to fail.
+        // The space of inputs is 2^256, the space of the field is ~2^256 - 2^129.
+        // This mean that you'd have to run 2^127 hashes to find a value that causes this to fail.
         Scalar::from_bytes(hash).expect("Derived epsilon value falls outside of the field")
     }
 }
@@ -36,7 +36,8 @@ fn scalar_fails_as_expected() {
     assert!(Scalar::from_bytes(too_high).is_none());
 
     let mut not_too_high = [0xFF; 32];
-    not_too_high[27] = 0xFD;
+    // Order is of k256 is FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFEBAAEDCE6AF48A03BBFD25E8CD0364141
+    not_too_high[15] = 0xFD;
     assert!(Scalar::from_bytes(not_too_high).is_some());
 }
 


### PR DESCRIPTION
This test isn't running on CI, but Phuong has a PR that fixes that.

I confused the modulus of the field and the order of the curve. This is still safe since it more hashes than the bitcoin network has ever run to make our server crash and embarass us a little bit.