### PR TITLE
chore: add `near_responder_id` and number of responder keys in `gcp-start.sh` logic

### DIFF
--- a/deployment/gcp-start.sh
+++ b/deployment/gcp-start.sh
@@ -27,10 +27,19 @@ json.dump(config, open("$NEAR_NODE_CONFIG_FILE", 'w'), indent=2)
 EOF
 }
 
+if [ -n "$MPC_RESPONDER_ID" ]; then
+  responder_id="$MPC_RESPONDER_ID"
+else
+  echo "WARNING: \$MPC_RESPONDER_ID is not set, falling back to \$MPC_ACCOUNT_ID"
+  responder_id="$MPC_ACCOUNT_ID"
+fi
+
 initialize_mpc_config() {
   cat <<EOF > "$1"
 # Configuration File
 my_near_account_id: $MPC_ACCOUNT_ID
+near_responder_account_id: $responder_id
+number_of_responder_keys: 50
 web_ui:
   host: 0.0.0.0
   port: 8080


### PR DESCRIPTION
After #445 we generate responder keys inside a node, thus we no longer read values from `respond.yaml` config, that was supplying the keys and the responder account id.
Responder account id field migrated into `config.yaml`.

This PR brings back default behaviour when responder id wasn't specified + sets the value in the config