### PR TITLE
chore: renamed candidate_account_id to candidate

### DIFF
--- a/chain-signatures/contract/src/lib.rs
+++ b/chain-signatures/contract/src/lib.rs
@@ -334,11 +334,11 @@ impl VersionedMpcContract {
     }
 
     #[handle_result]
-    pub fn vote_join(&mut self, candidate_account_id: AccountId) -> Result<bool, Error> {
+    pub fn vote_join(&mut self, candidate: AccountId) -> Result<bool, Error> {
         log!(
-            "vote_join: signer={}, candidate_account_id={}",
+            "vote_join: signer={}, candidate={}",
             env::signer_account_id(),
-            candidate_account_id
+            candidate
         );
         let voter = self.voter()?;
         let protocol_state = self.mutable_state();
@@ -353,14 +353,13 @@ impl VersionedMpcContract {
                 ..
             }) => {
                 let candidate_info = candidates
-                    .get(&candidate_account_id)
+                    .get(&candidate)
                     .ok_or(VoteError::JoinNotCandidate)?;
-                let voted = join_votes.entry(candidate_account_id.clone());
+                let voted = join_votes.entry(candidate.clone());
                 voted.insert(voter);
                 if voted.len() >= *threshold {
                     let mut new_participants = participants.clone();
-                    new_participants
-                        .insert(candidate_account_id.clone(), candidate_info.clone().into());
+                    new_participants.insert(candidate, candidate_info.clone().into());
                     *protocol_state = ProtocolContractState::Resharing(ResharingContractState {
                         old_epoch: *epoch,
                         old_participants: participants.clone(),

--- a/chain-signatures/contract/tests/vote.rs
+++ b/chain-signatures/contract/tests/vote.rs
@@ -76,7 +76,7 @@ async fn test_vote_join() -> anyhow::Result<()> {
     let execution = accounts[0]
         .call(contract.id(), "vote_join")
         .args_json(json!({
-            "candidate_account_id": alice.id()
+            "candidate": alice.id()
         }))
         .transact()
         .await?;
@@ -88,7 +88,7 @@ async fn test_vote_join() -> anyhow::Result<()> {
     let execution = alice
         .call(contract.id(), "vote_join")
         .args_json(json!({
-            "candidate_account_id": alice.id()
+            "candidate": alice.id()
         }))
         .transact()
         .await?;
@@ -98,7 +98,7 @@ async fn test_vote_join() -> anyhow::Result<()> {
     let execution = accounts[1]
         .call(contract.id(), "vote_join")
         .args_json(json!({
-            "candidate_account_id": alice.id()
+            "candidate": alice.id()
         }))
         .transact()
         .await?;
@@ -267,7 +267,7 @@ async fn test_vote_reshare() -> anyhow::Result<()> {
     let execution = accounts[0]
         .call(contract.id(), "vote_join")
         .args_json(json!({
-            "candidate_account_id": alice.id()
+            "candidate": alice.id()
         }))
         .transact()
         .await?;
@@ -277,7 +277,7 @@ async fn test_vote_reshare() -> anyhow::Result<()> {
     let execution = accounts[1]
         .call(contract.id(), "vote_join")
         .args_json(json!({
-            "candidate_account_id": alice.id()
+            "candidate": alice.id()
         }))
         .transact()
         .await?;

--- a/integration-tests/chain-signatures/src/utils.rs
+++ b/integration-tests/chain-signatures/src/utils.rs
@@ -20,7 +20,7 @@ pub async fn vote_join(
             account
                 .call(mpc_contract, "vote_join")
                 .args_json(serde_json::json!({
-                    "candidate_account_id": account_id
+                    "candidate": account_id
                 }))
                 .transact()
         })


### PR DESCRIPTION
minor change. Wanted to make this before any additional tooling was built around voting