### PR TITLE
fix: Use separate port seed for indexer stuck test

### DIFF
--- a/node/src/p2p.rs
+++ b/node/src/p2p.rs
@@ -634,6 +634,7 @@ pub mod testing {
         pub const KEY_RESHARING_MULTISTAGE_TEST: Self = Self(6);
         pub const KEY_RESHARING_SIGNATURE_BUFFERING_TEST: Self = Self(7);
         pub const BASIC_MULTIDOMAIN_TEST: Self = Self(8);
+        pub const FAULTY_STUCK_INDEXER_TEST: Self = Self(9);
     }
 
     /// Converts a keypair to an ED25519 secret key, asserting that it is the

--- a/node/src/tests/faulty.rs
+++ b/node/src/tests/faulty.rs
@@ -166,7 +166,7 @@ async fn test_indexer_stuck() {
         accounts.clone(),
         THRESHOLD,
         TXN_DELAY_BLOCKS,
-        PortSeed::FAULTY_CLUSTER_TEST,
+        PortSeed::FAULTY_STUCK_INDEXER_TEST,
         std::time::Duration::from_millis(50),
     );
 


### PR DESCRIPTION
Backport of fix from https://github.com/near/mpc/pull/600/commits/00a7d1816e70a6ef2e63ab94907dd35356c36f79 to prevent the test from hanging up