### PR TITLE
[frost] Keyshare protocol

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2409,8 +2409,7 @@ dependencies = [
 [[package]]
 name = "frost-core"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1858230cabb6792a5020daf4b0074f57b7d1e2a520ac544c77f102babee62ff4"
+source = "git+https://github.com/kuksag/frost?rev=5807812176b7b7b220286bc4ec7c080da72c04b8#5807812176b7b7b220286bc4ec7c080da72c04b8"
 dependencies = [
  "byteorder",
  "const-crc32-nostd",
@@ -2432,8 +2431,7 @@ dependencies = [
 [[package]]
 name = "frost-ed25519"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c350ac3d0463a009a061aba12b67920acee94338951c849bb4c492d55223dece"
+source = "git+https://github.com/kuksag/frost?rev=5807812176b7b7b220286bc4ec7c080da72c04b8#5807812176b7b7b220286bc4ec7c080da72c04b8"
 dependencies = [
  "curve25519-dalek",
  "document-features",
@@ -2446,8 +2444,7 @@ dependencies = [
 [[package]]
 name = "frost-rerandomized"
 version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
+source = "git+https://github.com/kuksag/frost?rev=5807812176b7b7b220286bc4ec7c080da72c04b8#5807812176b7b7b220286bc4ec7c080da72c04b8"
 dependencies = [
  "derive-getters",
  "document-features",
@@ -3824,7 +3821,6 @@ dependencies = [
  "borsh",
  "cait-sith",
  "clap",
- "curve25519-dalek",
  "flume",
  "frost-core",
  "frost-ed25519",
@@ -3835,6 +3831,7 @@ dependencies = [
  "hex-literal",
  "hkdf",
  "humantime",
+ "itertools 0.12.1",
  "k256",
  "lazy_static",
  "lru 0.12.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -710,6 +710,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-polyfill"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cf2bce30dfe09ef0bfaef228b9d414faaf7e563035494d7fe092dba54b300f4"
+dependencies = [
+ "critical-section",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1236,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/Near-One/cait-sith.git?rev=1bb67e2a04f01cc7835ce4d8a611064229acc10c#1bb67e2a04f01cc7835ce4d8a611064229acc10c"
+source = "git+https://github.com/Near-One/cait-sith.git?rev=f708ee8ae2aad32bf0f20d9e350ac0f698478f61#f708ee8ae2aad32bf0f20d9e350ac0f698478f61"
 dependencies = [
  "auto_ops",
  "ck-meow",
@@ -1446,6 +1455,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-crc32-nostd"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "808ac43170e95b11dd23d78aa9eaac5bea45776a602955552c4e833f3f0f823d"
+
+[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1630,6 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1751,6 +1772,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest 0.10.7",
  "fiat-crypto",
+ "rand_core",
  "rustc_version 0.4.1",
  "subtle",
  "zeroize",
@@ -1809,6 +1831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
+name = "debugless-unwrap"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f400d0750c0c069e8493f2256cb4da6f604b6d2eeb69a0ca8863acde352f8400"
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1868,17 @@ checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
  "serde",
+]
+
+[[package]]
+name = "derive-getters"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74ef43543e701c01ad77d3a5922755c6a1d71b22d942cb8042be4994b380caff"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1960,6 +1999,15 @@ name = "dlv-list"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+
+[[package]]
+name = "document-features"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95249b50c6c185bee49034bcb378a49dc2b5dff0be90ff6616d31d64febab05d"
+dependencies = [
+ "litrs",
+]
 
 [[package]]
 name = "dotenv"
@@ -2359,6 +2407,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "frost-core"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1858230cabb6792a5020daf4b0074f57b7d1e2a520ac544c77f102babee62ff4"
+dependencies = [
+ "byteorder",
+ "const-crc32-nostd",
+ "debugless-unwrap",
+ "derive-getters",
+ "document-features",
+ "hex",
+ "itertools 0.14.0",
+ "postcard",
+ "rand_core",
+ "serde",
+ "serdect",
+ "thiserror 2.0.4",
+ "thiserror-nostd-notrait",
+ "visibility",
+ "zeroize",
+]
+
+[[package]]
+name = "frost-ed25519"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350ac3d0463a009a061aba12b67920acee94338951c849bb4c492d55223dece"
+dependencies = [
+ "curve25519-dalek",
+ "document-features",
+ "frost-core",
+ "frost-rerandomized",
+ "rand_core",
+ "sha2",
+]
+
+[[package]]
+name = "frost-rerandomized"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a3b10d9c1e9f298522510940b5b8c3d55040420517ec8d2bb86c4c2d1ae3ee"
+dependencies = [
+ "derive-getters",
+ "document-features",
+ "frost-core",
+ "hex",
+ "rand_core",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2619,6 +2717,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c35f58762feb77d74ebe43bdbc3210f09be9fe6742234d573bacc26ed92b67"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,6 +2753,20 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc6457c0eb62c71aac4bc17216026d8410337c4126773b9c5daba343f17964f"
+dependencies = [
+ "atomic-polyfill",
+ "hash32",
+ "rustc_version 0.4.1",
+ "serde",
+ "spin 0.9.8",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3214,6 +3335,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,6 +3531,12 @@ name = "litemap"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+
+[[package]]
+name = "litrs"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce301924b7887e9d637144fdade93f9dfff9b60981d4ac161db09720d39aa5"
 
 [[package]]
 name = "local-channel"
@@ -3688,7 +3824,10 @@ dependencies = [
  "borsh",
  "cait-sith",
  "clap",
+ "curve25519-dalek",
  "flume",
+ "frost-core",
+ "frost-ed25519",
  "futures",
  "futures-util",
  "gcloud-sdk",
@@ -5755,6 +5894,7 @@ dependencies = [
  "cobs",
  "embedded-io 0.4.0",
  "embedded-io 0.6.1",
+ "heapless",
  "serde",
 ]
 
@@ -7662,6 +7802,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-nostd-notrait"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8444e638022c44d2a9337031dee8acb732bcc7fbf52ac654edc236b26408b61"
+dependencies = [
+ "thiserror-nostd-notrait-impl",
+]
+
+[[package]]
+name = "thiserror-nostd-notrait-impl"
+version = "1.0.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "585e5ef40a784ce60b49c67d762110688d211d395d39e096be204535cf64590e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8209,6 +8369,17 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "visibility"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d674d135b4a8c1d7e813e2f8d1c9a58308aee4a680323066025e53132218bd91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
 
 [[package]]
 name = "void"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,7 +1245,7 @@ dependencies = [
 [[package]]
 name = "cait-sith"
 version = "0.8.0"
-source = "git+https://github.com/Near-One/cait-sith.git?rev=f708ee8ae2aad32bf0f20d9e350ac0f698478f61#f708ee8ae2aad32bf0f20d9e350ac0f698478f61"
+source = "git+https://github.com/Near-One/cait-sith.git?rev=d0144f8dd94e6e78f85a526fb45b5c891bf8bf7e#d0144f8dd94e6e78f85a526fb45b5c891bf8bf7e"
 dependencies = [
  "auto_ops",
  "ck-meow",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -44,9 +44,8 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2"
 x509-parser = "0.16.0"
 
-frost-ed25519 = "2.1.0"
-frost-core = "2.1.0"
-curve25519-dalek = "4.1.3"
+frost-ed25519 = { git = "https://github.com/kuksag/frost", rev = "5807812176b7b7b220286bc4ec7c080da72c04b8" }
+frost-core = { git = "https://github.com/kuksag/frost", rev = "5807812176b7b7b220286bc4ec7c080da72c04b8" }
 
 near-indexer = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
 near-indexer-primitives = { git = "https://github.com/near/nearcore",rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
@@ -61,3 +60,4 @@ mpc-contract = { git = "https://github.com/near/mpc/", tag = "1.0.0-rc.5" }
 [dev-dependencies]
 serial_test = "3.2.0"
 reqwest = "0.12.9"
+itertools = "0.12.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/Near-One/cait-sith.git", rev = "f708ee8ae2aad32bf0f20d9e350ac0f698478f61", features = ["k256", "internals"] }
+cait-sith = { git = "https://github.com/Near-One/cait-sith.git", rev = "d0144f8dd94e6e78f85a526fb45b5c891bf8bf7e", features = ["k256", "internals"] }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"
@@ -46,6 +46,7 @@ x509-parser = "0.16.0"
 
 frost-ed25519 = { git = "https://github.com/kuksag/frost", rev = "5807812176b7b7b220286bc4ec7c080da72c04b8" }
 frost-core = { git = "https://github.com/kuksag/frost", rev = "5807812176b7b7b220286bc4ec7c080da72c04b8" }
+itertools = "0.12.1"
 
 near-indexer = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
 near-indexer-primitives = { git = "https://github.com/near/nearcore",rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
@@ -60,4 +61,3 @@ mpc-contract = { git = "https://github.com/near/mpc/", tag = "1.0.0-rc.5" }
 [dev-dependencies]
 serial_test = "3.2.0"
 reqwest = "0.12.9"
-itertools = "0.12.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -10,7 +10,7 @@ anyhow = "1.0.92"
 async-trait = "0.1.83"
 axum = "0.7.9"
 borsh = { version = "1.5.1", features = ["derive"] }
-cait-sith = { git = "https://github.com/Near-One/cait-sith.git", features = ["k256"], rev = "1bb67e2a04f01cc7835ce4d8a611064229acc10c" }
+cait-sith = { git = "https://github.com/Near-One/cait-sith.git", rev = "f708ee8ae2aad32bf0f20d9e350ac0f698478f61", features = ["k256", "internals"] }
 clap = { version = "4.5.20", features = ["derive", "env"] }
 flume = "0.11.1"
 futures = "0.3.31"
@@ -43,6 +43,10 @@ tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 url = "2"
 x509-parser = "0.16.0"
+
+frost-ed25519 = "2.1.0"
+frost-core = "2.1.0"
+curve25519-dalek = "4.1.3"
 
 near-indexer = { git = "https://github.com/near/nearcore", rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }
 near-indexer-primitives = { git = "https://github.com/near/nearcore",rev = "39882d8d34281fae2e5551c000eeeede2e75f8da" }

--- a/node/src/frost/common.rs
+++ b/node/src/frost/common.rs
@@ -1,0 +1,49 @@
+use std::collections::BTreeMap;
+use cait_sith::participants::{ParticipantCounter, ParticipantList};
+use cait_sith::protocol::{Participant, ProtocolError, SharedChannel};
+use frost_ed25519::Identifier;
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+use crate::frost::to_frost_identifier;
+
+pub(crate) async fn distribute_packages<T>(
+    chan: &mut SharedChannel,
+    participants: &[Participant],
+    packages: &BTreeMap<Identifier, T>,
+    waitpoint: u64,
+) where
+    T: Clone + Serialize,
+{
+    let from_frost_identifiers = participants
+        .iter()
+        .map(|&p| (to_frost_identifier(p), p))
+        .collect::<BTreeMap<_, _>>();
+
+    for (identifier, package) in packages {
+        chan.send_private(
+            waitpoint,
+            from_frost_identifiers[&identifier],
+            &package,
+        ).await;
+    }
+}
+
+pub(crate) async fn collect_packages<P: Clone + DeserializeOwned>(
+    chan: &SharedChannel,
+    participants: &[Participant],
+    wait_point: u64,
+) -> Result<BTreeMap<Identifier, P>, ProtocolError> {
+    let participants_list = ParticipantList::new(participants)
+        .ok_or(ProtocolError::AssertionFailed("Participants contain duplicates".to_string()))?;
+    let mut seen = {
+        ParticipantCounter::new(&participants_list)
+    };
+    let mut packages = BTreeMap::new();
+    while !seen.full() {
+        let (from, package): (_, P) = chan.recv(wait_point).await?;
+        if seen.put(from) {
+            packages.insert(to_frost_identifier(from), package);
+        }
+    }
+    Ok(packages)
+}

--- a/node/src/frost/common.rs
+++ b/node/src/frost/common.rs
@@ -22,7 +22,7 @@ pub(crate) async fn distribute_packages<T>(
     for (identifier, package) in packages {
         chan.send_private(
             waitpoint,
-            from_frost_identifiers[&identifier],
+            from_frost_identifiers[identifier],
             &package,
         ).await;
     }

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -1,0 +1,22 @@
+use cait_sith::protocol::{Participant, Protocol};
+use frost_ed25519::keys::{KeyPackage, PublicKeyPackage};
+use frost_ed25519::Signature;
+use rand::{CryptoRng, RngCore};
+
+mod refresh;
+mod tests;
+
+/// Participant's key-pair in Frost
+#[derive(Debug, Clone)]
+pub struct KeygenOutput {
+    pub key_package: KeyPackage,
+    // Although group's public key can be found in `KeyPackage` too,
+    //  `PublicKeyPackage` is needed when calling signature `aggregate()`.
+    pub public_key_package: PublicKeyPackage,
+}
+
+/// Derive Frost identifier (ed25519 scalar) from u32
+pub fn to_frost_identifier(participant: Participant) -> frost_ed25519::Identifier {
+    frost_ed25519::Identifier::derive(participant.bytes().as_slice())
+        .expect("Identifier derivation must succeed: cipher suite is guaranteed to be implemented")
+}

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -4,6 +4,7 @@ use frost_ed25519::keys::{KeyPackage, PublicKeyPackage};
 mod refresh;
 mod repair;
 mod tests;
+mod reshare;
 
 /// Participant's key-pair in Frost
 #[derive(Debug, Clone)]

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -5,6 +5,7 @@ use rand::{CryptoRng, RngCore};
 
 mod refresh;
 mod tests;
+mod repair;
 
 /// Participant's key-pair in Frost
 #[derive(Debug, Clone)]

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -1,11 +1,52 @@
-use cait_sith::protocol::Participant;
+use aes_gcm::aead::rand_core::{CryptoRng, RngCore};
+use cait_sith::protocol::{Participant, Protocol};
 use frost_ed25519::keys::{KeyPackage, PublicKeyPackage};
 
+mod common;
 mod refresh;
 mod repair;
-mod tests;
 mod reshare;
-mod common;
+mod tests;
+
+#[allow(dead_code)] // TODO(#119): remove the directive when this will be actually used.
+pub(crate) fn reshare_old_participant<RNG: CryptoRng + RngCore + 'static + Send + Clone>(
+    rng: RNG,
+    old_participants: &[Participant],
+    old_threshold: usize,
+    new_participants: &[Participant],
+    new_threshold: usize,
+    me: Participant,
+    my_share: KeygenOutput,
+) -> anyhow::Result<impl Protocol<Output = KeygenOutput>> {
+    reshare::reshare_old_participant_internal(
+        rng,
+        old_participants,
+        old_threshold,
+        new_participants,
+        new_threshold,
+        me,
+        my_share,
+    )
+}
+
+#[allow(dead_code)] // TODO(#119): remove the directive when this will be actually used.
+pub(crate) fn reshare_new_participant<RNG: CryptoRng + RngCore + 'static + Send + Clone>(
+    rng: RNG,
+    old_participants: &[Participant],
+    old_threshold: usize,
+    new_participants: &[Participant],
+    new_threshold: usize,
+    me: Participant,
+) -> anyhow::Result<impl Protocol<Output = KeygenOutput>> {
+    reshare::reshare_new_participant_internal(
+        rng,
+        old_participants,
+        old_threshold,
+        new_participants,
+        new_threshold,
+        me,
+    )
+}
 
 /// Participant's key-pair in Frost
 #[derive(Debug, Clone)]

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -1,11 +1,9 @@
-use cait_sith::protocol::{Participant, Protocol};
+use cait_sith::protocol::Participant;
 use frost_ed25519::keys::{KeyPackage, PublicKeyPackage};
-use frost_ed25519::Signature;
-use rand::{CryptoRng, RngCore};
 
 mod refresh;
-mod tests;
 mod repair;
+mod tests;
 
 /// Participant's key-pair in Frost
 #[derive(Debug, Clone)]

--- a/node/src/frost/mod.rs
+++ b/node/src/frost/mod.rs
@@ -5,6 +5,7 @@ mod refresh;
 mod repair;
 mod tests;
 mod reshare;
+mod common;
 
 /// Participant's key-pair in Frost
 #[derive(Debug, Clone)]

--- a/node/src/frost/refresh.rs
+++ b/node/src/frost/refresh.rs
@@ -1,3 +1,9 @@
+//! Wrapper for Frost `refresh` algorithm:
+//! Any subset of `>= threshold` participants can generate new secret shares, with the same group's public key.
+//! This can be useful when we want to exclude a participant from a signing schema.
+//!
+//! As a result each participant of the protocol receives new instance of `KeygenOutput`.
+
 use crate::frost::{to_frost_identifier, KeygenOutput};
 use aes_gcm::aead::rand_core::{CryptoRng, RngCore};
 use cait_sith::participants::{ParticipantCounter, ParticipantList};
@@ -5,7 +11,7 @@ use cait_sith::protocol::{
     make_protocol, Context, Participant, Protocol, ProtocolError, SharedChannel,
 };
 use frost_ed25519::keys::dkg::{round1, round2};
-use frost_ed25519::{Group, Identifier};
+use frost_ed25519::Identifier;
 use serde::de::DeserializeOwned;
 use std::collections::BTreeMap;
 

--- a/node/src/frost/refresh.rs
+++ b/node/src/frost/refresh.rs
@@ -1,0 +1,277 @@
+use crate::frost::{to_frost_identifier, KeygenOutput};
+use aes_gcm::aead::rand_core::{CryptoRng, RngCore};
+use cait_sith::participants::{ParticipantCounter, ParticipantList};
+use cait_sith::protocol::{
+    make_protocol, Context, Participant, Protocol, ProtocolError, SharedChannel,
+};
+use frost_ed25519::keys::dkg::{round1, round2};
+use frost_ed25519::{Group, Identifier};
+use serde::de::DeserializeOwned;
+use std::collections::BTreeMap;
+
+pub fn refresh_internal<RNG: CryptoRng + RngCore + 'static + Send>(
+    rng: RNG,
+    participants: Vec<Participant>,
+    threshold: usize,
+    me: Participant,
+    keygen_output: KeygenOutput,
+) -> anyhow::Result<impl Protocol<Output = KeygenOutput>> {
+    if participants.len() < threshold {
+        anyhow::bail!("Threshold must be less than or equal to number of participants");
+    }
+
+    let Some(participants) = ParticipantList::new(&participants) else {
+        anyhow::bail!("Participants list contains duplicates")
+    };
+
+    if !participants.contains(me) {
+        anyhow::bail!("Participant list must contain this participant");
+    }
+
+    let ctx = Context::new();
+    let fut = do_refresh(
+        ctx.shared_channel(),
+        rng,
+        participants,
+        me,
+        keygen_output,
+        threshold,
+    );
+    Ok(make_protocol(ctx, fut))
+}
+
+async fn do_refresh<RNG: CryptoRng + RngCore + 'static + Send>(
+    mut chan: SharedChannel,
+    rng: RNG,
+    participants: ParticipantList,
+    me: Participant,
+    keygen_output: KeygenOutput,
+    threshold: usize,
+) -> Result<KeygenOutput, ProtocolError> {
+    // --- Round 1
+    let (round1_secret, round1_packages) =
+        handle_round1(&mut chan, &participants, threshold, me, rng).await?;
+
+    // --- Round 2
+    let (round2_secret, round2_packages) = handle_round2(
+        &mut chan,
+        &participants,
+        round1_secret,
+        &round1_packages,
+        me,
+    )
+    .await?;
+
+    // --- Final Key Package Generation
+    let (key_package, public_key_package) = frost_core::keys::refresh::refresh_dkg_shares(
+        &round2_secret,
+        &round1_packages,
+        &round2_packages,
+        keygen_output.public_key_package,
+        keygen_output.key_package,
+    )
+    .map_err(|e| ProtocolError::AssertionFailed(format!("keyshare::part3: {:?}", e)))?;
+
+    Ok(KeygenOutput {
+        key_package,
+        public_key_package,
+    })
+}
+
+async fn handle_round1<RNG: CryptoRng + RngCore + 'static + Send>(
+    chan: &mut SharedChannel,
+    participants: &ParticipantList,
+    threshold: usize,
+    me: Participant,
+    rng: RNG,
+) -> Result<(round1::SecretPackage, BTreeMap<Identifier, round1::Package>), ProtocolError> {
+    let (round1_secret, my_round1_package) = frost_core::keys::refresh::refresh_dkg_part_1(
+        to_frost_identifier(me),
+        participants.len() as u16,
+        threshold as u16,
+        rng,
+    )
+    .map_err(|e| ProtocolError::AssertionFailed(format!("keyshare::part1: {:?}", e)))?;
+
+    let round1_wait_point = chan.next_waitpoint();
+
+    chan.send_many(round1_wait_point, &my_round1_package).await;
+
+    let mut seen = ParticipantCounter::new(participants);
+    seen.put(me);
+    let round1_packages: BTreeMap<Identifier, round1::Package> =
+        wait_for_packages(chan, &mut seen, round1_wait_point).await?;
+
+    Ok((round1_secret, round1_packages))
+}
+
+async fn handle_round2(
+    chan: &mut SharedChannel,
+    participants: &ParticipantList,
+    round1_secret: round1::SecretPackage,
+    round1_packages: &BTreeMap<Identifier, round1::Package>,
+    me: Participant,
+) -> Result<(round2::SecretPackage, BTreeMap<Identifier, round2::Package>), ProtocolError> {
+    let from_frost_identifiers = Vec::from(participants.clone())
+        .iter()
+        .map(|&p| (to_frost_identifier(p), p))
+        .collect::<BTreeMap<_, _>>();
+
+    let (round2_secret, my_round2_packages) =
+        frost_core::keys::refresh::refresh_dkg_part2(round1_secret, round1_packages)
+            .map_err(|e| ProtocolError::AssertionFailed(format!("keyshare::part2: {:?}", e)))?;
+
+    let round2_wait_point = chan.next_waitpoint();
+
+    for (identifier, round2_package) in my_round2_packages {
+        chan.send_private(
+            round2_wait_point,
+            from_frost_identifiers[&identifier],
+            &round2_package,
+        )
+        .await;
+    }
+
+    let mut seen = ParticipantCounter::new(participants);
+    seen.put(me);
+    let round2_packages: BTreeMap<Identifier, round2::Package> =
+        wait_for_packages(chan, &mut seen, round2_wait_point).await?;
+
+    Ok((round2_secret, round2_packages))
+}
+
+pub(crate) async fn wait_for_packages<P: Clone + DeserializeOwned>(
+    chan: &mut SharedChannel,
+    seen: &mut ParticipantCounter<'_>,
+    wait_point: u64,
+) -> Result<BTreeMap<Identifier, P>, ProtocolError> {
+    let mut packages = BTreeMap::new();
+    while !seen.full() {
+        let (from, package): (_, P) = chan.recv(wait_point).await?;
+        if seen.put(from) {
+            packages.insert(to_frost_identifier(from), package);
+        }
+    }
+    Ok(packages)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::tests::{build_key_packages_with_dealer, reconstruct_signing_key};
+    use frost_ed25519::VerifyingKey;
+
+    #[cfg(test)]
+    pub(crate) fn build_and_run_refresh_protocol(
+        participants: &[(Participant, KeygenOutput)],
+        threshold: usize,
+    ) -> anyhow::Result<Vec<(Participant, KeygenOutput)>> {
+        use cait_sith::protocol::run_protocol;
+        use rand::prelude::StdRng;
+        use rand::SeedableRng;
+
+        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> =
+            Vec::with_capacity(participants.len());
+
+        let participants_list = participants.iter().map(|(id, _)| *id).collect::<Vec<_>>();
+
+        for (participant, key_pair) in participants {
+            let rng: StdRng = StdRng::seed_from_u64(protocols.len() as u64);
+
+            let protocol = refresh_internal(
+                rng,
+                participants_list.clone(),
+                threshold,
+                *participant,
+                key_pair.clone(),
+            )?;
+            let protocol = Box::new(protocol);
+
+            protocols.push((*participant, protocol))
+        }
+
+        Ok(run_protocol(protocols)?)
+    }
+
+    #[test]
+    fn test_refresh() {
+        let participants_count = 5;
+        let threshold = 3;
+
+        let participants_old = build_key_packages_with_dealer(participants_count, threshold);
+        let verifying_key_expected = *participants_old
+            .first()
+            .unwrap()
+            .1
+            .public_key_package
+            .verifying_key();
+
+        let participants_new =
+            build_and_run_refresh_protocol(&participants_old, threshold).unwrap();
+        let signing_key = reconstruct_signing_key(&participants_new).unwrap();
+        let verifying_key_actual = VerifyingKey::from(&signing_key);
+
+        assert_eq!(verifying_key_expected, verifying_key_actual);
+
+        participants_old
+            .iter()
+            .zip(participants_new)
+            .for_each(|(old, new)| {
+                assert_ne!(
+                    old.1.key_package.signing_share(),
+                    new.1.key_package.signing_share()
+                );
+            })
+    }
+
+    #[test]
+    fn exclude_one() {
+        let participants_count = 5;
+        let threshold = 3;
+
+        let participants = build_key_packages_with_dealer(participants_count, threshold);
+        let verifying_key_expected = *participants
+            .first()
+            .unwrap()
+            .1
+            .public_key_package
+            .verifying_key();
+
+        let participants_new = build_and_run_refresh_protocol(
+            participants
+                .iter()
+                .take(participants_count - 1)
+                .cloned()
+                .collect::<Vec<_>>()
+                .as_slice(),
+            threshold,
+        )
+        .unwrap();
+        let signing_key = reconstruct_signing_key(&participants_new).unwrap();
+        let verifying_key_actual = VerifyingKey::from(&signing_key);
+
+        assert_eq!(verifying_key_expected, verifying_key_actual);
+    }
+
+    #[test]
+    fn stress() {
+        let participants_count = 5;
+        let threshold = 3;
+
+        let mut participants = build_key_packages_with_dealer(participants_count, threshold);
+        let verifying_key_expected = *participants
+            .first()
+            .unwrap()
+            .1
+            .public_key_package
+            .verifying_key();
+
+        for _ in 0..participants_count - threshold {
+            participants = participants.iter().skip(1).cloned().collect::<Vec<_>>();
+            participants = build_and_run_refresh_protocol(&participants, threshold).unwrap();
+            let signing_key = reconstruct_signing_key(&participants).unwrap();
+            let verifying_key_actual = VerifyingKey::from(&signing_key);
+            assert_eq!(verifying_key_expected, verifying_key_actual);
+        }
+    }
+}

--- a/node/src/frost/repair.rs
+++ b/node/src/frost/repair.rs
@@ -11,13 +11,22 @@
 //! As a result `helpers` receive updated `PublicKeyPackage`. Group's public key stays the same,
 //!  but we have to update internally stored `verifying_shares` mapping which is updated with the new entry.
 //!
-//! You have to update `PublicKeyPackage` on other participants too, who weren't participating in repairing.
+//! Other participants, who didn't participate in repairing, have to update their `PublicKeyPackage` too.
 //!
-//! TODO: Deviation from VSS
+//! Algorithm:
+//!     # Round 1. Helpers send deltas to each other, in order for each to generate a sigma value.
+//!     # Round 2.
+//!         1. Each helper send their sigma to the target.
+//!         2. Target collects sigmas and build their `KeyPackage` (secret share).
+//!     # Round 3.
+//!         1. Each helper send their public package.
+//!         3. Target collects it and builds `PublicKeyPackage`.
+//!         2. Target sends updated `PublicKeyPackage` to helpers.
+//!
 
 use crate::frost::common::{collect_packages, distribute_packages};
 use crate::frost::{to_frost_identifier, KeygenOutput};
-use cait_sith::protocol::{make_protocol, Context, Participant, Protocol, ProtocolError, SharedChannel};
+use cait_sith::protocol::{Participant, Protocol, ProtocolError, SharedChannel};
 use frost_core::serialization::SerializableScalar;
 use frost_core::Field;
 use frost_ed25519::keys::{KeyPackage, PublicKeyPackage, SigningShare, VerifyingShare};
@@ -25,142 +34,254 @@ use frost_ed25519::{Group, Identifier};
 use rand::{CryptoRng, RngCore};
 use std::collections::{BTreeMap, BTreeSet};
 
-/// Public function for the target role in the repair protocol.
-/// The target (i.e. the participant whose share is lost) collects
-/// sigma values from helpers to reconstruct its share.
-pub(crate) fn repair_internal_target(
-    helpers: Vec<Participant>,
-    me: Participant,
-    threshold: usize,
-) -> anyhow::Result<impl Protocol<Output=KeygenOutput>> {
-    if helpers.is_empty() {
-        anyhow::bail!("Helpers list cannot be empty");
+pub(crate) mod target {
+    use super::*;
+    pub async fn do_repair(
+        mut channel: SharedChannel,
+        me: Participant,
+        helpers: Vec<Participant>,
+        threshold: usize,
+    ) -> Result<KeygenOutput, ProtocolError> {
+
+        // Round 2.
+
+        let (signing_share, verifying_share) = handle_round2(&mut channel, helpers.as_slice()).await?;
+
+        // Round 3.
+
+        let mut public_key_package = collect_public_keys(&mut channel, helpers.as_slice())
+            .await
+            .map_err(|e| ProtocolError::AssertionFailed(format!("collect_public_keys: {:?}", e)))?;
+
+        // Do verification and build a key pair.
+
+        let frost_identifier_me = to_frost_identifier(me);
+
+        verify_share_consistency(
+            frost_identifier_me,
+            verifying_share,
+            public_key_package.verifying_shares(),
+        )
+            .map_err(|e| {
+                ProtocolError::AssertionFailed(format!("verify_share_consistency: {:?}", e))
+            })?;
+
+        public_key_package = build_pubkey_with_updated_verifying_shares(
+            &public_key_package,
+            frost_identifier_me,
+            verifying_share,
+        );
+
+        let verifying_key = *public_key_package.verifying_key();
+        let key_package = KeyPackage::new(
+            frost_identifier_me,
+            signing_share,
+            verifying_share,
+            verifying_key,
+            threshold as u16,
+        );
+
+        {
+            let waitpoint = channel.next_waitpoint();
+            channel.send_many(waitpoint, &verifying_share).await;
+        }
+
+        Ok(KeygenOutput {
+            key_package,
+            public_key_package,
+        })
     }
 
-    let ctx = Context::new();
-    let fut = do_repair_target(
-        ctx.shared_channel(),
-        me,
-        helpers,
-        threshold
-    );
-    Ok(make_protocol(ctx, fut))
+    async fn handle_round2(
+        channel: &mut SharedChannel,
+        helpers: &[Participant],
+    ) -> Result<(SigningShare, VerifyingShare), ProtocolError> {
+        let sigmas: BTreeMap<Identifier, SerializableScalar<frost_ed25519::Ed25519Sha512>> = {
+            let waitpoint = channel.next_waitpoint();
+            collect_packages(channel, helpers, waitpoint).await?
+        };
+
+        let mut share = frost_ed25519::Ed25519ScalarField::zero();
+        for &s in sigmas.values() {
+            share += s.0;
+        }
+        let signing_share = SigningShare::new(share);
+        let verifying_share = VerifyingShare::from(signing_share);
+
+        Ok((signing_share, verifying_share))
+    }
 }
 
-/// Public function for the helper role in the repair protocol.
-/// Helpers compute and exchange delta values
-/// (to derive a sigma), and then send their sigma privately to the target.
-pub(crate) fn repair_internal_helper<RNG: CryptoRng + RngCore + 'static + Send>(
-    rng: RNG,
-    helpers: Vec<Participant>,
-    me: Participant,
-    target_participant: Participant,
-    keygen_output: KeygenOutput,
-) -> anyhow::Result<impl Protocol<Output=KeygenOutput>> {
-    let ctx = Context::new();
-    let fut = do_repair_helper(
-        ctx.shared_channel(),
-        rng,
-        helpers,
-        me,
-        target_participant,
-        keygen_output,
-    );
-    Ok(make_protocol(ctx, fut))
-}
+pub(crate) mod helper {
+    use super::*;
 
+    pub async fn do_repair<RNG: CryptoRng + RngCore + 'static + Send>(
+        mut channel: SharedChannel,
+        mut rng: RNG,
+        helpers: Vec<Participant>,
+        me: Participant,
+        target_participant: Participant,
+        mut keygen_output: KeygenOutput,
+    ) -> Result<KeygenOutput, ProtocolError> {
+        // Round 1.
 
-/// Verify that the repaired secret share matches the secret polynomial.
-/// Normally, this would involve using the `VerifiableSecretSharingCommitment` from the FROST library,
-/// which provides the coefficients of `Big_f = f(x) * G`. However, this is not available from DKG
-/// (though it could be added).
-/// To verify, we instead use participants' verifying shares (`s_i * G`) and interpolate them
-/// at the target participant's identifier (the share being repaired),
-/// then confirm that the computed and actual values match.
-fn verify_share_consistency(
-    identifier: Identifier,
-    verifying_share: VerifyingShare,
-    other_verifying_shares: &BTreeMap<Identifier, VerifyingShare>,
-) -> anyhow::Result<()> {
-    let mut expected = frost_ed25519::Ed25519Group::identity();
+        let round1_packages = handle_round1(
+            // Create sub-channel for helpers only. `child(0)` is safe to use since there is no `Participant(0)`
+            &mut channel.child(0),
+            
+            helpers.as_slice(),
+            me,
+            target_participant,
+            &keygen_output,
+            &mut rng,
+        )
+        .await
+        .map_err(|e| ProtocolError::AssertionFailed(format!("repair:round1: {:?}", e)))?;
 
-    let x_set = other_verifying_shares.keys().cloned().collect::<BTreeSet<_>>();
-    for (&other_identifier, other_verifying_share) in other_verifying_shares {
-        let phi_i = frost_core::compute_lagrange_coefficient(
-            &x_set,
-            Some(identifier),
-            other_identifier,
-        )?;
-        expected += phi_i * other_verifying_share.to_element()
+        // Round 2.
+
+        handle_round2(&mut channel, &round1_packages, target_participant)
+            .await
+            .map_err(|e| ProtocolError::AssertionFailed(format!("repair:round2: {:?}", e)))?;
+
+        // Round 3.
+
+        let target_verifying_share = handle_round3(
+            &mut channel,
+            target_participant,
+            keygen_output.public_key_package.clone(),
+        )
+        .await
+        .map_err(|e| ProtocolError::AssertionFailed(format!("repair:round3: {:?}", e)))?;
+
+        // Do verification and update key pair.
+
+        verify_share_consistency(
+            to_frost_identifier(target_participant),
+            target_verifying_share,
+            keygen_output.public_key_package.verifying_shares(),
+        )
+        .map_err(|e| {
+            ProtocolError::AssertionFailed(format!("verify_share_consistency: {:?}", e))
+        })?;
+
+        keygen_output.public_key_package = build_pubkey_with_updated_verifying_shares(
+            &keygen_output.public_key_package,
+            to_frost_identifier(target_participant),
+            target_verifying_share,
+        );
+
+        Ok(keygen_output)
     }
 
-    if verifying_share.to_element() != expected {
-        anyhow::bail!("Verifying share does not match expected value");
-    }
-
-    Ok(())
-}
-
-pub(crate) async fn do_repair_target(
-    mut channel: SharedChannel,
-    me: Participant,
-    helpers: Vec<Participant>,
-    threshold: usize,
-) -> Result<KeygenOutput, ProtocolError> {
-    let sigmas: BTreeMap<Identifier, SerializableScalar<frost_ed25519::Ed25519Sha512>> = {
-        let waitpoint = channel.next_waitpoint();
-        collect_packages(&mut channel, helpers.as_slice(), waitpoint).await?
-    };
-
-    let mut share = frost_ed25519::Ed25519ScalarField::zero();
-    for &s in sigmas.values() {
-        share += s.0;
-    }
-    let signing_share = SigningShare::new(share);
-
-    let verifying_share = VerifyingShare::from(signing_share);
-
-    //
-
-    let mut public_key_package = collect_public_keys(
-        &mut channel,
-        helpers.as_slice(),
-    ).await.map_err(|e| ProtocolError::AssertionFailed(format!("collect_public_keys: {:?}", e)))?;
-
-    //
-
-    let frost_identifier_me = to_frost_identifier(me);
-
-    verify_share_consistency(
-        frost_identifier_me,
-        verifying_share,
-        public_key_package.verifying_shares(),
-    ).map_err(|e| ProtocolError::AssertionFailed(format!("verify_share_consistency: {:?}", e)))?;
-
-    public_key_package = build_pubkey_with_updated_verifying_shares(
-        &public_key_package,
-        frost_identifier_me,
-        verifying_share,
-    );
-
-    let verifying_key = *public_key_package.verifying_key();
-    let key_package = KeyPackage::new(
-        frost_identifier_me,
-        signing_share,
-        verifying_share,
-        verifying_key,
-        threshold as u16,
-    );
-
+    async fn handle_round1<RNG: CryptoRng + RngCore + 'static + Send>(
+        channel: &mut SharedChannel,
+        helpers: &[Participant],
+        me: Participant,
+        target_participant: Participant,
+        keygen_output: &KeygenOutput,
+        rng: &mut RNG,
+    ) -> anyhow::Result<BTreeMap<Identifier, SerializableScalar<frost_ed25519::Ed25519Sha512>>>
     {
-        let waitpoint = channel.next_waitpoint();
-        channel.send_many(waitpoint, &verifying_share).await;
+        let frost_identifier_me = to_frost_identifier(me);
+        let frost_identifiers = helpers
+            .iter()
+            .map(|&p| to_frost_identifier(p))
+            .collect::<Vec<_>>();
+
+        let mut packages_to_send = frost_core::keys::repairable::repair_share_step_1(
+            frost_identifiers.as_slice(),
+            frost_identifier_me,
+            keygen_output.key_package.signing_share(),
+            rng,
+            to_frost_identifier(target_participant),
+        )?
+        .iter()
+        .map(|(identifier, delta)| {
+            (
+                *identifier,
+                SerializableScalar::<frost_ed25519::Ed25519Sha512>(*delta),
+            )
+        })
+        .collect::<BTreeMap<_, _>>();
+
+        let my_package = packages_to_send
+            .remove(&frost_identifier_me)
+            .ok_or(anyhow::anyhow!("Missing package for me"))?;
+
+        let mut received_packages: BTreeMap<_, _> = {
+            let waitpoint = channel.next_waitpoint();
+            let other_helpers = helpers
+                .iter()
+                .filter(|&&x| x != me)
+                .cloned()
+                .collect::<Vec<_>>();
+
+            distribute_packages(channel, other_helpers.as_slice(), &packages_to_send, waitpoint).await;
+
+            collect_packages(channel, other_helpers.as_slice(), waitpoint).await?
+        };
+
+        received_packages.insert(frost_identifier_me, my_package);
+        if received_packages.len() != helpers.len() {
+            anyhow::bail!(
+                "Expected {} packages, got {}",
+                helpers.len(),
+                received_packages.len()
+            );
+        }
+
+        Ok(received_packages)
     }
 
-    Ok(KeygenOutput {
-        key_package,
-        public_key_package,
-    })
+    async fn handle_round2(
+        channel: &mut SharedChannel,
+        round1_packages: &BTreeMap<Identifier, SerializableScalar<frost_ed25519::Ed25519Sha512>>,
+        target_participant: Participant,
+    ) -> anyhow::Result<()> {
+        let deltas = round1_packages
+            .values()
+            .copied()
+            .map(|s| s.0)
+            .collect::<Vec<_>>();
+        let sigma = frost_core::keys::repairable::repair_share_step_2::<frost_ed25519::Ed25519Sha512>(
+            deltas.as_slice(),
+        );
+
+        let waitpoint = channel.next_waitpoint();
+
+        channel.send_private(
+            waitpoint,
+            target_participant,
+            &SerializableScalar::<frost_ed25519::Ed25519Sha512>(sigma),
+        )
+        .await;
+
+        Ok(())
+    }
+
+    async fn handle_round3(
+        channel: &mut SharedChannel,
+        target_participant: Participant,
+        public_key_package: PublicKeyPackage,
+    ) -> anyhow::Result<VerifyingShare> {
+        {
+            let waitpoint = channel.next_waitpoint();
+            channel.send_private(waitpoint, target_participant, &public_key_package)
+                .await;
+        }
+
+        let (from, verifying_share): (_, VerifyingShare) = {
+            let waitpoint = channel.next_waitpoint();
+            channel.recv(waitpoint).await?
+        };
+
+        if from != target_participant {
+            anyhow::bail!("Received a message from an unexpected participant");
+        }
+
+        Ok(verifying_share)
+    }
 }
 
 async fn collect_public_keys(
@@ -173,11 +294,18 @@ async fn collect_public_keys(
         collect_packages(&channel, participants, wait_point).await?;
 
     let Some((_, public_key)) = public_keys.first_key_value() else {
-        return Err(ProtocolError::AssertionFailed("No public keys received".to_string()));
+        return Err(ProtocolError::AssertionFailed(
+            "No public keys received".to_string(),
+        ));
     };
 
-    if public_keys.iter().any(|(_, public_key)| public_key != public_key) {
-        return Err(ProtocolError::AssertionFailed("Received different public key packages".to_string()));
+    if public_keys
+        .iter()
+        .any(|(_, public_key)| public_key != public_key)
+    {
+        return Err(ProtocolError::AssertionFailed(
+            "Received different public key packages".to_string(),
+        ));
     }
 
     Ok(public_key.clone())
@@ -186,175 +314,50 @@ async fn collect_public_keys(
 fn build_pubkey_with_updated_verifying_shares(
     public_key_package: &PublicKeyPackage,
     identifier: Identifier,
-    verifying_share: VerifyingShare
+    verifying_share: VerifyingShare,
 ) -> PublicKeyPackage {
     let mut verifying_shares = public_key_package.verifying_shares().clone();
     verifying_shares.insert(identifier, verifying_share);
-    PublicKeyPackage::new(
-        verifying_shares,
-        *public_key_package.verifying_key(),
-    )
+    PublicKeyPackage::new(verifying_shares, *public_key_package.verifying_key())
 }
 
-pub(crate) async fn do_repair_helper<RNG: CryptoRng + RngCore + 'static + Send>(
-    mut chan: SharedChannel,
-    mut rng: RNG,
-    helpers: Vec<Participant>,
-    me: Participant,
-    target_participant: Participant,
-    mut keygen_output: KeygenOutput,
-) -> Result<KeygenOutput, ProtocolError> {
-    // Round 1.
-    // In first round only helpers communicate between each other, sharing their deltas.
+/// Verify that the repaired secret share matches the secret polynomial.
+/// Normally, this would involve using the `VerifiableSecretSharingCommitment` from the FROST library,
+/// which provides the coefficients of `Big_f = f(x) * G`. However, this is not available from the current DKG implementation.
+/// To verify, we instead use participants' verifying shares (`s_i * G`) and interpolate them
+/// at the target participant's identifier (the share being repaired),
+/// then confirm that the computed and actual values match.
+fn verify_share_consistency(
+    identifier: Identifier,
+    verifying_share: VerifyingShare,
+    other_verifying_shares: &BTreeMap<Identifier, VerifyingShare>,
+) -> anyhow::Result<()> {
+    let mut expected = frost_ed25519::Ed25519Group::identity();
 
-    let round1_packages = handle_round1(
-        &mut chan.child(0), // TODO: is it safe to use 0?, Create sub-channel for helpers only, `id` doesn't matter.
-        helpers.as_slice(),
-        me,
-        target_participant,
-        &keygen_output,
-        &mut rng,
-    ).await.map_err(|e| ProtocolError::AssertionFailed(format!("repair:round1: {:?}", e)))?;
-
-
-    // Round 2.
-    // After each helper received all deltas, they craft their sigma and send it to the target participant.
-
-    handle_round2(
-        &mut chan,
-        &round1_packages,
-        target_participant,
-    ).await.map_err(|e| ProtocolError::AssertionFailed(format!("repair:round2: {:?}", e)))?;
-
-    // Round 3.
-
-    let target_verifying_share = handle_round3(
-        &mut chan,
-        target_participant,
-        keygen_output.public_key_package.clone(),
-    ).await.map_err(|e| ProtocolError::AssertionFailed(format!("repair:round3: {:?}", e)))?;
-
-    //
-
-    verify_share_consistency(
-        to_frost_identifier(target_participant),
-        target_verifying_share,
-        keygen_output.public_key_package.verifying_shares(),
-    ).map_err(|e| ProtocolError::AssertionFailed(format!("verify_share_consistency: {:?}", e)))?;
-
-    keygen_output.public_key_package = build_pubkey_with_updated_verifying_shares(
-        &keygen_output.public_key_package,
-        to_frost_identifier(target_participant),
-        target_verifying_share,
-    );
-
-    Ok(keygen_output)
-}
-
-async fn handle_round1<RNG: CryptoRng + RngCore + 'static + Send>(
-    chan: &mut SharedChannel,
-    helpers: &[Participant],
-    me: Participant,
-    target_participant: Participant,
-    keygen_output: &KeygenOutput,
-    rng: &mut RNG,
-) -> anyhow::Result<BTreeMap<Identifier, SerializableScalar<frost_ed25519::Ed25519Sha512>>> {
-    let frost_identifier_me = to_frost_identifier(me);
-    let frost_identifiers = helpers.iter().map(|&p| to_frost_identifier(p)).collect::<Vec<_>>();
-
-    let mut packages_to_send = frost_core::keys::repairable::repair_share_step_1(
-        frost_identifiers.as_slice(),
-        frost_identifier_me,
-        keygen_output.key_package.signing_share(),
-        rng,
-        to_frost_identifier(target_participant),
-    )?.iter().map(|(identifier, delta)| (
-        *identifier,
-        SerializableScalar::<frost_ed25519::Ed25519Sha512>(*delta),
-    )).collect::<BTreeMap<_, _>>();
-
-    let my_package = packages_to_send.remove(&frost_identifier_me).ok_or(
-        anyhow::anyhow!(
-            "Missing package for me"
-        ))?;
-
-    let mut received_packages: BTreeMap<_, _> = {
-        let waitpoint = chan.next_waitpoint();
-        let other_helpers = helpers.iter().filter(|&&x| x != me).cloned().collect::<Vec<_>>();
-
-        distribute_packages(
-            chan,
-            other_helpers.as_slice(),
-            &packages_to_send,
-            waitpoint,
-        ).await;
-
-        collect_packages(chan, other_helpers.as_slice(), waitpoint).await?
-    };
-
-    received_packages.insert(
-        frost_identifier_me,
-        my_package,
-    );
-    if received_packages.len() != helpers.len() {
-        anyhow::bail!("Expected {} packages, got {}", helpers.len(), received_packages.len());
+    let x_set = other_verifying_shares
+        .keys()
+        .cloned()
+        .collect::<BTreeSet<_>>();
+    for (&other_identifier, other_verifying_share) in other_verifying_shares {
+        let phi_i =
+            frost_core::compute_lagrange_coefficient(&x_set, Some(identifier), other_identifier)?;
+        expected += phi_i * other_verifying_share.to_element()
     }
 
-    Ok(received_packages)
-}
-
-async fn handle_round2(
-    chan: &mut SharedChannel,
-    round1_packages: &BTreeMap<Identifier, SerializableScalar<frost_ed25519::Ed25519Sha512>>,
-    target_participant: Participant,
-) -> anyhow::Result<()> {
-    let deltas =
-        round1_packages.values().copied().map(|s| s.0).collect::<Vec<_>>();
-    let sigma = frost_core::keys::repairable::repair_share_step_2::<frost_ed25519::Ed25519Sha512>(
-        deltas.as_slice()
-    );
-
-    let waitpoint = chan.next_waitpoint();
-
-    chan.send_private(
-        waitpoint,
-        target_participant,
-        &SerializableScalar::<frost_ed25519::Ed25519Sha512>(sigma)
-    ).await;
+    if verifying_share.to_element() != expected {
+        anyhow::bail!("Verifying share does not match expected value");
+    }
 
     Ok(())
 }
 
-async fn handle_round3(
-    chan: &mut SharedChannel,
-    target_participant: Participant,
-    public_key_package: PublicKeyPackage,
-) -> anyhow::Result<VerifyingShare> {
-    {
-        let waitpoint = chan.next_waitpoint();
-        chan.send_private(
-            waitpoint,
-            target_participant,
-            &public_key_package,
-        ).await;
-    }
-
-    let (from, verifying_share): (_, VerifyingShare) = {
-        let waitpoint = chan.next_waitpoint();
-        chan.recv(waitpoint).await?
-    };
-
-    if from != target_participant {
-        anyhow::bail!("Received a message from an unexpected participant");
-    }
-
-    Ok(verifying_share)
-}
-
 #[cfg(test)]
 mod tests {
-    use crate::frost::repair::{do_repair_helper, do_repair_target};
-    use crate::frost::tests::{assert_public_key_invariant, assert_signing_schema_threshold_holds, build_key_packages_with_dealer, reconstruct_signing_key};
+    use crate::frost::repair::{helper, target};
+    use crate::frost::tests::{
+        assert_public_key_invariant, assert_signing_schema_threshold_holds,
+        build_key_packages_with_dealer, reconstruct_signing_key,
+    };
     use crate::frost::KeygenOutput;
     use aes_gcm::aead::OsRng;
     use cait_sith::protocol::{make_protocol, Context, Participant, Protocol};
@@ -368,14 +371,14 @@ mod tests {
     ) -> anyhow::Result<Vec<(Participant, KeygenOutput)>> {
         use cait_sith::protocol::run_protocol;
 
-        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output=KeygenOutput>>)> =
+        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> =
             Vec::with_capacity(helpers.len() + 1);
 
         let helpers_list = helpers.iter().map(|(x, _)| *x).collect::<Vec<_>>();
 
         for (participant, key_pair) in helpers {
             let ctx = Context::new();
-            let fut = do_repair_helper(
+            let fut = helper::do_repair(
                 ctx.shared_channel(),
                 OsRng,
                 helpers_list.clone(),
@@ -384,20 +387,20 @@ mod tests {
                 key_pair.clone(),
             );
             let protocol = make_protocol(ctx, fut);
-            let protocol: Box<dyn Protocol<Output=KeygenOutput>> = Box::new(protocol);
+            let protocol: Box<dyn Protocol<Output = KeygenOutput>> = Box::new(protocol);
             protocols.push((*participant, protocol));
         }
 
         {
             let ctx = Context::new();
-            let fut = do_repair_target(
+            let fut = target::do_repair(
                 ctx.shared_channel(),
                 target_participant,
                 helpers_list,
                 threshold,
             );
             let protocol = make_protocol(ctx, fut);
-            let protocol: Box<dyn Protocol<Output=KeygenOutput>> = Box::new(protocol);
+            let protocol: Box<dyn Protocol<Output = KeygenOutput>> = Box::new(protocol);
             protocols.push((target_participant, protocol));
         }
 
@@ -410,13 +413,19 @@ mod tests {
         threshold: usize,
         helpers_count: usize,
     ) -> anyhow::Result<Vec<(Participant, KeygenOutput)>> {
-        let participants = participants.unwrap_or_else(|| build_key_packages_with_dealer(participants_count, threshold));
+        let participants = participants
+            .unwrap_or_else(|| build_key_packages_with_dealer(participants_count, threshold));
         let signing_key = reconstruct_signing_key(participants.as_slice())?;
 
-        let helpers = participants.iter().take(helpers_count).cloned().collect::<Vec<_>>();
+        let helpers = participants
+            .iter()
+            .take(helpers_count)
+            .cloned()
+            .collect::<Vec<_>>();
         let target_participant = Participant::from(OsRng.next_u32());
 
-        let new_participants = build_and_run_repair_protocols(&helpers, target_participant, threshold)?;
+        let new_participants =
+            build_and_run_repair_protocols(&helpers, target_participant, threshold)?;
         {
             let new_participants = new_participants.iter().cloned().collect::<BTreeMap<_, _>>();
             if !new_participants.contains_key(&target_participant) {
@@ -424,14 +433,14 @@ mod tests {
             }
         };
 
-        if helpers_count == participants.len() { // We didn't update pubkey on other participants, so the check will fail otherwise
+        if helpers_count == participants.len() {
+            // We didn't update pubkey on other participants, so the check will fail otherwise
             assert_public_key_invariant(new_participants.as_slice())?;
         }
         assert_signing_schema_threshold_holds(signing_key, threshold, new_participants.as_slice())?;
 
         Ok(new_participants)
     }
-
 
     #[test]
     fn repair_one_participant() -> anyhow::Result<()> {
@@ -464,7 +473,7 @@ mod tests {
                 participants,
                 participants_count,
                 threshold,
-                participants_count + i // Taking all participants as helpers
+                participants_count + i, // Taking all participants as helpers
             )?;
 
             participants = Some(new_participants);

--- a/node/src/frost/repair.rs
+++ b/node/src/frost/repair.rs
@@ -26,7 +26,7 @@
 
 use crate::frost::common::{collect_packages, distribute_packages};
 use crate::frost::{to_frost_identifier, KeygenOutput};
-use cait_sith::protocol::{Participant, Protocol, ProtocolError, SharedChannel};
+use cait_sith::protocol::{Participant, ProtocolError, SharedChannel};
 use frost_core::serialization::SerializableScalar;
 use frost_core::Field;
 use frost_ed25519::keys::{KeyPackage, PublicKeyPackage, SigningShare, VerifyingShare};
@@ -291,7 +291,7 @@ async fn collect_public_keys(
     let wait_point = channel.next_waitpoint();
 
     let public_keys: BTreeMap<_, PublicKeyPackage> =
-        collect_packages(&channel, participants, wait_point).await?;
+        collect_packages(channel, participants, wait_point).await?;
 
     let Some((_, public_key)) = public_keys.first_key_value() else {
         return Err(ProtocolError::AssertionFailed(
@@ -301,7 +301,7 @@ async fn collect_public_keys(
 
     if public_keys
         .iter()
-        .any(|(_, public_key)| public_key != public_key)
+        .any(|(_, other_public_key)| other_public_key != public_key)
     {
         return Err(ProtocolError::AssertionFailed(
             "Received different public key packages".to_string(),

--- a/node/src/frost/repair.rs
+++ b/node/src/frost/repair.rs
@@ -42,10 +42,10 @@ pub(crate) mod target {
         helpers: Vec<Participant>,
         threshold: usize,
     ) -> Result<KeygenOutput, ProtocolError> {
-
         // Round 2.
 
-        let (signing_share, verifying_share) = handle_round2(&mut channel, helpers.as_slice()).await?;
+        let (signing_share, verifying_share) =
+            handle_round2(&mut channel, helpers.as_slice()).await?;
 
         // Round 3.
 
@@ -62,9 +62,9 @@ pub(crate) mod target {
             verifying_share,
             public_key_package.verifying_shares(),
         )
-            .map_err(|e| {
-                ProtocolError::AssertionFailed(format!("verify_share_consistency: {:?}", e))
-            })?;
+        .map_err(|e| {
+            ProtocolError::AssertionFailed(format!("verify_share_consistency: {:?}", e))
+        })?;
 
         public_key_package = build_pubkey_with_updated_verifying_shares(
             &public_key_package,
@@ -128,7 +128,6 @@ pub(crate) mod helper {
         let round1_packages = handle_round1(
             // Create sub-channel for helpers only. `child(0)` is safe to use since there is no `Participant(0)`
             &mut channel.child(0),
-            
             helpers.as_slice(),
             me,
             target_participant,
@@ -217,7 +216,13 @@ pub(crate) mod helper {
                 .cloned()
                 .collect::<Vec<_>>();
 
-            distribute_packages(channel, other_helpers.as_slice(), &packages_to_send, waitpoint).await;
+            distribute_packages(
+                channel,
+                other_helpers.as_slice(),
+                &packages_to_send,
+                waitpoint,
+            )
+            .await;
 
             collect_packages(channel, other_helpers.as_slice(), waitpoint).await?
         };
@@ -250,12 +255,13 @@ pub(crate) mod helper {
 
         let waitpoint = channel.next_waitpoint();
 
-        channel.send_private(
-            waitpoint,
-            target_participant,
-            &SerializableScalar::<frost_ed25519::Ed25519Sha512>(sigma),
-        )
-        .await;
+        channel
+            .send_private(
+                waitpoint,
+                target_participant,
+                &SerializableScalar::<frost_ed25519::Ed25519Sha512>(sigma),
+            )
+            .await;
 
         Ok(())
     }
@@ -267,7 +273,8 @@ pub(crate) mod helper {
     ) -> anyhow::Result<VerifyingShare> {
         {
             let waitpoint = channel.next_waitpoint();
-            channel.send_private(waitpoint, target_participant, &public_key_package)
+            channel
+                .send_private(waitpoint, target_participant, &public_key_package)
                 .await;
         }
 

--- a/node/src/frost/repair.rs
+++ b/node/src/frost/repair.rs
@@ -1,6 +1,6 @@
-//! Wrapper for Frost `repair` algorithm: 
+//! Wrapper for Frost `repair` algorithm:
 //! Any subset of `>= threshold` participants can generate a secret share for another participant.
-//! It's useful when: 
+//! It's useful when:
 //!     (a) participant lost their share
 //!     (b) a new participant is introduced to the set (which after all the same as (a))
 //!
@@ -9,7 +9,7 @@
 //!
 //! As a result `target_participant` receives an instance of `KeygenOutput`.
 //! As a result `helpers` receive updated `PublicKeyPackage`. Group's public key stays the same,
-//!  but we have to update internally stored `verifying_shares` mapping which is updated with the new entry.  
+//!  but we have to update internally stored `verifying_shares` mapping which is updated with the new entry.
 //!
 //! You have to update `PublicKeyPackage` on other participants too, who weren't participating in repairing.
 
@@ -27,7 +27,7 @@ use std::collections::{BTreeMap, BTreeSet};
 /// Public function for the target role in the repair protocol.
 /// The target (i.e. the participant whose share is lost) collects
 /// sigma values from helpers to reconstruct its share.
-pub(crate) fn repair_internal_target<RNG: CryptoRng + RngCore + 'static + Send>(
+pub(crate) fn repair_internal_target(
     helpers: Vec<Participant>,
     me: Participant,
     public_key_package: PublicKeyPackage,
@@ -122,7 +122,7 @@ async fn do_repair_target(
 
     let mut share = frost_ed25519::Ed25519ScalarField::zero();
     for &s in sigmas.values() {
-        share = share + s.0;
+        share += s.0;
     }
     let signing_share = SigningShare::new(share);
 
@@ -244,7 +244,7 @@ async fn handle_round1<RNG: CryptoRng + RngCore + 'static + Send>(
     for (identifier, package) in packages.iter() {
         chan.send_private(
             round1_wait_point,
-            from_frost_identifiers[&identifier],
+            from_frost_identifiers[identifier],
             &SerializableScalar::<frost_ed25519::Ed25519Sha512>(*package),
         )
             .await;
@@ -307,6 +307,7 @@ mod tests {
 
 
     #[derive(Clone)]
+    #[allow(dead_code)]
     pub(crate) enum RepairOutput {
         Target(KeygenOutput),
         Helper(PublicKeyPackage),

--- a/node/src/frost/reshare.rs
+++ b/node/src/frost/reshare.rs
@@ -202,7 +202,6 @@ async fn do_reshare_old_participant<RNG: CryptoRng + RngCore + 'static + Send + 
     keygen_output = do_refresh(
         // Create sub-channel for refresh part only. `child(0)` is safe to use since there is no `Participant(0)`
         ctx.shared_channel().child(0),
-
         rng.clone(),
         old_subset.clone(),
         me,

--- a/node/src/frost/reshare.rs
+++ b/node/src/frost/reshare.rs
@@ -1,0 +1,404 @@
+//!
+//! Composition of `repair ∘ refresh`
+//!
+//!
+
+use crate::frost::refresh::do_refresh;
+use crate::frost::repair::{do_repair_helper, do_repair_target};
+use crate::frost::KeygenOutput;
+use aes_gcm::aead::rand_core::{CryptoRng, RngCore};
+use cait_sith::participants::ParticipantList;
+use cait_sith::protocol::{
+    make_protocol, Context, InitializationError, Participant, Protocol, ProtocolError,
+};
+use itertools::Itertools;
+
+pub(crate) fn reshare_old_participant_internal<
+    RNG: CryptoRng + RngCore + 'static + Send + Clone,
+>(
+    rng: RNG,
+    old_participants: &[Participant],
+    old_threshold: usize,
+    new_participants: &[Participant],
+    new_threshold: usize,
+    me: Participant,
+    my_share: KeygenOutput,
+) -> anyhow::Result<impl Protocol<Output = KeygenOutput>> {
+    let (old_subset, new_subset) = get_subsets(
+        old_participants,
+        old_threshold,
+        new_participants,
+        new_threshold,
+        me,
+    )?;
+
+    if !old_subset.contains(&me) {
+        anyhow::bail!("old participant list must contain this participant");
+    }
+
+    let ctx = Context::new();
+    let fut = do_reshare_old_participant(
+        ctx.clone(),
+        rng,
+        old_subset,
+        new_subset,
+        new_threshold,
+        me,
+        my_share,
+    );
+    let protocol = make_protocol(ctx, fut);
+
+    Ok(protocol)
+}
+
+pub(crate) fn reshare_new_participant_internal<
+    RNG: CryptoRng + RngCore + 'static + Send + Clone,
+>(
+    rng: RNG,
+    old_participants: &[Participant],
+    old_threshold: usize,
+    new_participants: &[Participant],
+    new_threshold: usize,
+    me: Participant,
+) -> anyhow::Result<impl Protocol<Output = KeygenOutput>> {
+    let (old_subset, new_subset) = get_subsets(
+        old_participants,
+        old_threshold,
+        new_participants,
+        new_threshold,
+        me,
+    )?;
+
+    if !new_subset.contains(&me) {
+        anyhow::bail!("old participant list must contain this participant");
+    }
+
+    let ctx = Context::new();
+    let fut =
+        do_reshare_new_participant(ctx.clone(), rng, old_subset, new_subset, new_threshold, me);
+    let protocol = make_protocol(ctx, fut);
+
+    Ok(protocol)
+}
+
+/// TODO: explain
+fn get_subsets(
+    old_participants: &[Participant],
+    old_threshold: usize,
+    new_participants: &[Participant],
+    new_threshold: usize,
+    me: Participant,
+) -> anyhow::Result<(Vec<Participant>, Vec<Participant>)> {
+    if new_threshold != old_threshold {
+        // TODO(#119)
+        anyhow::bail!("threshold adjusting is not supported at the moment");
+    }
+
+    if new_participants.len() < 2 {
+        anyhow::bail!(
+            "participant count cannot be < 2, found: {}",
+            new_participants.len()
+        );
+    };
+    if new_threshold > new_participants.len() {
+        anyhow::bail!(
+            "threshold must be <= participant count, found: {}",
+            new_threshold
+        );
+    }
+
+    let new_participants = ParticipantList::new(new_participants).ok_or_else(|| {
+        InitializationError::BadParameters(
+            "new participant list cannot contain duplicates".to_string(),
+        )
+    })?;
+
+    if !new_participants.contains(me) {
+        anyhow::bail!("new participant list must contain this participant");
+    }
+
+    let old_participants = ParticipantList::new(old_participants).ok_or_else(|| {
+        InitializationError::BadParameters(
+            "old participant list cannot contain duplicates".to_string(),
+        )
+    })?;
+
+    let old_subset = old_participants.intersection(&new_participants);
+    if old_subset.len() < old_threshold {
+        anyhow::bail!("not enough old participants to reconstruct private key for resharing");
+    };
+
+    let new_subset = Vec::from(new_participants)
+        .iter()
+        .filter(|&&x| !old_subset.contains(x))
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let old_subset = Vec::from(old_subset);
+    Ok((old_subset, new_subset))
+}
+
+async fn do_reshare_new_participant<RNG: CryptoRng + RngCore + 'static + Send + Clone>(
+    ctx: Context<'_>,
+    rng: RNG,
+    old_subset: Vec<Participant>,
+    new_subset: Vec<Participant>,
+    threshold: usize,
+    me: Participant,
+) -> Result<KeygenOutput, ProtocolError> {
+    let mut helpers = new_subset
+        .iter()
+        .sorted()
+        .cloned()
+        .filter(|&x| x < me)
+        .chain(old_subset.iter().cloned())
+        .collect::<Vec<_>>();
+
+    let channel = ctx.shared_channel().child(u32::from(me) as u64);
+
+    let keygen_output = do_repair_target(channel, me, helpers.clone(), threshold).await?;
+
+    //
+
+    helpers.push(me);
+    let targets = new_subset
+        .iter()
+        .filter(|&&x| x > me)
+        .sorted()
+        .cloned()
+        .collect::<Vec<_>>();
+
+    let keygen_output =
+        repair_for_targets(ctx, rng.clone(), helpers, targets, me, keygen_output).await?;
+
+    Ok(keygen_output)
+}
+
+async fn do_reshare_old_participant<RNG: CryptoRng + RngCore + 'static + Send + Clone>(
+    ctx: Context<'_>,
+    rng: RNG,
+    old_subset: Vec<Participant>,
+    new_subset: Vec<Participant>,
+    threshold: usize,
+    me: Participant,
+    mut keygen_output: KeygenOutput,
+) -> Result<KeygenOutput, ProtocolError> {
+    keygen_output = do_refresh(
+        ctx.shared_channel().child(0), // TODO: use of zero safety?
+        rng.clone(),
+        old_subset.clone(),
+        me,
+        keygen_output,
+        threshold,
+    )
+    .await?;
+
+    keygen_output = repair_for_targets(ctx, rng, old_subset, new_subset, me, keygen_output).await?;
+
+    Ok(keygen_output)
+}
+
+async fn repair_for_targets<RNG: CryptoRng + RngCore + 'static + Send + Clone>(
+    ctx: Context<'_>,
+    rng: RNG,
+    mut helpers: Vec<Participant>,
+    targets: Vec<Participant>,
+    me: Participant,
+    mut keygen_output: KeygenOutput,
+) -> Result<KeygenOutput, ProtocolError> {
+    for &target in targets.iter().sorted() {
+        let chan = ctx.shared_channel().child(u32::from(target) as u64);
+        keygen_output = do_repair_helper(
+            chan,
+            rng.clone(),
+            helpers.clone(),
+            me,
+            target,
+            keygen_output.clone(),
+        )
+        .await?;
+        helpers.push(target);
+    }
+
+    Ok(keygen_output)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frost::tests::{
+        assert_public_key_invariant, assert_signing_schema_threshold_holds,
+        build_key_packages_with_dealer, reconstruct_signing_key,
+    };
+    use aes_gcm::aead::OsRng;
+    use rand::Rng;
+    use std::collections::BTreeMap;
+
+    pub(crate) fn build_and_run_reshare_protocols(
+        old_participants: &[(Participant, KeygenOutput)],
+        old_threshold: usize,
+        new_participants: &[Participant],
+        new_threshold: usize,
+    ) -> anyhow::Result<Vec<(Participant, KeygenOutput)>> {
+        use cait_sith::protocol::run_protocol;
+
+        let mut protocols: Vec<(Participant, Box<dyn Protocol<Output = KeygenOutput>>)> =
+            Vec::with_capacity(new_participants.len());
+
+        let old_participants_map = old_participants.iter().cloned().collect::<BTreeMap<_, _>>();
+        let old_participants = old_participants_map.keys().cloned().collect::<Vec<_>>();
+
+        for new_participant in new_participants {
+            match old_participants_map.get(new_participant) {
+                None => {
+                    let protocol = reshare_new_participant_internal(
+                        OsRng,
+                        old_participants.clone().as_slice(),
+                        old_threshold,
+                        new_participants,
+                        new_threshold,
+                        *new_participant,
+                    )?;
+                    let protocol: Box<dyn Protocol<Output = KeygenOutput>> = Box::new(protocol);
+                    protocols.push((*new_participant, protocol));
+                }
+                Some(keygen_output) => {
+                    let protocol = reshare_old_participant_internal(
+                        OsRng,
+                        old_participants.clone().as_slice(),
+                        old_threshold,
+                        new_participants,
+                        new_threshold,
+                        *new_participant,
+                        keygen_output.clone(),
+                    )?;
+                    let protocol: Box<dyn Protocol<Output = KeygenOutput>> = Box::new(protocol);
+                    protocols.push((*new_participant, protocol));
+                }
+            }
+        }
+
+        Ok(run_protocol(protocols)?)
+    }
+
+    fn do_test(
+        old_participants: Option<Vec<(Participant, KeygenOutput)>>,
+        old_participant_count: usize,
+        old_threshold: usize,
+        added_participant_count: usize,
+        removed_participant_count: usize,
+        new_threshold: usize,
+    ) -> anyhow::Result<Vec<(Participant, KeygenOutput)>> {
+        let old_participants = old_participants.unwrap_or_else(|| {
+            build_key_packages_with_dealer(old_participant_count, old_threshold)
+        });
+        let signing_key = reconstruct_signing_key(old_participants.as_slice())?;
+
+        let new_participants = old_participants
+            .iter()
+            .map(|(x, _)| x)
+            .skip(removed_participant_count)
+            .cloned()
+            .chain((0..added_participant_count).map(|_| Participant::from(OsRng.next_u32())))
+            .collect::<Vec<_>>();
+
+        let result = build_and_run_reshare_protocols(
+            old_participants.as_slice(),
+            old_threshold,
+            new_participants.as_slice(),
+            new_threshold,
+        )?;
+
+        assert_public_key_invariant(result.as_slice())?;
+        assert_signing_schema_threshold_holds(signing_key, new_threshold, result.as_slice())?;
+
+        Ok(result)
+    }
+
+    #[test]
+    fn remove_one_participant() -> Result<(), anyhow::Error> {
+        let old_participant_count = 4;
+        let old_threshold = 3;
+        let added_participant_count = 0;
+        let removed_participant_count = 1;
+        let new_threshold = old_threshold;
+        do_test(
+            None,
+            old_participant_count,
+            old_threshold,
+            added_participant_count,
+            removed_participant_count,
+            new_threshold,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn add_one_participant() -> Result<(), anyhow::Error> {
+        let old_participant_count = 4;
+        let old_threshold = 3;
+        let added_participant_count = 1;
+        let removed_participant_count = 0;
+        let new_threshold = old_threshold;
+        do_test(
+            None,
+            old_participant_count,
+            old_threshold,
+            added_participant_count,
+            removed_participant_count,
+            new_threshold,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn add_one_remove_one_participant() -> Result<(), anyhow::Error> {
+        let old_participant_count = 4;
+        let old_threshold = 3;
+        let added_participant_count = 1;
+        let removed_participant_count = 1;
+        let new_threshold = old_threshold;
+        do_test(
+            None,
+            old_participant_count,
+            old_threshold,
+            added_participant_count,
+            removed_participant_count,
+            new_threshold,
+        )?;
+        Ok(())
+    }
+
+    #[test]
+    fn sequential_reshare() -> Result<(), anyhow::Error> {
+        let old_participant_count = 4;
+        let old_threshold = 3;
+        let new_threshold = old_threshold;
+        let max_number_of_participants = 7;
+        let iterations = 10;
+
+        let mut old_participants = build_key_packages_with_dealer(old_participant_count, old_threshold);
+
+        for _ in 0..iterations {
+            let removed_participants = OsRng.gen_range(0..=old_participants.len() - old_threshold);
+            let added_participants = {
+                let can_be_added_count =
+                    max_number_of_participants - (old_participants.len() - removed_participants);
+                OsRng.gen_range(0..=can_be_added_count)
+            };
+
+            let new_participants = do_test(
+                Some(old_participants),
+                old_participant_count,
+                old_threshold,
+                added_participants,
+                removed_participants,
+                new_threshold,
+            )?;
+
+            old_participants = new_participants;
+        }
+
+        Ok(())
+    }
+}

--- a/node/src/frost/tests.rs
+++ b/node/src/frost/tests.rs
@@ -1,0 +1,63 @@
+#[cfg(test)]
+use crate::frost::KeygenOutput;
+#[cfg(test)]
+use cait_sith::protocol::Participant;
+
+#[cfg(test)]
+pub(crate) fn build_key_packages_with_dealer(
+    max_signers: usize,
+    min_signers: usize,
+) -> Vec<(Participant, KeygenOutput)> {
+    use crate::frost::to_frost_identifier;
+    use aes_gcm::aead::OsRng;
+    use rand::RngCore;
+    use std::collections::BTreeMap;
+
+    let mut identifiers = Vec::with_capacity(max_signers);
+    for _ in 0..max_signers {
+        // from 1 to avoid assigning 0 to a ParticipantId
+        identifiers.push(Participant::from(OsRng.next_u32()))
+    }
+
+    let from_frost_identifiers = identifiers
+        .iter()
+        .map(|&x| (to_frost_identifier(x), x))
+        .collect::<BTreeMap<_, _>>();
+
+    let identifiers_list = from_frost_identifiers.keys().cloned().collect::<Vec<_>>();
+
+    let (shares, pubkey_package) = frost_ed25519::keys::generate_with_dealer(
+        max_signers as u16,
+        min_signers as u16,
+        frost_ed25519::keys::IdentifierList::Custom(identifiers_list.as_slice()),
+        OsRng,
+    )
+        .unwrap();
+
+    shares
+        .into_iter()
+        .map(|(id, share)| {
+            (
+                from_frost_identifiers[&id],
+                KeygenOutput {
+                    key_package: frost_ed25519::keys::KeyPackage::try_from(share).unwrap(),
+                    public_key_package: pubkey_package.clone(),
+                },
+            )
+        })
+        .collect::<Vec<_>>()
+}
+
+#[cfg(test)]
+pub(crate) fn reconstruct_signing_key(
+    participants: &[(Participant, KeygenOutput)],
+) -> anyhow::Result<frost_ed25519::SigningKey> {
+    let key_packages = participants
+        .iter()
+        .map(|(_, key_pair)| key_pair.key_package.clone())
+        .collect::<Vec<_>>();
+
+    let signing_key = frost_ed25519::keys::reconstruct(&key_packages)?;
+
+    Ok(signing_key)
+}

--- a/node/src/frost/tests.rs
+++ b/node/src/frost/tests.rs
@@ -1,7 +1,12 @@
+use anyhow::Context;
 #[cfg(test)]
 use crate::frost::KeygenOutput;
 #[cfg(test)]
 use cait_sith::protocol::Participant;
+use frost_core::Group;
+use frost_ed25519::keys::VerifyingShare;
+use itertools::Itertools;
+use crate::frost::to_frost_identifier;
 
 #[cfg(test)]
 pub(crate) fn build_key_packages_with_dealer(
@@ -48,6 +53,9 @@ pub(crate) fn build_key_packages_with_dealer(
         .collect::<Vec<_>>()
 }
 
+/// Extract group signin key from participants.
+/// The caller is responsible for providing at least `min_signers` shares:
+///  if less than that is provided, a different key will be returned.
 #[cfg(test)]
 pub(crate) fn reconstruct_signing_key(
     participants: &[(Participant, KeygenOutput)],
@@ -60,4 +68,81 @@ pub(crate) fn reconstruct_signing_key(
     let signing_key = frost_ed25519::keys::reconstruct(&key_packages)?;
 
     Ok(signing_key)
+}
+
+/// Assert that:
+///     1. Each participant has the same view of `PublicKeyPackage`
+///     2. Each participant is present in `PublicKeyPackage::verifying_shares()`
+///     3. No "other" participant is present in `PublicKeyPackage::verifying_shares()`
+///     4. For each participant their `verifying_share = secret_share * G`
+///     5. For each participant their `verifying_share` is the same across `KeyPackage` and `PublicKeyPackage`
+#[cfg(test)]
+pub(crate) fn assert_public_key_invariant(participants: &[(Participant, KeygenOutput)]) -> anyhow::Result<()> {
+    let public_key_package = participants.first().unwrap().1.public_key_package.clone();
+
+    if participants.iter().any(|(_, key_pair)| key_pair.public_key_package != public_key_package) {
+        anyhow::bail!("public key package is not the same for all participants");
+    }
+
+    if public_key_package.verifying_shares().len() != participants.len() {
+        anyhow::bail!("public key package has different number of verifying shares than participants");
+    }
+
+    for (participant, key_pair) in participants {
+        let scalar = key_pair.key_package.signing_share().to_scalar();
+        let actual_verifying_share = {
+            let point = frost_ed25519::Ed25519Group::generator() * scalar;
+            VerifyingShare::new(point)
+        };
+
+        if actual_verifying_share != *key_pair.key_package.verifying_share() {
+            anyhow::bail!("verifying share in `KeyPackage` is not equal to secret share * G");
+        }
+
+        {
+            let expected_verifying_share = key_pair
+                .public_key_package
+                .verifying_shares()
+                .get(&to_frost_identifier(*participant))
+                .context("participant not found in `PublicKeyPackage` verifying shares")?;
+            if actual_verifying_share != *expected_verifying_share {
+                anyhow::bail!("verifying share in `PublicKeyPackage` is not equal to secret share * G");
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Assert that:
+///     1. For each subset of size `< threshold` incorrect signing key is reconstructed.
+///     2. For each subset of size `>= threshold` correct signing key is constructed.
+#[cfg(test)]
+pub(crate) fn assert_signing_schema_threshold_holds(
+    expected_signing_key: frost_ed25519::SigningKey,
+    threshold: usize,
+    participants: &[(Participant, KeygenOutput)],
+) -> anyhow::Result<()> {
+    for actual_signers_count in 1..=participants.len() {
+        participants
+            .iter()
+            .cloned()
+            .combinations(actual_signers_count)
+            .map(|signers| {
+                if actual_signers_count < threshold {
+                    if !reconstruct_signing_key(signers.as_slice()).is_err() {
+                        anyhow::bail!("signing key should not be reconstructed \
+                        for subset of size {}", actual_signers_count);
+                    }
+                } else {
+                    let actual_signing_key = reconstruct_signing_key(signers.as_slice())?;
+                    if actual_signing_key != expected_signing_key {
+                        anyhow::bail!("signing key should be reconstructed for subset of size {},\
+                     which is greater or equal to threshold: {}", actual_signers_count, threshold);
+                    }
+                }
+                Ok(())
+            }).collect::<anyhow::Result<()>>()?;
+    }
+    Ok(())
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,3 +1,5 @@
+extern crate core;
+
 use clap::Parser;
 use tracing::init_logging;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -11,6 +11,7 @@ mod cli;
 mod config;
 mod coordinator;
 mod db;
+mod frost;
 mod hkdf;
 mod indexer;
 mod key_generation;
@@ -32,7 +33,6 @@ mod tracing;
 mod tracking;
 mod triple;
 mod web;
-mod frost;
 
 fn main() -> anyhow::Result<()> {
     init_logging();

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -30,6 +30,7 @@ mod tracing;
 mod tracking;
 mod triple;
 mod web;
+mod frost;
 
 fn main() -> anyhow::Result<()> {
     init_logging();


### PR DESCRIPTION
* Add wrappers for `refresh` and `repair` protocols
* Build `reshare` protocol on top of them 

Each file can be reviewed on its own. Separating might lead to the context loss.  