### PR TITLE
lower timesouts on calls

### DIFF
--- a/chain-signatures/node/src/cli.rs
+++ b/chain-signatures/node/src/cli.rs
@@ -136,7 +136,7 @@ fn is_running_on_gcp() -> bool {
     let resp = reqwest::blocking::Client::new()
         .get("http://metadata.google.internal/computeMetadata/v1/instance/id")
         .header("Metadata-Flavor", "Google")
-        .timeout(Duration::from_secs(1))
+        .timeout(Duration::from_millis(200))
         .send();
 
     match resp {

--- a/chain-signatures/node/src/http_client.rs
+++ b/chain-signatures/node/src/http_client.rs
@@ -46,7 +46,7 @@ async fn send_encrypted<U: IntoUrl>(
             .post(url.clone())
             .header("content-type", "application/json")
             .json(&message)
-            .timeout(Duration::from_secs(2))
+            .timeout(Duration::from_millis(200))
             .send()
             .await
             .map_err(SendError::ReqwestClientError)?;

--- a/chain-signatures/node/src/mesh/connection.rs
+++ b/chain-signatures/node/src/mesh/connection.rs
@@ -52,7 +52,7 @@ impl Pool {
             let Ok(resp) = self
                 .http
                 .get(url.clone())
-                .timeout(Duration::from_secs(1))
+                .timeout(Duration::from_millis(200))
                 .send()
                 .await
             else {
@@ -102,7 +102,7 @@ impl Pool {
             let Ok(resp) = self
                 .http
                 .get(url)
-                .timeout(Duration::from_secs(1))
+                .timeout(Duration::from_millis(200))
                 .send()
                 .await
             else {


### PR DESCRIPTION
speed up the loop when /state or /msg is unavailable.  Lower timeout from 2s to 200ms. 2s is too slow and no triple gets generated, always timeout. 

Tested on dev that this change will enable nodes to generate triples, presigs and signatures even when 3 out of 12 nodes are offline. 