### PR TITLE
Sign and DKG protocol wrappers for Frost via `Protocol` trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/Near-One/cait-sith.git?rev=1bb67e2a04f01cc7835ce4d8a611064229acc10c#1bb67e2a04f01cc7835ce4d8a611064229acc10c"
+source = "git+https://github.com/kuksag/cait-sith?rev=59d032582196f3bf7aee402b924b36094bdc4c51#59d032582196f3bf7aee402b924b36094bdc4c51"
 dependencies = [
  "auto_ops",
  "ck-meow",
@@ -1446,6 +1455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1772,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "rand_core",
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
@@ -1809,6 +1831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "debugless-unwrap"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1868,17 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1960,6 +1999,15 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "document-features"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb6969eaabd2421f8a2775cfd2471a2b634372b4a25d41e3bd647b79912850a0"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dotenv"
@@ -2359,6 +2407,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "frost-core"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1858230cabb6792a5020daf4b0074f57b7d1e2a520ac544c77f102babee62ff4"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "debugless-unwrap",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core",
+ "serde",
+ "serdect",
+ "thiserror 2.0.4",
+ "thiserror-nostd-notrait",
+ "visibility",
+ "zeroize",
+]
+
+[[package]]
+name = "frost-ed25519"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350ac3d0463a009a061aba12b67920acee94338951c849bb4c492d55223dece"
+dependencies = [
+ "curve25519-dalek",
+ "document-features",
+ "frost-core",
+ "frost-rerandomized",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2753,20 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3214,6 +3335,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,6 +3531,12 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "local-channel"
@@ -3689,6 +3825,7 @@ dependencies = [
  "cait-sith",
  "clap",
  "flume",
+ "frost-ed25519",
  "futures",
  "futures-util",
  "gcloud-sdk",
@@ -5753,6 +5890,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "serde",
 ]
 
@@ -7660,6 +7798,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-nostd-notrait"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
+dependencies = [
+ "thiserror-nostd-notrait-impl",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8207,6 +8365,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "void"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/Near-One/cait-sith.git", features = ["k256"], rev = "1bb67e2a04f01cc7835ce4d8a611064229acc10c" }
+cait-sith = { git = "https://github.com/kuksag/cait-sith", rev = "59d032582196f3bf7aee402b924b36094bdc4c51", features = ["k256", "internals"] }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"
@@ -55,6 +55,8 @@ near-o11y = { git = "https://github.com/near/nearcore", rev = "88ec6c83b10e68747
 near-time = { git = "https://github.com/near/nearcore", rev = "88ec6c83b10e687474316517279f5bab76698db5", features = ["clock"] }
 
 mpc-contract = { git = "https://github.com/near/mpc/", tag = "1.0.0-rc.5" }
+
+frost-ed25519 = "2.1.0"
 
 [dev-dependencies]
 serial_test = "3.2.0"

--- a/node/src/frost/dkg.rs
+++ b/node/src/frost/dkg.rs
@@ -1,0 +1,170 @@
+use crate::frost::{to_frost_identifier, KeygenOutput};
+use cait_sith::participants::{ParticipantCounter, ParticipantList};
+use cait_sith::protocol::{
+    make_protocol, Context, Participant, Protocol, ProtocolError, SharedChannel,
+};
+use frost_ed25519::keys::dkg::{round1, round2};
+use frost_ed25519::Identifier;
+use rand::{CryptoRng, RngCore, SeedableRng};
+use std::collections::BTreeMap;
+
+pub(crate) fn dkg_internal<RNG: CryptoRng + RngCore + 'static + Send>(
+    rng: RNG,
+    participants: Vec<Participant>,
+    me: Participant,
+    threshold: u16,
+) -> anyhow::Result<impl Protocol<Output = KeygenOutput>> {
+    let ctx = Context::new();
+    let fut = dkg(ctx.shared_channel(), rng, participants, me, threshold);
+    Ok(make_protocol(ctx, fut))
+}
+
+async fn dkg<RNG: CryptoRng + RngCore + 'static + Send>(
+    mut chan: SharedChannel,
+    rng: RNG,
+    participants: Vec<Participant>,
+    me: Participant,
+    threshold: u16,
+) -> Result<KeygenOutput, ProtocolError> {
+    let from_frost_identifiers = participants
+        .iter()
+        .map(|&p| (to_frost_identifier(p), p))
+        .collect::<BTreeMap<_, _>>();
+    let participants = ParticipantList::new(participants.as_slice())
+        .ok_or_else(|| ProtocolError::Other("Participants contain duplicates".into()))?;
+    let max_signers = participants.len() as u16;
+
+    let mut seen = ParticipantCounter::new(&participants);
+
+    // --- Round 1.
+    // * Generate round1 package pair, and distribute the same public part to all participants.
+    // * Wait all parts from the others.
+
+    // We don't add our public package into the map by design.
+    let mut round1_packages: BTreeMap<Identifier, round1::Package> = BTreeMap::new();
+    let (round1_secret, my_round1_package) =
+        frost_ed25519::keys::dkg::part1(to_frost_identifier(me), max_signers, threshold, rng)
+            .map_err(|e| ProtocolError::AssertionFailed(format!("dkg::part1: {:?}", e)))?;
+
+    let r1_wait_point = chan.next_waitpoint();
+    {
+        chan.send_many(r1_wait_point, &my_round1_package).await;
+    }
+
+    seen.put(me);
+    while !seen.full() {
+        let (from, round1_package): (_, round1::Package) = chan.recv(r1_wait_point).await?;
+        if !seen.put(from) {
+            continue;
+        }
+        round1_packages.insert(to_frost_identifier(from), round1_package);
+    }
+
+    // --- Round 2.
+    // * Generate round2 package pair, and distribute to each participant dedicated public part.
+    // * Wait all parts from the others.
+
+    // We don't add our public package into the map by design.
+    let mut round2_packages: BTreeMap<Identifier, round2::Package> = BTreeMap::new();
+    let (round2_secret, my_round2_packages) =
+        frost_ed25519::keys::dkg::part2(round1_secret, &round1_packages)
+            .map_err(|e| ProtocolError::AssertionFailed(format!("dkg::part2: {:?}", e)))?;
+
+    let r2_wait_point = chan.next_waitpoint();
+    {
+        for (identifier, round2_package) in my_round2_packages {
+            chan.send_private(
+                r2_wait_point,
+                from_frost_identifiers[&identifier],
+                &round2_package,
+            )
+            .await;
+        }
+    }
+
+    seen.clear();
+    seen.put(me);
+    while !seen.full() {
+        let (from, round2_package): (_, round2::Package) = chan.recv(r2_wait_point).await?;
+        if !seen.put(from) {
+            continue;
+        }
+        round2_packages.insert(to_frost_identifier(from), round2_package);
+    }
+
+    // --- Round 3.
+    // * Aggregate packages and build the key pair.
+
+    let (key_package, public_key_package) =
+        frost_ed25519::keys::dkg::part3(&round2_secret, &round1_packages, &round2_packages)
+            .map_err(|e| ProtocolError::AssertionFailed(format!("dkg::part3: {:?}", e)))?;
+
+    Ok(KeygenOutput {
+        key_package,
+        public_key_package,
+    })
+}
+
+#[cfg(test)]
+pub(crate) fn build_dkg_protocols(
+    max_signers: usize,
+    threshold: usize,
+) -> Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> {
+    use rand::prelude::StdRng;
+
+    let mut participants = Vec::with_capacity(max_signers);
+    for i in 0..max_signers {
+        participants.push(Participant::from((10 * i + 123) as u32))
+    }
+
+    let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> =
+        Vec::with_capacity(max_signers);
+    for participant in &participants {
+        let rng: StdRng = StdRng::seed_from_u64(protocols.len() as u64);
+        let protocol = dkg_internal(
+            rng,
+            participants.clone(),
+            participant.clone(),
+            threshold as u16,
+        )
+        .unwrap();
+        protocols.push((participant.clone(), Box::new(protocol)));
+    }
+
+    protocols
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::KeygenOutput;
+    use cait_sith::protocol::run_protocol;
+
+    fn assert_public_packages(data: Vec<(Participant, KeygenOutput)>) {
+        let expected = &data.first().unwrap().1.public_key_package;
+        for item in &data {
+            assert_eq!(expected, &item.1.public_key_package);
+        }
+    }
+
+    #[test]
+    fn simple_dkg_3_2() {
+        let max_signers = 3;
+        let threshold = 2;
+
+        let protocols = build_dkg_protocols(max_signers, threshold);
+        let data = run_protocol(protocols).unwrap();
+        assert_public_packages(data);
+    }
+
+    #[test]
+    fn stress() {
+        for max_signers in 2..7 {
+            for threshold in 2..max_signers {
+                let protocols = build_dkg_protocols(max_signers, threshold);
+                let data = run_protocol(protocols).unwrap();
+                assert_public_packages(data);
+            }
+        }
+    }
+}

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -1,0 +1,35 @@
+mod sign;
+
+use aes_gcm::aead::rand_core::{CryptoRng, RngCore};
+use cait_sith::protocol::{Participant, Protocol};
+
+#[derive(Debug)]
+pub enum SignatureOutput {
+    Coordinator(frost_ed25519::Signature),
+    Participant,
+}
+
+pub fn sign<RNG: CryptoRng + RngCore + 'static + Send>(
+    rng: RNG,
+    is_coordinator: bool,
+    participants: Vec<Participant>,
+    me: Participant,
+    key_package: frost_ed25519::keys::KeyPackage,
+    pubkeys: frost_ed25519::keys::PublicKeyPackage,
+    msg_hash: Vec<u8>,
+) -> anyhow::Result<Box<dyn Protocol<Output = SignatureOutput>>> {
+    sign::sign_internal(
+        rng,
+        is_coordinator,
+        participants,
+        me,
+        key_package,
+        pubkeys,
+        msg_hash,
+    )
+}
+
+fn to_frost_identifier(participant: Participant) -> frost_ed25519::Identifier {
+    frost_ed25519::Identifier::derive(participant.bytes().as_slice())
+        .expect("Identifier derivation must succeed: cipher suite is guaranteed to be implemented")
+}

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -1,16 +1,25 @@
-/// This module serves as a wrapper for Frost protocol.
-///
-/// Frost library exposes methods like `sign::round1()`, `sign::round2()`, `sign::aggregate()`, etc.
-/// The output of those functions needs to be communicated to other participants in a specific order.
-/// Such a process can be described as a state machine and its state transitions.  
-///
-/// To construct it, an `impl Protocol` from `cait_sith` library was used, together with related "plumbing"
-/// code, that allows us to implement a protocol as an async function with yield points,
-/// which simplifies code maintenance.
-///
-/// There's no identifiable aborts, i.e. you might see an Err(_) with e.g. "incorrect number of shares supplied",
-/// or "Participant X supplied malicious data", but pragmatically you will not be able to do anything with this info.
+//! This module serves as a wrapper for Frost protocol.
+//!
+//! Frost library exposes methods like `sign::round1()`, `sign::round2()`, `sign::aggregate()`, etc.
+//! The output of those functions needs to be communicated to other participants in a specific order.
+//! Such a process can be described as a state machine and its state transitions.
+//!
+//! To construct it, an `impl Protocol` from `cait_sith` library was used, together with related "plumbing"
+//! code, that allows us to implement a protocol as an async function with yield points,
+//! which simplifies code maintenance.
+//!
+//! To run Frost protocol, we have to assign each participant its identifier.
+//! We do so by converting existing `ParticipantId` via `to_frost_identifier()`.
+//! This is a one way process, since the conversion requires hashing/modulo reduce.
+//! In order to do the inverse cast (frost, EdDSA identifier) -> (cait-sith, Participant),
+//! one should have all (historical) `Participants`.
+//!
+//! There's no identifiable aborts, i.e. you might see an Err(_) with e.g. "incorrect number of shares supplied",
+//! or "Participant X supplied incorrect data", but pragmatically you will not be able to do anything with this info.
+
+mod dkg;
 mod sign;
+mod tests;
 
 use cait_sith::protocol::{Participant, Protocol};
 use rand::{CryptoRng, RngCore};
@@ -56,7 +65,23 @@ pub enum SignatureOutput {
     Participant,
 }
 
-fn to_frost_identifier(participant: Participant) -> frost_ed25519::Identifier {
+pub struct KeygenOutput {
+    key_package: frost_ed25519::keys::KeyPackage,
+    public_key_package: frost_ed25519::keys::PublicKeyPackage,
+}
+
+/// Distributed Key Generation protocol.
+pub fn dkg<RNG: CryptoRng + RngCore + 'static + Send>(
+    rng: RNG,
+    participants: Vec<Participant>,
+    me: Participant,
+    threshold: u16,
+) -> anyhow::Result<impl Protocol<Output = KeygenOutput>> {
+    dkg::dkg_internal(rng, participants, me, threshold)
+}
+
+/// Derive Frost identifier (ed25519 scalar) from u32
+pub fn to_frost_identifier(participant: Participant) -> frost_ed25519::Identifier {
     frost_ed25519::Identifier::derive(participant.bytes().as_slice())
         .expect("Identifier derivation must succeed: cipher suite is guaranteed to be implemented")
 }

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -1,14 +1,34 @@
+/// This module serves as a wrapper for Frost protocol.
+///
+/// Frost library exposes methods like `sign::round1()`, `sign::round2()`, `sign::aggregate()`, etc.
+/// The output of those functions needs to be communicated to other participants in a specific order.
+/// Such a process can be described as a state machine and its state transitions.  
+///
+/// To construct it, an `impl Protocol` from `cait_sith` library was used, together with related "plumbing"
+/// code, that allows us to implement a protocol as an async function with yield points,
+/// which simplifies code maintenance.
+///
+/// There's no identifiable aborts, i.e. you might see an Err(_) with e.g. "incorrect number of shares supplied",
+/// or "Participant X supplied malicious data", but pragmatically you will not be able to do anything with this info.
 mod sign;
 
-use aes_gcm::aead::rand_core::{CryptoRng, RngCore};
 use cait_sith::protocol::{Participant, Protocol};
+use rand::{CryptoRng, RngCore};
 
-#[derive(Debug)]
-pub enum SignatureOutput {
-    Coordinator(frost_ed25519::Signature),
-    Participant,
-}
-
+/// Build a signature protocol.
+///
+/// Amongst protocol `participants` has to be exactly one Coordinator.
+/// It's the only party, who eventually constructs a full signature.
+/// This party calls the function with `is_coordinator=true`, while everyone else supplies `false`.
+/// It's up to the application to decide who needs to be the coordinator.
+///
+/// If a party is included in `participants` set, then it has to supply their share to the coordinator
+/// in order for a protocol to succeed. Even if the set size is greater than the required `threshold`.
+/// It is up to the application to construct such a set.
+///
+/// Return type is a boxed protocol, because we can have:
+///     (a) single entry point for a coordinator/participant protocol creation
+///     (b) test executor for such protocols
 pub fn sign<RNG: CryptoRng + RngCore + 'static + Send>(
     rng: RNG,
     is_coordinator: bool,
@@ -27,6 +47,13 @@ pub fn sign<RNG: CryptoRng + RngCore + 'static + Send>(
         pubkeys,
         msg_hash,
     )
+}
+
+/// Mentioned Coordinator/Participant separation in sign protocol results in different return types.
+#[derive(Debug)]
+pub enum SignatureOutput {
+    Coordinator(frost_ed25519::Signature),
+    Participant,
 }
 
 fn to_frost_identifier(participant: Participant) -> frost_ed25519::Identifier {

--- a/node/src/frost/sign.rs
+++ b/node/src/frost/sign.rs
@@ -1,0 +1,293 @@
+use crate::frost::{to_frost_identifier, SignatureOutput};
+use cait_sith::participants::{ParticipantCounter, ParticipantList};
+use cait_sith::protocol::{
+    make_protocol, Context, Participant, Protocol, ProtocolError, SharedChannel,
+};
+use frost_ed25519::{round1, round2};
+use rand::{CryptoRng, RngCore};
+use std::collections::BTreeMap;
+
+
+pub(crate) fn sign_internal<RNG: CryptoRng + RngCore + 'static + Send>(
+    rng: RNG,
+    is_coordinator: bool,
+    participants: Vec<Participant>,
+    me: Participant,
+    key_package: frost_ed25519::keys::KeyPackage,
+    pubkeys: frost_ed25519::keys::PublicKeyPackage,
+    msg_hash: Vec<u8>,
+) -> anyhow::Result<Box<dyn Protocol<Output =SignatureOutput>>> {
+    let Some(participants) = ParticipantList::new(&participants) else {
+        anyhow::bail!("Participants list contains duplicates")
+    };
+    let ctx = Context::new();
+    let protocol: Box<dyn Protocol<Output =SignatureOutput>> = if is_coordinator {
+        let fut = do_sign_coordinator(
+            ctx.shared_channel(),
+            rng,
+            participants,
+            me,
+            key_package,
+            pubkeys,
+            msg_hash,
+        );
+        Box::new(make_protocol(ctx, fut))
+    } else {
+        let fut = do_sign_participant(ctx.shared_channel(), rng, key_package, msg_hash);
+
+        Box::new(make_protocol(ctx, fut))
+    };
+
+    Ok(protocol)
+}
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct InitMessage();
+
+async fn do_sign_coordinator<RNG: CryptoRng + RngCore + 'static + Send>(
+    mut chan: SharedChannel,
+    mut rng: RNG,
+    participants: ParticipantList,
+    me: Participant,
+    key_package: frost_ed25519::keys::KeyPackage,
+    pubkeys: frost_ed25519::keys::PublicKeyPackage,
+    message: Vec<u8>,
+) -> Result<SignatureOutput, ProtocolError> {
+    let mut seen = ParticipantCounter::new(&participants);
+    let mut commitments_map: BTreeMap<frost_ed25519::Identifier, round1::SigningCommitments> =
+        BTreeMap::new();
+    let mut signature_shares: BTreeMap<frost_ed25519::Identifier, round2::SignatureShare> =
+        BTreeMap::new();
+
+    // ---
+
+    let r1_wait_point = chan.next_waitpoint();
+    {
+        chan.send_many(r1_wait_point, &InitMessage()).await;
+    }
+
+    let (nonces, commitments) = round1::commit(key_package.signing_share(), &mut rng);
+    commitments_map.insert(to_frost_identifier(me), commitments);
+    seen.put(me);
+
+    while !seen.full() {
+        let (from, commitment): (_, round1::SigningCommitments) = chan.recv(r1_wait_point).await?;
+        if !seen.put(from) {
+            continue;
+        }
+        commitments_map.insert(to_frost_identifier(from), commitment);
+    }
+
+    let signing_package = frost_ed25519::SigningPackage::new(commitments_map, message.as_slice());
+
+    // ---
+
+    let r2_wait_point = chan.next_waitpoint();
+    {
+        chan.send_many(r2_wait_point, &signing_package).await;
+    }
+
+    let signature_share = round2::sign(&signing_package, &nonces, &key_package)
+        .map_err(|e| ProtocolError::AssertionFailed(e.to_string()))?;
+    signature_shares.insert(to_frost_identifier(me), signature_share);
+    seen.clear();
+    seen.put(me);
+
+    while !seen.full() {
+        let (from, signature_share): (_, round2::SignatureShare) = chan.recv(r2_wait_point).await?;
+        if !seen.put(from) {
+            continue;
+        }
+        signature_shares.insert(to_frost_identifier(from), signature_share);
+    }
+
+    // ---
+
+    let signature = frost_ed25519::aggregate(&signing_package, &signature_shares, &pubkeys)
+        .map_err(|e| ProtocolError::AssertionFailed(e.to_string()))?;
+
+    // Signature has been verified during the aggregation
+    Ok(SignatureOutput::Coordinator(signature))
+}
+
+async fn do_sign_participant<RNG: CryptoRng + RngCore + 'static>(
+    mut chan: SharedChannel,
+    mut rng: RNG,
+    key_package: frost_ed25519::keys::KeyPackage,
+    message: Vec<u8>,
+) -> Result<SignatureOutput, ProtocolError> {
+    let (nonces, commitments) = round1::commit(key_package.signing_share(), &mut rng);
+
+    // ---
+
+    let r1_wait_point = chan.next_waitpoint();
+    let (coordinator, _): (_, InitMessage) = chan.recv(r1_wait_point).await?;
+    chan.send_private(r1_wait_point, coordinator, &commitments)
+        .await;
+
+    // ---
+
+    let r2_wait_point = chan.next_waitpoint();
+    let signing_package = loop {
+        let (from, signing_package): (_, frost_ed25519::SigningPackage) =
+            chan.recv(r2_wait_point).await?;
+        if from != coordinator {
+            continue;
+        }
+        break signing_package;
+    };
+
+    if signing_package.message() != message.as_slice() {
+        return Err(ProtocolError::AssertionFailed(
+            "Expected message doesn't match with the actual message received in a signing package"
+                .to_string(),
+        ));
+    }
+
+    let signature_share = round2::sign(&signing_package, &nonces, &key_package)
+        .map_err(|e| ProtocolError::AssertionFailed(e.to_string()))?;
+
+    {
+        chan.send_private(r2_wait_point, coordinator, &signature_share)
+            .await;
+    }
+
+    Ok(SignatureOutput::Participant {})
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::frost::{to_frost_identifier, SignatureOutput};
+    use cait_sith::protocol::{
+        run_protocol, Participant, Protocol,
+    };
+    use frost_ed25519::rand_core::SeedableRng;
+    use frost_ed25519::Identifier;
+    use near_indexer::near_primitives::hash::hash;
+    use rand::prelude::{SliceRandom, StdRng};
+    use rand::thread_rng;
+    use std::collections::BTreeMap;
+    use crate::frost::sign::sign_internal;
+
+    fn build_protocols(
+        max_signers: usize,
+        min_signers: usize,
+        coordinators: usize,
+    ) -> Vec<(Participant, Box<dyn Protocol<Output =SignatureOutput>>)> {
+        assert!(max_signers >= min_signers);
+
+        let mut identifiers = Vec::with_capacity(max_signers);
+        for i in 0..max_signers {
+            // from 1 to avoid assigning 0 to a ParticipantId
+            identifiers.push(Participant::from((10 * i + 123) as u32))
+        }
+
+        let frost_identifiers = identifiers
+            .iter()
+            .map(|&x| to_frost_identifier(x.into()))
+            .collect::<Vec<_>>();
+
+        let mut rng: StdRng = StdRng::seed_from_u64(42u64);
+        let (shares, pubkey_package) = frost_ed25519::keys::generate_with_dealer(
+            max_signers as u16,
+            min_signers as u16,
+            frost_ed25519::keys::IdentifierList::Custom(&frost_identifiers),
+            &mut rng,
+        )
+        .unwrap();
+
+        let key_packages = shares
+            .iter()
+            .map(|(id, share)| {
+                (
+                    id,
+                    frost_ed25519::keys::KeyPackage::try_from(share.clone()).unwrap(),
+                )
+            })
+            .collect::<BTreeMap<_, _>>();
+
+        let msg = "hello_near";
+        let msg_hash = hash(msg.as_bytes());
+
+        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output =SignatureOutput>>)> =
+            Vec::with_capacity(max_signers);
+
+        for i in 0..min_signers {
+            protocols.push((
+                identifiers[i].into(),
+                sign_internal(
+                    rng.clone(),
+                    i >= min_signers - coordinators,
+                    identifiers.iter().take(min_signers).cloned().collect(),
+                    identifiers[i],
+                    key_packages[&frost_identifiers[i]].clone(),
+                    pubkey_package.clone(),
+                    msg_hash.as_bytes().to_vec(),
+                )
+                .unwrap(),
+            ))
+        }
+
+        protocols
+    }
+
+    fn assert_single_coordinator_result(data: Vec<(Participant, SignatureOutput)>) {
+        let count = data.iter().filter(|(_, output)| {
+            if let SignatureOutput::Coordinator(_) = output {
+                true
+            } else { false }
+        }).count();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn basic_two_participants() {
+        let max_signers = 2;
+        let min_signers = 2;
+        let coordinators = 1;
+
+        let protocols = build_protocols(max_signers, min_signers, coordinators);
+        let data = run_protocol(protocols).unwrap();
+        assert_single_coordinator_result(data);
+    }
+
+    #[test]
+    #[should_panic]
+    fn multiple_coordinators() {
+        let max_signers = 3;
+        let min_signers = 2;
+        let coordinators = 2;
+
+        let protocols = build_protocols(max_signers, min_signers, coordinators);
+        let data = run_protocol(protocols).unwrap();
+        assert_single_coordinator_result(data);
+    }
+
+    #[test]
+    fn stress() {
+        let max_signers = 7;
+        let coordinators = 1;
+        for min_signers in 2..max_signers {
+            let mut protocols = build_protocols(max_signers, min_signers, coordinators);
+
+            let mut rng = thread_rng();
+            protocols.shuffle(&mut rng);
+
+            let data = run_protocol(protocols).unwrap();
+            assert_single_coordinator_result(data);
+        }
+    }
+
+    #[test]
+    fn verify_stability_of_identifier_derivation() {
+        let participant = Participant::from(1e9 as u32);
+        let identifier = Identifier::derive(participant.bytes().as_slice()).unwrap();
+        assert_eq!(
+            identifier.serialize(),
+            vec![
+                96, 203, 29, 92, 230, 35, 120, 169, 19, 185, 45, 28, 48, 68, 84, 190, 12, 186, 169,
+                192, 196, 21, 238, 181, 134, 181, 203, 236, 162, 68, 212, 4
+            ]
+        );
+    }
+}

--- a/node/src/frost/tests.rs
+++ b/node/src/frost/tests.rs
@@ -1,0 +1,51 @@
+#[cfg(test)]
+mod tests {
+    use crate::frost::dkg::build_dkg_protocols;
+    use crate::frost::sign::build_sign_protocols;
+    use crate::frost::SignatureOutput;
+    use cait_sith::protocol::{run_protocol, Participant};
+    use frost_ed25519::Identifier;
+    use near_indexer::near_primitives::hash::hash;
+
+    #[test]
+    fn verify_stability_of_identifier_derivation() {
+        let participant = Participant::from(1e9 as u32);
+        let identifier = Identifier::derive(participant.bytes().as_slice()).unwrap();
+        assert_eq!(
+            identifier.serialize(),
+            vec![
+                96, 203, 29, 92, 230, 35, 120, 169, 19, 185, 45, 28, 48, 68, 84, 190, 12, 186, 169,
+                192, 196, 21, 238, 181, 134, 181, 203, 236, 162, 68, 212, 4
+            ]
+        );
+    }
+
+    #[test]
+    fn dkg_and_sign() {
+        let max_signers = 9;
+        let threshold = 6;
+
+        let dkg_protocols = build_dkg_protocols(max_signers, threshold);
+        let keys = run_protocol(dkg_protocols).unwrap();
+
+        let group_public_key = keys.first().unwrap().1.public_key_package.verifying_key();
+
+        let sign_protocols = build_sign_protocols(&keys, threshold, |idx| idx == 0);
+        let signature = run_protocol(sign_protocols)
+            .unwrap()
+            .into_iter()
+            .filter_map(|(_, s)| match s {
+                SignatureOutput::Coordinator(signature) => Some(signature),
+                SignatureOutput::Participant => None,
+            })
+            .next()
+            .unwrap();
+
+        let msg = "hello_near";
+        let msg_hash = hash(msg.as_bytes());
+
+        group_public_key
+            .verify(msg_hash.as_bytes(), &signature)
+            .unwrap();
+    }
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -29,6 +29,7 @@ mod tracing;
 mod tracking;
 mod triple;
 mod web;
+mod frost;
 
 fn main() -> anyhow::Result<()> {
     init_logging();


### PR DESCRIPTION
This PR aims to simplify development and maintenance of Frost wrappers.
First attempt to describe an explicit state machine was made here https://github.com/Near-One/mpc/pull/172.
After coding/reviewing process, a little more time was spent to investigate how `cait-sith` model of writing protocols can be applied. 

Thus, instead of implementing `Protocol` trait directly, we write an `async` function, and convert it to the trait via `run_protocol`. This is where we need to expose some primitives from `cait-sith` lib, which is done here https://github.com/Near-One/cait-sith/pull/5.
