### PR TITLE
[node setup] Remove p2p and signer key retrival via gcp

### DIFF
--- a/deployment/gcp-start.sh
+++ b/deployment/gcp-start.sh
@@ -80,22 +80,5 @@ else
   echo "Using provided MPC_SECRET_STORE_KEY from environment"
 fi
 
-# Check if MPC_P2P_PRIVATE_KEY is empty - if so, fetch from GCP Secret Manager
-if [ -z "${MPC_P2P_PRIVATE_KEY}" ]; then
-  echo "MPC_P2P_PRIVATE_KEY not provided in environment, will fetch from GCP Secret Manager..."
-  export MPC_P2P_PRIVATE_KEY=$(gcloud secrets versions access latest --project $GCP_PROJECT_ID --secret=$GCP_P2P_PRIVATE_KEY_SECRET_ID)
-else
-  echo "Using provided MPC_P2P_PRIVATE_KEY from environment"
-fi
-
-# Check if MPC_ACCOUNT_SK is empty - if so, fetch from GCP Secret Manager
-if [ -z "${MPC_ACCOUNT_SK}" ]; then
-  echo "MPC_ACCOUNT_SK not provided in environment, will fetch from GCP Secret Manager..."
-  export MPC_ACCOUNT_SK=$(gcloud secrets versions access latest --project $GCP_PROJECT_ID --secret=$GCP_ACCOUNT_SK_SECRET_ID)
-else
-  echo "Using provided MPC_ACCOUNT_SK from environment"
-fi
-
-
 echo "Starting mpc node..."
 /app/mpc-node start


### PR DESCRIPTION
After #445 we generate those keys inside a node, so we should stop retrieving it from GCP on start.