### PR TITLE
Fix decrease request counter fails

### DIFF
--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -40,7 +40,7 @@ const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(250);
 const DATA_ID_REGISTER: u64 = 0;
 
 // Prepaid gas for a `clear_state_on_finish` call
-const CLEAR_STATE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);
+const CLEAR_STATE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(10);
 
 // Prepaid gas for a `return_signature_on_finish` call
 const RETURN_SIGNATURE_ON_FINISH_CALL_GAS: Gas = Gas::from_tgas(5);


### PR DESCRIPTION
Based on analysis on code, it is quite solid and should always decrement the request counter, unless the execution of clear_state_on_finish is fail. This is because:

- we only increase and decrease request counter via helper function `add_request` and `remove_request`, so it's not possible it becomes out of sync to the actual request LookupMap
- `add_request` is only called by `sign_helper`
- `remove_request` is in `clear_state_on_finish`, only in a promise created by `sign_helper` and the promise will be executed by yield_resume.
- yield_resume will either happen by our node calls `respond`, or when timeout (200 blocks), automatically execute by protocol
- `add_request` and the promise creation is atomic, it's not possible `add_request` happens but the promise containing `remove_request` not happens, and the promise is guaranteed to be executed by protocol

Assume protocol yield resume works correctly, the only possibility corresponding remove_request is not executed with add_request is: clear_state_on_finish fails. Looking at its code it can fail two case:
- return err when remove_request does not remove a request due to not exist, this is fine since it doesn't remove anything in pending request. 
- it runs of gas

So we only need to fix it runs out of gas.

An example of this failure: https://testnet.nearblocks.io/txns/BWMiXjpwaKWu9T5RMBR2YvYiAjbYvdpG8j63b8MtWyC6#execution, right after it, required_deposit increased from 1 yocto to 0.05 NEAR, due to pending request increased from 3 to 4: https://testnet.nearblocks.io/txns/DRFLMMXiaXdzDdwU9FY86em7UZPETFNALB9FzsfrBYvm#execution.

Increase the gas used for clear_state_on_finish should be good for future request. To cleaning up, we should clean up the contract LookupMap manually, which required make remove_request a public method, which require deploy a temp contract, or migrate to a new contract account with empty pending requests.
