### PR TITLE
Minor improvements coming from testing on real machines.

### DIFF
--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -7,6 +7,12 @@ use std::path::Path;
 pub struct Config {
     pub mpc: MpcConfig,
     pub web_ui: WebUIConfig,
+    pub triple: TripleConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TripleConfig {
+    pub concurrency: usize,
 }
 
 #[derive(Debug)]
@@ -35,6 +41,7 @@ pub struct ConfigFile {
     /// Private key used for the P2P communication's TLS.
     pub p2p_private_key_file: String,
     pub web_ui: WebUIConfig,
+    pub triple: TripleConfig,
 }
 
 impl ConfigFile {
@@ -89,6 +96,7 @@ pub fn load_config(home_dir: &Path) -> anyhow::Result<Config> {
     let config = Config {
         mpc: mpc_config,
         web_ui: web_config,
+        triple: file_config.triple,
     };
     Ok(config)
 }

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -1,4 +1,4 @@
-use crate::config::MpcConfig;
+use crate::config::{MpcConfig, TripleConfig};
 use crate::key_generation::run_key_generation;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::MpcTaskId;
@@ -14,11 +14,12 @@ use tokio::time::timeout;
 /// multiparty computation.
 pub async fn run_mpc_client(
     config: Arc<MpcConfig>,
+    triple_config: Arc<TripleConfig>,
     client: Arc<MeshNetworkClient>,
     mut channel_receiver: mpsc::Receiver<NetworkTaskChannel>,
 ) -> anyhow::Result<()> {
     // TODO: make it into a config for each kind of task.
-    const TASK_TIMEOUT: Duration = Duration::from_secs(5);
+    const TASK_TIMEOUT: Duration = Duration::from_secs(60);
     {
         let client = client.clone();
         let config = config.clone();
@@ -74,7 +75,7 @@ pub async fn run_mpc_client(
     // Generate 4 triples at once.
     let triples_generated = Arc::new(AtomicUsize::new(0));
     let mut handles = Vec::new();
-    for i in 0..4 {
+    for i in 0..triple_config.concurrency {
         let client = client.clone();
         let config = config.clone();
         let triples_generated = triples_generated.clone();

--- a/test-configs/0/config.yaml
+++ b/test-configs/0/config.yaml
@@ -28,3 +28,5 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20000
+triple:
+  concurrency: 4

--- a/test-configs/1/config.yaml
+++ b/test-configs/1/config.yaml
@@ -28,3 +28,5 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20001
+triple:
+  concurrency: 4

--- a/test-configs/2/config.yaml
+++ b/test-configs/2/config.yaml
@@ -28,3 +28,5 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20002
+triple:
+  concurrency: 4

--- a/test-configs/3/config.yaml
+++ b/test-configs/3/config.yaml
@@ -28,3 +28,5 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20003
+triple:
+  concurrency: 4


### PR DESCRIPTION
* Resolve DNS when connecting, not when initializing - since other nodes may not be online yet.
* Wait for everyone to be connected once, before starting the client logic. It avoids having a bunch of errors at the beginning for no good reason.
* Enlarge some channel sizes. This is just a temporary measure... There is some logical deadlock going on due to saturated channels when running too many triple generations at once over a slow network. I'm not sure where the deadlock comes from, but for now I'm just enlarging them. I'm not sure if it's a good idea to make them just unbounded channels, because then some channels might grow infinitely? I think the right thing to do here is spend some time to understand where and how exactly the flow control should be done.
* Introduce a simple TripleConfig that currently just has a concurrency setting.