### PR TITLE
fix: ignore peers who are behind in a computation

### DIFF
--- a/libs/chain-signatures/rust-toolchain.toml
+++ b/libs/chain-signatures/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.85.1"
+components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,28 +1,33 @@
-use crate::config::{
-    load_config_file, BlockArgs, KeygenConfig, PresignatureConfig, SecretsConfig, SignatureConfig,
-    SyncMode, TripleConfig, WebUIConfig,
+use crate::{
+    config::{
+        load_config_file, BlockArgs, ConfigFile, IndexerConfig, KeygenConfig, PresignatureConfig,
+        SecretsConfig, SignatureConfig, SyncMode, TripleConfig, WebUIConfig,
+    },
+    coordinator::Coordinator,
+    db::SecretDB,
+    indexer::{real::spawn_real_indexer, IndexerAPI},
+    keyshare::{
+        compat::legacy_ecdsa_key_from_keyshares,
+        local::LocalPermanentKeyStorageBackend,
+        permanent::{LegacyRootKeyshareData, PermanentKeyStorage, PermanentKeyStorageBackend},
+        GcpPermanentKeyStorageConfig, KeyStorageConfig,
+    },
+    p2p::testing::{generate_test_p2p_configs, PortSeed},
+    tracking::{self, start_root_task},
+    web::start_web_server,
 };
-use crate::config::{ConfigFile, IndexerConfig};
-use crate::coordinator::Coordinator;
-use crate::db::SecretDB;
-use crate::indexer::{real::spawn_real_indexer, IndexerAPI};
-use crate::keyshare::compat::legacy_ecdsa_key_from_keyshares;
-use crate::keyshare::local::LocalPermanentKeyStorageBackend;
-use crate::keyshare::permanent::{
-    LegacyRootKeyshareData, PermanentKeyStorage, PermanentKeyStorageBackend,
-};
-use crate::keyshare::{GcpPermanentKeyStorageConfig, KeyStorageConfig};
-use crate::p2p::testing::{generate_test_p2p_configs, PortSeed};
-use crate::tracking::{self, start_root_task};
-use crate::web::start_web_server;
+use anyhow::Context;
 use clap::Parser;
 use hex::FromHex;
 use near_crypto::SecretKey;
 use near_indexer_primitives::types::Finality;
 use near_sdk::AccountId;
 use near_time::Clock;
-use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::{
+    path::PathBuf,
+    sync::{Arc, Mutex},
+};
+use tokio::sync::oneshot;
 
 #[derive(Parser, Debug)]
 pub enum Cli {
@@ -132,11 +137,13 @@ impl StartCmd {
             SecretsConfig::from_cli(&self.secret_store_key_hex, self.p2p_private_key.clone())?;
         let config = load_config_file(&home_dir)?;
 
-        let (indexer_handle, indexer_api) = spawn_real_indexer(
+        let (indexer_exit_sender, indexer_exit_receiver) = oneshot::channel();
+        let indexer_api = spawn_real_indexer(
             home_dir.clone(),
             config.indexer.clone(),
             config.my_near_account_id.clone(),
             self.account_secret_key.clone(),
+            indexer_exit_sender,
         );
 
         let root_future = Self::create_root_future(
@@ -154,22 +161,15 @@ impl StartCmd {
             .build()?;
 
         let root_task = root_runtime.spawn(start_root_task("root", root_future).0);
-        let indexer_handle = root_runtime.spawn_blocking(move || {
-            if let Err(e) = indexer_handle.join() {
-                anyhow::bail!("Indexer thread failed: {:?}", e);
-            }
-            anyhow::Ok(())
-        });
 
         tokio::select! {
-            res = root_task => {
-                res??;
+            root_task_result = root_task => {
+                root_task_result?
             }
-            res = indexer_handle => {
-                res??;
+            indexer_exit_response = indexer_exit_receiver => {
+                indexer_exit_response.context("Indexer thread dropped response channel.")?
             }
         }
-        Ok(())
     }
 
     async fn create_root_future(

--- a/node/src/indexer/real.rs
+++ b/node/src/indexer/real.rs
@@ -8,23 +8,26 @@ use near_crypto::SecretKey;
 use near_sdk::AccountId;
 use std::path::PathBuf;
 use std::sync::Arc;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex};
 
-/// Spawn a real indexer, returning a handle to the indexer root thread,
-/// and an API to interact with the indexer.
+/// Spawns a real indexer, returning a handle to the indexer, [`IndexerApi`].
+///
+/// If an unrecoverable error occurs, the spawned indexer will terminate, and the provided [`oneshot::Sender`]
+/// will be used to propagate the error.
 pub fn spawn_real_indexer(
     home_dir: PathBuf,
     indexer_config: IndexerConfig,
     my_near_account_id: AccountId,
     account_secret_key: SecretKey,
-) -> (std::thread::JoinHandle<()>, IndexerAPI) {
+    indexer_exit_sender: oneshot::Sender<anyhow::Result<()>>,
+) -> IndexerAPI {
     let (chain_config_sender, chain_config_receiver) =
         tokio::sync::watch::channel::<ContractState>(ContractState::WaitingForSync);
     let (block_update_sender, block_update_receiver) = mpsc::unbounded_channel();
     let (chain_txn_sender, chain_txn_receiver) = mpsc::channel(10000);
 
-    let thread = std::thread::spawn(move || {
-        // TODO(#156): replace actix with tokio
+    // TODO(#156): replace actix with tokio
+    std::thread::spawn(move || {
         actix::System::new().block_on(async {
             let indexer =
                 near_indexer::Indexer::new(indexer_config.to_near_indexer_config(home_dir.clone()))
@@ -66,7 +69,7 @@ pub fn spawn_real_indexer(
                 respond_config,
                 indexer_state.clone(),
             ));
-            listen_blocks(
+            let indexer_result = listen_blocks(
                 stream,
                 indexer_config.concurrency,
                 Arc::clone(&stats),
@@ -74,14 +77,16 @@ pub fn spawn_real_indexer(
                 block_update_sender,
             )
             .await;
+
+            if indexer_exit_sender.send(indexer_result).is_err() {
+                tracing::error!("Indexer thread could not send result back to main driver.")
+            };
         });
     });
-    (
-        thread,
-        IndexerAPI {
-            contract_state_receiver: chain_config_receiver,
-            block_update_receiver: Arc::new(Mutex::new(block_update_receiver)),
-            txn_sender: chain_txn_sender,
-        },
-    )
+
+    IndexerAPI {
+        contract_state_receiver: chain_config_receiver,
+        block_update_receiver: Arc::new(Mutex::new(block_update_receiver)),
+        txn_sender: chain_txn_sender,
+    }
 }

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -91,6 +91,10 @@ impl NetworkTaskChannelManager {
 const LRU_CAPACITY: usize = 10000;
 
 impl MeshNetworkClient {
+    /// The maximum height difference that we are willing to accept.
+    /// This is used to filter out participants that are too far behind in the indexer height.
+    const MAX_HEIGHT_DIFF: u64 = 100;
+
     /// Primary functionality for the MeshNetworkClient: returns a channel for the given
     /// new MPC task. It is expected that the caller is the leader of this MPC task, and that the
     /// way the MPC task IDs are assigned ensures that no two participants would initiate
@@ -142,14 +146,20 @@ impl MeshNetworkClient {
     /// This is a subset of all_participant_ids, and includes our own participant ID.
     pub fn all_alive_participant_ids(&self) -> Vec<ParticipantId> {
         let mut result = Vec::new();
+        let my_height = *self
+            .get_indexer_heights()
+            .get(&self.my_participant_id())
+            .unwrap_or(&0);
         for participant in self.all_participant_ids() {
             if participant == self.my_participant_id() {
                 continue;
             }
-            if self
-                .transport_sender
-                .connectivity(participant)
-                .is_bidirectionally_connected()
+            let peer_height = *self.get_indexer_heights().get(&participant).unwrap_or(&0);
+            if my_height <= peer_height + Self::MAX_HEIGHT_DIFF
+                && self
+                    .transport_sender
+                    .connectivity(participant)
+                    .is_bidirectionally_connected()
             {
                 result.push(participant);
             }


### PR DESCRIPTION
Ignore peers who are behind in a computation to prevent them from ruining a computation because they are stuck

TODO: add tests