### PR TITLE
adjust prepaid gas in contract

### DIFF
--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -48,7 +48,7 @@ const GAS_FOR_SIGN_CALL: Gas = Gas::from_tgas(10);
 // Register used to receive data id from `promise_await_data`.
 const DATA_ID_REGISTER: u64 = 0;
 // Prepaid gas for a `return_signature_and_clean_state_on_success` call
-const RETURN_SIGNATURE_AND_CLEAN_STATE_ON_SUCCESS_CALL_GAS: Gas = Gas::from_tgas(5);
+const RETURN_SIGNATURE_AND_CLEAN_STATE_ON_SUCCESS_CALL_GAS: Gas = Gas::from_tgas(6);
 // Prepaid gas for a `update_config` call
 const UPDATE_CONFIG_GAS: Gas = Gas::from_tgas(5);
 // Maximum time after which TEE MPC nodes must be upgraded to the latest version
@@ -992,7 +992,7 @@ impl VersionedMpcContract {
                     "fail_on_timeout".to_string(),
                     vec![],
                     NearToken::from_near(0),
-                    Gas::from_tgas(1),
+                    Gas::from_tgas(2),
                 );
                 near_sdk::PromiseOrValue::Promise(promise.as_return())
             }

--- a/libs/chain-signatures/rust-toolchain.toml
+++ b/libs/chain-signatures/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.85.1"
+components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
The contract still seems to run [out of gas](https://testnet.nearblocks.io/txns/GNWMQfbdPAkBYH5hsLy4mqhsCPoSvUrZHibUKvfG7TN3?tab=execution#CJdLFzGkvUYitWGUQ14oG8UZzc8vUiPkxXWjPvQ2q6n2) when a signature request fails.

Since #380, we successfully remove the transaction from the contract state, but now run out of gas in the very last step `fail_on_timeout`.

This is not a pressing issue, because this will not result in any inconsistent state and the final execution outcome is still a failure, which is desirable.

However, might be good to fix this with the next release.