### PR TITLE
limit number of cores in main function (#60) - simple way

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -368,6 +368,7 @@ impl Cli {
                             timeout_sec: 60,
                         },
                         signature: SignatureConfig { timeout_sec: 60 },
+                        cores: Some(24),
                     };
                     std::fs::write(
                         format!("{}/p2p_key", subdir),

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -123,6 +123,10 @@ pub struct ConfigFile {
     /// If specified, this is the static configuration for the MPC protocol,
     /// replacing what would be read from the contract.
     pub participants: Option<ParticipantsConfig>,
+
+    /// This value is only considered when the node is run in normal node. It defines the number of
+    /// working threads for the runtime and defaults to 24
+    pub cores: Option<usize>,
 }
 
 impl ConfigFile {


### PR DESCRIPTION
resolves (#60):
- when run in normal mode, the number of worker threads can be limited by populating the optional field "cores" in the config file;
- if no value is given, it defaults to 24. The value is ignored for all other modes (GenerateKey, GenerateTestConfig and GenerateIndexConfigs);
- main function is now synchronous.

This should work, because the indexer is spawned in a separate thread and not controlled by the tokio runtime.

Note:
Tried to make cli::run() synchronous, but with little success and probably at the detriment of the test suite performance (c.f. #104).


 
