### PR TITLE
CI: replace cache with rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
+      - name: Check Docker image can be built
         uses: docker/build-push-action@v6
         with:
           context: .


### PR DESCRIPTION
Run results are pretty much same with rust-cache but it can update cache after each run while with actions/cache manually removal or key changes are required.
First run - without cache and second run with cache
<img width="1149" alt="Screenshot 2024-11-28 at 10 59 43" src="https://github.com/user-attachments/assets/4f5f3d5a-c777-4aaf-b43a-b18031c84d76">

Added back docker build with gha cache enabled: docker build time reduced from 15 minutes to 2 minutes with cache:
<img width="1156" alt="Screenshot 2024-11-28 at 12 07 23" src="https://github.com/user-attachments/assets/f805244a-a225-43f0-9db1-8e2730249def">
