### PR TITLE
feat: Bump near core to 2.7 on testnet release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -953,12 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1509,12 +1503,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -1536,15 +1524,6 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bindgen"
@@ -1659,25 +1638,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b17679a8d69b6d7fd9cd9801a536cec9fa5e5970b69f9d4747f70b39b031f5e7"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if 1.0.0",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1816,36 +1782,14 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive 0.6.12",
- "ptr_meta 0.1.4",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3"
 dependencies = [
- "bytecheck_derive 0.8.1",
- "ptr_meta 0.3.0",
+ "bytecheck_derive",
+ "ptr_meta",
  "rancor",
  "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1989,10 +1933,8 @@ checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2067,38 +2009,6 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
-
-[[package]]
-name = "cloud-storage"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7602ac4363f68ac757d6b87dd5d850549a14d37489902ae639c06ecec06ad275"
-dependencies = [
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "chrono",
- "dotenv",
- "futures-util",
- "hex",
- "jsonwebtoken 7.2.0",
- "lazy_static",
- "openssl",
- "percent-encoding",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "cobs"
@@ -2180,12 +2090,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2207,6 +2111,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2451,7 +2365,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2463,7 +2377,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2471,7 +2385,7 @@ dependencies = [
 [[package]]
 name = "crypto-shared"
 version = "0.1.1"
-source = "git+https://github.com/Near-One/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
+source = "git+https://github.com/near/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2705,20 +2619,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -2786,12 +2691,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "dstack-sdk"
 version = "0.1.0"
 source = "git+https://github.com/Dstack-TEE/dstack.git?tag=v0.5.2#45ebd05a25ad4ffacce3b8f003e4f5a8b609b2e2"
@@ -2822,21 +2721,6 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "dynasm"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "dynasm"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33dc03612f42465a8ed7f5e354bc2b79ba54cedefa81d5bd3a064f1835adaba8"
@@ -2852,23 +2736,12 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm 1.2.3",
- "memmap2",
-]
-
-[[package]]
-name = "dynasmrt"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7dccc31a678058996aef614f6bd418ced384da70f284e83e2b7bf29b27b6a28"
 dependencies = [
  "byteorder",
- "dynasm 2.0.0",
+ "dynasm",
  "fnv",
  "memmap2",
 ]
@@ -2935,7 +2808,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array 0.14.7",
+ "generic-array",
  "group",
  "pkcs8",
  "rand_core 0.6.4",
@@ -3033,33 +2906,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -3215,7 +3067,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -3458,7 +3310,7 @@ dependencies = [
  "chrono",
  "futures",
  "hyper 1.6.0",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "once_cell",
  "prost 0.13.5",
  "prost-types",
@@ -3473,15 +3325,6 @@ dependencies = [
  "tower-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -3650,7 +3493,7 @@ dependencies = [
  "hash32",
  "rustc_version 0.4.1",
  "serde",
- "spin 0.9.8",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -3920,6 +3763,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -4251,7 +4095,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -4383,31 +4227,17 @@ checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "jsonwebtoken"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
-dependencies = [
- "base64 0.12.3",
- "pem 0.8.3",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1 0.4.1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
  "base64 0.22.1",
  "js-sys",
- "pem 3.0.5",
- "ring 0.17.14",
+ "pem",
+ "ring",
  "serde",
  "serde_json",
- "simple_asn1 0.6.3",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -4456,7 +4286,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -4586,21 +4416,13 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -4751,16 +4573,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4771,9 +4583,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -4854,7 +4666,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 [[package]]
 name = "mpc-contract"
 version = "1.0.1"
-source = "git+https://github.com/Near-One/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
+source = "git+https://github.com/near/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
 dependencies = [
  "borsh",
  "crypto-shared",
@@ -4922,13 +4734,13 @@ dependencies = [
  "mpc-contract 1.0.1",
  "mpc-contract 2.2.0-rc.1",
  "near-client",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "near-config-utils 0.0.0",
+ "near-crypto 0.0.0",
  "near-indexer",
  "near-indexer-primitives",
  "near-o11y",
  "near-sdk",
- "near-time 2.6.0-rc.1",
+ "near-time 0.0.0",
  "prometheus",
  "rand 0.8.5",
  "rand_xorshift",
@@ -4994,16 +4806,16 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
 
 [[package]]
 name = "near-account-id"
-version = "1.0.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35cbb989542587b47205e608324ddd391f0cee1c22b4b64ae49f458334b95907"
+checksum = "4ed69d94899cfdfba16182bd681ad9e6b7f888e29532b04c56da9ae05a4c5bc4"
 dependencies = [
  "borsh",
  "serde",
@@ -5011,17 +4823,16 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
- "derive_more 1.0.0",
  "futures",
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.6.0-rc.1",
- "once_cell",
+ "near-time 0.0.0",
+ "parking_lot 0.12.3",
  "serde",
  "serde_json",
  "time",
@@ -5031,8 +4842,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5041,16 +4852,17 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "lru 0.12.5",
+ "parking_lot 0.12.3",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "anyhow",
@@ -5061,30 +4873,26 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "itertools 0.12.1",
- "itoa",
  "lru 0.12.5",
- "more-asserts",
  "near-async",
- "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 0.0.0",
  "near-epoch-manager",
- "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
+ "near-parameters 0.0.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-primitives 0.0.0",
+ "near-schema-checker-lib 0.0.0",
  "near-store",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 0.0.0",
  "node-runtime",
  "num-rational",
- "once_cell",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
@@ -5099,20 +4907,21 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
- "derive_more 1.0.0",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "derive_more 2.0.1",
+ "near-config-utils 0.0.0",
+ "near-crypto 0.0.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-parameters 0.0.0",
+ "near-primitives 0.0.0",
+ "near-time 0.0.0",
  "num-rational",
+ "parking_lot 0.12.3",
  "serde",
  "serde_json",
  "sha2",
@@ -5123,42 +4932,38 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
- "near-crypto 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-crypto 0.0.0",
+ "near-primitives 0.0.0",
+ "near-time 0.0.0",
  "thiserror 2.0.12",
- "time",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
- "borsh",
- "chrono",
- "derive_more 1.0.0",
- "futures",
  "itertools 0.12.1",
  "lru 0.12.5",
  "near-async",
  "near-chain",
  "near-chain-configs",
  "near-chunks-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 0.0.0",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "near-store",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "reed-solomon-erasure",
  "strum 0.24.1",
@@ -5168,27 +4973,23 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-trait",
  "borsh",
  "bytesize",
- "chrono",
- "cloud-storage",
- "derive_more 1.0.0",
  "futures",
  "itertools 0.12.1",
  "lru 0.12.5",
@@ -5199,34 +5000,34 @@ dependencies = [
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 0.0.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
+ "near-parameters 0.0.0",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 0.0.0",
  "num-rational",
- "once_cell",
+ "object_store",
+ "parking_lot 0.12.3",
  "percent-encoding",
  "rand 0.8.5",
  "rayon",
  "reed-solomon-erasure",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.15",
  "rust-s3",
  "serde",
  "serde_json",
  "strum 0.24.1",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -5237,22 +5038,30 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
- "chrono",
  "near-chain-configs",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-crypto 0.0.0",
+ "near-primitives 0.0.0",
+ "near-time 0.0.0",
  "serde",
- "serde_json",
  "strum 0.24.1",
  "thiserror 2.0.12",
- "time",
+ "tracing",
+]
+
+[[package]]
+name = "near-config-utils"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+dependencies = [
+ "anyhow",
+ "json_comments",
+ "thiserror 2.0.12",
  "tracing",
 ]
 
@@ -5269,14 +5078,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-config-utils"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+name = "near-crypto"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
- "anyhow",
- "json_comments",
+ "blake2",
+ "borsh",
+ "bs58 0.4.0",
+ "curve25519-dalek",
+ "derive_more 2.0.1",
+ "ed25519-dalek",
+ "hex",
+ "near-account-id",
+ "near-config-utils 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-stdx 0.0.0",
+ "primitive-types 0.10.1",
+ "rand 0.8.5",
+ "secp256k1 0.27.0",
+ "serde",
+ "serde_json",
+ "subtle",
  "thiserror 2.0.12",
- "tracing",
 ]
 
 [[package]]
@@ -5305,73 +5128,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-crypto"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-dependencies = [
- "blake2",
- "borsh",
- "bs58 0.4.0",
- "curve25519-dalek",
- "derive_more 1.0.0",
- "ed25519-dalek",
- "hex",
- "near-account-id",
- "near-config-utils 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
- "primitive-types 0.10.1",
- "rand 0.8.5",
- "secp256k1 0.27.0",
- "serde",
- "serde_json",
- "subtle",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "near-dyn-configs"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "anyhow",
  "near-chain-configs",
- "near-crypto 2.6.0-rc.1",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
- "prometheus",
- "serde",
+ "near-primitives 0.0.0",
+ "near-time 0.0.0",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "near-cache",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 0.0.0",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-primitives 0.0.0",
+ "near-schema-checker-lib 0.0.0",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational",
+ "parking_lot 0.12.3",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rand_hc",
  "serde",
- "serde_json",
- "smart-default",
  "tracing",
+]
+
+[[package]]
+name = "near-fmt"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+dependencies = [
+ "near-primitives-core 0.0.0",
 ]
 
 [[package]]
@@ -5381,14 +5182,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "913b8f3d375cad633cf609bdeecedbd51711ca6243e478afc57915b427386020"
 dependencies = [
  "near-primitives-core 0.29.1",
-]
-
-[[package]]
-name = "near-fmt"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-dependencies = [
- "near-primitives-core 2.6.0-rc.1",
 ]
 
 [[package]]
@@ -5414,55 +5207,48 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
  "near-chain-configs",
  "near-client",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "near-config-utils 0.0.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-indexer-primitives",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
+ "near-parameters 0.0.0",
+ "near-primitives 0.0.0",
  "near-store",
  "nearcore",
  "node-runtime",
+ "parking_lot 0.12.3",
  "rocksdb",
- "serde",
- "serde_json",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
- "actix",
  "actix-cors",
  "actix-web",
  "bs58 0.4.0",
- "derive_more 1.0.0",
  "easy-ext",
- "futures",
- "hex",
  "near-async",
  "near-chain-configs",
  "near-client",
@@ -5471,40 +5257,38 @@ dependencies = [
  "near-jsonrpc-primitives",
  "near-network",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "serde",
  "serde_json",
- "serde_with",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
- "actix-http",
  "awc",
  "futures",
  "near-jsonrpc-primitives",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "arbitrary",
  "near-chain-configs",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-crypto 0.0.0",
+ "near-primitives 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-time 0.0.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -5513,30 +5297,27 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "near-account-id",
  "near-chain-configs",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "anyhow",
  "arc-swap",
- "async-trait",
  "borsh",
  "bytes",
  "bytesize",
- "chrono",
  "crossbeam-channel",
- "derive_more 1.0.0",
  "enum-map",
  "futures",
  "futures-util",
@@ -5545,13 +5326,13 @@ dependencies = [
  "lru 0.12.5",
  "near-async",
  "near-chain-configs",
- "near-crypto 2.6.0-rc.1",
- "near-fmt 2.6.0-rc.1",
+ "near-crypto 0.0.0",
+ "near-fmt 0.0.0",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-primitives 0.0.0",
+ "near-schema-checker-lib 0.0.0",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.3",
@@ -5563,40 +5344,55 @@ dependencies = [
  "reed-solomon-erasure",
  "serde",
  "sha2",
- "smart-default",
  "strum 0.24.1",
  "stun",
  "thiserror 2.0.12",
  "time",
  "tokio",
- "tokio-stream",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "near-o11y"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
+ "near-crypto 0.0.0",
+ "near-primitives-core 0.0.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "parking_lot 0.12.3",
  "prometheus",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "tokio",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "near-parameters"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+dependencies = [
+ "borsh",
+ "enum-map",
+ "near-account-id",
+ "near-primitives-core 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "num-rational",
+ "serde",
+ "serde_repr",
+ "serde_yaml",
+ "strum 0.24.1",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -5619,42 +5415,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-parameters"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-dependencies = [
- "borsh",
- "enum-map",
- "near-account-id",
- "near-primitives-core 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "num-rational",
- "serde",
- "serde_repr",
- "serde_yaml",
- "strum 0.24.1",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "near-performance-metrics"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
- "bitflags 1.3.2",
- "bytes",
  "futures",
  "libc",
- "tokio",
- "tokio-util",
+ "parking_lot 0.12.3",
  "tracing",
 ]
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -5662,14 +5437,55 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "borsh",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 0.0.0",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "rand 0.8.5",
+]
+
+[[package]]
+name = "near-primitives"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+dependencies = [
+ "arbitrary",
+ "base64 0.21.7",
+ "bitvec",
+ "borsh",
+ "bytes",
+ "bytesize",
+ "chrono",
+ "derive_more 2.0.1",
+ "easy-ext",
+ "enum-map",
+ "hex",
+ "itertools 0.12.1",
+ "near-crypto 0.0.0",
+ "near-fmt 0.0.0",
+ "near-parameters 0.0.0",
+ "near-primitives-core 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-stdx 0.0.0",
+ "near-time 0.0.0",
+ "num-rational",
+ "ordered-float",
+ "primitive-types 0.10.1",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "reed-solomon-erasure",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "sha3",
+ "smart-default",
+ "strum 0.24.1",
+ "thiserror 2.0.12",
+ "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -5713,45 +5529,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+name = "near-primitives-core"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
- "bitvec",
  "borsh",
- "bytes",
- "bytesize",
- "cfg-if 1.0.0",
- "chrono",
- "derive_more 1.0.0",
- "easy-ext",
+ "bs58 0.4.0",
+ "derive_more 2.0.1",
  "enum-map",
- "hex",
- "itertools 0.12.1",
- "near-crypto 2.6.0-rc.1",
- "near-fmt 2.6.0-rc.1",
- "near-parameters 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-account-id",
+ "near-schema-checker-lib 0.0.0",
  "num-rational",
- "ordered-float",
- "primitive-types 0.10.1",
- "rand 0.8.5",
- "rand_chacha 0.3.1",
- "reed-solomon-erasure",
  "serde",
- "serde_json",
- "serde_with",
- "sha3",
- "smart-default",
- "strum 0.24.1",
+ "serde_repr",
+ "sha2",
  "thiserror 2.0.12",
- "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -5776,36 +5570,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-primitives-core"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "borsh",
- "bs58 0.4.0",
- "derive_more 1.0.0",
- "enum-map",
- "near-account-id",
- "near-schema-checker-lib 2.6.0-rc.1",
- "num-rational",
- "serde",
- "serde_repr",
- "sha2",
- "thiserror 2.0.12",
-]
-
-[[package]]
 name = "near-rosetta-rpc"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "actix-cors",
- "actix-http",
  "actix-web",
- "awc",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "futures",
  "hex",
  "insta",
@@ -5813,11 +5585,11 @@ dependencies = [
  "near-chain-configs",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 0.0.0",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
+ "near-parameters 0.0.0",
+ "near-primitives 0.0.0",
  "node-runtime",
  "paperclip",
  "serde",
@@ -5829,14 +5601,23 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+
+[[package]]
+name = "near-schema-checker-core"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "943ce3e4f7e8bf6ccd757dd4eb2bfa7de0fba198c4f53db86a5f4e03e807be7e"
 
 [[package]]
-name = "near-schema-checker-core"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+name = "near-schema-checker-lib"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+dependencies = [
+ "near-schema-checker-core 0.0.0",
+ "near-schema-checker-macro 0.0.0",
+]
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -5849,24 +5630,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-schema-checker-lib"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-dependencies = [
- "near-schema-checker-core 2.6.0-rc.1",
- "near-schema-checker-macro 2.6.0-rc.1",
-]
+name = "near-schema-checker-macro"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 
 [[package]]
 name = "near-schema-checker-macro"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0906c4a3962bc31e9737da0884e3595065b37eb3117848c6d73be3746cc734b"
-
-[[package]]
-name = "near-schema-checker-macro"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
 
 [[package]]
 name = "near-sdk"
@@ -5912,19 +5684,19 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+
+[[package]]
+name = "near-stdx"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9259168eb4953dddd96a27aafdeabae2c3909658ea66f60f6836859662cfdf2f"
 
 [[package]]
-name = "near-stdx"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-
-[[package]]
 name = "near-store"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "actix-rt",
@@ -5933,7 +5705,7 @@ dependencies = [
  "bytesize",
  "crossbeam",
  "derive-where",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "enum-map",
  "hex",
  "itertools 0.12.1",
@@ -5941,16 +5713,17 @@ dependencies = [
  "lru 0.12.5",
  "near-chain-configs",
  "near-chain-primitives",
- "near-crypto 2.6.0-rc.1",
- "near-fmt 2.6.0-rc.1",
+ "near-crypto 0.0.0",
+ "near-fmt 0.0.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
- "near-vm-runner 2.6.0-rc.1",
+ "near-parameters 0.0.0",
+ "near-primitives 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-stdx 0.0.0",
+ "near-time 0.0.0",
+ "near-vm-runner 0.0.0",
  "num_cpus",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "rayon",
  "reed-solomon-erasure",
@@ -5963,7 +5736,6 @@ dependencies = [
  "strum 0.24.1",
  "tempfile",
  "thiserror 2.0.12",
- "thread_local",
  "tokio",
  "tracing",
 ]
@@ -5976,8 +5748,8 @@ checksum = "dbf4ca5c805cb78700e10e43484902d8da05f25788db277999d209568aaf4c8e"
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "awc",
@@ -5986,11 +5758,20 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.6.0-rc.1",
- "openssl",
  "serde",
  "serde_json",
  "tracing",
+]
+
+[[package]]
+name = "near-time"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+dependencies = [
+ "parking_lot 0.12.3",
+ "serde",
+ "time",
+ "tokio",
 ]
 
 [[package]]
@@ -6001,16 +5782,6 @@ checksum = "ed079661e2bd03c60d858ba2b2991adb59749b971c36bce0758dffedb59315df"
 dependencies = [
  "serde",
  "time",
-]
-
-[[package]]
-name = "near-time"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-dependencies = [
- "serde",
- "time",
- "tokio",
 ]
 
 [[package]]
@@ -6025,14 +5796,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "enumset",
  "finite-wasm",
  "near-vm-types",
  "near-vm-vm",
- "rkyv 0.8.10",
+ "rkyv",
  "target-lexicon 0.12.16",
  "thiserror 2.0.12",
  "tracing",
@@ -6041,15 +5812,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
- "dynasm 2.0.0",
- "dynasmrt 2.0.0",
+ "dynasm",
+ "dynasmrt",
  "enumset",
  "finite-wasm",
  "memoffset 0.8.0",
- "more-asserts",
  "near-vm-compiler",
  "near-vm-types",
  "near-vm-vm",
@@ -6061,24 +5831,67 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "backtrace",
- "cfg-if 1.0.0",
- "enumset",
  "finite-wasm",
  "more-asserts",
  "near-vm-compiler",
  "near-vm-types",
  "near-vm-vm",
- "region",
- "rkyv 0.8.10",
+ "parking_lot 0.12.3",
+ "rkyv",
  "rustc-demangle",
  "rustix 1.0.5",
- "target-lexicon 0.12.16",
  "thiserror 2.0.12",
  "tracing",
+]
+
+[[package]]
+name = "near-vm-runner"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
+dependencies = [
+ "anyhow",
+ "blst",
+ "borsh",
+ "bytesize",
+ "ed25519-dalek",
+ "enum-map",
+ "finite-wasm",
+ "lru 0.12.5",
+ "memoffset 0.8.0",
+ "near-crypto 0.0.0",
+ "near-o11y",
+ "near-parameters 0.0.0",
+ "near-primitives-core 0.0.0",
+ "near-schema-checker-lib 0.0.0",
+ "near-stdx 0.0.0",
+ "near-vm-compiler",
+ "near-vm-compiler-singlepass",
+ "near-vm-engine",
+ "near-vm-types",
+ "near-vm-vm",
+ "num-rational",
+ "parking_lot 0.12.3",
+ "prefix-sum-vec",
+ "prometheus",
+ "rand 0.8.5",
+ "rayon",
+ "ripemd",
+ "rustix 1.0.5",
+ "serde",
+ "sha2",
+ "sha3",
+ "strum 0.24.1",
+ "tempfile",
+ "thiserror 2.0.12",
+ "tracing",
+ "wasm-encoder 0.224.1",
+ "wasmparser 0.78.2",
+ "wasmtime",
+ "zeropool-bn",
 ]
 
 [[package]]
@@ -6114,89 +5927,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "near-vm-runner"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
-dependencies = [
- "anyhow",
- "blst",
- "borsh",
- "bytesize",
- "ed25519-dalek",
- "enum-map",
- "finite-wasm",
- "lru 0.12.5",
- "memoffset 0.8.0",
- "near-crypto 2.6.0-rc.1",
- "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
- "near-vm-compiler",
- "near-vm-compiler-singlepass",
- "near-vm-engine",
- "near-vm-types",
- "near-vm-vm",
- "num-rational",
- "parity-wasm 0.41.0",
- "parity-wasm 0.42.2",
- "prefix-sum-vec",
- "prometheus",
- "pwasm-utils",
- "rand 0.8.5",
- "rayon",
- "ripemd",
- "rustix 1.0.5",
- "serde",
- "serde_repr",
- "sha2",
- "sha3",
- "strum 0.24.1",
- "tempfile",
- "thiserror 2.0.12",
- "tracing",
- "wasm-encoder 0.224.1",
- "wasmer-compiler-near",
- "wasmer-compiler-singlepass-near",
- "wasmer-engine-near",
- "wasmer-engine-universal-near",
- "wasmer-runtime-core-near",
- "wasmer-runtime-near",
- "wasmer-types-near",
- "wasmer-vm-near",
- "wasmparser 0.78.2",
- "wasmtime",
- "zeropool-bn",
-]
-
-[[package]]
 name = "near-vm-types"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "indexmap 2.8.0",
  "num-traits",
- "rkyv 0.8.10",
+ "rkyv",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if 1.0.0",
  "finite-wasm",
- "indexmap 2.8.0",
  "libc",
  "memoffset 0.8.0",
  "more-asserts",
  "near-vm-types",
+ "parking_lot 0.12.3",
  "region",
- "rkyv 0.8.10",
+ "rkyv",
  "thiserror 2.0.12",
  "tracing",
  "winapi",
@@ -6204,28 +5960,25 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.0-rc.1",
- "near-vm-runner 2.6.0-rc.1",
+ "near-primitives-core 0.0.0",
+ "near-vm-runner 0.0.0",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "actix",
  "actix-rt",
  "actix-web",
  "anyhow",
- "awc",
  "borsh",
  "bytesize",
- "chrono",
- "cloud-storage",
  "dirs",
  "easy-ext",
  "futures",
@@ -6240,8 +5993,8 @@ dependencies = [
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "near-config-utils 0.0.0",
+ "near-crypto 0.0.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
@@ -6249,27 +6002,23 @@ dependencies = [
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
+ "near-parameters 0.0.0",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 0.0.0",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 0.0.0",
  "node-runtime",
  "num-rational",
+ "object_store",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
- "rayon",
- "regex",
- "reqwest 0.11.27",
- "rlimit",
- "rust-s3",
+ "reqwest 0.12.15",
  "serde",
  "serde_ignored",
  "serde_json",
- "smart-default",
- "strum 0.24.1",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -6280,47 +6029,36 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.15.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.0",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
 name = "node-runtime"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "0.0.0"
+source = "git+https://github.com/near/nearcore?rev=17538564ced6dde9cf9ad019f8b81f69295a012e#17538564ced6dde9cf9ad019f8b81f69295a012e"
 dependencies = [
  "borsh",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 0.0.0",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
+ "near-parameters 0.0.0",
+ "near-primitives 0.0.0",
+ "near-primitives-core 0.0.0",
  "near-store",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 0.0.0",
  "near-wallet-contract",
  "num-bigint 0.3.3",
  "num-traits",
+ "parking_lot 0.12.3",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
@@ -6357,17 +6095,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -6471,6 +6198,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781f96d79ed0f961a7021424ab01840efbda64ae7a505aaea195efc91eaaec4"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "humantime",
+ "hyper 1.6.0",
+ "itertools 0.14.0",
+ "parking_lot 0.12.3",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.9.0",
+ "reqwest 0.12.15",
+ "ring",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6524,15 +6287,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.4.2+3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168ce4e058f975fe43e89d9ccf78ca668601887ae736090aacc23ae353c298e2"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6540,7 +6294,6 @@ checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -6648,16 +6401,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "page_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "paperclip"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6759,32 +6502,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-wasm"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
-
-[[package]]
-name = "parity-wasm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.3",
-]
 
 [[package]]
 name = "parking_lot"
@@ -6793,7 +6514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.12",
+ "lock_api",
  "parking_lot_core 0.8.6",
 ]
 
@@ -6803,22 +6524,8 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
- "lock_api 0.4.12",
+ "lock_api",
  "parking_lot_core 0.9.10",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93f386bb233083c799e6e642a9d73db98c24a5deeb95ffc85bf281255dffc98"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi",
 ]
 
 [[package]]
@@ -6859,17 +6566,6 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
-name = "pem"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
-dependencies = [
- "base64 0.13.1",
- "once_cell",
- "regex",
-]
 
 [[package]]
 name = "pem"
@@ -7347,31 +7043,11 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive 0.1.4",
-]
-
-[[package]]
-name = "ptr_meta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
 dependencies = [
- "ptr_meta_derive 0.3.0",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "ptr_meta_derive",
 ]
 
 [[package]]
@@ -7397,21 +7073,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "pwasm-utils"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
-dependencies = [
- "byteorder",
- "log",
- "parity-wasm 0.41.0",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quinn"
@@ -7442,7 +7117,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.2",
  "rand 0.9.0",
- "ring 0.17.14",
+ "ring",
  "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
@@ -7494,7 +7169,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
 dependencies = [
- "ptr_meta 0.3.0",
+ "ptr_meta",
 ]
 
 [[package]]
@@ -7614,18 +7289,12 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
- "pem 3.0.5",
- "ring 0.17.14",
+ "pem",
+ "ring",
  "rustls-pki-types",
  "time",
  "yasna",
 ]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -7668,7 +7337,7 @@ dependencies = [
  "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -7749,20 +7418,11 @@ dependencies = [
 
 [[package]]
 name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck 0.6.12",
-]
-
-[[package]]
-name = "rend"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 dependencies = [
- "bytecheck 0.8.1",
+ "bytecheck",
 ]
 
 [[package]]
@@ -7817,6 +7477,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.8",
@@ -7839,6 +7500,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -7879,21 +7541,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
@@ -7902,7 +7549,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "getrandom 0.2.15",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -7917,50 +7564,21 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
-dependencies = [
- "bitvec",
- "bytecheck 0.6.12",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta 0.1.4",
- "rend 0.4.2",
- "rkyv_derive 0.7.45",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
 dependencies = [
- "bytecheck 0.8.1",
+ "bytecheck",
  "bytes",
  "hashbrown 0.15.2",
  "indexmap 2.8.0",
  "munge",
- "ptr_meta 0.3.0",
+ "ptr_meta",
  "rancor",
- "rend 0.5.2",
- "rkyv_derive 0.8.10",
+ "rend",
+ "rkyv_derive",
  "tinyvec",
  "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8126,15 +7744,6 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -8167,7 +7776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.3.10",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
@@ -8181,7 +7790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.0",
- "errno 0.3.10",
+ "errno",
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
@@ -8194,7 +7803,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
 dependencies = [
  "bitflags 2.9.0",
- "errno 0.3.10",
+ "errno",
  "libc",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
@@ -8208,11 +7817,23 @@ checksum = "822ee9188ac4ec04a2f0531e55d035fb2de73f18b41a63c70c2712503b6fb13c"
 dependencies = [
  "log",
  "once_cell",
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -8248,9 +7869,9 @@ version = "0.103.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fef8b8769aaccf73098557a87cd1816b4f9c7c16811c9c77142aa695c16f2c03"
 dependencies = [
- "ring 0.17.14",
+ "ring",
  "rustls-pki-types",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -8293,6 +7914,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scc"
@@ -8349,12 +7979,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8362,7 +7986,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8",
  "serdect",
  "subtle",
@@ -8429,7 +8053,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -8447,20 +8084,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.3",
+ "semver-parser",
 ]
 
 [[package]]
@@ -8468,12 +8096,6 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -8494,16 +8116,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-bench"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d733da87e79faaac25616e33d26299a41143fd4cd42746cbb0e91d8feea243fd"
-dependencies = [
- "byteorder",
- "serde",
-]
-
-[[package]]
 name = "serde-xml-rs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8513,15 +8125,6 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "xml-rs",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -8768,17 +8371,6 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
-dependencies = [
- "chrono",
- "num-bigint 0.2.6",
- "num-traits",
-]
-
-[[package]]
-name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
@@ -8878,17 +8470,11 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api 0.4.12",
+ "lock_api",
 ]
 
 [[package]]
@@ -8968,16 +8554,16 @@ dependencies = [
 
 [[package]]
 name = "stun"
-version = "0.4.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
+checksum = "ea256fb46a13f9204e9dee9982997b2c3097db175a9fddaa8350310d03c4d5a3"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
  "rand 0.8.5",
- "ring 0.16.20",
+ "ring",
  "subtle",
  "thiserror 1.0.69",
  "tokio",
@@ -9073,7 +8659,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -9084,7 +8670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -9113,12 +8699,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "target-lexicon"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 
 [[package]]
 name = "target-lexicon"
@@ -9709,12 +9289,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -9790,12 +9364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9809,6 +9377,16 @@ name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -9936,180 +9514,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
-
-[[package]]
-name = "wasmer-compiler-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fdae7245128f284476e6db9653ef0a15b011975091bcd7f9d7303132409662"
-dependencies = [
- "enumset",
- "rkyv 0.7.45",
- "smallvec",
- "target-lexicon 0.12.16",
- "thiserror 1.0.69",
- "wasmer-types-near",
- "wasmer-vm-near",
- "wasmparser 0.78.2",
-]
-
-[[package]]
-name = "wasmer-compiler-singlepass-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4af0e438015585eb27b2c6f6869c58c540bfe27408b686b1778470bf301050"
-dependencies = [
- "byteorder",
- "dynasm 1.2.3",
- "dynasmrt 1.2.3",
- "lazy_static",
- "memoffset 0.6.5",
- "more-asserts",
- "rayon",
- "smallvec",
- "wasmer-compiler-near",
- "wasmer-types-near",
- "wasmer-vm-near",
-]
-
-[[package]]
-name = "wasmer-engine-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4048411cabb2c94c7d8d11d9d0282cc6b15308b61ebc1e122c40e89865ebb5c5"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "target-lexicon 0.12.16",
- "thiserror 1.0.69",
- "wasmer-compiler-near",
- "wasmer-types-near",
- "wasmer-vm-near",
-]
-
-[[package]]
-name = "wasmer-engine-universal-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f31c3d2850ac7957406d3c9581d9435ea8126a26478709fa7e931b6f562b4d"
-dependencies = [
- "cfg-if 1.0.0",
- "enumset",
- "leb128",
- "region",
- "rkyv 0.7.45",
- "thiserror 1.0.69",
- "wasmer-compiler-near",
- "wasmer-engine-near",
- "wasmer-types-near",
- "wasmer-vm-near",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-runtime-core-near"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9c54899b847f8bab6d47295487c9827f14cc411bd70b168e87a4ea017ccd7e"
-dependencies = [
- "bincode",
- "blake3",
- "borsh",
- "cc",
- "digest 0.8.1",
- "errno 0.2.8",
- "hex",
- "indexmap 2.8.0",
- "lazy_static",
- "libc",
- "nix 0.15.0",
- "page_size",
- "parking_lot 0.10.2",
- "rustc_version 0.2.3",
- "serde",
- "serde-bench",
- "serde_bytes",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.10.0",
- "wasmparser 0.51.4",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-runtime-near"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158e6fff11e5e1ef805af50637374d5bd43d92017beafa18992cdf7f3f7ae3e4"
-dependencies = [
- "lazy_static",
- "memmap",
- "serde",
- "serde_derive",
- "wasmer-runtime-core-near",
- "wasmer-singlepass-backend-near",
-]
-
-[[package]]
-name = "wasmer-singlepass-backend-near"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9358673d39c3b4a15374fba0536bfe5e50485e7c826de50d2dbef8c96df07674"
-dependencies = [
- "bincode",
- "borsh",
- "byteorder",
- "dynasm 1.2.3",
- "dynasmrt 1.2.3",
- "lazy_static",
- "libc",
- "nix 0.15.0",
- "serde",
- "serde_derive",
- "smallvec",
- "wasmer-runtime-core-near",
-]
-
-[[package]]
-name = "wasmer-types-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba154adffb0fbd33f5dabd3788a1744d846b43e6e090d44269c7ee8fa5743e4"
-dependencies = [
- "indexmap 1.9.3",
- "rkyv 0.7.45",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "wasmer-vm-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a5585596f6e9915d606de944aece51626736fb1191aefb5b2ef108c6f7604a"
-dependencies = [
- "backtrace",
- "cc",
- "cfg-if 1.0.0",
- "indexmap 1.9.3",
- "libc",
- "memoffset 0.6.5",
- "more-asserts",
- "region",
- "rkyv 0.7.45",
- "thiserror 1.0.69",
- "wasmer-types-near",
- "winapi",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.51.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmparser"
@@ -10355,19 +9759,19 @@ dependencies = [
 
 [[package]]
 name = "webrtc-util"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f1db1727772c05cf7a2cfece52c3aca8045ca1e176cd517d323489aa3c6d87"
+checksum = "1438a8fd0d69c5775afb4a71470af92242dbd04059c61895163aa3c1ef933375"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "bytes",
- "cc",
  "ipnet",
  "lazy_static",
  "libc",
  "log",
- "nix 0.24.3",
+ "nix",
+ "portable-atomic",
  "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",

--- a/libs/chain-signatures/contract/Cargo.toml
+++ b/libs/chain-signatures/contract/Cargo.toml
@@ -33,7 +33,7 @@ k256 = { version = "0.13.4", features = [
 ] }
 
 near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }
-near-account-id = "1"
+near-account-id = "1.1.1"
 thiserror = "1"
 sha3 = "0.10.8"
 hex = "0.4.3"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -57,15 +57,15 @@ x509-parser = "0.16.0"
 
 curve25519-dalek = "4.1.3"
 
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", rev = "17538564ced6dde9cf9ad019f8b81f69295a012e" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", rev = "17538564ced6dde9cf9ad019f8b81f69295a012e" }
+near-client = { git = "https://github.com/near/nearcore", rev = "17538564ced6dde9cf9ad019f8b81f69295a012e" }
+near-config-utils = { git = "https://github.com/near/nearcore", rev = "17538564ced6dde9cf9ad019f8b81f69295a012e" }
+near-crypto = { git = "https://github.com/near/nearcore", rev = "17538564ced6dde9cf9ad019f8b81f69295a012e" }
+near-o11y = { git = "https://github.com/near/nearcore", rev = "17538564ced6dde9cf9ad019f8b81f69295a012e" }
+near-time = { git = "https://github.com/near/nearcore", rev = "17538564ced6dde9cf9ad019f8b81f69295a012e" }
 # todo: update once 1.1.0 is pulbished (though the api did not change)
-legacy-mpc-contract = { package = "mpc-contract", git = "https://github.com/Near-One/mpc/", rev = "1d4954dff28e8eb988fb7762eff414a602a2b124" }
+legacy-mpc-contract = { package = "mpc-contract", git = "https://github.com/near/mpc/", rev = "1d4954dff28e8eb988fb7762eff414a602a2b124" }
 mpc-contract = { path = "../libs/chain-signatures/contract/", features = [
     "dev-utils",
 ] }

--- a/node/src/indexer/mod.rs
+++ b/node/src/indexer/mod.rs
@@ -23,7 +23,7 @@ pub(crate) struct IndexerState {
     /// For querying blockchain sync status.
     client: actix::Addr<near_client::ClientActor>,
     /// For sending txs to the chain.
-    tx_processor: actix::Addr<near_client::TxRequestHandlerActor>,
+    tx_processor: actix::Addr<near_client::RpcHandlerActor>,
     /// AccountId for the mpc contract.
     mpc_contract_id: AccountId,
 }
@@ -32,7 +32,7 @@ impl IndexerState {
     pub fn new(
         view_client: actix::Addr<near_client::ViewClientActor>,
         client: actix::Addr<near_client::ClientActor>,
-        tx_processor: actix::Addr<near_client::TxRequestHandlerActor>,
+        tx_processor: actix::Addr<near_client::RpcHandlerActor>,
         mpc_contract_id: AccountId,
     ) -> Self {
         Self {


### PR DESCRIPTION
Cherry picking these commits https://github.com/near/mpc/compare/main...test-build-2.2.0#diff-adb834fd214ef7b0f6cf6859677ae86fea9e374fe05af3a2ecd28df0d6099b2a.

This PR bumps the near core submodule and deps to the 2.7 version (using a hard coded commit since it's unreleased).