### PR TITLE
feat(Tee): Automatic kickout mechanism for invalid TEE status

### DIFF
--- a/libs/chain-signatures/contract/src/errors/impls.rs
+++ b/libs/chain-signatures/contract/src/errors/impls.rs
@@ -6,7 +6,7 @@ use crate::crypto_shared::kdf::TweakNotOnCurve;
 use super::{
     ConversionError, DomainError, Error, ErrorKind, ErrorRepr, InvalidCandidateSet,
     InvalidParameters, InvalidState, InvalidThreshold, KeyEventError, PublicKeyError, RespondError,
-    SignError, VoteError,
+    SignError, TeeError, VoteError,
 };
 
 impl Error {
@@ -132,6 +132,12 @@ impl ConversionError {
 impl From<KeyEventError> for Error {
     fn from(code: KeyEventError) -> Self {
         Self::simple(ErrorKind::KeyEventError(code))
+    }
+}
+
+impl From<TeeError> for Error {
+    fn from(code: TeeError) -> Self {
+        Self::simple(ErrorKind::TeeError(code))
     }
 }
 

--- a/libs/chain-signatures/contract/src/errors/mod.rs
+++ b/libs/chain-signatures/contract/src/errors/mod.rs
@@ -2,6 +2,12 @@ use std::borrow::Cow;
 mod impls;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TeeError {
+    #[error("Due to previously failed tee validation, the network is not accepting new signature requests at this point in time. Try again later.")]
+    TeeValidationFailed,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum SignError {
     #[error("Signature request has timed out.")]
     Timeout,
@@ -198,6 +204,9 @@ pub enum ErrorKind {
     // Domain errors
     #[error("{0}")]
     DomainError(#[from] DomainError),
+    // Tee errors
+    #[error("{0}")]
+    TeeError(#[from] TeeError),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/libs/chain-signatures/contract/src/errors/mod.rs
+++ b/libs/chain-signatures/contract/src/errors/mod.rs
@@ -3,7 +3,7 @@ mod impls;
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum TeeError {
-    #[error("Due to previously failed tee validation, the network is not accepting new signature requests at this point in time. Try again later.")]
+    #[error("Due to previously failed TEE validation, the network is not accepting new signature requests at this point in time. Try again later.")]
     TeeValidationFailed,
 }
 

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -136,7 +136,7 @@ impl TeeState {
         }
     }
 
-    /// Maps `account_id` to its `TeeQuoteStatus`. If `accoun_id` has no TEE information associated to it, then it is mapped to
+    /// Maps `account_id` to its `TeeQuoteStatus`. If `account_id` has no TEE information associated to it, then it is mapped to
     /// `TeeQuoteStatus::None`.
     pub fn tee_status(&self, account_id: &AccountId) -> TeeQuoteStatus {
         let now_sec = env::block_timestamp_ms() / 1_000;
@@ -184,7 +184,6 @@ pub struct MpcContract {
     proposed_updates: ProposedUpdates,
     config: Config,
     tee_state: TeeState,
-    // todo: move `accept_signature_requests` into `tee_state` once PR #410 is merged
     accept_signature_requests: bool,
 }
 
@@ -608,9 +607,6 @@ impl VersionedMpcContract {
             return Err(RespondError::InvalidSignature.into());
         }
 
-        //let Self::V2(mpc_contract) = self else {
-        //    env::panic_str("expected V2")
-        //};
         // First get the yield promise of the (potentially timed out) request.
         if let Some(YieldIndex { data_id }) = mpc_contract.pending_requests.remove(&request) {
             // Finally, resolve the promise. This will have no effect if the request already timed.
@@ -994,12 +990,9 @@ impl VersionedMpcContract {
                             contract.accept_signature_requests = false;
                             return Ok(false);
                         }
-                        // todo: should we set `accept_signature_requests` to false for the duration of the
-                        // resharing (kind of defeats the purpose of implementing rehsharing in
-                        // parallel to running)
 
                         // here, we set it to true, because at this point, we have at least `threshold`
-                        // number of participants running a valid docker image.
+                        // number of participants with an accepted Tee status.
                         contract.accept_signature_requests = true;
 
                         // do we want to adjust the threshold?

--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -969,7 +969,7 @@ impl VersionedMpcContract {
             env::panic_str("expected V1")
         };
         let ProtocolContractState::Running(running_state) = &mut contract.protocol_state else {
-            env::panic_str("require running state");
+            return Err(InvalidState::ProtocolStateNotRunning.into());
         };
         let current_params = running_state.parameters.clone();
         match contract

--- a/libs/chain-signatures/contract/src/primitives/participants.rs
+++ b/libs/chain-signatures/contract/src/primitives/participants.rs
@@ -109,10 +109,6 @@ impl Participants {
         }
         Ok(())
     }
-}
-
-#[cfg(any(test, feature = "test-utils"))]
-impl Participants {
     pub fn init(
         next_id: ParticipantId,
         participants: Vec<(AccountId, ParticipantId, ParticipantInfo)>,
@@ -122,7 +118,10 @@ impl Participants {
             participants,
         }
     }
+}
 
+#[cfg(any(test, feature = "test-utils"))]
+impl Participants {
     pub fn id(&self, account_id: &AccountId) -> Result<ParticipantId, Error> {
         self.participants
             .iter()

--- a/libs/chain-signatures/contract/src/state/running.rs
+++ b/libs/chain-signatures/contract/src/state/running.rs
@@ -47,6 +47,36 @@ impl RunningContractState {
         }
     }
 
+    pub fn transition_to_resharing_no_checks(
+        &mut self,
+        proposal: &ThresholdParameters,
+    ) -> Option<ResharingContractState> {
+        if let Some(first_domain) = self.domains.get_domain_by_index(0) {
+            Some(ResharingContractState {
+                previous_running_state: RunningContractState::new(
+                    self.domains.clone(),
+                    self.keyset.clone(),
+                    self.parameters.clone(),
+                ),
+                reshared_keys: Vec::new(),
+                resharing_key: KeyEvent::new(
+                    self.keyset.epoch_id.next(),
+                    first_domain.clone(),
+                    proposal.clone(),
+                ),
+            })
+        } else {
+            // A new ThresholdParameters was proposed, but we have no keys, so directly
+            // transition into Running state but bump the EpochId.
+            *self = RunningContractState::new(
+                self.domains.clone(),
+                Keyset::new(self.keyset.epoch_id.next(), Vec::new()),
+                proposal.clone(),
+            );
+            None
+        }
+    }
+
     /// Casts a vote for `proposal` to the current state, propagating any errors.
     /// Returns ResharingContractState if the proposal is accepted.
     pub fn vote_new_parameters(
@@ -58,29 +88,7 @@ impl RunningContractState {
             return Err(InvalidParameters::EpochMismatch.into());
         }
         if self.process_new_parameters_proposal(proposal)? {
-            if let Some(first_domain) = self.domains.get_domain_by_index(0) {
-                return Ok(Some(ResharingContractState {
-                    previous_running_state: RunningContractState::new(
-                        self.domains.clone(),
-                        self.keyset.clone(),
-                        self.parameters.clone(),
-                    ),
-                    reshared_keys: Vec::new(),
-                    resharing_key: KeyEvent::new(
-                        self.keyset.epoch_id.next(),
-                        first_domain.clone(),
-                        proposal.clone(),
-                    ),
-                }));
-            } else {
-                // A new ThresholdParameters was proposed, but we have no keys, so directly
-                // transition into Running state but bump the EpochId.
-                *self = RunningContractState::new(
-                    self.domains.clone(),
-                    Keyset::new(self.keyset.epoch_id.next(), Vec::new()),
-                    proposal.clone(),
-                );
-            }
+            return Ok(self.transition_to_resharing_no_checks(proposal));
         }
         Ok(None)
     }

--- a/libs/chain-signatures/contract/src/v0_state/mod.rs
+++ b/libs/chain-signatures/contract/src/v0_state/mod.rs
@@ -152,6 +152,7 @@ impl From<MpcContractV1> for MpcContract {
             proposed_updates: value.proposed_updates,
             config: value.config,
             tee_state: crate::TeeState::default(),
+            accept_signature_requests: true,
         }
     }
 }

--- a/libs/chain-signatures/contract/tests/common.rs
+++ b/libs/chain-signatures/contract/tests/common.rs
@@ -5,7 +5,7 @@ use frost_ed25519::{keys::SigningShare, Ed25519Group, Group, VerifyingKey};
 use fs2::FileExt;
 use k256::{
     elliptic_curve::{point::DecompressPoint as _, sec1::ToEncodedPoint, PrimeField},
-    AffinePoint, FieldBytes, Scalar, Secp256k1, SecretKey,
+    AffinePoint, FieldBytes, Scalar, Secp256k1,
 };
 use mpc_contract::{
     config::InitConfig,
@@ -186,6 +186,7 @@ pub async fn init() -> (Worker<Sandbox>, Contract) {
     (worker, contract)
 }
 
+/// Initializes the contract with `pks` as public keys, a set of participants and a threshold.
 pub async fn init_with_candidates(
     pks: Vec<near_crypto::PublicKey>,
 ) -> (Worker<Sandbox>, Contract, Vec<Account>) {
@@ -247,6 +248,25 @@ pub async fn init_with_candidates(
     dbg!(init);
     (worker, contract, accounts)
 }
+pub enum SharedSecretKey {
+    Secp256k1(k256::elliptic_curve::SecretKey<k256::Secp256k1>),
+    Ed25519(KeygenOutput),
+}
+
+pub fn new_secp256k1() -> (
+    near_crypto::PublicKey,
+    k256::elliptic_curve::SecretKey<k256::Secp256k1>,
+) {
+    let sk = k256::SecretKey::random(&mut rand::thread_rng());
+    let pk = sk.public_key();
+    let pk = near_crypto::PublicKey::SECP256K1(
+        near_crypto::Secp256K1PublicKey::try_from(
+            &pk.as_affine().to_encoded_point(false).as_bytes()[1..65],
+        )
+        .unwrap(),
+    );
+    (pk, sk)
+}
 
 pub async fn init_env_secp256k1(
     num_domains: usize,
@@ -254,56 +274,72 @@ pub async fn init_env_secp256k1(
     Worker<Sandbox>,
     Contract,
     Vec<Account>,
-    Vec<k256::SecretKey>,
+    Vec<SharedSecretKey>,
 ) {
-    let mut public_keys = Vec::new();
-    let mut secret_keys = Vec::new();
-    for _ in 0..num_domains {
-        // TODO: Also add some ed25519 keys.
-        let sk = k256::SecretKey::random(&mut rand::thread_rng());
-        let pk = sk.public_key();
-        public_keys.push(near_crypto::PublicKey::SECP256K1(
-            near_crypto::Secp256K1PublicKey::try_from(
-                &pk.as_affine().to_encoded_point(false).as_bytes()[1..65],
-            )
-            .unwrap(),
-        ));
-        secret_keys.push(sk);
-    }
+    let (public_keys, secret_keys) =
+        make_key_for_domains(vec![SignatureScheme::Secp256k1; num_domains]);
     let (worker, contract, accounts) = init_with_candidates(public_keys).await;
 
     (worker, contract, accounts, secret_keys)
 }
 
-pub async fn init_env_ed25519(
-    num_domains: usize,
-) -> (Worker<Sandbox>, Contract, Vec<Account>, Vec<KeygenOutput>) {
+pub fn make_key_for_domains(
+    schemes: Vec<SignatureScheme>,
+) -> (Vec<near_crypto::PublicKey>, Vec<SharedSecretKey>) {
     let mut public_keys = Vec::new();
     let mut secret_keys = Vec::new();
-    for _ in 0..num_domains {
-        let scalar = curve25519_dalek::Scalar::random(&mut OsRng);
-        let private_share = SigningShare::new(scalar);
-        let public_key_element = Ed25519Group::generator() * scalar;
-        let public_key = VerifyingKey::new(public_key_element);
-
-        let keygen_output = KeygenOutput {
-            private_share,
-            public_key,
-        };
-
-        public_keys.push(near_crypto::PublicKey::ED25519(
-            near_crypto::ED25519PublicKey::from(public_key.to_element().compress().to_bytes()),
-        ));
-
-        secret_keys.push(keygen_output);
+    for scheme in schemes {
+        match scheme {
+            SignatureScheme::Secp256k1 => {
+                let (pk, sk) = new_secp256k1();
+                public_keys.push(pk);
+                secret_keys.push(SharedSecretKey::Secp256k1(sk));
+            }
+            SignatureScheme::Ed25519 => {
+                let (pk, sk) = new_ed25519();
+                public_keys.push(pk);
+                secret_keys.push(SharedSecretKey::Ed25519(sk));
+            }
+        }
     }
+    (public_keys, secret_keys)
+}
+
+pub fn new_ed25519() -> (near_crypto::PublicKey, KeygenOutput) {
+    let scalar = curve25519_dalek::Scalar::random(&mut OsRng);
+    let private_share = SigningShare::new(scalar);
+    let public_key_element = Ed25519Group::generator() * scalar;
+    let public_key = VerifyingKey::new(public_key_element);
+
+    let keygen_output = KeygenOutput {
+        private_share,
+        public_key,
+    };
+
+    let pk = near_crypto::PublicKey::ED25519(near_crypto::ED25519PublicKey::from(
+        public_key.to_element().compress().to_bytes(),
+    ));
+
+    (pk, keygen_output)
+}
+
+pub async fn init_env_ed25519(
+    num_domains: usize,
+) -> (
+    Worker<Sandbox>,
+    Contract,
+    Vec<Account>,
+    Vec<SharedSecretKey>,
+) {
+    let (public_keys, secret_keys) =
+        make_key_for_domains(vec![SignatureScheme::Ed25519; num_domains]);
     let (worker, contract, accounts) = init_with_candidates(public_keys).await;
 
     (worker, contract, accounts, secret_keys)
 }
 
 /// Process the message, creating the same hash with type of [`Digest`] and [`Payload`]
-pub async fn process_message(msg: &str) -> (impl Digest, Payload) {
+pub fn process_message(msg: &str) -> (impl Digest, Payload) {
     let msg = msg.as_bytes();
     let digest = <k256::Secp256k1 as ecdsa::hazmat::DigestPrimitive>::Digest::new_with_prefix(msg);
     let bytes: FieldBytes = digest.clone().finalize_fixed();
@@ -314,7 +350,7 @@ pub async fn process_message(msg: &str) -> (impl Digest, Payload) {
 
 pub fn derive_secret_key_secp256k1(secret_key: &k256::SecretKey, tweak: &Tweak) -> k256::SecretKey {
     let tweak = Scalar::from_repr(tweak.as_bytes().into()).unwrap();
-    SecretKey::new((tweak + secret_key.to_nonzero_scalar().as_ref()).into())
+    k256::SecretKey::new((tweak + secret_key.to_nonzero_scalar().as_ref()).into())
 }
 
 pub fn derive_secret_key_ed25519(secret_key: &KeygenOutput, tweak: &Tweak) -> KeygenOutput {
@@ -333,9 +369,21 @@ pub async fn create_response(
     predecessor_id: &AccountId,
     msg: &str,
     path: &str,
+    sk: &SharedSecretKey,
+) -> (Payload, SignatureRequest, SignatureResponse) {
+    match sk {
+        SharedSecretKey::Secp256k1(sk) => create_response_secp256k1(predecessor_id, msg, path, sk),
+        SharedSecretKey::Ed25519(sk) => create_response_ed25519(predecessor_id, msg, path, sk),
+    }
+}
+
+pub fn create_response_secp256k1(
+    predecessor_id: &AccountId,
+    msg: &str,
+    path: &str,
     sk: &k256::SecretKey,
 ) -> (Payload, SignatureRequest, SignatureResponse) {
-    let (digest, payload) = process_message(msg).await;
+    let (digest, payload) = process_message(msg);
     let pk = sk.public_key();
 
     let tweak = derive_tweak(predecessor_id, path);
@@ -377,7 +425,7 @@ pub async fn create_response(
     (payload, respond_req, respond_resp)
 }
 
-pub async fn create_response_ed25519(
+pub fn create_response_ed25519(
     predecessor_id: &AccountId,
     msg: &str,
     path: &str,

--- a/libs/chain-signatures/contract/tests/sign.rs
+++ b/libs/chain-signatures/contract/tests/sign.rs
@@ -1,7 +1,6 @@
 pub mod common;
 use common::{
-    candidates, create_response, create_response_ed25519, init, init_env_ed25519,
-    init_env_secp256k1, sign_and_validate,
+    candidates, create_response, init, init_env_ed25519, init_env_secp256k1, sign_and_validate,
 };
 use mpc_contract::{
     config::InitConfig,
@@ -393,7 +392,7 @@ async fn test_contract_sign_request_eddsa() -> anyhow::Result<()> {
     for msg in messages {
         println!("submitting: {msg}");
         let (payload, respond_req, respond_resp) =
-            create_response_ed25519(predecessor_id, msg, path, &sks[0]).await;
+            create_response(predecessor_id, msg, path, &sks[0]).await;
 
         let request = SignRequestArgs {
             payload_v2: Some(payload),
@@ -408,7 +407,7 @@ async fn test_contract_sign_request_eddsa() -> anyhow::Result<()> {
     // check duplicate requests can also be signed:
     let duplicate_msg = "welp";
     let (payload, respond_req, respond_resp) =
-        create_response_ed25519(predecessor_id, duplicate_msg, path, &sks[0]).await;
+        create_response(predecessor_id, duplicate_msg, path, &sks[0]).await;
     let request = SignRequestArgs {
         payload_v2: Some(payload),
         path: path.into(),

--- a/libs/chain-signatures/contract/tests/tee.rs
+++ b/libs/chain-signatures/contract/tests/tee.rs
@@ -35,19 +35,4 @@ async fn test_tee_verify_no_tee() -> anyhow::Result<()> {
     Ok(())
 }
 
-#[tokio::test]
-async fn test_tee_verify_with_tee() -> anyhow::Result<()> {
-    let (_, contract, _, _) = init_env_ed25519(1).await;
-    let n_participants_start = get_participants(&contract).await?;
-
-    let verified_tee: bool = contract
-        .call("verify_tee")
-        .args_json(serde_json::json!(""))
-        .max_gas()
-        .transact()
-        .await?
-        .json()?;
-    assert!(verified_tee);
-    assert_eq!(n_participants_start, get_participants(&contract).await?);
-    Ok(())
-}
+// todo [#514](https://github.com/near/mpc/issues/514)

--- a/libs/chain-signatures/contract/tests/tee.rs
+++ b/libs/chain-signatures/contract/tests/tee.rs
@@ -1,0 +1,53 @@
+use common::init_env_ed25519;
+use mpc_contract::state::ProtocolContractState;
+use near_workspaces::Contract;
+
+pub mod common;
+
+async fn get_participants(contract: &Contract) -> anyhow::Result<usize> {
+    let state = contract
+        .call("state")
+        .args_json(serde_json::json!(""))
+        .max_gas()
+        .transact()
+        .await?;
+    let value: ProtocolContractState = state.json()?;
+    let ProtocolContractState::Running(running) = value else {
+        panic!("Expected running state")
+    };
+    Ok(running.parameters.participants().len())
+}
+
+#[tokio::test]
+async fn test_tee_verify_no_tee() -> anyhow::Result<()> {
+    let (_, contract, _, _) = init_env_ed25519(1).await;
+    let n_participants_start = get_participants(&contract).await?;
+
+    let verified_tee: bool = contract
+        .call("verify_tee")
+        .args_json(serde_json::json!(""))
+        .max_gas()
+        .transact()
+        .await?
+        .json()?;
+    assert!(verified_tee);
+    assert_eq!(n_participants_start, get_participants(&contract).await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_tee_verify_with_tee() -> anyhow::Result<()> {
+    let (_, contract, _, _) = init_env_ed25519(1).await;
+    let n_participants_start = get_participants(&contract).await?;
+
+    let verified_tee: bool = contract
+        .call("verify_tee")
+        .args_json(serde_json::json!(""))
+        .max_gas()
+        .transact()
+        .await?
+        .json()?;
+    assert!(verified_tee);
+    assert_eq!(n_participants_start, get_participants(&contract).await?);
+    Ok(())
+}

--- a/libs/chain-signatures/contract/tests/user_views.rs
+++ b/libs/chain-signatures/contract/tests/user_views.rs
@@ -3,6 +3,7 @@ use common::init_env_secp256k1;
 use near_sdk::{CurveType, PublicKey};
 use serde_json::json;
 use std::str::FromStr;
+
 #[tokio::test]
 async fn test_key_version() -> anyhow::Result<()> {
     let (_, contract, _, _) = init_env_secp256k1(1).await;

--- a/node/src/indexer/fake.rs
+++ b/node/src/indexer/fake.rs
@@ -380,6 +380,9 @@ impl FakeIndexerCore {
                         let mut contract = contract.lock().await;
                         contract.vote_abort_key_event(account_id, abort.key_event_id);
                     }
+                    ChainSendTransactionRequest::VerifyTee() => {
+                        // do nothing
+                    }
                 }
             }
             self.block_update_sender.send(block_update).ok();

--- a/node/src/indexer/fake.rs
+++ b/node/src/indexer/fake.rs
@@ -380,9 +380,7 @@ impl FakeIndexerCore {
                         let mut contract = contract.lock().await;
                         contract.vote_abort_key_event(account_id, abort.key_event_id);
                     }
-                    ChainSendTransactionRequest::VerifyTee() => {
-                        // do nothing
-                    }
+                    ChainSendTransactionRequest::VerifyTee() => {}
                 }
             }
             self.block_update_sender.send(block_update).ok();

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -140,6 +140,10 @@ async fn observe_tx_result(
             // we don't care. The contract state change will handle this.
             Ok(ChainTransactionState::Unknown)
         }
+        ChainSendTransactionRequest::VerifyTee() => {
+            // we don't care. The contract state change will handle this.
+            Ok(ChainTransactionState::Unknown)
+        }
     }
 }
 

--- a/node/src/indexer/types.rs
+++ b/node/src/indexer/types.rs
@@ -127,6 +127,7 @@ pub enum ChainSendTransactionRequest {
     VoteReshared(ChainVoteResharedArgs),
     StartReshare(ChainStartReshareArgs),
     VoteAbortKeyEvent(ChainVoteAbortKeyEventArgs),
+    VerifyTee(),
 }
 
 impl ChainSendTransactionRequest {
@@ -138,6 +139,7 @@ impl ChainSendTransactionRequest {
             ChainSendTransactionRequest::StartReshare(_) => "start_reshare_instance",
             ChainSendTransactionRequest::StartKeygen(_) => "start_keygen_instance",
             ChainSendTransactionRequest::VoteAbortKeyEvent(_) => "vote_abort_key_event",
+            ChainSendTransactionRequest::VerifyTee() => "verify_tee",
         }
     }
 
@@ -148,7 +150,8 @@ impl ChainSendTransactionRequest {
             | Self::VoteReshared(_)
             | Self::StartReshare(_)
             | Self::StartKeygen(_)
-            | Self::VoteAbortKeyEvent(_) => 300 * TGAS,
+            | Self::VoteAbortKeyEvent(_)
+            | Self::VerifyTee() => 300 * TGAS,
         }
     }
 }

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -205,3 +205,12 @@ lazy_static! {
         )
         .unwrap();
 }
+
+lazy_static! {
+    pub static ref VERIFY_TEE_REQUESTS_SENT: prometheus::IntCounter =
+        prometheus::register_int_counter!(
+            "verify_tee_requests_sent",
+            "failed to send on channel in sign_request_channel",
+        )
+        .unwrap();
+}

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -25,7 +25,8 @@ use tokio::time::{sleep, timeout};
 /// responded to multiple times. It doesn't affect correctness, but can make tests less flaky and
 /// production runs experience fewer redundant signatures.
 const INITIAL_STARTUP_SIGNATURE_PROCESSING_DELAY: Duration = Duration::from_secs(2);
-const TWO_DAYS_S: Duration = Duration::from_secs(60 * 60 * 24 * 2);
+const TEE_CONTRACT_VERIFICATION_INVOCATION_INTERVAL_DURATION: Duration =
+    Duration::from_secs(60 * 60 * 24 * 2);
 
 #[derive(Clone)]
 pub struct MpcClient {
@@ -108,7 +109,8 @@ impl MpcClient {
                         );
                         return;
                     }
-                    sleep(TWO_DAYS_S).await;
+                    metrics::VERIFY_TEE_REQUESTS_SENT.inc();
+                    sleep(TEE_CONTRACT_VERIFICATION_INVOCATION_INTERVAL_DURATION).await;
                 }
             })
         };

--- a/node/src/mpc_client.rs
+++ b/node/src/mpc_client.rs
@@ -101,8 +101,6 @@ impl MpcClient {
                         .send(ChainSendTransactionRequest::VerifyTee())
                         .await
                     {
-                        // does this mean we panic and exit here??
-                        // We should not
                         tracing::error!("Error sending VerifyTee request: {:?}", e);
                     }
                     sleep(Duration::from_secs(60 * 60 * 24 * 2)).await; // every 2 days


### PR DESCRIPTION
Resolves #424:

This PR introduces a new unprotected endpoint: `verify_tee`.
The purpose of this endpoint is to assess the current TEE status of all participants and take corrective action if necessary:
- If `threshold` or more participants have a `Valid` or `None` TEE status:
    - A re-sharing is triggered, excluding participants with an `Invalid` status, preserving the current threshold.
- If fewer than `threshold` participants have a `Valid` or `None` TEE status:
    - The contract stops accepting new signature requests until enough participants update their status and `verify_tee` is called again.

Note that this endpoint can only be called while the protocol is in running state.


(not sure about where to place the background task in the node @near-bookrock any suggestions?)


Requires additional testing https://github.com/near/mpc/issues/514