### PR TITLE
Significantly optimize how we run cait-sith protocols.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,7 +661,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/LIT-Protocol/cait-sith.git?rev=8ad2316#8ad2316f804a39d6039bb87519406cf25df1b078"
+source = "git+https://github.com/Near-One/cait-sith.git?rev=b82c3546c4ace84f771b311b4cd5e40fed9bc3d5#b82c3546c4ace84f771b311b4cd5e40fed9bc3d5"
 dependencies = [
  "auto_ops",
  "ck-meow",
@@ -669,6 +669,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "event-listener 2.5.3",
+ "futures",
  "k256",
  "magikitten",
  "rand_core",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -8,7 +8,7 @@ actix-web = "4.9.0"
 anyhow = "1.0.92"
 async-trait = "0.1.83"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/LIT-Protocol/cait-sith.git", features = ["k256"], rev = "8ad2316" }
+cait-sith = { git = "https://github.com/Near-One/cait-sith.git", features = ["k256"], rev = "b82c3546c4ace84f771b311b4cd5e40fed9bc3d5" }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,4 +1,7 @@
-use crate::config::{load_config, ConfigFile, TripleConfig, WebUIConfig};
+use crate::config::{
+    load_config, ConfigFile, KeyGenerationConfig, PresignatureConfig, SignatureConfig,
+    TripleConfig, WebUIConfig,
+};
 use crate::mpc_client::MpcClient;
 use crate::network::{run_network_client, MeshNetworkTransportSender};
 use crate::p2p::{generate_test_p2p_configs, new_quic_mesh_network};
@@ -41,9 +44,9 @@ impl Cli {
                     let (network_client, channel_receiver) =
                         run_network_client(Arc::new(sender), Box::new(receiver));
 
+                    let config = Arc::new(config);
                     let mpc_client = MpcClient::new(
-                        config.mpc.into(),
-                        config.triple.into(),
+                        config.clone(),
                         network_client,
                         Arc::new(SimpleTripleStore::new()),
                         Arc::new(SimplePresignatureStore::new()),
@@ -52,7 +55,7 @@ impl Cli {
 
                     tracking::spawn_checked(
                         "web server",
-                        run_web_server(root_task_handle, config.web_ui, mpc_client.clone()),
+                        run_web_server(root_task_handle, config.web_ui.clone(), mpc_client.clone()),
                     );
                     mpc_client.clone().run(channel_receiver).await?;
                     anyhow::Ok(())
@@ -77,10 +80,15 @@ impl Cli {
                             host: "127.0.0.1".to_owned(),
                             port: 20000 + i as u16,
                         },
+                        key_generation: KeyGenerationConfig { timeout_sec: 60 },
                         triple: TripleConfig {
                             concurrency: 4,
                             desired_triples_to_buffer: 65536,
+                            timeout_sec: 60,
+                            parallel_triple_generation_stagger_time_sec: 1,
                         },
+                        presignature: PresignatureConfig { timeout_sec: 60 },
+                        signature: SignatureConfig { timeout_sec: 60 },
                     };
                     std::fs::write(
                         format!("{}/p2p.pem", subdir),

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -7,13 +7,35 @@ use std::path::Path;
 pub struct Config {
     pub mpc: MpcConfig,
     pub web_ui: WebUIConfig,
+    pub key_generation: KeyGenerationConfig,
     pub triple: TripleConfig,
+    pub presignature: PresignatureConfig,
+    pub signature: SignatureConfig,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct KeyGenerationConfig {
+    pub timeout_sec: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TripleConfig {
     pub concurrency: usize,
     pub desired_triples_to_buffer: usize,
+    pub timeout_sec: u64,
+    /// If we issued a triple generation, wait at least this number of seconds
+    /// before issuing another one. This is to avoid thundering herd situations.
+    pub parallel_triple_generation_stagger_time_sec: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresignatureConfig {
+    pub timeout_sec: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SignatureConfig {
+    pub timeout_sec: u64,
 }
 
 #[derive(Debug)]
@@ -42,7 +64,10 @@ pub struct ConfigFile {
     /// Private key used for the P2P communication's TLS.
     pub p2p_private_key_file: String,
     pub web_ui: WebUIConfig,
+    pub key_generation: KeyGenerationConfig,
     pub triple: TripleConfig,
+    pub presignature: PresignatureConfig,
+    pub signature: SignatureConfig,
 }
 
 impl ConfigFile {
@@ -97,7 +122,10 @@ pub fn load_config(home_dir: &Path) -> anyhow::Result<Config> {
     let config = Config {
         mpc: mpc_config,
         web_ui: web_config,
+        key_generation: file_config.key_generation,
         triple: file_config.triple,
+        presignature: file_config.presignature,
+        signature: file_config.signature,
     };
     Ok(config)
 }

--- a/node/src/primitives.rs
+++ b/node/src/primitives.rs
@@ -35,10 +35,13 @@ impl Display for ParticipantId {
     }
 }
 
+/// A batched list of multiple cait-sith protocol messages.
+pub type BatchedMessages = Vec<Vec<u8>>;
+
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
 pub struct MpcMessage {
     pub task_id: MpcTaskId,
-    pub data: Vec<u8>,
+    pub data: BatchedMessages,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, BorshSerialize, BorshDeserialize)]
@@ -50,7 +53,6 @@ pub struct MpcPeerMessage {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, BorshSerialize, BorshDeserialize)]
 pub enum MpcTaskId {
     KeyGeneration,
-    Triple(u64),
     ManyTriples {
         start: u64,
         end: u64,

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -1,7 +1,11 @@
-use crate::network::NetworkTaskChannel;
-use crate::primitives::ParticipantId;
+use std::sync::{atomic::AtomicUsize, Arc};
+
+use crate::primitives::{BatchedMessages, ParticipantId};
 use crate::tracking;
+use crate::{network::NetworkTaskChannel, tracking::TaskHandle};
 use cait_sith::protocol::{Action, Protocol};
+use futures::TryFutureExt;
+use tokio::sync::mpsc;
 
 /// Runs any cait-sith protocol, returning the result. Exports tracking progress
 /// describing how many messages are sent and received to each participant.
@@ -12,38 +16,195 @@ pub async fn run_protocol<T>(
     me: ParticipantId,
     mut protocol: impl Protocol<Output = T>,
 ) -> anyhow::Result<T> {
-    let mut actions_taken = 0;
-    let mut messages_sent = vec![0; participants.len()];
-    let mut messages_received = vec![0; participants.len()];
-    let result = 'outer: loop {
-        loop {
-            actions_taken += 1;
-            match protocol.poke()? {
-                Action::Wait => break,
-                Action::SendMany(vec) => {
-                    for participant in &participants {
-                        if participant == &me {
-                            continue;
+    let counters = Arc::new(MessageCounters::new(name.to_string(), participants.len()));
+    let mut queue_senders: Vec<mpsc::UnboundedSender<BatchedMessages>> = Vec::new();
+    let mut queue_receivers: Vec<mpsc::UnboundedReceiver<BatchedMessages>> = Vec::new();
+
+    for _ in 0..participants.len() {
+        let (send, recv) = mpsc::unbounded_channel();
+        queue_senders.push(send);
+        queue_receivers.push(recv);
+    }
+
+    // We split the protocol into two tasks: one dedicated to sending messages, and one dedicated
+    // to computation and receiving messages. There are two reasons for this:
+    //  - If we just used a loop to poke the protocol, and send messages whenever the protocol asks
+    //    us to, then we can run into a situation where the protocol is asking us to send 1000
+    //    messages to participant 1, but because of bandwidth limitations, the sending blocks on
+    //    waiting for enough outgoing buffer to hold the messages. Even though the protocol, at this
+    //    moment, may have more messages to send to other participants, we don't get a chance to
+    //    send any of that until we've sent all 1000 messages to participant 1. This is very
+    //    inefficient, so instead we put messages into queues, indexed by the recipient, and have
+    //    a parallel task for each recipient that sends the messages.
+    //  - We need the sending task to be a separate spawn from the computation task because while
+    //    we're computing, we would not be able to cooperatively run any other tasks, and that can
+    //    unnecessarily block sending. It is OK to have the receiving side blocked by computation,
+    //    because on the receiving side, the network channel already provides us with a buffer
+    //    dedicated to our task.
+    let sending_handle = {
+        let counters = counters.clone();
+        let sender = channel.sender();
+        let participants = participants.clone();
+        tracking::spawn_checked("send messages", async move {
+            // One future for each recipient. For the same recipient it is OK to send messages
+            // serially, but for multiple recipients we want them to not block each other.
+            // These futures are IO-bound, so we don't have to spawn them separately.
+            let futures = queue_receivers
+                .into_iter()
+                .enumerate()
+                .map(move |(i, mut receiver)| {
+                    let participant_id = participants[i];
+                    let sender = sender.clone();
+                    let counters = counters.clone();
+                    async move {
+                        while let Some(messages) = receiver.recv().await {
+                            let num_messages = messages.len();
+                            sender(participant_id, messages).await?;
+                            counters.sent(i, num_messages);
                         }
-                        channel.send(*participant, vec.clone()).await?;
-                        messages_sent[participant.0 as usize] += 1;
+                        anyhow::Ok(())
+                    }
+                });
+            futures::future::try_join_all(futures).await?;
+            anyhow::Ok(())
+        })
+        .map_err(anyhow::Error::from)
+    };
+
+    let computation_handle = async move {
+        loop {
+            let mut messages_to_send = (0..participants.len())
+                .map(|_| Vec::new())
+                .collect::<Vec<_>>();
+            let done = loop {
+                match protocol.poke()? {
+                    Action::Wait => break None,
+                    Action::SendMany(vec) => {
+                        for participant in &participants {
+                            if participant == &me {
+                                continue;
+                            }
+                            messages_to_send[participant.0 as usize].push(vec.clone());
+                        }
+                    }
+                    Action::SendPrivate(participant, vec) => {
+                        messages_to_send[u32::from(participant) as usize].push(vec);
+                    }
+                    Action::Return(result) => {
+                        // Warning: we cannot return immediately!! There may be some important
+                        // messages to send to others to enable others to complete their computation.
+                        break Some(result);
                     }
                 }
-                Action::SendPrivate(participant, vec) => {
-                    channel.send(ParticipantId(participant.into()), vec).await?;
-                    messages_sent[u32::from(participant) as usize] += 1;
+            };
+
+            // Batch-send the messages. This is a useful optimization as cait-sith tends to ask us
+            // to send many messages at once to the same recipient.
+            // TODO(#21): maybe we can fix the cait-sith protocol to not ask us to send so many
+            // messages in the first place.
+            for (i, messages) in messages_to_send.into_iter().enumerate() {
+                if messages.is_empty() {
+                    continue;
                 }
-                Action::Return(result) => break 'outer result,
+                counters.queue_send(i, messages.len());
+                queue_senders[i].send(messages).unwrap();
+            }
+
+            if let Some(result) = done {
+                return anyhow::Ok(result);
+            }
+
+            counters.set_receiving();
+
+            let msg = channel.receive().await?;
+            counters.received(msg.from.0 as usize, msg.message.data.len());
+
+            for one_msg in msg.message.data {
+                protocol.message(msg.from.into(), one_msg);
             }
         }
-        tracking::set_progress(&format!(
-            "{}: steps {}, tx {:?}, rx {:?}",
-            name, actions_taken, messages_sent, messages_received
-        ));
-
-        let msg = channel.receive().await?;
-        messages_received[msg.from.0 as usize] += 1;
-        protocol.message(msg.from.into(), msg.message.data);
     };
-    Ok(result)
+    let (computation_result, _) = futures::try_join!(computation_handle, sending_handle)?;
+    Ok(computation_result)
+}
+
+/// Debugging counters to be used to export progress for tracking::set_progress, while
+/// the computation is happening.
+struct MessageCounters {
+    name: String,
+    task: Arc<TaskHandle>,
+    sent: Vec<AtomicUsize>,
+    in_flight: Vec<AtomicUsize>,
+    received: Vec<AtomicUsize>,
+    current_action: AtomicUsize, // 1 = receiving, 0 = computing
+}
+
+impl MessageCounters {
+    pub fn new(name: String, participants: usize) -> Self {
+        Self {
+            name,
+            task: tracking::current_task(),
+            sent: (0..participants)
+                .map(|_| AtomicUsize::new(0))
+                .collect::<Vec<_>>(),
+            in_flight: (0..participants)
+                .map(|_| AtomicUsize::new(0))
+                .collect::<Vec<_>>(),
+            received: (0..participants)
+                .map(|_| AtomicUsize::new(0))
+                .collect::<Vec<_>>(),
+            current_action: AtomicUsize::new(0),
+        }
+    }
+
+    pub fn queue_send(&self, participant: usize, num_messages: usize) {
+        self.in_flight[participant].fetch_add(num_messages, std::sync::atomic::Ordering::Relaxed);
+        self.report_progress();
+    }
+
+    pub fn sent(&self, participant: usize, num_messages: usize) {
+        self.sent[participant].fetch_add(num_messages, std::sync::atomic::Ordering::Relaxed);
+        self.in_flight[participant].fetch_sub(num_messages, std::sync::atomic::Ordering::Relaxed);
+        self.report_progress();
+    }
+
+    pub fn received(&self, participant: usize, num_messages: usize) {
+        self.received[participant].fetch_add(num_messages, std::sync::atomic::Ordering::Relaxed);
+        self.current_action
+            .store(0, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub fn set_receiving(&self) {
+        self.current_action
+            .store(1, std::sync::atomic::Ordering::Relaxed);
+        self.report_progress();
+    }
+
+    fn report_progress(&self) {
+        self.task.set_progress(&format!(
+            "{}: sent {:?} (inflight {:?}), received {:?} ({})",
+            self.name,
+            self.sent
+                .iter()
+                .map(|a| a.load(std::sync::atomic::Ordering::Relaxed))
+                .collect::<Vec<_>>(),
+            self.in_flight
+                .iter()
+                .map(|a| a.load(std::sync::atomic::Ordering::Relaxed))
+                .collect::<Vec<_>>(),
+            self.received
+                .iter()
+                .map(|a| a.load(std::sync::atomic::Ordering::Relaxed))
+                .collect::<Vec<_>>(),
+            if self
+                .current_action
+                .load(std::sync::atomic::Ordering::Relaxed)
+                == 1
+            {
+                "receiving"
+            } else {
+                "computing"
+            },
+        ));
+    }
 }

--- a/test-configs/0/config.yaml
+++ b/test-configs/0/config.yaml
@@ -28,6 +28,14 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20000
+key_generation:
+  timeout_sec: 60
 triple:
   concurrency: 4
   desired_triples_to_buffer: 65536
+  timeout_sec: 60
+  parallel_triple_generation_stagger_time_sec: 1
+presignature:
+  timeout_sec: 60
+signature:
+  timeout_sec: 60

--- a/test-configs/1/config.yaml
+++ b/test-configs/1/config.yaml
@@ -28,6 +28,14 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20001
+key_generation:
+  timeout_sec: 60
 triple:
   concurrency: 4
   desired_triples_to_buffer: 65536
+  timeout_sec: 60
+  parallel_triple_generation_stagger_time_sec: 1
+presignature:
+  timeout_sec: 60
+signature:
+  timeout_sec: 60

--- a/test-configs/2/config.yaml
+++ b/test-configs/2/config.yaml
@@ -28,6 +28,14 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20002
+key_generation:
+  timeout_sec: 60
 triple:
   concurrency: 4
   desired_triples_to_buffer: 65536
+  timeout_sec: 60
+  parallel_triple_generation_stagger_time_sec: 1
+presignature:
+  timeout_sec: 60
+signature:
+  timeout_sec: 60

--- a/test-configs/3/config.yaml
+++ b/test-configs/3/config.yaml
@@ -28,6 +28,14 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20003
+key_generation:
+  timeout_sec: 60
 triple:
   concurrency: 4
   desired_triples_to_buffer: 65536
+  timeout_sec: 60
+  parallel_triple_generation_stagger_time_sec: 1
+presignature:
+  timeout_sec: 60
+signature:
+  timeout_sec: 60


### PR DESCRIPTION
A large change containing multiple improvements:

Major changes:
* Split the protocol running code into a sender task and a computation/receiving task. This gets rid of a major bottleneck where multiple parallel triple generation protocols are all waiting to send to the same target participant before sending anyone else anything. See the comments in the code for details.
* Batch messages before sending them, since cait-sith sends too many small messages at once to the same recipient.
* Stagger parallel triple generations to avoid thundering herd when the node starts up that leads to more performance issues down the line.
* Add a network visualization test (the UI side will be in a separate PR) that runs a triple generation protocol and exports stats about network messages; this was very helpful in gaining insight into where the network bottlenecks likely are.

Minor changes:
* Remove singular triple generation code that's no longer needed.
* Add timeouts to configs.
* For tracking::set_progress, also keep track of when the progress was updated, so that in /debug/tasks one can see how long the task has spent in this state.
* No longer track the quic stream handling code, as it tends to just spam /debug/tasks without adding any useful information.