### PR TITLE
fetch neard binary in ci as a function of platform, branch and commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,11 @@ jobs:
           arch=$(uname -m)
           os_and_arch=${os}-${arch}
           cd libs/nearcore
+
+          branch_name=$(git branch -r --contains HEAD | grep -o 'origin/.*' | sed 's|origin/||' | head -n 1 || echo "no-branch")
           commit_hash=$(git rev-parse HEAD)
           mkdir -p target/debug
-          curl -o target/debug/neard https://s3.us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${os_and_arch}/master/${commit_hash}/neard
+          curl -o target/debug/neard https://s3.us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${os_and_arch}/${branch_name}/${commit_hash}/neard
           chmod +x target/debug/neard
 
       - name: Build near core as fallback


### PR DESCRIPTION
This ensures that we test with the correct version of neard.