### PR TITLE
toolchain fix

### DIFF
--- a/libs/chain-signatures/rust-toolchain.toml
+++ b/libs/chain-signatures/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.85.1"
+components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
fix the rust toolchain:
```
error: 'cargo-clippy' is not installed for the toolchain '1.85.1-x86_64-unknown-linux-gnu'.
To install, run `rustup component add --toolchain 1.85.1-x86_64-unknown-linux-gnu clippy`
```