### PR TITLE
chore: remove log message on every incoming network channel

### DIFF
--- a/node/src/coordinator.rs
+++ b/node/src/coordinator.rs
@@ -430,7 +430,6 @@ impl Coordinator {
                                 break;
                             };
 
-                            tracing::info!("received channel {:?}", network_channel.task_id());
                             let is_resharing_message = matches!(
                                 network_channel.task_id(),
                                 MpcTaskId::EcdsaTaskId(EcdsaTaskId::KeyResharing { .. })
@@ -451,7 +450,7 @@ impl Coordinator {
                         }
 
                         _ = cancellation_token_child.cancelled() => {
-                            info!("cancelled token.");
+                            info!("Network multiplexer cancelled.");
                             break;
                         }
 


### PR DESCRIPTION
The removed log message was firing off too frequently, clogging up our logs, and does not serve much value.