### PR TITLE
fix: Threshold check for previous running state was using new resharing threshold

### DIFF
--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -385,7 +385,7 @@ impl Coordinator {
 
         let mut running_participants = running_state.participants.clone();
 
-        let participants = match &running_state.resharing_state {
+        let participants_config = match &running_state.resharing_state {
             Some(resharing_state) => resharing_state.new_participants.clone(),
             None => running_participants.clone(),
         };
@@ -393,10 +393,10 @@ impl Coordinator {
         // Only consider the running participants that are also members of the new resharing state.
         running_participants
             .participants
-            .retain(|p| participants.participants.contains(p));
+            .retain(|p| participants_config.participants.contains(p));
 
         let Some(mpc_config) = MpcConfig::from_participants_with_near_account_id(
-            participants,
+            participants_config,
             &config_file.my_near_account_id,
         ) else {
             tracing::info!("We are not a participant in the current epoch; doing nothing until contract state change");
@@ -407,15 +407,11 @@ impl Coordinator {
 
         let (sender, receiver) =
             new_tls_mesh_network(&mpc_config, &secrets.p2p_private_key).await?;
-
-        tracing::info!("wait for ready.");
-        sender
-            .wait_for_ready(mpc_config.participants.threshold as usize)
-            .await?;
+        let sender = Arc::new(sender);
 
         tracing::info!("Creating network client.");
         let (network_client, mut channel_receiver, _handle) =
-            run_network_client(Arc::new(sender), Box::new(receiver));
+            run_network_client(sender.clone(), Box::new(receiver));
 
         let cancellation_token = CancellationToken::new();
         let cancellation_token_child = cancellation_token.child_token();
@@ -522,6 +518,11 @@ impl Coordinator {
                     "Running epoch {:?} as participant {}",
                     running_state.keyset.epoch_id, running_mpc_config.my_participant_id
                 ));
+
+                tracing::info!("wait for ready.");
+                sender
+                    .wait_for_ready(mpc_config.participants.threshold as usize)
+                    .await?;
 
                 let sign_request_store = Arc::new(SignRequestStorage::new(secret_db.clone())?);
 


### PR DESCRIPTION
We have a checkpoint [0] in the running state that waits on a threshold number of participants are online before starting the running state. We have a bug where this check is done before spawning the resharing handle, which is not the correct behavior. The resharing handle should be spawned independently of the conditions of the running state.

Another bug is that it was using the threshold size of the new resharing state, instead of the threshold size of the previous running state that is being spawned.

Both issues are fixed in this PR. This is consistent with the behavior previous to merging running and resharing state in the node https://github.com/near/mpc/blob/83e0970a3e7428011d3ab1fb7bbd916fdc0e299f/node/src/coordinator.rs#L378

[0]
```rust
sender
    .wait_for_ready(mpc_config.participants.threshold as usize)
    .await?;
```