### PR TITLE
fix(node): add timeout to avoid race condition in integration test

### DIFF
--- a/node/src/network/conn.rs
+++ b/node/src/network/conn.rs
@@ -172,7 +172,6 @@ impl<I: Send + Sync + 'static, O: Send + Sync + 'static> NodeConnectivity<I, O> 
             anyhow::bail!("Connection was dropped");
         };
 
-        info!("Got a connection handle.");
         Ok(conn)
     }
 }

--- a/node/src/tests/multidomain.rs
+++ b/node/src/tests/multidomain.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::p2p::testing::PortSeed;
 use crate::tests::{request_signature_and_await_response, IntegrationTestSetup};
 use crate::tracking::AutoAbortTask;
@@ -92,6 +94,9 @@ async fn test_basic_multidomain() {
         let mut contract = setup.indexer.contract_mut().await;
         contract.start_resharing(setup.participants);
     }
+
+    // give nodes time to enter resharing so we don't lose the request.
+    tokio::time::sleep(Duration::from_millis(500));
 
     for domain in &domains {
         assert!(request_signature_and_await_response(


### PR DESCRIPTION
In #394 , we introduced the capability to handle signature requests while being in resharing state.
Unfortunately, this lead to a race condition, resulting in at least one flaky test (c.f. https://github.com/near/mpc/issues/439).

This PR adds a timeout to avoid the race condition.
In addition, it removes a log statement that was a bit excessive.


See these logs as an example of a failed run:

https://github.com/near/mpc/actions/runs/15635164527/job/44048349639

[log file](https://github.com/user-attachments/files/20727510/logs.log)