### PR TITLE
Make participant IDs no longer need to be indexes.

### DIFF
--- a/node/src/assets.rs
+++ b/node/src/assets.rs
@@ -29,7 +29,8 @@ pub struct UniqueId(u128);
 impl UniqueId {
     /// Only for testing. Use `generate` or `pick_new_after` instead.
     pub fn new(participant_id: ParticipantId, timestamp: u64, counter: u32) -> Self {
-        let id = ((participant_id.0 as u128) << 96) | ((timestamp as u128) << 32) | counter as u128;
+        let id =
+            ((participant_id.raw() as u128) << 96) | ((timestamp as u128) << 32) | counter as u128;
         Self(id)
     }
 
@@ -43,7 +44,7 @@ impl UniqueId {
     }
 
     pub fn participant_id(&self) -> ParticipantId {
-        ParticipantId((self.0 >> 96) as u32)
+        ParticipantId::from_raw((self.0 >> 96) as u32)
     }
 
     pub fn timestamp(&self) -> u64 {
@@ -57,7 +58,7 @@ impl UniqueId {
     /// Returns the key prefix for the given participant ID. It can be used to
     /// perform a range query in the database for all keys for this participant.
     pub fn prefix_for_participant_id(participant_id: ParticipantId) -> Vec<u8> {
-        participant_id.0.to_be_bytes().to_vec()
+        participant_id.raw().to_be_bytes().to_vec()
     }
 
     /// Pick a new unique ID based on the current time, but ensuring that it is
@@ -158,7 +159,9 @@ where
         for item in db.iter_range(
             col,
             &UniqueId::prefix_for_participant_id(my_participant_id),
-            &UniqueId::prefix_for_participant_id(ParticipantId(my_participant_id.0 + 1)),
+            &UniqueId::prefix_for_participant_id(ParticipantId::from_raw(
+                my_participant_id.raw().checked_add(1).unwrap(),
+            )),
         ) {
             let (key, value) = item?;
             let id = UniqueId::try_from_slice(&key)?;
@@ -333,8 +336,9 @@ mod tests {
 
     #[test]
     fn test_unique_id() {
-        let id = UniqueId::new(ParticipantId(42), 123, 456);
-        assert_eq!(id.participant_id(), ParticipantId(42));
+        let participant_id = ParticipantId::from_raw(42);
+        let id = UniqueId::new(participant_id, 123, 456);
+        assert_eq!(id.participant_id(), participant_id);
         assert_eq!(id.timestamp(), 123);
         assert_eq!(id.counter(), 456);
         assert_eq!(id.add_to_counter(2).unwrap().counter(), 458);
@@ -348,10 +352,10 @@ mod tests {
             id
         );
         assert_eq!(
-            UniqueId::prefix_for_participant_id(ParticipantId(42)),
+            UniqueId::prefix_for_participant_id(participant_id),
             [0, 0, 0, 42]
         );
-        let time_based_1 = UniqueId::generate(ParticipantId(42));
+        let time_based_1 = UniqueId::generate(participant_id);
         let time_based_2 = time_based_1.pick_new_after();
         assert!(time_based_2 > time_based_1);
         std::thread::sleep(std::time::Duration::from_secs(1));
@@ -366,7 +370,7 @@ mod tests {
         let store = super::DistributedAssetStorage::<u32>::new(
             db,
             crate::db::DBCol::Triple,
-            ParticipantId(42),
+            ParticipantId::from_raw(42),
         )
         .unwrap();
         assert_eq!(store.num_owned(), 0);
@@ -409,7 +413,7 @@ mod tests {
         let store = super::DistributedAssetStorage::<u32>::new(
             db.clone(),
             crate::db::DBCol::Triple,
-            ParticipantId(42),
+            ParticipantId::from_raw(42),
         )
         .unwrap();
 
@@ -455,7 +459,7 @@ mod tests {
         let store = super::DistributedAssetStorage::<u32>::new(
             db,
             crate::db::DBCol::Triple,
-            ParticipantId(42),
+            ParticipantId::from_raw(42),
         )
         .unwrap();
         assert_eq!(store.take_owned().now_or_never().unwrap(), (id5, 5));
@@ -469,11 +473,11 @@ mod tests {
         let store = super::DistributedAssetStorage::<u32>::new(
             db,
             crate::db::DBCol::Triple,
-            ParticipantId(42),
+            ParticipantId::from_raw(42),
         )
         .unwrap();
 
-        let other = ParticipantId(43);
+        let other = ParticipantId::from_raw(43);
         let id1 = UniqueId::new(other, 1, 0);
 
         // Put an unowned asset in, take it right after.
@@ -514,10 +518,11 @@ mod tests {
     fn test_distributed_store_persistence() {
         let dir = tempfile::tempdir().unwrap();
         let db = crate::db::SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let myself = ParticipantId::from_raw(42);
         let store = super::DistributedAssetStorage::<u32>::new(
             db.clone(),
             crate::db::DBCol::Triple,
-            ParticipantId(42),
+            myself,
         )
         .unwrap();
 
@@ -527,19 +532,16 @@ mod tests {
         store.add_owned(id1.add_to_counter(2).unwrap(), 3);
         store.add_owned(id1.add_to_counter(3).unwrap(), 4);
 
-        let other = ParticipantId(43);
+        let other = ParticipantId::from_raw(43);
         store.prepare_unowned(UniqueId::new(other, 1, 0)).commit(5);
         store.prepare_unowned(UniqueId::new(other, 2, 0)).commit(6);
         store.prepare_unowned(UniqueId::new(other, 3, 0)).commit(7);
         store.prepare_unowned(UniqueId::new(other, 4, 0)).commit(8);
 
         drop(store);
-        let store = super::DistributedAssetStorage::<u32>::new(
-            db,
-            crate::db::DBCol::Triple,
-            ParticipantId(42),
-        )
-        .unwrap();
+        let store =
+            super::DistributedAssetStorage::<u32>::new(db, crate::db::DBCol::Triple, myself)
+                .unwrap();
         assert_eq!(store.num_owned(), 4);
         assert_eq!(store.take_owned().now_or_never().unwrap(), (id1, 1));
         assert_eq!(

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -401,7 +401,7 @@ pub mod testing {
         FR: std::future::Future<Output = anyhow::Result<T>> + Send + 'static,
     {
         let participants = (0..num_participants)
-            .map(|id| ParticipantId(id as u32))
+            .map(|_| ParticipantId::from_raw(rand::random::<u32>()))
             .collect::<Vec<_>>();
         let transports = new_test_transports(participants.clone());
         let join_handles = transports
@@ -485,7 +485,7 @@ mod tests {
             let expected_total: u64 = other_participant_ids
                 .iter()
                 .map(|id| {
-                    let input = id.0 as u64 + seed;
+                    let input = id.raw() as u64 + seed;
                     input * input
                 })
                 .sum();
@@ -510,7 +510,7 @@ mod tests {
             channel.sender()(
                 *other_participant_id,
                 vec![borsh::to_vec(&TestTripleMessage {
-                    data: other_participant_id.0 as u64 + seed,
+                    data: other_participant_id.raw() as u64 + seed,
                 })
                 .unwrap()],
                 channel.participants.clone(),

--- a/node/src/primitives.rs
+++ b/node/src/primitives.rs
@@ -21,7 +21,7 @@ use std::fmt::Display;
     Serialize,
     Deserialize,
 )]
-pub struct ParticipantId(pub u32);
+pub struct ParticipantId(u32);
 
 impl From<Participant> for ParticipantId {
     fn from(participant: Participant) -> Self {
@@ -32,6 +32,16 @@ impl From<Participant> for ParticipantId {
 impl From<ParticipantId> for Participant {
     fn from(participant_id: ParticipantId) -> Self {
         Participant::from(participant_id.0)
+    }
+}
+
+impl ParticipantId {
+    pub fn raw(self) -> u32 {
+        self.0
+    }
+
+    pub fn from_raw(raw: u32) -> Self {
+        ParticipantId(raw)
     }
 }
 

--- a/test-configs/0/config.yaml
+++ b/test-configs/0/config.yaml
@@ -1,4 +1,4 @@
-my_participant_id: 0
+my_participant_id: 2455124061
 participants:
   threshold: 3
   dummy_issuer_private_key: |
@@ -8,19 +8,19 @@ participants:
     Olwk91pXchOVPAiVd7uqOjxaAl8k5yIyT7Bn5Ye+hWT88kdWUIkDCLEn
     -----END PRIVATE KEY-----
   participants:
-  - id: 0
+  - id: 2455124061
     address: 127.0.0.1
     port: 10000
     p2p_public_key: 04750cd78cf89ef8769f7d006a4272ecaf09047575a6d0732a104d5f1dcbe3d1445f3b54cad5798eb7fa70a8f679fdbe7f6f540192a4c132eefe52b30e9fabb422
-  - id: 1
+  - id: 874570413
     address: 127.0.0.1
     port: 10001
     p2p_public_key: 046ca2b7db8e64af82ba8724eb6cf670732948a4751be343930dfb0ce6010b1f5ba6c61c2ca2326fcb9c7a0ed78763bad6b1aca3bde69968aeafcbd84531fcddcd
-  - id: 2
+  - id: 323023767
     address: 127.0.0.1
     port: 10002
     p2p_public_key: 0481db60f21e6f6be03a202b322ea047c3c20c7406cdfd465c09dc647b68581c1d7541d5156dbd8afe65ac0351117604e3ad1e9d7f2c05f38a892987a4b74b0b14
-  - id: 3
+  - id: 484079850
     address: 127.0.0.1
     port: 10003
     p2p_public_key: 04a2b2694a3ce08bb9a3a3525ac75eecf4b117b49b6e5778e8fdd804ce9473e322c95a09ee10b805ae0f1534b4c9a31ed956ef4cea84e21827c9ccb336fd9c8bd4
@@ -28,6 +28,11 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20000
+indexer:
+  stream_while_syncing: false
+  validate_genesis: true
+  sync_mode: SyncFromInterruption
+  concurrency: 1
 key_generation:
   timeout_sec: 60
 triple:

--- a/test-configs/1/config.yaml
+++ b/test-configs/1/config.yaml
@@ -1,4 +1,4 @@
-my_participant_id: 1
+my_participant_id: 874570413
 participants:
   threshold: 3
   dummy_issuer_private_key: |
@@ -8,19 +8,19 @@ participants:
     Olwk91pXchOVPAiVd7uqOjxaAl8k5yIyT7Bn5Ye+hWT88kdWUIkDCLEn
     -----END PRIVATE KEY-----
   participants:
-  - id: 0
+  - id: 2455124061
     address: 127.0.0.1
     port: 10000
     p2p_public_key: 04750cd78cf89ef8769f7d006a4272ecaf09047575a6d0732a104d5f1dcbe3d1445f3b54cad5798eb7fa70a8f679fdbe7f6f540192a4c132eefe52b30e9fabb422
-  - id: 1
+  - id: 874570413
     address: 127.0.0.1
     port: 10001
     p2p_public_key: 046ca2b7db8e64af82ba8724eb6cf670732948a4751be343930dfb0ce6010b1f5ba6c61c2ca2326fcb9c7a0ed78763bad6b1aca3bde69968aeafcbd84531fcddcd
-  - id: 2
+  - id: 323023767
     address: 127.0.0.1
     port: 10002
     p2p_public_key: 0481db60f21e6f6be03a202b322ea047c3c20c7406cdfd465c09dc647b68581c1d7541d5156dbd8afe65ac0351117604e3ad1e9d7f2c05f38a892987a4b74b0b14
-  - id: 3
+  - id: 484079850
     address: 127.0.0.1
     port: 10003
     p2p_public_key: 04a2b2694a3ce08bb9a3a3525ac75eecf4b117b49b6e5778e8fdd804ce9473e322c95a09ee10b805ae0f1534b4c9a31ed956ef4cea84e21827c9ccb336fd9c8bd4
@@ -28,6 +28,11 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20001
+indexer:
+  stream_while_syncing: false
+  validate_genesis: true
+  sync_mode: SyncFromInterruption
+  concurrency: 1
 key_generation:
   timeout_sec: 60
 triple:

--- a/test-configs/2/config.yaml
+++ b/test-configs/2/config.yaml
@@ -1,4 +1,4 @@
-my_participant_id: 2
+my_participant_id: 323023767
 participants:
   threshold: 3
   dummy_issuer_private_key: |
@@ -8,19 +8,19 @@ participants:
     Olwk91pXchOVPAiVd7uqOjxaAl8k5yIyT7Bn5Ye+hWT88kdWUIkDCLEn
     -----END PRIVATE KEY-----
   participants:
-  - id: 0
+  - id: 2455124061
     address: 127.0.0.1
     port: 10000
     p2p_public_key: 04750cd78cf89ef8769f7d006a4272ecaf09047575a6d0732a104d5f1dcbe3d1445f3b54cad5798eb7fa70a8f679fdbe7f6f540192a4c132eefe52b30e9fabb422
-  - id: 1
+  - id: 874570413
     address: 127.0.0.1
     port: 10001
     p2p_public_key: 046ca2b7db8e64af82ba8724eb6cf670732948a4751be343930dfb0ce6010b1f5ba6c61c2ca2326fcb9c7a0ed78763bad6b1aca3bde69968aeafcbd84531fcddcd
-  - id: 2
+  - id: 323023767
     address: 127.0.0.1
     port: 10002
     p2p_public_key: 0481db60f21e6f6be03a202b322ea047c3c20c7406cdfd465c09dc647b68581c1d7541d5156dbd8afe65ac0351117604e3ad1e9d7f2c05f38a892987a4b74b0b14
-  - id: 3
+  - id: 484079850
     address: 127.0.0.1
     port: 10003
     p2p_public_key: 04a2b2694a3ce08bb9a3a3525ac75eecf4b117b49b6e5778e8fdd804ce9473e322c95a09ee10b805ae0f1534b4c9a31ed956ef4cea84e21827c9ccb336fd9c8bd4
@@ -28,6 +28,11 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20002
+indexer:
+  stream_while_syncing: false
+  validate_genesis: true
+  sync_mode: SyncFromInterruption
+  concurrency: 1
 key_generation:
   timeout_sec: 60
 triple:

--- a/test-configs/3/config.yaml
+++ b/test-configs/3/config.yaml
@@ -1,4 +1,4 @@
-my_participant_id: 3
+my_participant_id: 484079850
 participants:
   threshold: 3
   dummy_issuer_private_key: |
@@ -8,19 +8,19 @@ participants:
     Olwk91pXchOVPAiVd7uqOjxaAl8k5yIyT7Bn5Ye+hWT88kdWUIkDCLEn
     -----END PRIVATE KEY-----
   participants:
-  - id: 0
+  - id: 2455124061
     address: 127.0.0.1
     port: 10000
     p2p_public_key: 04750cd78cf89ef8769f7d006a4272ecaf09047575a6d0732a104d5f1dcbe3d1445f3b54cad5798eb7fa70a8f679fdbe7f6f540192a4c132eefe52b30e9fabb422
-  - id: 1
+  - id: 874570413
     address: 127.0.0.1
     port: 10001
     p2p_public_key: 046ca2b7db8e64af82ba8724eb6cf670732948a4751be343930dfb0ce6010b1f5ba6c61c2ca2326fcb9c7a0ed78763bad6b1aca3bde69968aeafcbd84531fcddcd
-  - id: 2
+  - id: 323023767
     address: 127.0.0.1
     port: 10002
     p2p_public_key: 0481db60f21e6f6be03a202b322ea047c3c20c7406cdfd465c09dc647b68581c1d7541d5156dbd8afe65ac0351117604e3ad1e9d7f2c05f38a892987a4b74b0b14
-  - id: 3
+  - id: 484079850
     address: 127.0.0.1
     port: 10003
     p2p_public_key: 04a2b2694a3ce08bb9a3a3525ac75eecf4b117b49b6e5778e8fdd804ce9473e322c95a09ee10b805ae0f1534b4c9a31ed956ef4cea84e21827c9ccb336fd9c8bd4
@@ -28,6 +28,11 @@ p2p_private_key_file: p2p.pem
 web_ui:
   host: 127.0.0.1
   port: 20003
+indexer:
+  stream_while_syncing: false
+  validate_genesis: true
+  sync_mode: SyncFromInterruption
+  concurrency: 1
 key_generation:
   timeout_sec: 60
 triple:


### PR DESCRIPTION
See #31 for context. We do not have choice over participant IDs. So this PR gets rid of any remaining assumption in the codebase that the participant ID correspond to indexes. Also make ParticipantId have raw() and from_raw(u32) functions to make it very clear when code uses the underlying u32.

Regenerate the test configs to also have non-index participant IDs.

Closes #26 