### PR TITLE
feat: enable network hardship simulation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
           cargo build -p neard --release
 
       - name: Build mpc node
-        run: cargo build -p mpc-node --release
+        run: cargo build -p mpc-node --release --features=network-hardship-simulation
 
       - name: Setup python
         uses: actions/setup-python@v4

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -88,3 +88,4 @@ rstest = "0.25.0"
 
 [features]
 tee = []
+network-hardship-simulation = []

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -193,6 +193,7 @@ async fn ensure_send_transaction(
     }
 }
 
+#[cfg(not(feature = "network-hardship-simulation"))]
 pub(crate) async fn handle_txn_requests(
     mut receiver: mpsc::Receiver<ChainSendTransactionRequest>,
     owner_account_id: AccountId,

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -193,7 +193,6 @@ async fn ensure_send_transaction(
     }
 }
 
-#[cfg(not(feature = "network-hardship-simulation"))]
 pub(crate) async fn handle_txn_requests(
     mut receiver: mpsc::Receiver<ChainSendTransactionRequest>,
     owner_account_id: AccountId,

--- a/node/src/tests/faulty.rs
+++ b/node/src/tests/faulty.rs
@@ -220,13 +220,14 @@ async fn test_indexer_stuck() {
     );
 
     tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-
-    assert!(request_signature_and_await_response(
-        &mut setup.indexer,
-        "user2",
-        &domain,
-        std::time::Duration::from_secs(60)
-    )
-    .await
-    .is_some());
+    for _ in 0..5 {
+        assert!(request_signature_and_await_response(
+            &mut setup.indexer,
+            "user2",
+            &domain,
+            std::time::Duration::from_secs(60)
+        )
+        .await
+        .is_some());
+    }
 }

--- a/node/src/tests/mod.rs
+++ b/node/src/tests/mod.rs
@@ -43,7 +43,7 @@ mod research;
 mod resharing;
 
 const DEFAULT_BLOCK_TIME: std::time::Duration = std::time::Duration::from_millis(300);
-const DEFAULT_MAX_PROTOCOL_WAIT_TIME: std::time::Duration = std::time::Duration::from_secs(20);
+const DEFAULT_MAX_PROTOCOL_WAIT_TIME: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Convenient test utilities to generate keys, triples, presignatures, and signatures.
 pub struct TestGenerators {

--- a/node/src/tests/resharing.rs
+++ b/node/src/tests/resharing.rs
@@ -111,7 +111,7 @@ async fn test_key_resharing_multistage() {
         THRESHOLD,
         TXN_DELAY_BLOCKS,
         PortSeed::KEY_RESHARING_MULTISTAGE_TEST,
-        DEFAULT_BLOCK_TIME,
+        std::time::Duration::from_millis(600),
     );
 
     // Initialize the contract with two fewer participants.

--- a/pytest/common_lib/constants.py
+++ b/pytest/common_lib/constants.py
@@ -5,6 +5,8 @@ MPC_REPO_DIR = pathlib.Path(__file__).resolve().parents[2]
 MPC_BINARY_PATH = os.path.join(MPC_REPO_DIR / 'target' / 'release', 'mpc-node')
 CONFIG_PATH = os.path.join(MPC_REPO_DIR / 'pytest' / 'config.json')
 
+LISTEN_BLOCKS_FILE = "listen_blocks.flag"
+
 TIMEOUT = 60
 SHORT_TIMEOUT = 10
 NEAR_BASE = 10**24

--- a/pytest/common_lib/shared/__init__.py
+++ b/pytest/common_lib/shared/__init__.py
@@ -309,6 +309,7 @@ def start_cluster_with_mpc(
             pytest_signer_keys,
         )
         cluster.contract_node.send_txn_and_check_success(tx)
+        mpc_node.set_block_ingestion(True)
         mpc_nodes.append(mpc_node)
 
     # Deploy the mpc contract

--- a/pytest/common_lib/shared/mpc_cluster.py
+++ b/pytest/common_lib/shared/mpc_cluster.py
@@ -95,7 +95,7 @@ class MpcCluster:
     def mpc_contract_account(self):
         return self.contract_node.account_id()
 
-    def get_int_metric_value(self, metric_name):
+    def get_int_metric_value(self, metric_name) -> List[Optional[int]]:
         return [
             node.metrics.get_int_metric_value(metric_name)
             for node in self.mpc_nodes

--- a/pytest/common_lib/shared/mpc_node.py
+++ b/pytest/common_lib/shared/mpc_node.py
@@ -6,7 +6,7 @@ import time
 from key import Key
 from ruamel.yaml import YAML
 
-from common_lib.constants import MPC_BINARY_PATH, TIMEOUT
+from common_lib.constants import LISTEN_BLOCKS_FILE, MPC_BINARY_PATH, TIMEOUT
 from common_lib.shared.near_account import NearAccount
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -126,7 +126,7 @@ class MpcNode(NearAccount):
                 conns = self.metrics.get_metric_all_values(
                     "mpc_network_live_connections")
                 print("mpc_network_live_connections", conns)
-                connection_count = int(sum([kv[1] for kv in conns]))
+                connection_count = int(sum([int(kv[1]) for kv in conns]))
                 if connection_count == awaited_count:
                     break
             except requests.exceptions.ConnectionError:
@@ -138,3 +138,9 @@ class MpcNode(NearAccount):
         file_path = file_path / "temporary_keys" / f"started_{epoch_id}_{domain_id}_{attempt_id}"
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.touch()
+
+    def set_block_ingestion(self, value: bool):
+        file_path = pathlib.Path(self.home_dir)
+        file_path = file_path / LISTEN_BLOCKS_FILE
+        print(f"setting {file_path} to {value}")
+        file_path.write_text(str(value).lower())

--- a/pytest/exec_pytest.sh
+++ b/pytest/exec_pytest.sh
@@ -110,7 +110,7 @@ if ! log_output bash -c "cd '$LIB_DIR/nearcore' && cargo build --quiet --color=a
 fi
 
 printf "\nBuilding main node"
-if ! log_output bash -c "cd '$GIT_ROOT' && cargo build --quiet --color=always -p mpc-node --release"; then
+if ! log_output bash -c "cd '$GIT_ROOT' && cargo build --quiet --color=always -p mpc-node --release --features=network-hardship-simulation"; then
     echo "Cargo failed to complete mpc node compilation:"
     exit 1
 fi

--- a/pytest/readme.md
+++ b/pytest/readme.md
@@ -16,7 +16,7 @@ git submodule update --init --recursive --force
 cd libs/nearcore && cargo build -p neard --release
 
 # build the main node
-cd ../.. && cargo build -p mpc-node --release
+cd ../.. && cargo build -p mpc-node --release --features=network-hardship-simulation
 ```
 
 3. Set up virtualenv (optional, but recommended):

--- a/pytest/tests/test_lost_assets.py
+++ b/pytest/tests/test_lost_assets.py
@@ -10,7 +10,6 @@ import time
 import pathlib
 import argparse
 from typing import List
-from datetime import datetime
 import requests
 
 from common_lib.shared import MpcCluster, MpcNode
@@ -107,6 +106,9 @@ def test_lost_assets():
 
 
 def test_signature_pause_block_ingestion():
+    """
+    This test requires the MPC binary to be compiled with the feature flag "network-hardship-simulation"
+    """
     cluster, mpc_nodes = shared.start_cluster_with_mpc(
         2,
         3,
@@ -125,34 +127,8 @@ def test_signature_pause_block_ingestion():
 
     # we wait for the other nodes to cleanup
     wait_for_asset_cleanup(cluster.mpc_nodes[1:])
-    # we pause
-    #for _ in range(0, 120):
-    #    print(
-    #        "owned and online:\n",
-    #        cluster.get_int_metric_value("mpc_owned_num_presignatures_online"))
-    #    print(
-    #        "owned and offline:\n",
-    #        cluster.get_int_metric_value(
-    #            "mpc_owned_num_presignatures_with_offline_participant"))
-    #    print("block height:\n",
-    #          cluster.get_int_metric_value("mpc_indexer_latest_block_height"))
-    #    sleep(1)
-    t0 = datetime.now()
-    cluster.send_and_await_signature_requests(1)
-    t1 = datetime.now()
-    delay = t1 - t0
-    print(f"time passed: {delay}")
 
-    cluster.send_and_await_signature_requests(1)
-    t2 = datetime.now()
-    delay = t2 - t1
-    print(f"time passed: {delay}")
-    # we would expect to get faster
-    cluster.send_and_await_signature_requests(1)
-    t3 = datetime.now()
-    delay = t3 - t2
-    print(f"time passed: {delay}")
-    # we would expect to get faster
+    cluster.send_and_await_signature_requests(5)
 
 
 if __name__ == '__main__':

--- a/pytest/tests/test_lost_assets.py
+++ b/pytest/tests/test_lost_assets.py
@@ -9,7 +9,11 @@ import sys
 import time
 import pathlib
 import argparse
-import pytest
+from typing import List
+from datetime import datetime
+import requests
+
+from common_lib.shared import MpcCluster, MpcNode
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from common_lib import shared
@@ -19,22 +23,7 @@ from common_lib.constants import TIMEOUT
 PRESIGNATURES_TO_BUFFER = 8
 
 
-@pytest.mark.parametrize("num_requests, num_respond_access_keys", [(10, 1)])
-def test_lost_assets(num_requests, num_respond_access_keys):
-    cluster, mpc_nodes = shared.start_cluster_with_mpc(
-        2,
-        3,
-        num_respond_access_keys,
-        load_mpc_contract(),
-        presignatures_to_buffer=PRESIGNATURES_TO_BUFFER)
-    cluster.init_cluster(participants=mpc_nodes, threshold=2)
-
-    # Cluster should connect in a full mesh, including self-connections
-    cluster.mpc_nodes[0].wait_for_connection_count(3)
-    cluster.mpc_nodes[1].wait_for_connection_count(3)
-    cluster.mpc_nodes[2].wait_for_connection_count(3)
-
-    # Wait for presignatures to buffer
+def wait_for_presignatures_to_buffer(cluster: MpcCluster):
     started = time.time()
     while True:
         assert time.time() - started < TIMEOUT, "Waiting for presignatures"
@@ -49,6 +38,46 @@ def test_lost_assets(num_requests, num_respond_access_keys):
             pass
         time.sleep(1)
 
+
+def wait_for_asset_cleanup(mpc_nodes: List[MpcNode]):
+    started = time.time()
+    while True:
+        assert time.time() - started < TIMEOUT, "Waiting for asset cleanup"
+        try:
+            cleanup_done = True
+            for node in mpc_nodes:
+                available = node.metrics.get_int_metric_value(
+                    "mpc_owned_num_presignatures_available")
+                online = node.metrics.get_int_metric_value(
+                    "mpc_owned_num_presignatures_online")
+                offline = node.metrics.get_int_metric_value(
+                    "mpc_owned_num_presignatures_with_offline_participant")
+                print(
+                    f"node {node.print()} has owned presignatures available={available} online={online} with_offline_participant={offline}"
+                )
+                if not (online == PRESIGNATURES_TO_BUFFER and offline == 0):
+                    cleanup_done = False
+            if cleanup_done:
+                break
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(1)
+
+
+def test_lost_assets():
+    cluster, mpc_nodes = shared.start_cluster_with_mpc(
+        2,
+        3,
+        1,
+        load_mpc_contract(),
+        presignatures_to_buffer=PRESIGNATURES_TO_BUFFER,
+    )
+    cluster.init_cluster(participants=mpc_nodes, threshold=2)
+    cluster.wait_for_state("Running")
+
+    # Wait for nodes to have assets with everyone else
+    wait_for_presignatures_to_buffer(cluster)
+
     # Stop mpc node 0 and wipe its database. Any assets generated before this point
     # which included node 0 are now unusable because node 0 has lost its share.
     cluster.mpc_nodes[0].kill(gentle=True)
@@ -60,28 +89,7 @@ def test_lost_assets(num_requests, num_respond_access_keys):
     cluster.mpc_nodes[2].wait_for_connection_count(2)
 
     # Wait for nodes 1 and 2 to clean up assets involving node 0
-    started = time.time()
-    while True:
-        assert time.time() - started < TIMEOUT, "Waiting for asset cleanup"
-        try:
-            cleanup_done = True
-            for i in range(1, len(cluster.mpc_nodes)):
-                available = cluster.get_int_metric_value_for_node(
-                    "mpc_owned_num_presignatures_available", i)
-                online = cluster.get_int_metric_value_for_node(
-                    "mpc_owned_num_presignatures_online", i)
-                offline = cluster.get_int_metric_value_for_node(
-                    "mpc_owned_num_presignatures_with_offline_participant", i)
-                print(
-                    f"node {i} has owned presignatures available={available} online={online} with_offline_participant={offline}"
-                )
-                if not (online == PRESIGNATURES_TO_BUFFER and offline == 0):
-                    cleanup_done = False
-            if cleanup_done:
-                break
-        except requests.exceptions.ConnectionError:
-            pass
-        time.sleep(1)
+    wait_for_asset_cleanup(cluster.mpc_nodes)
 
     # Start node 0 again
     cluster.mpc_nodes[0].run()
@@ -96,6 +104,55 @@ def test_lost_assets(num_requests, num_respond_access_keys):
     presignatures_available = sum(
         cluster.get_int_metric_value('mpc_owned_num_presignatures_available'))
     cluster.send_and_await_signature_requests(presignatures_available // 4)
+
+
+def test_signature_pause_block_ingestion():
+    cluster, mpc_nodes = shared.start_cluster_with_mpc(
+        2,
+        3,
+        1,
+        load_mpc_contract(),
+        presignatures_to_buffer=PRESIGNATURES_TO_BUFFER,
+    )
+    cluster.init_cluster(mpc_nodes, 2)
+    cluster.wait_for_state("Running")
+
+    # Wait for nodes to have assets with everyone else
+    wait_for_presignatures_to_buffer(cluster)
+
+    # Simulate node 0's indexer falling behind
+    mpc_nodes[0].set_block_ingestion(False)
+
+    # we wait for the other nodes to cleanup
+    wait_for_asset_cleanup(cluster.mpc_nodes[1:])
+    # we pause
+    #for _ in range(0, 120):
+    #    print(
+    #        "owned and online:\n",
+    #        cluster.get_int_metric_value("mpc_owned_num_presignatures_online"))
+    #    print(
+    #        "owned and offline:\n",
+    #        cluster.get_int_metric_value(
+    #            "mpc_owned_num_presignatures_with_offline_participant"))
+    #    print("block height:\n",
+    #          cluster.get_int_metric_value("mpc_indexer_latest_block_height"))
+    #    sleep(1)
+    t0 = datetime.now()
+    cluster.send_and_await_signature_requests(1)
+    t1 = datetime.now()
+    delay = t1 - t0
+    print(f"time passed: {delay}")
+
+    cluster.send_and_await_signature_requests(1)
+    t2 = datetime.now()
+    delay = t2 - t1
+    print(f"time passed: {delay}")
+    # we would expect to get faster
+    cluster.send_and_await_signature_requests(1)
+    t3 = datetime.now()
+    delay = t3 - t2
+    print(f"time passed: {delay}")
+    # we would expect to get faster
 
 
 if __name__ == '__main__':

--- a/pytest/tests/test_lost_assets.py
+++ b/pytest/tests/test_lost_assets.py
@@ -145,6 +145,9 @@ def test_signature_pause_block_ingestion():
 
     cluster.send_and_await_signature_requests(5)
 
+    # re-enable block ingestion, in case any tests run afterwards
+    mpc_nodes[0].set_block_ingestion(True)
+
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
### This PR introduces:

- a pytest for https://github.com/near/mpc/pull/595
- the ability to simulate network hardship for the indexer.

Additionally, resolves https://github.com/near/mpc/issues/561

### Hardship Testing:
The binary can now be compiled with the feature `--network-hardship-simulation`. If done so, then the indexer will read the contents of a file `listen_blocks.flag`, located in the home directory of the node.

If the the file exists, then it must contain a boolean value. If that value is `false`, then the indexer will stop ingesting blocks, simulating an error similar to what we encountered on mainnet.

This feature can be used to test the fix introduced in #595 in pytests, testnet or mainnet clusters

If we need to put https://github.com/near/mpc/issues/592 on hold or not implement it at all, due to constants of our TEE set-up, then this would be an alternative for simulating network hardship.