### PR TITLE
Expand Keyshare Storage functionality to support different signature providers

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -436,11 +436,13 @@ mod tests {
         // Create a dummy private key - this is only for testing
         let private_share = Scalar::ONE;
         let public_key = AffinePoint::default();
-        RootKeyshareData {
-            epoch: 1,
-            private_share,
-            public_key,
-        }
+        RootKeyshareData::new(
+            1,
+            cait_sith::KeygenOutput {
+                private_share,
+                public_key,
+            }
+        )
     }
 
     #[tokio::test]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -441,7 +441,7 @@ mod tests {
             cait_sith::KeygenOutput {
                 private_share,
                 public_key,
-            }
+            },
         )
     }
 

--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -7,7 +7,9 @@ use crate::indexer::participants::{
 };
 use crate::indexer::types::{ChainSendTransactionRequest, ChainVotePkArgs, ChainVoteResharedArgs};
 use crate::indexer::IndexerAPI;
-use crate::keyshare::{KeyshareStorage, KeyshareStorageFactory, PartialRootKeyshareData, RootKeyshareData};
+use crate::keyshare::{
+    KeyshareStorage, KeyshareStorageFactory, PartialRootKeyshareData, RootKeyshareData,
+};
 use crate::metrics;
 use crate::mpc_client::MpcClient;
 use crate::network::{run_network_client, MeshNetworkTransportSender};
@@ -283,8 +285,7 @@ impl Coordinator {
             .load()
             .await?
             .as_ref()
-            .map(PartialRootKeyshareData::as_complete)
-            .flatten();
+            .and_then(PartialRootKeyshareData::as_complete);
         if let Some(existing_key) = existing_key {
             if existing_key.epoch != 0 {
                 tracing::error!(
@@ -388,8 +389,7 @@ impl Coordinator {
             .load()
             .await?
             .as_ref()
-            .map(PartialRootKeyshareData::as_complete)
-            .flatten();
+            .and_then(PartialRootKeyshareData::as_complete);
         let keyshare = match keyshare {
             Some(keyshare) if keyshare.epoch == contract_state.epoch => keyshare,
             _ => {
@@ -475,8 +475,7 @@ impl Coordinator {
             .load()
             .await?
             .as_ref()
-            .map(PartialRootKeyshareData::as_complete)
-            .flatten();
+            .and_then(PartialRootKeyshareData::as_complete);
         let existing_keyshare = match existing_keyshare {
             Some(existing_keyshare) => {
                 // only enter this if the full key event id matches.

--- a/node/src/keyshare/gcp.rs
+++ b/node/src/keyshare/gcp.rs
@@ -1,4 +1,5 @@
 use super::{KeyshareStorage, PartialRootKeyshareData, RootKeyshareData};
+use crate::keyshare::migration::try_load_from_old_keyshare;
 use anyhow::Context;
 use gcloud_sdk::google::cloud::secretmanager::v1::secret_manager_service_client::SecretManagerServiceClient;
 use gcloud_sdk::google::cloud::secretmanager::v1::secret_version::State;
@@ -7,7 +8,6 @@ use gcloud_sdk::google::cloud::secretmanager::v1::{
 };
 use gcloud_sdk::proto_ext::secretmanager::SecretPayload;
 use gcloud_sdk::{GoogleApi, GoogleAuthMiddleware, SecretValue};
-use crate::keyshare::migration::try_load_from_old_keyshare;
 
 /// Keyshare storage that loads and stores the key from Google Secret Manager.
 pub struct GcpKeyshareStorage {
@@ -71,7 +71,7 @@ impl KeyshareStorage for GcpKeyshareStorage {
         let data = secret.data.as_sensitive_bytes();
         let keyshare = match try_load_from_old_keyshare(data) {
             None => serde_json::from_slice(data).context("Failed to parse keygen")?,
-            Some(old_keyshare) => old_keyshare
+            Some(old_keyshare) => old_keyshare,
         };
         Ok(Some(keyshare))
     }

--- a/node/src/keyshare/migration.rs
+++ b/node/src/keyshare/migration.rs
@@ -1,15 +1,9 @@
 //! This is a temporal code which addresses migration from old format,
 //!  when we didn't have distinction on `SignatureProviders`.
 
-use aes_gcm::aead::generic_array::GenericArray;
-use aes_gcm::{Aes128Gcm, KeyInit};
-use anyhow::Context;
-use crate::keyshare::{KeyshareStorage, PartialRootKeyshareData};
+use crate::keyshare::PartialRootKeyshareData;
 use k256::{AffinePoint, Scalar};
 use serde::{Deserialize, Serialize};
-use crate::db;
-use crate::keyshare::local::LocalKeyshareStorage;
-use crate::tests::TestGenerators;
 
 #[derive(Clone, Serialize, Deserialize)]
 pub struct OldRootKeyshareData {
@@ -19,7 +13,7 @@ pub struct OldRootKeyshareData {
 }
 
 pub(crate) fn try_load_from_old_keyshare(data: &[u8]) -> Option<PartialRootKeyshareData> {
-    serde_json::from_slice::<OldRootKeyshareData>(&data)
+    serde_json::from_slice::<OldRootKeyshareData>(data)
         .ok()
         .map(|data| PartialRootKeyshareData {
             epoch: data.epoch,
@@ -30,43 +24,54 @@ pub(crate) fn try_load_from_old_keyshare(data: &[u8]) -> Option<PartialRootKeysh
         })
 }
 
-#[tokio::test]
-async fn test_local_keyshare_storage() -> anyhow::Result<()> {
-    let dir = tempfile::tempdir().unwrap();
-    let dir_path = dir.path().to_path_buf();
-    let key_path = dir_path.join("key");
+#[cfg(test)]
+mod tests {
+    use crate::db;
+    use crate::keyshare::local::LocalKeyshareStorage;
+    use crate::keyshare::migration::OldRootKeyshareData;
+    use crate::keyshare::KeyshareStorage;
+    use crate::tests::TestGenerators;
+    use aes_gcm::aead::generic_array::GenericArray;
+    use aes_gcm::{Aes128Gcm, KeyInit};
+    use anyhow::Context;
 
-    let encryption_key = [1; 16];
+    #[tokio::test]
+    async fn test_local_keyshare_storage() -> anyhow::Result<()> {
+        let dir = tempfile::tempdir().unwrap();
+        let dir_path = dir.path().to_path_buf();
+        let key_path = dir_path.join("key");
 
-    let old_keyshare = {
-        let generated_key = TestGenerators::new(2, 2)
-            .make_keygens()
-            .into_iter()
-            .next()
-            .unwrap()
-            .1;
+        let encryption_key = [1; 16];
 
-        OldRootKeyshareData {
-            epoch: 42,
-            private_share: generated_key.private_share,
-            public_key: generated_key.public_key,
+        let old_keyshare = {
+            let generated_key = TestGenerators::new(2, 2)
+                .make_keygens()
+                .into_iter()
+                .next()
+                .unwrap()
+                .1;
+
+            OldRootKeyshareData {
+                epoch: 42,
+                private_share: generated_key.private_share,
+                public_key: generated_key.public_key,
+            }
+        };
+
+        // Save data into old keyshare format
+        {
+            let cipher = Aes128Gcm::new(GenericArray::from_slice(&encryption_key));
+            let data = serde_json::to_vec(&old_keyshare).context("Failed to serialize keygen")?;
+            let encrypted = db::encrypt(&cipher, &data);
+            tokio::fs::write(&key_path, &encrypted).await?;
         }
-    };
 
-    // Save data into old keyshare format
-    {
-        let cipher = Aes128Gcm::new(GenericArray::from_slice(&encryption_key));
-        let data = serde_json::to_vec(&old_keyshare).context("Failed to serialize keygen")?;
-        let encrypted = db::encrypt(&cipher, &data);
-        tokio::fs::write(&key_path, &encrypted)
-            .await?;
+        let storage = LocalKeyshareStorage::new(dir_path, encryption_key);
+        let loaded_key = storage.load().await?.unwrap();
+        let ecdsa = loaded_key.ecdsa.as_ref().unwrap();
+        assert_eq!(old_keyshare.private_share, ecdsa.private_share);
+        assert_eq!(old_keyshare.public_key, ecdsa.public_key);
+        assert_eq!(old_keyshare.epoch, loaded_key.epoch);
+        Ok(())
     }
-
-    let storage = LocalKeyshareStorage::new(dir_path, encryption_key);
-    let loaded_key = storage.load().await?.unwrap();
-    let ecdsa = loaded_key.ecdsa.as_ref().unwrap();
-    assert_eq!(old_keyshare.private_share, ecdsa.private_share);
-    assert_eq!(old_keyshare.public_key, ecdsa.public_key);
-    assert_eq!(old_keyshare.epoch, loaded_key.epoch);
-    Ok(())
 }

--- a/node/src/keyshare/migration.rs
+++ b/node/src/keyshare/migration.rs
@@ -1,0 +1,72 @@
+//! This is a temporal code which addresses migration from old format,
+//!  when we didn't have distinction on `SignatureProviders`.
+
+use aes_gcm::aead::generic_array::GenericArray;
+use aes_gcm::{Aes128Gcm, KeyInit};
+use anyhow::Context;
+use crate::keyshare::{KeyshareStorage, PartialRootKeyshareData};
+use k256::{AffinePoint, Scalar};
+use serde::{Deserialize, Serialize};
+use crate::db;
+use crate::keyshare::local::LocalKeyshareStorage;
+use crate::tests::TestGenerators;
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct OldRootKeyshareData {
+    pub epoch: u64,
+    pub private_share: Scalar,
+    pub public_key: AffinePoint,
+}
+
+pub(crate) fn try_load_from_old_keyshare(data: &[u8]) -> Option<PartialRootKeyshareData> {
+    serde_json::from_slice::<OldRootKeyshareData>(&data)
+        .ok()
+        .map(|data| PartialRootKeyshareData {
+            epoch: data.epoch,
+            ecdsa: Some(cait_sith::KeygenOutput {
+                private_share: data.private_share,
+                public_key: data.public_key,
+            }),
+        })
+}
+
+#[tokio::test]
+async fn test_local_keyshare_storage() -> anyhow::Result<()> {
+    let dir = tempfile::tempdir().unwrap();
+    let dir_path = dir.path().to_path_buf();
+    let key_path = dir_path.join("key");
+
+    let encryption_key = [1; 16];
+
+    let old_keyshare = {
+        let generated_key = TestGenerators::new(2, 2)
+            .make_keygens()
+            .into_iter()
+            .next()
+            .unwrap()
+            .1;
+
+        OldRootKeyshareData {
+            epoch: 42,
+            private_share: generated_key.private_share,
+            public_key: generated_key.public_key,
+        }
+    };
+
+    // Save data into old keyshare format
+    {
+        let cipher = Aes128Gcm::new(GenericArray::from_slice(&encryption_key));
+        let data = serde_json::to_vec(&old_keyshare).context("Failed to serialize keygen")?;
+        let encrypted = db::encrypt(&cipher, &data);
+        tokio::fs::write(&key_path, &encrypted)
+            .await?;
+    }
+
+    let storage = LocalKeyshareStorage::new(dir_path, encryption_key);
+    let loaded_key = storage.load().await?.unwrap();
+    let ecdsa = loaded_key.ecdsa.as_ref().unwrap();
+    assert_eq!(old_keyshare.private_share, ecdsa.private_share);
+    assert_eq!(old_keyshare.public_key, ecdsa.public_key);
+    assert_eq!(old_keyshare.epoch, loaded_key.epoch);
+    Ok(())
+}

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -1,5 +1,6 @@
 pub mod gcp;
 pub mod local;
+mod migration;
 
 use serde::{Deserialize, Serialize};
 use crate::providers::{EcdsaSignatureProvider, SignatureProvider};

--- a/node/src/keyshare/mod.rs
+++ b/node/src/keyshare/mod.rs
@@ -1,34 +1,73 @@
 pub mod gcp;
 pub mod local;
 
-use cait_sith::KeygenOutput;
-use k256::{AffinePoint, Scalar, Secp256k1};
 use serde::{Deserialize, Serialize};
+use crate::providers::{EcdsaSignatureProvider, SignatureProvider};
 
-/// The root keyshare data along with an epoch. The epoch is incremented
-/// for each key resharing. This is the format stored in the old MPC
-/// implementation, and we're keeping it the same to ease migration.
+
+/// The root keyshare data along with an epoch. The epoch is incremented for each key resharing.
+/// This structure is used in context, where we should have all key shares present (e.g. "Running" state)
 #[derive(Clone, Serialize, Deserialize)]
 pub struct RootKeyshareData {
     pub epoch: u64,
-    pub private_share: Scalar,
-    pub public_key: AffinePoint,
+    pub ecdsa: <EcdsaSignatureProvider as SignatureProvider>::KeygenOutput,
+}
+
+/// A helper structure that allows loading each share separately.
+/// It's useful when we want to introduce a new signature provider without breaking back-compatibility.
+#[derive(Clone, Serialize, Deserialize)]
+pub struct PartialRootKeyshareData {
+    pub epoch: u64,
+    pub ecdsa: Option<<EcdsaSignatureProvider as SignatureProvider>::KeygenOutput>,
+}
+
+impl PartialRootKeyshareData {
+    /// Returns a complete RootKeyshareData if all fields are set.
+    pub(crate) fn as_complete(&self) -> Option<RootKeyshareData> {
+        let Some(ecdsa) = self.ecdsa.clone() else {
+            return None;
+        };
+        Some(RootKeyshareData { epoch: self.epoch, ecdsa })
+    }
 }
 
 impl RootKeyshareData {
-    pub fn keygen_output(&self) -> KeygenOutput<Secp256k1> {
-        KeygenOutput {
-            private_share: self.private_share,
-            public_key: self.public_key,
+    pub fn new(epoch: u64, ecdsa: <EcdsaSignatureProvider as SignatureProvider>::KeygenOutput) -> Self {
+        Self {
+            epoch,
+            ecdsa,
         }
     }
 
-    pub fn new(epoch: u64, keygen_output: KeygenOutput<Secp256k1>) -> Self {
-        Self {
-            epoch,
-            private_share: keygen_output.private_share,
-            public_key: keygen_output.public_key,
-        }
+    /// If some data exists already, check that we can safely overwrite it
+    fn compare_against_existing_share(
+        to_save: &RootKeyshareData,
+        existing: &PartialRootKeyshareData
+    ) -> anyhow::Result<()> {
+        match existing.as_complete() {
+            // Key shares for all signature providers generated -> we do resharing
+            //  -> we have to check, that epoch is greater than it was.
+            Some(existing) => {
+                if existing.epoch >= to_save.epoch {
+                    return Err(anyhow::anyhow!(
+                        "Refusing to overwrite existing keyshare of epoch {} with new keyshare of older epoch {}",
+                        existing.epoch,
+                        to_save.epoch,
+                    ))
+                }
+            }
+
+            // We are still generating a key share for some signature provider -> we have to make sure,
+            //  that we do not overwrite existing key shares
+            None => {
+                if let Some(ecdsa) = &existing.ecdsa {
+                    if ecdsa.private_share != to_save.ecdsa.private_share {
+                        return Err(anyhow::anyhow!("Refusing to overwrite existing ecdsa keyshare"))
+                    }
+                }
+            }
+        };
+        Ok(())
     }
 }
 
@@ -38,7 +77,7 @@ pub trait KeyshareStorage: Send {
     /// Loads the most recent root keyshare data. Returns an error if the data
     /// cannot be read. Returns Ok(None) if the data does not exist (i.e. we've
     /// never participated successfully in a key generation).
-    async fn load(&self) -> anyhow::Result<Option<RootKeyshareData>>;
+    async fn load(&self) -> anyhow::Result<Option<PartialRootKeyshareData>>;
 
     /// Stores the most recent root keyshare data. This can only succeed if the
     /// keyshare didn't exist before or if the new data has a higher epoch.

--- a/node/src/providers/ecdsa/mod.rs
+++ b/node/src/providers/ecdsa/mod.rs
@@ -14,7 +14,7 @@ use crate::db::{DBCol, SecretDB};
 use crate::indexer::participants::ContractResharingState;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::MpcTaskId;
-use crate::providers::{HasParticipants, KeyshareId, SignatureProvider};
+use crate::providers::{HasParticipants, SignatureProvider};
 use crate::sign_request::{SignRequestStorage, SignatureId};
 use crate::tracking;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -105,12 +105,6 @@ pub enum EcdsaTaskId {
 impl From<EcdsaTaskId> for MpcTaskId {
     fn from(val: EcdsaTaskId) -> Self {
         MpcTaskId::EcdsaTaskId(val)
-    }
-}
-
-impl KeyshareId for KeygenOutput<Secp256k1> {
-    fn keyshare_id() -> &'static str {
-        "ecdsa"
     }
 }
 

--- a/node/src/providers/mod.rs
+++ b/node/src/providers/mod.rs
@@ -20,17 +20,11 @@ use crate::config::MpcConfig;
 use crate::indexer::participants::ContractResharingState;
 use crate::primitives::{MpcTaskId, ParticipantId};
 
-/// This `keyshare_id` is used for persisting a key share.
-/// The returned value should be unique across all `SignatureProviders`.
-#[allow(dead_code)] // TODO: To be fixed in #252 follow-up
-pub trait KeyshareId {
-    fn keyshare_id() -> &'static str;
-}
 
 /// The interface that defines the requirements for a signing schema to be correctly used in the code.
 #[allow(dead_code)] // TODO: To be fixed in #252 follow-up
 pub trait SignatureProvider {
-    type KeygenOutput: KeyshareId;
+    type KeygenOutput;
     type SignatureOutput;
 
     /// Trait bound `Into<MpcTaskId>` serves as a way to see what logic needs to be added,

--- a/node/src/providers/mod.rs
+++ b/node/src/providers/mod.rs
@@ -20,7 +20,6 @@ use crate::config::MpcConfig;
 use crate::indexer::participants::ContractResharingState;
 use crate::primitives::{MpcTaskId, ParticipantId};
 
-
 /// The interface that defines the requirements for a signing schema to be correctly used in the code.
 #[allow(dead_code)] // TODO: To be fixed in #252 follow-up
 pub trait SignatureProvider {


### PR DESCRIPTION
* Introduce "partial keyshare storage" - where we optionally load each keyshare.
This allows adding new signature providers (and thus new data to keyshare to serialize) without breaking existing schema
* Add back-compatibility test 
* Adjust coordinator's code, while preserving the same logic
* Remove `KeyshareId` trait trait as unnecessary