### PR TITLE
fix: harden launcher docker-compose config against privilege escalation

### DIFF
--- a/tee-launcher/launcher-docker-compose.yaml
+++ b/tee-launcher/launcher-docker-compose.yaml
@@ -2,16 +2,27 @@ version: '3.8'
 
 services:
   web:
-    image: barakeinavhnear/launcher:latest # todo (security) use spesific image hash  
+    image: barakeinavhnear/launcher:latest  # TODO (security): Replace with a specific image digest
     container_name: launcher
+
     environment:
       - DOCKER_CONTENT_TRUST=1
-      - DEFAULT_IMAGE_DIGEST=sha256:4b08c2745a33aa28503e86e33547cc5a564abbb13ed73755937ded1429358c9d # nearone/mpc-node-gcp:testnet-release
+      - DEFAULT_IMAGE_DIGEST=sha256:4b08c2745a33aa28503e86e33547cc5a564abbb13ed73755937ded1429358c9d  # nearone/mpc-node-gcp:testnet-release
+
     volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
+      - /var/run/docker.sock:/var/run/docker.sock 
       - /var/run/dstack.sock:/var/run/dstack.sock
       - /tapp:/tapp:ro
       - shared-volume:/mnt/shared:ro
+
+    security_opt:
+      - no-new-privileges:true
+
+    read_only: true
+
+    tmpfs:
+      - /tmp  # Required for many apps to function correctly when root FS is read-only
+
 volumes:
   shared-volume:
     name: shared-volume


### PR DESCRIPTION
This PR addresses security hardening recommendations identified in the TEE audit (Finding ID: TOB-NROTDX-3) by applying the following changes to launcher-docker-compose.yaml:

Ensures minimal privilege use by:

Setting a read-only root filesystem (read_only: true)

Adding security_opt: no-new-privileges:true to prevent privilege escalation

Documents the image hash usage and TODO comment for replacing the tag with a verified digest

Maintains necessary volume mounts for Docker and Dstack operation

These updates reduce attack surface while preserving the required functionality of the launcher container.