### PR TITLE
Persist keygen and presigs; background presig generation.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1145,7 +1145,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/Near-One/cait-sith.git?rev=b82c3546c4ace84f771b311b4cd5e40fed9bc3d5#b82c3546c4ace84f771b311b4cd5e40fed9bc3d5"
+source = "git+https://github.com/Near-One/cait-sith.git?rev=75af6bf8c25359dd2be25a838057f3a0dc88f633#75af6bf8c25359dd2be25a838057f3a0dc88f633"
 dependencies = [
  "auto_ops",
  "ck-meow",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ aes-gcm = "0.10.3"
 anyhow = "1.0.92"
 async-trait = "0.1.83"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/Near-One/cait-sith.git", features = ["k256"], rev = "b82c3546c4ace84f771b311b4cd5e40fed9bc3d5" }
+cait-sith = { git = "https://github.com/Near-One/cait-sith.git", features = ["k256"], rev = "75af6bf8c25359dd2be25a838057f3a0dc88f633" }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"

--- a/node/src/assets.rs
+++ b/node/src/assets.rs
@@ -268,7 +268,9 @@ where
             pending.await.ok();
         }
         let key = borsh::to_vec(&id).unwrap();
-        let value_ser = self.db.get(self.col, &key)?.context("Asset not found")?;
+        let value_ser = self.db.get(self.col, &key)?.ok_or_else(|| {
+            anyhow::anyhow!("Unowned {} not found in the database: {:?}", self.col, id)
+        })?;
         let mut update = self.db.update();
         update.delete(self.col, &key);
         update

--- a/node/src/background.rs
+++ b/node/src/background.rs
@@ -1,0 +1,51 @@
+use std::sync::atomic::AtomicUsize;
+use std::sync::Arc;
+
+/// Tracks number of in-flight generations so we don't generate too many at the same time.
+pub struct InFlightGenerationTracker {
+    generations_in_flight: Arc<AtomicUsize>,
+}
+
+impl InFlightGenerationTracker {
+    pub fn new() -> Self {
+        Self {
+            generations_in_flight: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    pub fn in_flight(&self, count: usize) -> InFlightGenerations {
+        InFlightGenerations::new(self.generations_in_flight.clone(), count)
+    }
+
+    pub fn num_in_flight(&self) -> usize {
+        self.generations_in_flight
+            .load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    pub fn num_in_flight_atomic(&self) -> Arc<AtomicUsize> {
+        self.generations_in_flight.clone()
+    }
+}
+
+/// Drop guard to increment and decrement number of generations in flight.
+pub struct InFlightGenerations {
+    generations_in_flight: Arc<AtomicUsize>,
+    count: usize,
+}
+
+impl InFlightGenerations {
+    pub fn new(generations_in_flight: Arc<AtomicUsize>, count: usize) -> Self {
+        generations_in_flight.fetch_add(count, std::sync::atomic::Ordering::Relaxed);
+        Self {
+            generations_in_flight,
+            count,
+        }
+    }
+}
+
+impl Drop for InFlightGenerations {
+    fn drop(&mut self) {
+        self.generations_in_flight
+            .fetch_sub(self.count, std::sync::atomic::Ordering::Relaxed);
+    }
+}

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -38,6 +38,8 @@ pub struct TripleConfig {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PresignatureConfig {
+    pub concurrency: usize,
+    pub desired_presignatures_to_buffer: usize,
     pub timeout_sec: u64,
 }
 

--- a/node/src/db.rs
+++ b/node/src/db.rs
@@ -1,6 +1,7 @@
 use aes_gcm::aead::generic_array::GenericArray;
 use aes_gcm::aead::Aead;
 use aes_gcm::{AeadCore, Aes128Gcm, AesGcm, KeyInit};
+use std::fmt::Display;
 use std::path::Path;
 use std::sync::Arc;
 
@@ -30,6 +31,12 @@ impl DBCol {
 
     fn all() -> [DBCol; 3] {
         [DBCol::GeneratedKey, DBCol::Triple, DBCol::Presignature]
+    }
+}
+
+impl Display for DBCol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
     }
 }
 
@@ -78,8 +85,7 @@ impl SecretDB {
     /// Returns the undecrypted ciphertext, for testing.
     #[cfg(test)]
     pub fn get_ciphertext(&self, col: DBCol, key: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
-        let value = self.db.get_cf(&self.cf_handle(col), key)?;
-        value.map(|v| Ok(v)).transpose()
+        Ok(self.db.get_cf(&self.cf_handle(col), key)?)
     }
 
     /// Returns an iterator for all values in the given range.

--- a/node/src/key_generation.rs
+++ b/node/src/key_generation.rs
@@ -1,9 +1,12 @@
+use crate::db::{DBCol, SecretDB};
 use crate::network::NetworkTaskChannel;
 use crate::primitives::ParticipantId;
 use crate::protocol::run_protocol;
 use cait_sith::protocol::Participant;
 use cait_sith::KeygenOutput;
 use k256::Secp256k1;
+use std::sync::Arc;
+use tokio_util::sync::CancellationToken;
 
 /// Runs the key generation protocol, returning the key generated.
 /// This protocol is identical for the leader and the followers.
@@ -22,14 +25,94 @@ pub async fn run_key_generation(
     run_protocol("key generation", channel, me, protocol).await
 }
 
+/// Stores a single generated root key.
+pub struct KeygenStorage {
+    db: Arc<SecretDB>,
+    generated: CancellationToken,
+    key: Arc<tokio::sync::OnceCell<KeygenOutput<Secp256k1>>>,
+}
+
+impl KeygenStorage {
+    /// Reads the generated key from the database, if it exists.
+    /// If it exists, returns (self, None). Otherwise, returns (self, Some(KeygenNeeded))
+    /// where the latter can be used to commit the key once it is generated.
+    pub fn new(db: Arc<SecretDB>) -> anyhow::Result<(Arc<Self>, Option<KeygenNeeded>)> {
+        let existing_key = read_generated_key_from_db(&db)?;
+        let generated = CancellationToken::new();
+        let key = Arc::new(tokio::sync::OnceCell::new());
+        Ok(if let Some(existing_key) = existing_key {
+            key.set(existing_key).ok();
+            generated.cancel();
+            (Self { db, generated, key }.into(), None)
+        } else {
+            let store = Arc::new(Self {
+                db: db.clone(),
+                generated: generated.clone(),
+                key: key.clone(),
+            });
+            (store.clone(), Some(KeygenNeeded { store }))
+        })
+    }
+
+    /// Retrieves the generated key, blocking until it is generated.
+    pub async fn get_generated_key(&self) -> KeygenOutput<Secp256k1> {
+        self.generated.cancelled().await;
+        self.key.get().cloned().unwrap()
+    }
+}
+
+pub struct KeygenNeeded {
+    store: Arc<KeygenStorage>,
+}
+
+impl Drop for KeygenNeeded {
+    fn drop(&mut self) {
+        if !self.store.generated.is_cancelled() {
+            panic!("Key generation was not completed");
+        }
+    }
+}
+
+impl KeygenNeeded {
+    pub fn commit(self, keygen_out: KeygenOutput<Secp256k1>) {
+        write_generated_key_to_db(&self.store.db, &keygen_out);
+        self.store.key.set(keygen_out).ok();
+        self.store.generated.cancel();
+    }
+}
+
+fn read_generated_key_from_db(db: &SecretDB) -> anyhow::Result<Option<KeygenOutput<Secp256k1>>> {
+    let keygen = db.get(DBCol::GeneratedKey, b"")?;
+    Ok(keygen
+        .map(|keygen| serde_json::from_slice(&keygen))
+        .transpose()?)
+}
+
+fn write_generated_key_to_db(db: &Arc<SecretDB>, keygen: &KeygenOutput<Secp256k1>) {
+    let mut update = db.update();
+    update.put(
+        DBCol::GeneratedKey,
+        b"",
+        &serde_json::to_vec(keygen).unwrap(),
+    );
+    update
+        .commit()
+        .expect("Failed to commit generated key to db");
+}
+
 #[cfg(test)]
 mod tests {
     use super::run_key_generation;
+    use crate::db::SecretDB;
+    use crate::key_generation::KeygenStorage;
     use crate::network::testing::run_test_clients;
     use crate::network::{MeshNetworkClient, NetworkTaskChannel};
     use crate::primitives::MpcTaskId;
+    use crate::tests::TestGenerators;
     use crate::tracking::testing::start_root_task_with_periodic_dump;
     use cait_sith::KeygenOutput;
+    use futures::future::{maybe_done, MaybeDone};
+    use futures::FutureExt;
     use k256::Secp256k1;
     use std::sync::Arc;
     use tokio::sync::mpsc;
@@ -63,5 +146,35 @@ mod tests {
             run_key_generation(channel, participant_id, 3).await?;
 
         Ok(key)
+    }
+
+    #[test]
+    fn test_keygen_store() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let (store, needed) = KeygenStorage::new(db.clone()).unwrap();
+        assert!(needed.is_some());
+
+        // Getting the key should asynchronously block until the key is committed.
+        let MaybeDone::Future(key) = maybe_done(store.get_generated_key()) else {
+            panic!("Key should not already be available");
+        };
+        let generated_key = TestGenerators::new(2, 2)
+            .make_keygens()
+            .into_iter()
+            .next()
+            .unwrap()
+            .1;
+        needed.unwrap().commit(generated_key.clone());
+        let key = key.now_or_never().unwrap();
+        assert_eq!(key.private_share, generated_key.private_share);
+        assert_eq!(key.public_key, generated_key.public_key);
+        drop(store);
+
+        // Reload the store; the key should be available immediately.
+        let (store, needed) = KeygenStorage::new(db.clone()).unwrap();
+        assert!(needed.is_none());
+        let key = store.get_generated_key().now_or_never().unwrap();
+        assert_eq!(key.private_share, generated_key.private_share);
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use tracing::init_logging;
 
 mod assets;
+mod background;
 mod cli;
 mod config;
 mod db;
@@ -14,6 +15,8 @@ mod p2p;
 mod primitives;
 mod protocol;
 mod sign;
+#[cfg(test)]
+mod tests;
 mod tracing;
 mod tracking;
 mod triple;

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -28,6 +28,15 @@ lazy_static! {
 }
 
 lazy_static! {
+    pub static ref MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE: prometheus::IntGauge =
+        prometheus::register_int_gauge!(
+            "mpc_owned_num_presignatures_available",
+            "Number of presignatures generated that we own, and not yet used"
+        )
+        .unwrap();
+}
+
+lazy_static! {
     pub static ref MPC_NUM_SIGNATURES_GENERATED: prometheus::IntCounter =
         prometheus::register_int_counter!(
             "mpc_num_signatures_generated",

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -1,18 +1,20 @@
 use crate::config::Config;
-use crate::key_generation::run_key_generation;
+use crate::key_generation::{run_key_generation, KeygenNeeded, KeygenStorage};
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
-use crate::primitives::{MpcTaskId, participants_from_triples};
+use crate::primitives::MpcTaskId;
 use crate::sign::{
-    generate_presignature_id, generate_signature_id, pre_sign, pre_sign_unowned, sign,
-    SimplePresignatureStore,
+    pre_sign_unowned, run_background_presignature_generation, sign, PresignOutputWithParticipants,
+    PresignatureStorage, SignatureIdGenerator,
 };
 use crate::tracking;
-use crate::triple::{run_background_triple_generation, run_many_triple_generation, TripleStorage, SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE};
-use anyhow::Context;
-use cait_sith::{FullSignature, KeygenOutput};
+use crate::triple::{
+    run_background_triple_generation, run_many_triple_generation, TripleStorage,
+    SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE,
+};
+use cait_sith::FullSignature;
 use k256::elliptic_curve::PrimeField;
 use k256::{FieldBytes, Scalar, Secp256k1};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
@@ -22,8 +24,9 @@ pub struct MpcClient {
     config: Arc<Config>,
     client: Arc<MeshNetworkClient>,
     triple_store: Arc<TripleStorage>,
-    presignature_store: Arc<SimplePresignatureStore>,
-    keygen_out: Arc<tokio::sync::OnceCell<KeygenOutput<Secp256k1>>>,
+    presignature_store: Arc<PresignatureStorage>,
+    keygen_store: Arc<KeygenStorage>,
+    signature_id_generator: Arc<SignatureIdGenerator>,
 }
 
 impl MpcClient {
@@ -31,15 +34,17 @@ impl MpcClient {
         config: Arc<Config>,
         client: Arc<MeshNetworkClient>,
         triple_store: Arc<TripleStorage>,
-        presignature_store: Arc<SimplePresignatureStore>,
-        keygen_out: Arc<tokio::sync::OnceCell<KeygenOutput<Secp256k1>>>,
+        presignature_store: Arc<PresignatureStorage>,
+        keygen_store: Arc<KeygenStorage>,
     ) -> Self {
+        let my_participant_id = client.my_participant_id();
         Self {
             config,
             client,
             triple_store,
             presignature_store,
-            keygen_out,
+            keygen_store,
+            signature_id_generator: Arc::new(SignatureIdGenerator::new(my_participant_id)),
         }
     }
 
@@ -47,29 +52,36 @@ impl MpcClient {
     /// multiparty computation.
     pub async fn run(
         self,
+        keygen_needed: Option<KeygenNeeded>,
         mut channel_receiver: mpsc::Receiver<NetworkTaskChannel>,
     ) -> anyhow::Result<()> {
-        let (generated_key_sender, generated_key_receiver) = mpsc::channel(1);
+        let keygen_needed = Arc::new(Mutex::new(keygen_needed));
         {
             let client = self.client.clone();
             let config = self.config.clone();
             let triple_store = self.triple_store.clone();
             let presignature_store = self.presignature_store.clone();
-            let keygen_out = self.keygen_out.clone();
+            let keygen_store = self.keygen_store.clone();
+            let keygen_needed = keygen_needed.clone();
             tracking::spawn("monitor passive channels", async move {
                 loop {
                     let channel = channel_receiver.recv().await.unwrap();
                     let client = client.clone();
                     let config = config.clone();
-                    let generated_key_sender = generated_key_sender.clone();
                     let triple_store = triple_store.clone();
                     let presignature_store = presignature_store.clone();
-                    let keygen_out = keygen_out.clone();
+                    let keygen_store = keygen_store.clone();
+                    let keygen_needed = keygen_needed.clone();
                     tracking::spawn_checked(
                         &format!("passive task {:?}", channel.task_id),
                         async move {
                             match channel.task_id {
                                 MpcTaskId::KeyGeneration => {
+                                    let Some(keygen_needed) = keygen_needed.lock().unwrap().take()
+                                    else {
+                                        anyhow::bail!("Key already generated");
+                                    };
+
                                     let key = timeout(
                                         Duration::from_secs(config.key_generation.timeout_sec),
                                         run_key_generation(
@@ -79,10 +91,7 @@ impl MpcClient {
                                         ),
                                     )
                                     .await??;
-                                    generated_key_sender
-                                        .send(key)
-                                        .await
-                                        .context("Key generated twice")?;
+                                    keygen_needed.commit(key);
                                 }
                                 MpcTaskId::ManyTriples { start, count } => {
                                     if count as usize != SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE {
@@ -117,27 +126,26 @@ impl MpcClient {
                                 }
                                 MpcTaskId::Presignature {
                                     id,
-                                    paired_triple_id
+                                    paired_triple_id,
                                 } => {
-                                    let sender = presignature_store.add_their_presignature(id);
+                                    let pending_asset = presignature_store.prepare_unowned(id);
+                                    let participants = channel.participants.clone();
                                     let presignature = timeout(
                                         Duration::from_secs(config.presignature.timeout_sec),
                                         pre_sign_unowned(
                                             channel,
                                             client.my_participant_id(),
                                             config.mpc.participants.threshold as usize,
-                                            keygen_out
-                                                .get()
-                                                .ok_or_else(|| {
-                                                    anyhow::anyhow!("Key not generated")
-                                                })?
-                                                .clone(),
+                                            keygen_store.get_generated_key().await,
                                             triple_store.clone(),
                                             paired_triple_id,
                                         ),
                                     )
                                     .await??;
-                                    sender.send(presignature).ok();
+                                    pending_asset.commit(PresignOutputWithParticipants {
+                                        presignature,
+                                        participants,
+                                    });
                                 }
                                 MpcTaskId::Signature {
                                     presignature_id,
@@ -157,15 +165,11 @@ impl MpcClient {
                                         sign(
                                             channel,
                                             client.my_participant_id(),
-                                            keygen_out
-                                                .get()
-                                                .ok_or_else(|| {
-                                                    anyhow::anyhow!("Key not generated")
-                                                })?
-                                                .clone(),
+                                            keygen_store.get_generated_key().await,
                                             presignature_store
-                                                .take_their_presignature(presignature_id)
-                                                .await?,
+                                                .take_unowned(presignature_id)
+                                                .await?
+                                                .presignature,
                                             msg_hash,
                                         ),
                                     )
@@ -179,34 +183,48 @@ impl MpcClient {
             });
         }
 
-        self.keygen_out
-            .set(
-                if self.client.my_participant_id() == self.client.all_participant_ids()[0] {
-                    run_key_generation(
-                        self.client.new_channel_for_task(MpcTaskId::KeyGeneration, self.client.all_participant_ids())?,
-                        self.client.my_participant_id(),
-                        self.config.mpc.participants.threshold as usize,
-                    )
-                    .await?
-                } else {
-                    tracking::set_progress("Waiting for key generation");
-                    let mut generated_key_receiver = generated_key_receiver;
-                    generated_key_receiver
-                        .recv()
-                        .await
-                        .ok_or_else(|| anyhow::anyhow!("Key not generated"))?
-                },
-            )
-            .unwrap();
+        // If we're the first participant, initiate key generation if there is no key.
+        if self.client.my_participant_id() == self.client.all_participant_ids()[0] {
+            let keygen_needed = keygen_needed.lock().unwrap().take();
+            if let Some(keygen_needed) = keygen_needed {
+                let generated_key = run_key_generation(
+                    self.client.new_channel_for_task(
+                        MpcTaskId::KeyGeneration,
+                        self.client.all_participant_ids(),
+                    )?,
+                    self.client.my_participant_id(),
+                    self.config.mpc.participants.threshold as usize,
+                )
+                .await?;
+                keygen_needed.commit(generated_key);
+            }
+        }
         tracking::set_progress("Bootstrap complete");
 
-        run_background_triple_generation(
-            self.client.clone(),
-            self.config.mpc.participants.threshold as usize,
-            self.config.triple.clone().into(),
-            self.triple_store.clone(),
-        )
-        .await?;
+        let background_triple_generation = tracking::spawn(
+            "generate triples",
+            run_background_triple_generation(
+                self.client.clone(),
+                self.config.mpc.participants.threshold as usize,
+                self.config.triple.clone().into(),
+                self.triple_store.clone(),
+            ),
+        );
+
+        let background_presignature_generation = tracking::spawn(
+            "generate presignatures",
+            run_background_presignature_generation(
+                self.client.clone(),
+                self.config.mpc.participants.threshold as usize,
+                self.config.presignature.clone().into(),
+                self.triple_store.clone(),
+                self.presignature_store.clone(),
+                self.keygen_store.get_generated_key().await,
+            ),
+        );
+
+        background_triple_generation.await??;
+        background_presignature_generation.await??;
 
         Ok(())
     }
@@ -215,38 +233,20 @@ impl MpcClient {
         self,
         msg_hash: Scalar,
     ) -> anyhow::Result<FullSignature<Secp256k1>> {
-        let paired_triple= self.triple_store.take_owned().await;
-        let paired_triple_id = paired_triple.0;
-        let (triple0, triple1) = paired_triple.1;
-        let participants = participants_from_triples(&triple0, &triple1);
-        let presignature_id = generate_presignature_id(self.client.my_participant_id());
-        let key = self
-            .keygen_out
-            .get()
-            .ok_or_else(|| anyhow::anyhow!("Key not generated"))?
-            .clone();
-
-        let presignature = pre_sign(
-            self.client.new_channel_for_task(MpcTaskId::Presignature {
-                id: presignature_id,
-                paired_triple_id
-            }, participants.clone())?,
-            self.client.my_participant_id(),
-            self.config.mpc.participants.threshold as usize,
-            triple0,
-            triple1,
-            key.clone(),
-        )
-        .await?;
+        let keygen_out = self.keygen_store.get_generated_key().await;
+        let (presignature_id, presignature) = self.presignature_store.take_owned().await;
         let signature = sign(
-            self.client.new_channel_for_task(MpcTaskId::Signature {
-                id: generate_signature_id(self.client.my_participant_id()),
-                presignature_id,
-                msg_hash: msg_hash.to_repr().into(),
-            }, participants)?,
+            self.client.new_channel_for_task(
+                MpcTaskId::Signature {
+                    id: self.signature_id_generator.generate_signature_id(),
+                    presignature_id,
+                    msg_hash: msg_hash.to_repr().into(),
+                },
+                presignature.participants,
+            )?,
             self.client.my_participant_id(),
-            key,
-            presignature,
+            keygen_out,
+            presignature.presignature,
             msg_hash,
         )
         .await?;

--- a/node/src/primitives.rs
+++ b/node/src/primitives.rs
@@ -63,12 +63,12 @@ pub enum MpcTaskId {
         count: u32,
     },
     Presignature {
-        id: u64,
+        id: UniqueId,
         paired_triple_id: UniqueId,
     },
     Signature {
-        id: u64,
-        presignature_id: u64,
+        id: UniqueId,
+        presignature_id: UniqueId,
         // TODO(#9): We need a proof for any signature requests
         msg_hash: [u8; 32],
     },

--- a/node/src/sign.rs
+++ b/node/src/sign.rs
@@ -1,17 +1,20 @@
-use crate::assets::UniqueId;
-use crate::metrics;
-use crate::network::NetworkTaskChannel;
-use crate::primitives::ParticipantId;
+use crate::assets::{DistributedAssetStorage, UniqueId};
+use crate::background::InFlightGenerationTracker;
+use crate::config::PresignatureConfig;
+use crate::network::{MeshNetworkClient, NetworkTaskChannel};
+use crate::primitives::{participants_from_triples, ParticipantId};
 use crate::protocol::run_protocol;
 use crate::triple::TripleStorage;
+use crate::{metrics, tracking};
 use cait_sith::protocol::Participant;
 use cait_sith::triples::TripleGenerationOutput;
 use cait_sith::{FullSignature, KeygenOutput, PresignArguments, PresignOutput};
 use k256::{Scalar, Secp256k1};
-use std::collections::HashMap;
+use serde::{Deserialize, Serialize};
+use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::{Arc, Mutex};
-use tokio::sync::oneshot;
-
+use std::time::Duration;
+use tokio::time::timeout;
 
 /// Performs an MPC presignature operation. This is shared for the initiator
 /// and for passive participants.
@@ -58,15 +61,7 @@ pub async fn pre_sign_unowned(
     paired_triple_id: UniqueId,
 ) -> anyhow::Result<PresignOutput<Secp256k1>> {
     let (triple0, triple1) = triple_store.take_unowned(paired_triple_id).await?;
-    pre_sign(
-        channel,
-        me,
-        threshold,
-        triple0,
-        triple1,
-        keygen_out,
-    )
-    .await
+    pre_sign(channel, me, threshold, triple0, triple1, keygen_out).await
 }
 
 /// Performs an MPC signature operation. This is the same for the initiator
@@ -96,54 +91,149 @@ pub async fn sign(
     Ok(signature)
 }
 
-/// TODO(#10): is this a good way to generate IDs?
-pub fn generate_presignature_id(me: ParticipantId) -> u64 {
-    (rand::random::<u64>() >> 12) | ((me.0 as u64) << 52)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PresignOutputWithParticipants {
+    pub presignature: PresignOutput<Secp256k1>,
+    pub participants: Vec<ParticipantId>,
 }
 
-/// TODO(#10): is this a good way to generate IDs?
-pub fn generate_signature_id(me: ParticipantId) -> u64 {
-    (rand::random::<u64>() >> 12) | ((me.0 as u64) << 52)
+pub type PresignatureStorage = DistributedAssetStorage<PresignOutputWithParticipants>;
+
+/// Continuously generates presignatures, trying to maintain the desired number of
+/// presignatures available, using the desired number of concurrent computations as
+/// specified in the config. Most of the time, this process would be waiting for
+/// more triples to be generated, as presignature generation is significantly faster
+/// than triple generation.
+///
+/// Generated triples will be written to `presignature_store` as owned triples. Note
+/// that this function does not take care of the passive side of presignature
+/// generation (i.e. other participants of the computations this function initiates),
+/// so that needs to be separately handled.
+pub async fn run_background_presignature_generation(
+    client: Arc<MeshNetworkClient>,
+    threshold: usize,
+    config: Arc<PresignatureConfig>,
+    triple_store: Arc<TripleStorage>,
+    presignature_store: Arc<PresignatureStorage>,
+    keygen_out: KeygenOutput<Secp256k1>,
+) -> anyhow::Result<()> {
+    let in_flight_generations = InFlightGenerationTracker::new();
+    let progress_tracker = Arc::new(PresignatureGenerationProgressTracker {
+        desired_presignatures_to_buffer: config.desired_presignatures_to_buffer,
+        presignature_store: presignature_store.clone(),
+        in_flight_generations: in_flight_generations.num_in_flight_atomic(),
+        waiting_for_triples: AtomicBool::new(false),
+    });
+    let parallelism_limiter = Arc::new(tokio::sync::Semaphore::new(config.concurrency));
+    loop {
+        progress_tracker.update_progress();
+        let my_presignatures_count: usize = presignature_store.num_owned();
+        metrics::MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE.set(my_presignatures_count as i64);
+        if my_presignatures_count + in_flight_generations.num_in_flight()
+            < config.desired_presignatures_to_buffer
+            // There's no point to issue way too many in-flight computations, as they
+            // will just be limited by the concurrency anyway.
+            && in_flight_generations.num_in_flight()
+                < config.concurrency * 2
+        {
+            let id = presignature_store.generate_and_reserve_id();
+            progress_tracker.set_waiting_for_triples(true);
+            let (paired_triple_id, (triple0, triple1)) = triple_store.take_owned().await;
+            progress_tracker.set_waiting_for_triples(false);
+            let participants = participants_from_triples(&triple0, &triple1);
+            let task_id = crate::primitives::MpcTaskId::Presignature {
+                id,
+                paired_triple_id,
+            };
+            let channel = client.new_channel_for_task(task_id, participants.clone())?;
+            let in_flight = in_flight_generations.in_flight(1);
+            let client = client.clone();
+            let parallelism_limiter = parallelism_limiter.clone();
+            let presignature_store = presignature_store.clone();
+            let config_clone = config.clone();
+            let keygen_out = keygen_out.clone();
+            tracking::spawn_checked(&format!("{:?}", task_id), async move {
+                let _in_flight = in_flight;
+                let _semaphore_guard = parallelism_limiter.acquire().await?;
+                let presignature = timeout(
+                    Duration::from_secs(config_clone.timeout_sec),
+                    pre_sign(
+                        channel,
+                        client.my_participant_id(),
+                        threshold,
+                        triple0,
+                        triple1,
+                        keygen_out,
+                    ),
+                )
+                .await??;
+                presignature_store.add_owned(
+                    id,
+                    PresignOutputWithParticipants {
+                        presignature,
+                        participants,
+                    },
+                );
+
+                anyhow::Ok(())
+            });
+        } else {
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
 }
 
-/// Keeps track of presignatures that have been generated.
-/// TODO(#12): Probably need to make this like the triple store.
-pub struct SimplePresignatureStore {
-    others_presignatures: Mutex<HashMap<u64, oneshot::Receiver<PresignOutput<Secp256k1>>>>,
+struct PresignatureGenerationProgressTracker {
+    desired_presignatures_to_buffer: usize,
+    presignature_store: Arc<PresignatureStorage>,
+    in_flight_generations: Arc<AtomicUsize>,
+    waiting_for_triples: AtomicBool,
 }
 
-impl SimplePresignatureStore {
-    pub fn new() -> Self {
+impl PresignatureGenerationProgressTracker {
+    pub fn set_waiting_for_triples(&self, waiting: bool) {
+        self.waiting_for_triples
+            .store(waiting, std::sync::atomic::Ordering::Relaxed);
+        self.update_progress();
+    }
+
+    pub fn update_progress(&self) {
+        tracking::set_progress(&format!(
+            "Presignatures: available: {}/{}; generating: {}{}",
+            self.presignature_store.num_owned(),
+            self.desired_presignatures_to_buffer,
+            self.in_flight_generations
+                .load(std::sync::atomic::Ordering::Relaxed),
+            if self
+                .waiting_for_triples
+                .load(std::sync::atomic::Ordering::Relaxed)
+            {
+                " (waiting for triples)"
+            } else {
+                ""
+            }
+        ))
+    }
+}
+
+/// Simple ID generator for signatures. Generates monotonically increasing IDs.
+/// Does not persist state across restarts, so if the clock rewinds then the
+/// generated IDs can conflict with previously generated IDs.
+pub struct SignatureIdGenerator {
+    last_id: Mutex<UniqueId>,
+}
+
+impl SignatureIdGenerator {
+    pub fn new(my_participant_id: ParticipantId) -> Self {
         Self {
-            others_presignatures: Mutex::new(HashMap::new()),
+            last_id: Mutex::new(UniqueId::generate(my_participant_id)),
         }
     }
 
-    /// Removes a presignature we have helped someone else generate. This will asynchronously
-    /// block if we know the result will be available but it is not yet. It will return error
-    /// if we know we won't have the result.
-    pub async fn take_their_presignature(
-        &self,
-        id: u64,
-    ) -> anyhow::Result<PresignOutput<Secp256k1>> {
-        let receiver = self
-            .others_presignatures
-            .lock()
-            .unwrap()
-            .remove(&id)
-            .ok_or_else(|| anyhow::anyhow!("Presignature not found"))?;
-        Ok(receiver.await?)
-    }
-
-    /// This is not a one-shot operation. It declares the ID as "will be available", and the
-    /// caller should send the output when it's available using the returned sender.
-    /// See #8 for details.
-    pub fn add_their_presignature(&self, id: u64) -> oneshot::Sender<PresignOutput<Secp256k1>> {
-        let (sender, receiver) = oneshot::channel();
-        self.others_presignatures
-            .lock()
-            .unwrap()
-            .insert(id, receiver);
-        sender
+    pub fn generate_signature_id(&self) -> UniqueId {
+        let mut last_id = self.last_id.lock().unwrap();
+        let new_id = last_id.pick_new_after();
+        *last_id = new_id;
+        new_id
     }
 }

--- a/node/src/tests/benchmark.rs
+++ b/node/src/tests/benchmark.rs
@@ -1,0 +1,47 @@
+use super::TestGenerators;
+use cait_sith::protocol::Participant;
+use k256::elliptic_curve::Field;
+use k256::Scalar;
+
+#[test]
+fn benchmark_single_threaded_presignature_generation() {
+    let generator = TestGenerators::new(10, 7);
+    let keygens = generator.make_keygens();
+    let triple0s = generator.make_triples();
+    let triple1s = generator.make_triples();
+
+    let start_time = std::time::Instant::now();
+    const COUNT: usize = 1000;
+    for _ in 0..COUNT {
+        let _ = generator.make_presignatures(&triple0s, &triple1s, &keygens);
+    }
+    let end_time = std::time::Instant::now();
+    println!(
+        "Time taken per presignature: {:?}",
+        (end_time - start_time) / COUNT as u32
+    );
+}
+
+#[test]
+fn benchmark_single_threaded_signature_generation() {
+    let generator = TestGenerators::new(10, 7);
+    let keygens = generator.make_keygens();
+    let triple0s = generator.make_triples();
+    let triple1s = generator.make_triples();
+    let presignatures = generator.make_presignatures(&triple0s, &triple1s, &keygens);
+
+    let start_time = std::time::Instant::now();
+    const COUNT: usize = 1000;
+    for _ in 0..COUNT {
+        let _ = generator.make_signature(
+            &presignatures,
+            keygens[&Participant::from(0)].public_key,
+            Scalar::random(&mut rand::thread_rng()),
+        );
+    }
+    let end_time = std::time::Instant::now();
+    println!(
+        "Time taken per signature: {:?}",
+        (end_time - start_time) / COUNT as u32
+    );
+}

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -1,0 +1,130 @@
+use cait_sith::protocol::{run_protocol, Participant, Protocol};
+use cait_sith::triples::TripleGenerationOutput;
+use cait_sith::{FullSignature, KeygenOutput, PresignArguments, PresignOutput};
+use k256::{AffinePoint, Scalar, Secp256k1};
+use std::collections::HashMap;
+
+mod benchmark;
+mod research;
+
+/// Convenient test utilities to generate keys, triples, presignatures, and signatures.
+pub struct TestGenerators {
+    num_participants: usize,
+    threshold: usize,
+}
+
+type ParticipantAndProtocol<T> = (Participant, Box<dyn Protocol<Output = T>>);
+
+impl TestGenerators {
+    pub fn new(num_participants: usize, threshold: usize) -> Self {
+        Self {
+            num_participants,
+            threshold,
+        }
+    }
+
+    pub fn make_keygens(&self) -> HashMap<Participant, KeygenOutput<Secp256k1>> {
+        let mut protocols: Vec<ParticipantAndProtocol<KeygenOutput<Secp256k1>>> = Vec::new();
+        let participants = (0..self.num_participants)
+            .map(|i| Participant::from(i as u32))
+            .collect::<Vec<_>>();
+        for i in 0..self.num_participants {
+            protocols.push((
+                participants[i],
+                Box::new(
+                    cait_sith::keygen::<Secp256k1>(&participants, participants[i], self.threshold)
+                        .unwrap(),
+                ),
+            ));
+        }
+        run_protocol(protocols).unwrap().into_iter().collect()
+    }
+
+    pub fn make_triples(&self) -> HashMap<Participant, TripleGenerationOutput<Secp256k1>> {
+        let mut protocols: Vec<ParticipantAndProtocol<TripleGenerationOutput<Secp256k1>>> =
+            Vec::new();
+        let participants = (0..self.num_participants)
+            .map(|i| Participant::from(i as u32))
+            .collect::<Vec<_>>();
+        for i in 0..self.num_participants {
+            protocols.push((
+                participants[i],
+                Box::new(
+                    cait_sith::triples::generate_triple::<Secp256k1>(
+                        &participants,
+                        participants[i],
+                        self.threshold,
+                    )
+                    .unwrap(),
+                ),
+            ));
+        }
+        run_protocol(protocols).unwrap().into_iter().collect()
+    }
+
+    pub fn make_presignatures(
+        &self,
+        triple0s: &HashMap<Participant, TripleGenerationOutput<Secp256k1>>,
+        triple1s: &HashMap<Participant, TripleGenerationOutput<Secp256k1>>,
+        keygens: &HashMap<Participant, KeygenOutput<Secp256k1>>,
+    ) -> HashMap<Participant, PresignOutput<Secp256k1>> {
+        let mut protocols: Vec<ParticipantAndProtocol<PresignOutput<Secp256k1>>> = Vec::new();
+        let participants = (0..self.num_participants)
+            .map(|i| Participant::from(i as u32))
+            .collect::<Vec<_>>();
+        for i in 0..self.num_participants {
+            protocols.push((
+                participants[i],
+                Box::new(
+                    cait_sith::presign::<Secp256k1>(
+                        &participants,
+                        participants[i],
+                        &participants,
+                        participants[i],
+                        PresignArguments {
+                            triple0: triple0s[&participants[i]].clone(),
+                            triple1: triple1s[&participants[i]].clone(),
+                            keygen_out: keygens[&participants[i]].clone(),
+                            threshold: self.threshold,
+                        },
+                    )
+                    .unwrap(),
+                ),
+            ));
+        }
+        run_protocol(protocols).unwrap().into_iter().collect()
+    }
+
+    pub fn make_signature(
+        &self,
+        presignatures: &HashMap<Participant, PresignOutput<Secp256k1>>,
+        public_key: AffinePoint,
+        msg_hash: Scalar,
+    ) -> FullSignature<Secp256k1> {
+        let mut protocols: Vec<ParticipantAndProtocol<FullSignature<Secp256k1>>> = Vec::new();
+        let participants = (0..self.num_participants)
+            .map(|i| Participant::from(i as u32))
+            .collect::<Vec<_>>();
+        for i in 0..self.num_participants {
+            protocols.push((
+                participants[i],
+                Box::new(
+                    cait_sith::sign::<Secp256k1>(
+                        &participants,
+                        participants[i],
+                        public_key,
+                        presignatures[&participants[i]].clone(),
+                        msg_hash,
+                    )
+                    .unwrap(),
+                ),
+            ));
+        }
+        run_protocol(protocols)
+            .unwrap()
+            .into_iter()
+            .next()
+            .unwrap()
+            .1
+    }
+}

--- a/node/src/tests/research.rs
+++ b/node/src/tests/research.rs
@@ -1,0 +1,322 @@
+use crate::tests::TestGenerators;
+use cait_sith::{
+    protocol::{Participant, Protocol},
+    PresignArguments,
+};
+use k256::elliptic_curve::PrimeField;
+use k256::{Scalar, Secp256k1};
+use serde::Serialize;
+use std::collections::VecDeque;
+
+#[derive(Debug, Serialize)]
+pub struct NetworkResearchReport {
+    pub num_participants: usize,
+    pub steps: Vec<NetworkStep>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct NetworkStep {
+    pub peer_to_peer: Vec<Vec<PeerToPeerMessageStats>>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct PeerToPeerMessageStats {
+    pub num_messages: usize,
+    pub total_bytes: usize,
+}
+
+/// Simulates a network of participants doing a cait-sith MPC computation,
+/// and writes out a file for the network communication statistics for each
+/// round of communication, which can be visualized in a tool.
+///
+/// The difference between the best case and worst case is:
+/// - In the best case, in each round we have each participant receive as
+///   many messages as possible before proceeding. This gives the minimum
+///   possible number of rounds of communication that is absolutely
+///   necessary.
+/// - In the worst case, in each round we have each participant receive only
+///   as many messages as needed to make any progress. This gives some kind
+///   of worst-case estimate, even though it's not the absolute worst (which
+///   is kind of hard to define). It can result in many more rounds of
+///   communication.
+fn run_protocol_and_generate_network_report_for_best_case<P>(
+    mut protocols: Vec<P>,
+) -> NetworkResearchReport
+where
+    P: Protocol,
+{
+    let mut steps = Vec::<NetworkStep>::new();
+    let mut completed = vec![false; protocols.len()];
+    loop {
+        if completed.iter().all(|&b| b) {
+            break;
+        }
+        let mut p2p_messages_to_send =
+            vec![vec![Vec::<Vec<u8>>::new(); protocols.len()]; protocols.len()];
+        for i in 0..protocols.len() {
+            if completed[i] {
+                continue;
+            }
+            loop {
+                match protocols[i].poke().unwrap() {
+                    cait_sith::protocol::Action::Wait => break,
+                    cait_sith::protocol::Action::SendMany(vec) => {
+                        for j in 0..protocols.len() {
+                            if i == j {
+                                continue;
+                            }
+                            p2p_messages_to_send[i][j].push(vec.clone());
+                        }
+                    }
+                    cait_sith::protocol::Action::SendPrivate(participant, vec) => {
+                        p2p_messages_to_send[i][u32::from(participant) as usize].push(vec);
+                    }
+                    cait_sith::protocol::Action::Return(_) => {
+                        completed[i] = true;
+                        break;
+                    }
+                }
+            }
+        }
+
+        let mut step = NetworkStep {
+            peer_to_peer: Vec::new(),
+        };
+        for (i, messages) in p2p_messages_to_send.into_iter().enumerate() {
+            let mut peer_messages = Vec::new();
+            for (j, messages) in messages.into_iter().enumerate() {
+                for message in &messages {
+                    protocols[j].message(Participant::from(i as u32), message.clone());
+                }
+                let num_messages = messages.len();
+                let total_bytes = messages.iter().map(|v| v.len()).sum();
+                peer_messages.push(PeerToPeerMessageStats {
+                    num_messages,
+                    total_bytes,
+                });
+            }
+            step.peer_to_peer.push(peer_messages);
+        }
+        steps.push(step);
+    }
+    NetworkResearchReport {
+        num_participants: protocols.len(),
+        steps,
+    }
+}
+
+fn run_protocol_and_generate_network_report_for_worst_case(
+    mut protocols: Vec<impl Protocol>,
+) -> NetworkResearchReport {
+    let mut steps = Vec::<NetworkStep>::new();
+    let mut completed = vec![false; protocols.len()];
+    let mut p2p_messages_to_receive = vec![VecDeque::<(usize, Vec<u8>)>::new(); protocols.len()];
+    loop {
+        if completed.iter().all(|&b| b) {
+            break;
+        }
+        let mut p2p_messages_to_send =
+            vec![vec![Vec::<Vec<u8>>::new(); protocols.len()]; protocols.len()];
+        for i in 0..protocols.len() {
+            if completed[i] {
+                continue;
+            }
+            loop {
+                let mut made_progress = false;
+                loop {
+                    match protocols[i].poke().unwrap() {
+                        cait_sith::protocol::Action::Wait => break,
+                        cait_sith::protocol::Action::SendMany(vec) => {
+                            for j in 0..protocols.len() {
+                                if i == j {
+                                    continue;
+                                }
+                                p2p_messages_to_send[i][j].push(vec.clone());
+                                made_progress = true;
+                            }
+                        }
+                        cait_sith::protocol::Action::SendPrivate(participant, vec) => {
+                            p2p_messages_to_send[i][u32::from(participant) as usize].push(vec);
+                            made_progress = true;
+                        }
+                        cait_sith::protocol::Action::Return(_) => {
+                            completed[i] = true;
+                            made_progress = true;
+                            break;
+                        }
+                    }
+                }
+                if made_progress {
+                    break;
+                }
+                if let Some((from, message)) = p2p_messages_to_receive[i].pop_front() {
+                    protocols[i].message(Participant::from(from as u32), message);
+                } else {
+                    break;
+                }
+            }
+        }
+
+        let mut step = NetworkStep {
+            peer_to_peer: Vec::new(),
+        };
+        for (i, messages) in p2p_messages_to_send.into_iter().enumerate() {
+            let mut peer_messages = Vec::new();
+            for (j, messages) in messages.into_iter().enumerate() {
+                for message in &messages {
+                    p2p_messages_to_receive[j].push_back((i, message.clone()));
+                }
+                let num_messages = messages.len();
+                let total_bytes = messages.iter().map(|v| v.len()).sum();
+                peer_messages.push(PeerToPeerMessageStats {
+                    num_messages,
+                    total_bytes,
+                });
+            }
+            step.peer_to_peer.push(peer_messages);
+        }
+        steps.push(step);
+    }
+    NetworkResearchReport {
+        num_participants: protocols.len(),
+        steps,
+    }
+}
+
+const NUM_PARTICIPANTS: usize = 10;
+const THRESHOLD: usize = 7;
+
+#[test]
+fn triple_network_research_best_case() {
+    let mut protocols = Vec::new();
+    let participants = (0..NUM_PARTICIPANTS)
+        .map(|i| Participant::from(i as u32))
+        .collect::<Vec<_>>();
+    for i in 0..NUM_PARTICIPANTS {
+        protocols.push(
+            cait_sith::triples::generate_triple_many::<Secp256k1, 4>(
+                &participants,
+                participants[i],
+                THRESHOLD,
+            )
+            .unwrap(),
+        );
+    }
+
+    let report = run_protocol_and_generate_network_report_for_best_case(protocols);
+    std::fs::write(
+        "triple_network_report_best_case.json",
+        serde_json::to_string_pretty(&report).unwrap(),
+    )
+    .unwrap();
+    eprintln!(
+        "Report written to {}/triple_network_report_best_case.json",
+        std::env::current_dir().unwrap().to_string_lossy()
+    );
+}
+
+#[test]
+fn triple_network_research_worst_case() {
+    let mut protocols = Vec::new();
+    let participants = (0..NUM_PARTICIPANTS)
+        .map(|i| Participant::from(i as u32))
+        .collect::<Vec<_>>();
+    for i in 0..NUM_PARTICIPANTS {
+        protocols.push(
+            cait_sith::triples::generate_triple_many::<Secp256k1, 4>(
+                &participants,
+                participants[i],
+                THRESHOLD,
+            )
+            .unwrap(),
+        );
+    }
+
+    let report = run_protocol_and_generate_network_report_for_worst_case(protocols);
+    std::fs::write(
+        "triple_network_report_worst_case.json",
+        serde_json::to_string_pretty(&report).unwrap(),
+    )
+    .unwrap();
+    eprintln!(
+        "Report written to {}/triple_network_report_worst_case.json",
+        std::env::current_dir().unwrap().to_string_lossy()
+    );
+}
+
+#[test]
+fn presignature_network_research_best_case() {
+    let generator = TestGenerators::new(NUM_PARTICIPANTS, THRESHOLD);
+    let keygens = generator.make_keygens();
+    let triple0s = generator.make_triples();
+    let triple1s = generator.make_triples();
+
+    let mut protocols = Vec::new();
+    let participants = (0..NUM_PARTICIPANTS)
+        .map(|i| Participant::from(i as u32))
+        .collect::<Vec<_>>();
+
+    for i in 0..NUM_PARTICIPANTS {
+        protocols.push(
+            cait_sith::presign::<Secp256k1>(
+                &participants,
+                participants[i],
+                &participants,
+                participants[i],
+                PresignArguments {
+                    triple0: triple0s[&participants[i]].clone(),
+                    triple1: triple1s[&participants[i]].clone(),
+                    keygen_out: keygens[&participants[i]].clone(),
+                    threshold: THRESHOLD,
+                },
+            )
+            .unwrap(),
+        );
+    }
+    let report = run_protocol_and_generate_network_report_for_best_case(protocols);
+    std::fs::write(
+        "presignature_network_report_best_case.json",
+        serde_json::to_string_pretty(&report).unwrap(),
+    )
+    .unwrap();
+    eprintln!(
+        "Report written to {}/presignature_network_report_best_case.json",
+        std::env::current_dir().unwrap().to_string_lossy()
+    );
+}
+
+#[test]
+fn signature_network_research_best_case() {
+    let generator = TestGenerators::new(NUM_PARTICIPANTS, THRESHOLD);
+    let keygens = generator.make_keygens();
+    let triple0s = generator.make_triples();
+    let triple1s = generator.make_triples();
+    let presignatures = generator.make_presignatures(&triple0s, &triple1s, &keygens);
+
+    let mut protocols = Vec::new();
+    let participants = (0..NUM_PARTICIPANTS)
+        .map(|i| Participant::from(i as u32))
+        .collect::<Vec<_>>();
+    for i in 0..NUM_PARTICIPANTS {
+        protocols.push(
+            cait_sith::sign::<Secp256k1>(
+                &participants,
+                participants[i],
+                keygens[&participants[i]].public_key,
+                presignatures[&participants[i]].clone(),
+                Scalar::from_u128(100000),
+            )
+            .unwrap(),
+        );
+    }
+    let report = run_protocol_and_generate_network_report_for_best_case(protocols);
+    std::fs::write(
+        "signature_network_report_best_case.json",
+        serde_json::to_string_pretty(&report).unwrap(),
+    )
+    .unwrap();
+    eprintln!(
+        "Report written to {}/signature_network_report_best_case.json",
+        std::env::current_dir().unwrap().to_string_lossy()
+    );
+}

--- a/node/src/web.rs
+++ b/node/src/web.rs
@@ -3,13 +3,14 @@ use crate::mpc_client::MpcClient;
 use crate::tracking::{self, TaskHandle};
 use actix_web::error::ErrorInternalServerError;
 use actix_web::{get, web};
-use futures::{stream, StreamExt, TryStreamExt};
+use futures::{stream, FutureExt, StreamExt, TryStreamExt};
 use k256::elliptic_curve::scalar::FromUintUnchecked;
 use k256::sha2::{Digest, Sha256};
 use k256::{Scalar, U256};
 use prometheus::{default_registry, Encoder};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
+use std::time::Duration;
 
 #[get("/metrics")]
 async fn metrics() -> String {
@@ -35,18 +36,21 @@ async fn debug_sign(
         .scope("debug_sign", async move {
             let msg_hash = sha256hash(query.msg.as_bytes());
             let repeat = query.repeat.unwrap_or(1);
-            let signatures = stream::iter(0..repeat)
-                .map(|_| async {
-                    let signature = tracking::spawn(
-                        "debug sign repeat",
-                        (**mpc_client).clone().make_signature(msg_hash),
-                    )
-                    .await??;
-                    anyhow::Ok(signature)
-                })
-                .buffered(query.parallelism.unwrap_or(repeat))
-                .try_collect::<Vec<_>>()
-                .await?;
+            let timeout = Duration::from_secs(query.timeout.unwrap_or(60));
+            let signatures = tokio::time::timeout(
+                timeout,
+                stream::iter(0..repeat)
+                    .map(|i| {
+                        tracking::spawn(
+                            &format!("debug sign #{}", i),
+                            (**mpc_client).clone().make_signature(msg_hash),
+                        )
+                        .map(|result| anyhow::Ok(result??))
+                    })
+                    .buffered(query.parallelism.unwrap_or(repeat))
+                    .try_collect::<Vec<_>>(),
+            )
+            .await??;
             anyhow::Ok(web::Json(
                 signatures
                     .into_iter()
@@ -77,6 +81,8 @@ struct DebugSignatureRequest {
     repeat: Option<usize>,
     #[serde(default)]
     parallelism: Option<usize>,
+    #[serde(default)]
+    timeout: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/test-configs/0/config.yaml
+++ b/test-configs/0/config.yaml
@@ -36,6 +36,8 @@ triple:
   timeout_sec: 60
   parallel_triple_generation_stagger_time_sec: 1
 presignature:
+  concurrency: 16
+  desired_presignatures_to_buffer: 8192
   timeout_sec: 60
 signature:
   timeout_sec: 60

--- a/test-configs/1/config.yaml
+++ b/test-configs/1/config.yaml
@@ -36,6 +36,8 @@ triple:
   timeout_sec: 60
   parallel_triple_generation_stagger_time_sec: 1
 presignature:
+  concurrency: 16
+  desired_presignatures_to_buffer: 8192
   timeout_sec: 60
 signature:
   timeout_sec: 60

--- a/test-configs/2/config.yaml
+++ b/test-configs/2/config.yaml
@@ -36,6 +36,8 @@ triple:
   timeout_sec: 60
   parallel_triple_generation_stagger_time_sec: 1
 presignature:
+  concurrency: 16
+  desired_presignatures_to_buffer: 8192
   timeout_sec: 60
 signature:
   timeout_sec: 60

--- a/test-configs/3/config.yaml
+++ b/test-configs/3/config.yaml
@@ -36,6 +36,8 @@ triple:
   timeout_sec: 60
   parallel_triple_generation_stagger_time_sec: 1
 presignature:
+  concurrency: 16
+  desired_presignatures_to_buffer: 8192
   timeout_sec: 60
 signature:
   timeout_sec: 60


### PR DESCRIPTION
* Persist keygen into KeygenStorage. Removed the previous awkward/non-robust handling of generated keys.
* Persist presignatures into PresignatureStorage. This is very similar to the persistence of triples.
* Background presignature generation thread; pretty much copied from background triple generation thread.
* Simple signature ID generator.
* Add network research tests for presignature and signature as well as single-threaded benchmarks.