### PR TITLE
metric: monitor signature publish failures

### DIFF
--- a/chain-signatures/node/src/metrics.rs
+++ b/chain-signatures/node/src/metrics.rs
@@ -380,6 +380,24 @@ pub(crate) static SIGNATURE_FAILURES: Lazy<IntGaugeVec> = Lazy::new(|| {
     .unwrap()
 });
 
+pub(crate) static SIGNATURE_PUBLISH_FAILURES: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "multichain_signature_publish_failures",
+        "number of failed signature publish",
+        &["node_account_id"],
+    )
+    .unwrap()
+});
+
+pub(crate) static SIGNATURE_PUBLISH_RESPONSE_ERRORS: Lazy<IntGaugeVec> = Lazy::new(|| {
+    try_create_int_gauge_vec(
+        "multichain_signature_publish_response_errors",
+        "number of respond calls with response that cannot be converted to json",
+        &["node_account_id"],
+    )
+    .unwrap()
+});
+
 pub fn try_create_int_gauge_vec(name: &str, help: &str, labels: &[&str]) -> Result<IntGaugeVec> {
     check_metric_multichain_prefix(name)?;
     let opts = Opts::new(name, help);

--- a/chain-signatures/node/src/protocol/signature.rs
+++ b/chain-signatures/node/src/protocol/signature.rs
@@ -734,6 +734,9 @@ impl SignatureManager {
                 Ok(response) => response,
                 Err(err) => {
                     tracing::error!(%receipt_id, error = ?err, "Failed to publish the signature");
+                    crate::metrics::SIGNATURE_PUBLISH_FAILURES
+                        .with_label_values(&[self.my_account_id.as_str()])
+                        .inc();
                     // Push the response to the back of the queue if it hasn't been retried the max number of times
                     if to_publish.retry_count < MAX_RETRY {
                         to_publish.retry_count += 1;
@@ -749,6 +752,9 @@ impl SignatureManager {
                 }
                 Err(err) => {
                     tracing::error!(%receipt_id, bi_r = signature.big_r.affine_point.to_base58(), s = ?signature.s, error = ?err, "smart contract threw error");
+                    crate::metrics::SIGNATURE_PUBLISH_RESPONSE_ERRORS
+                        .with_label_values(&[self.my_account_id.as_str()])
+                        .inc();
                     continue;
                 }
             };


### PR DESCRIPTION
aka respond() errors so we can alert