### PR TITLE
ci: fix docker build and publish action

### DIFF
--- a/deployment/Dockerfile-gcp
+++ b/deployment/Dockerfile-gcp
@@ -9,7 +9,7 @@ COPY rust-toolchain.toml rust-toolchain.toml
 COPY libs/chain-signatures libs/chain-signatures
 COPY third-party-licenses third-party-licenses
 
-RUN cargo build --locked --release
+RUN cargo build -p mpc-node --locked --release
 
 FROM google/cloud-sdk:debian_component_based AS runtime
 RUN apt-get update -y \

--- a/deployment/Dockerfile-gcp
+++ b/deployment/Dockerfile-gcp
@@ -3,6 +3,7 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends clang  # nee
 
 WORKDIR /app
 COPY node node
+COPY devnet devnet
 COPY Cargo.lock Cargo.lock
 COPY Cargo.toml Cargo.toml
 COPY rust-toolchain.toml rust-toolchain.toml


### PR DESCRIPTION
The docker build and publish action is currently broken on`main`. The issue that the `devnet` package recently became a part of the workspace, but in the docker file we forgot to include the directory its defined in to the build action.

This PR includes copying the`devnet`directory in the build action docker file.

Link to failed action on main https://github.com/near/mpc/actions/runs/15872850961/job/44753339713
```
9.054 Caused by:
9.054   failed to read `/app/devnet/Cargo.toml`
```

Verified that it works with these changes:
https://github.com/near/mpc/actions/runs/15873852911