### PR TITLE
chore: Initial Changelog + CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
   pull_request:
   merge_group:
-    
 
 jobs:
   ci-tests:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -3,7 +3,6 @@ name: PR Title Lint
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened, ready_for_review]
-  merge_group:
 
 jobs:
   lint-pr-title:

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,29 @@
+name: PR Title Lint
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, ready_for_review]
+  merge_group:
+
+jobs:
+  lint-pr-title:
+    name: "Lint PR title for Conventional Commits"
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || github.event_name == 'merge_group'
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        with:
+          types: |
+            feat
+            fix
+            chore
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            revert
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,153 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+
+This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+## [unreleased]
+
+### 🧪 Testing
+
+- [#481](https://github.com/near/mpc/pull/481)(@near-bookrock): Test that threshold from previous running state is used when serving sign requests in resharing (#481)
+
+## [2.2.0-rc1] - 2025-06-11
+
+### ⚙️ Miscellaneous Tasks
+
+- [#490](https://github.com/near/mpc/pull/490)(@near-bookrock): Bump versions for new release candidate (#490)
+
+
+## [2.0.1-rc2] - 2025-06-10
+
+### 🚀 Features
+
+- [#466](https://github.com/near/mpc/pull/466)(@near-bookrock): *(TEE)* Implement remote attestation information generation (#466)
+
+
+### 🐛 Bug Fixes
+
+- [#480](https://github.com/near/mpc/pull/480)(@near-bookrock): Use threshold number for previous running state in resharing (#480)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- [#477](https://github.com/near/mpc/pull/477)(@netrome): Add MIT license and third party license notices (#477)
+
+
+## [2.0.1-rc1] - 2025-06-03
+
+### 🚀 Features
+
+- [#438](https://github.com/near/mpc/pull/438)(@near-bookrock): Parallel resharing and running (#438)
+
+
+### 🐛 Bug Fixes
+
+- [#370](https://github.com/near/mpc/pull/370)(@near-bookrock): Return early in Indexer thread and listen_blocks if channel to MPC node is closed.
+
+
+### 💼 Other
+
+- [#416](https://github.com/near/mpc/pull/416)(@andrei-near): Fix import keyshare  (#416)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- [#366](https://github.com/near/mpc/pull/366)(@near-bookrock): Add metrics for latency of signature request responses (#366)
+
+- [#373](https://github.com/near/mpc/pull/373)(@near-bookrock): Add metrics for latency of signature request responses in seconds
+
+- [#371](https://github.com/near/mpc/pull/371)(@near-bookrock): Remove spawn_blocking call wrapping the indexer thread (#371)
+
+- [#406](https://github.com/near/mpc/pull/406)(@near-bookrock): Remove unwrap in `monitor_passive_channels_inner` (#406)
+
+
+## [2.0.0-rc.1] - 2025-04-11
+
+### 🚀 Features
+
+- [#294](https://github.com/near/mpc/pull/294)(@near-bookrock): *(EdDSA)* Add support for EdDSA signature requests on the smart contract (#294)
+
+
+### 🐛 Bug Fixes
+
+- [#209](https://github.com/near/mpc/pull/209)(@pbeza): *(audit)* Fix TLS certificate verification (#209)
+
+- [#268](https://github.com/near/mpc/pull/268)(@near-bookrock): Pinned legacy contract dependency to git revistion (#268)
+
+- [#328](https://github.com/near/mpc/pull/328)(@near-bookrock): Add pre-computed edwards_point of EdDSA keys to contract state (#328)
+
+- [#358](https://github.com/near/mpc/pull/358)(@near-bookrock): Use internal tag for signature response type for backwards compatibility (#358)
+
+
+### 💼 Other
+
+- [#260](https://github.com/near/mpc/pull/260)(@andrei-near): MPC Load Balancer removal (#260)
+
+- [#267](https://github.com/near/mpc/pull/267)(@andrei-near): Implement import-export keyshare (#267)
+
+- [#274](https://github.com/near/mpc/pull/274)(@peter-near): Removed unused cipher key generation (#274)
+
+- [#292](https://github.com/near/mpc/pull/292)(@andrei-near): Tokio runtime for import/export keyshare commands (#292)
+
+- [#300](https://github.com/near/mpc/pull/300)(@andrei-near): Vote leave cmd (#300)
+
+- [#269](https://github.com/near/mpc/pull/269)(@kuksag): Reuse `PayloadHash` and `Epsilon` types from contact (#269)
+
+- [#304](https://github.com/near/mpc/pull/304)(@andrei-near): Warpbuild GHA runners (#304)
+
+- [#331](https://github.com/near/mpc/pull/331)(@andrei-near): Option to use own funding account (#331)
+
+- [#335](https://github.com/near/mpc/pull/335)(@andrei-near): MPC_HOME_DIR in image init script (#335)
+
+- [#336](https://github.com/near/mpc/pull/336)(@peter-near): Added IDE configs to git ignore (#336)
+
+
+### 🚜 Refactor
+
+- [#210](https://github.com/near/mpc/pull/210)(@pbeza): *(audit)* Remove explicit .into_iter (#210)
+
+- [#215](https://github.com/near/mpc/pull/215)(@pbeza): *(audit)* Shorten CLI's function bodies (#215)
+
+- [#283](https://github.com/near/mpc/pull/283)(@near-bookrock): Use `[u8; 32]` instead of Scalar type from `k256` crate in contract (#283)
+
+- [#341](https://github.com/near/mpc/pull/341)(@near-bookrock): Remove ScalarExt trait (#341)
+
+
+### 🧪 Testing
+
+- [#265](https://github.com/near/mpc/pull/265)(@bowenwang1996): Reduce flakiness by reducing the amount of assets buffered in tests (#265)
+
+- [#339](https://github.com/near/mpc/pull/339)(@near-bookrock): Test public key derivation in contract (#339)
+
+- [#347](https://github.com/near/mpc/pull/347)(@near-bookrock): *(eddsa)* Add integration test for EdDSA signature requests (#347)
+
+- [#348](https://github.com/near/mpc/pull/348)(@near-bookrock): Enable EdDSA signature requets in pytests (#348)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- [#281](https://github.com/near/mpc/pull/281)(@near-bookrock): Remove self dependency to `legacy_contract` (#281)
+
+- [#286](https://github.com/near/mpc/pull/286)(@near-bookrock): Pin `near-sdk` version to 5.2.1 (#286)
+
+- [#282](https://github.com/near/mpc/pull/282)(@near-bookrock): Move `crypto-shared` to a module in contract (#282)
+
+- [#359](https://github.com/near/mpc/pull/359)(@near-bookrock): Fix typo in codebase edd25519 to ed25519
+
+- [#334](https://github.com/near/mpc/pull/334)(@near-bookrock): Add docs to EdDSA fields in `PublicKeyExtended`. (#334)
+
+
+## [testnet-upgrade] - 2025-01-09
+
+### 💼 Other
+
+- [#59](https://github.com/near/mpc/pull/59)(@andrei-near): Replace cache with rust-cache (#59)
+
+- [#115](https://github.com/near/mpc/pull/115)(@andrei-near): Workflow to build and publish MPC docker images (#115)
+
+- [#116](https://github.com/near/mpc/pull/116)(@andrei-near): Docker image builder nit (#116)
+
+
+

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,109 @@
+# git-cliff ~ configuration file
+# https://git-cliff.org/docs/configuration
+
+
+[changelog]
+# A Tera template to be rendered as the changelog's footer.
+# See https://keats.github.io/tera/docs/#introduction
+header = """
+# Changelog\n
+All notable changes to this project will be documented in this file.\n
+
+This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
+
+"""
+# A Tera template to be rendered for each release in the changelog.
+# See https://keats.github.io/tera/docs/#introduction
+body = """
+{% if version %}\
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else %}\
+    ## [unreleased]
+{% endif %}\
+{% for group, commits in commits | group_by(attribute="group") %}
+    ### {{ group | striptags | trim | upper_first }}
+    {% for commit in commits %}
+        - {% if commit.remote.pr_number %}\
+            [#{{ commit.remote.pr_number }}](https://github.com/near/mpc/pull/{{ commit.remote.pr_number }})\
+          {%- endif %}\
+          {% if commit.remote.username %}(@{{ commit.remote.username }}){%- endif %}: \
+          {% if commit.scope %}*({{ commit.scope }})* {% endif %}\
+            {% if commit.breaking %}[**breaking**] {% endif %}\
+            {{ commit.message | upper_first }}
+    {% endfor %}
+{% endfor %}\n
+"""
+# A Tera template to be rendered as the changelog's footer.
+# See https://keats.github.io/tera/docs/#introduction
+footer = """
+"""
+# Remove leading and trailing whitespaces from the changelog's body.
+trim = true
+# Render body even when there are no releases to process.
+render_always = true
+# An array of regex based postprocessors to modify the changelog.
+postprocessors = [
+    # Replace the placeholder <REPO> with a URL.
+    #{ pattern = '<REPO>', replace = "https://github.com/orhun/git-cliff" },
+]
+# render body even when there are no releases to process
+# render_always = true
+# output file path
+# output = "test.md"
+
+[git]
+# Parse commits according to the conventional commits specification.
+# See https://www.conventionalcommits.org
+conventional_commits = true
+# Exclude commits that do not match the conventional commits specification.
+filter_unconventional = true
+# Require all commits to be conventional.
+# Takes precedence over filter_unconventional.
+require_conventional = false
+# Split commits on newlines, treating each line as an individual commit.
+split_commits = false
+# An array of regex based parsers to modify commit messages prior to further processing.
+commit_preprocessors = [
+    # Replace issue numbers with link templates to be updated in `changelog.postprocessors`.
+    #{ pattern = '\((\w+\s)?#([0-9]+)\)', replace = "([#${2}](<REPO>/issues/${2}))"},
+    # Check spelling of the commit message using https://github.com/crate-ci/typos.
+    # If the spelling is incorrect, it will be fixed automatically.
+    #{ pattern = '.*', replace_command = 'typos --write-changes -' },
+]
+# Prevent commits that are breaking from being excluded by commit parsers.
+protect_breaking_commits = false
+# An array of regex based parsers for extracting data from the commit message.
+# Assigns commits to groups.
+# Optionally sets the commit's scope and can decide to exclude commits from further processing.
+commit_parsers = [
+    { message = "^feat", group = "<!-- 0 -->🚀 Features" },
+    { message = "^fix", group = "<!-- 1 -->🐛 Bug Fixes" },
+    { message = "^doc", group = "<!-- 3 -->📚 Documentation" },
+    { message = "^perf", group = "<!-- 4 -->⚡ Performance" },
+    { message = "^refactor", group = "<!-- 2 -->🚜 Refactor" },
+    { message = "^style", group = "<!-- 5 -->🎨 Styling" },
+    { message = "^test", group = "<!-- 6 -->🧪 Testing" },
+    { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^chore\\(deps.*\\)", skip = true },
+    { message = "^chore\\(pr\\)", skip = true },
+    { message = "^chore\\(pull\\)", skip = true },
+    { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
+    { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
+    { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
+    { message = ".*", group = "<!-- 10 -->💼 Other" },
+]
+# Exclude commits that are not matched by any commit parser.
+filter_commits = false
+# An array of link parsers for extracting external references, and turning them into URLs, using regex.
+link_parsers = []
+# Include only the tags that belong to the current branch.
+use_branch_tags = false
+# Order releases topologically instead of chronologically.
+topo_order = false
+# Order releases topologically instead of chronologically.
+topo_order_commits = true
+# Order of commits in each group/release within the changelog.
+# Allowed values: newest, oldest
+sort_commits = "oldest"
+# Process submodules commits
+recurse_submodules = false


### PR DESCRIPTION
- closes #491 

This PR introduces an initial changelog, generated using `git-cliff`. Additionally, I've added a CI check to enforce the usage of conventional commits going forward. This will allow us to generate useful changelogs directly from our commit history for future releases.