### PR TITLE
chore: bump nearcore to `2.7.0-rc.2`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -286,7 +286,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
  "crypto-common",
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -953,12 +953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrayref"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
-
-[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1516,12 +1510,6 @@ checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
 name = "base64"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3441f0f7b02788e948e47f457ca01f1d7e6d92c693bc132c22b087d3141c03ff"
-
-[[package]]
-name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
@@ -1543,15 +1531,6 @@ name = "base64ct"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bindgen"
@@ -1666,25 +1645,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "blake3"
-version = "1.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if 1.0.1",
- "constant_time_eq",
-]
-
-[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -1823,36 +1789,14 @@ checksum = "7575182f7272186991736b70173b0ea045398f984bf5ebbb3804736ce1330c9d"
 
 [[package]]
 name = "bytecheck"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
-dependencies = [
- "bytecheck_derive 0.6.12",
- "ptr_meta 0.1.4",
- "simdutf8",
-]
-
-[[package]]
-name = "bytecheck"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50690fb3370fb9fe3550372746084c46f2ac8c9685c583d2be10eefd89d3d1a3"
 dependencies = [
- "bytecheck_derive 0.8.1",
- "ptr_meta 0.3.0",
+ "bytecheck_derive",
+ "ptr_meta",
  "rancor",
  "simdutf8",
-]
-
-[[package]]
-name = "bytecheck_derive"
-version = "0.6.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1996,10 +1940,8 @@ checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -2074,38 +2016,6 @@ name = "clap_lex"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
-
-[[package]]
-name = "cloud-storage"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7602ac4363f68ac757d6b87dd5d850549a14d37489902ae639c06ecec06ad275"
-dependencies = [
- "async-trait",
- "base64 0.13.1",
- "bytes",
- "chrono",
- "dotenv",
- "futures-util",
- "hex",
- "jsonwebtoken 7.2.0",
- "lazy_static",
- "openssl",
- "percent-encoding",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "tokio",
-]
-
-[[package]]
-name = "cloudabi"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-dependencies = [
- "bitflags 1.3.2",
-]
 
 [[package]]
 name = "cobs"
@@ -2187,12 +2097,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "constant_time_eq"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
-
-[[package]]
 name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2214,6 +2118,16 @@ name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -2458,7 +2372,7 @@ version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "subtle",
  "zeroize",
@@ -2470,7 +2384,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
  "rand_core 0.6.4",
  "typenum",
 ]
@@ -2479,6 +2393,23 @@ dependencies = [
 name = "crypto-shared"
 version = "0.1.1"
 source = "git+https://github.com/Near-One/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
+dependencies = [
+ "anyhow",
+ "borsh",
+ "getrandom 0.2.16",
+ "k256",
+ "near-account-id",
+ "near-sdk",
+ "serde",
+ "serde_json",
+ "sha3",
+ "subtle",
+]
+
+[[package]]
+name = "crypto-shared"
+version = "0.1.1"
+source = "git+https://github.com/near/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
 dependencies = [
  "anyhow",
  "borsh",
@@ -2587,7 +2518,7 @@ dependencies = [
  "hex",
  "log",
  "parity-scale-codec",
- "pem 3.0.5",
+ "pem",
  "ring 0.17.9",
  "rustls-webpki 0.103.0",
  "scale-info",
@@ -2752,20 +2683,11 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
-dependencies = [
- "generic-array 0.12.4",
-]
-
-[[package]]
-name = "digest"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -2833,12 +2755,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
-
-[[package]]
 name = "downcast"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2875,21 +2791,6 @@ checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
 
 [[package]]
 name = "dynasm"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add9a102807b524ec050363f09e06f1504214b0e1c7797f64261c891022dce8b"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "lazy_static",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "dynasm"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33dc03612f42465a8ed7f5e354bc2b79ba54cedefa81d5bd3a064f1835adaba8"
@@ -2905,23 +2806,12 @@ dependencies = [
 
 [[package]]
 name = "dynasmrt"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64fba5a42bd76a17cad4bfa00de168ee1cbfa06a5e8ce992ae880218c05641a9"
-dependencies = [
- "byteorder",
- "dynasm 1.2.3",
- "memmap2",
-]
-
-[[package]]
-name = "dynasmrt"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7dccc31a678058996aef614f6bd418ced384da70f284e83e2b7bf29b27b6a28"
 dependencies = [
  "byteorder",
- "dynasm 2.0.0",
+ "dynasm",
  "fnv",
  "memmap2",
 ]
@@ -2988,7 +2878,7 @@ dependencies = [
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
- "generic-array 0.14.7",
+ "generic-array",
  "group",
  "pkcs8",
  "rand_core 0.6.4",
@@ -3086,33 +2976,12 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
  "windows-sys 0.60.2",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -3274,7 +3143,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "nanorand",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -3529,7 +3398,7 @@ dependencies = [
  "chrono",
  "futures",
  "hyper 1.6.0",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "once_cell",
  "prost 0.13.5",
  "prost-types",
@@ -3544,15 +3413,6 @@ dependencies = [
  "tower-util",
  "tracing",
  "url",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffdf9f34f1447443d37393cc6c2b8313aebddcd96906caf34e54c68d8e57d7bd"
-dependencies = [
- "typenum",
 ]
 
 [[package]]
@@ -3721,7 +3581,7 @@ dependencies = [
  "hash32",
  "rustc_version 0.4.1",
  "serde",
- "spin 0.9.8",
+ "spin",
  "stable_deref_trait",
 ]
 
@@ -3990,6 +3850,7 @@ dependencies = [
  "hyper 1.6.0",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types 1.12.0",
  "tokio",
  "tokio-rustls",
@@ -4296,7 +4157,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
 dependencies = [
- "generic-array 0.14.7",
+ "generic-array",
 ]
 
 [[package]]
@@ -4437,31 +4298,17 @@ checksum = "9dbbfed4e59ba9750e15ba154fdfd9329cee16ff3df539c2666b70f58cc32105"
 
 [[package]]
 name = "jsonwebtoken"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afabcc15e437a6484fc4f12d0fd63068fe457bf93f1c148d3d9649c60b103f32"
-dependencies = [
- "base64 0.12.3",
- "pem 0.8.3",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1 0.4.1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "9.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
 dependencies = [
  "base64 0.22.1",
  "js-sys",
- "pem 3.0.5",
+ "pem",
  "ring 0.17.14",
  "serde",
  "serde_json",
- "simple_asn1 0.6.3",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -4510,7 +4357,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -4640,21 +4487,13 @@ checksum = "4d873d7c67ce09b42110d801813efbc9364414e356be9935700d368351657487"
 
 [[package]]
 name = "lock_api"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
-dependencies = [
- "scopeguard",
-]
-
-[[package]]
-name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]
@@ -4811,16 +4650,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memmap"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6585fd95e7bb50d6cc31e20d4cf9afb4e2ba16c5846fc76793f11218da9c475b"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "memmap2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4831,9 +4660,9 @@ dependencies = [
 
 [[package]]
 name = "memoffset"
-version = "0.6.5"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
 dependencies = [
  "autocfg",
 ]
@@ -4943,7 +4772,23 @@ version = "1.0.1"
 source = "git+https://github.com/Near-One/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
 dependencies = [
  "borsh",
- "crypto-shared",
+ "crypto-shared 0.1.1 (git+https://github.com/Near-One/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124)",
+ "k256",
+ "near-gas 0.2.5",
+ "near-sdk",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "mpc-contract"
+version = "1.0.1"
+source = "git+https://github.com/near/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124#1d4954dff28e8eb988fb7762eff414a602a2b124"
+dependencies = [
+ "borsh",
+ "crypto-shared 0.1.1 (git+https://github.com/near/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124)",
  "k256",
  "near-gas 0.2.5",
  "near-sdk",
@@ -4988,7 +4833,7 @@ dependencies = [
  "flume",
  "futures",
  "hex",
- "mpc-contract 1.0.1",
+ "mpc-contract 1.0.1 (git+https://github.com/Near-One/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124)",
  "mpc-contract 2.2.0-rc.1",
  "near-crypto 0.28.0",
  "near-jsonrpc-client",
@@ -5035,16 +4880,16 @@ dependencies = [
  "lazy_static",
  "lru 0.12.5",
  "mockall",
- "mpc-contract 1.0.1",
+ "mpc-contract 1.0.1 (git+https://github.com/near/mpc/?rev=1d4954dff28e8eb988fb7762eff414a602a2b124)",
  "mpc-contract 2.2.0-rc.1",
  "near-client",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.2",
  "near-indexer",
  "near-indexer-primitives",
  "near-o11y",
  "near-sdk",
- "near-time 2.6.0-rc.1",
+ "near-time 2.7.0-rc.2",
  "prometheus",
  "rand 0.8.5",
  "rand_xorshift 0.3.0",
@@ -5112,7 +4957,7 @@ dependencies = [
  "openssl-probe",
  "openssl-sys",
  "schannel",
- "security-framework",
+ "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
 ]
@@ -5129,17 +4974,16 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
- "derive_more 1.0.0",
  "futures",
  "near-async-derive",
  "near-o11y",
  "near-performance-metrics",
- "near-time 2.6.0-rc.1",
- "once_cell",
+ "near-time 2.7.0-rc.2",
+ "parking_lot 0.12.4",
  "serde",
  "serde_json",
  "time",
@@ -5149,8 +4993,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5159,16 +5003,17 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "lru 0.12.5",
+ "parking_lot 0.12.4",
 ]
 
 [[package]]
 name = "near-chain"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
@@ -5179,33 +5024,30 @@ dependencies = [
  "easy-ext",
  "enum-map",
  "itertools 0.12.1",
- "itoa",
  "lru 0.12.5",
- "more-asserts",
  "near-async",
- "near-cache",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-epoch-manager",
- "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "near-store",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 2.7.0-rc.2",
  "node-runtime",
  "num-rational",
- "once_cell",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
+ "reed-solomon-erasure",
  "serde",
  "strum 0.24.1",
  "tempfile",
@@ -5241,20 +5083,21 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
- "derive_more 1.0.0",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "derive_more 2.0.1",
+ "near-config-utils 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "num-rational",
+ "parking_lot 0.12.4",
  "serde",
  "serde_json",
  "sha2",
@@ -5265,42 +5108,38 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-crypto 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "thiserror 2.0.12",
- "time",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
- "borsh",
- "chrono",
- "derive_more 1.0.0",
- "futures",
  "itertools 0.12.1",
  "lru 0.12.5",
  "near-async",
  "near-chain",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-chunks-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "near-store",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "reed-solomon-erasure",
  "strum 0.24.1",
@@ -5310,65 +5149,61 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
  "anyhow",
- "async-trait",
  "borsh",
  "bytesize",
- "chrono",
- "cloud-storage",
- "derive_more 1.0.0",
  "futures",
  "itertools 0.12.1",
  "lru 0.12.5",
  "near-async",
  "near-cache",
  "near-chain",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
  "near-performance-metrics",
  "near-performance-metrics-macros",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 2.7.0-rc.2",
  "num-rational",
- "once_cell",
+ "object_store",
+ "parking_lot 0.12.4",
  "percent-encoding",
  "rand 0.8.5",
  "rayon",
  "reed-solomon-erasure",
  "regex",
- "reqwest 0.11.27",
+ "reqwest 0.12.20",
  "rust-s3",
  "serde",
  "serde_json",
  "strum 0.24.1",
  "sysinfo",
  "tempfile",
- "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-stream",
@@ -5379,22 +5214,19 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
- "chrono",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "serde",
- "serde_json",
  "strum 0.24.1",
  "thiserror 2.0.12",
- "time",
  "tracing",
 ]
 
@@ -5424,8 +5256,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -5486,20 +5318,20 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "blake2",
  "borsh",
  "bs58 0.4.0",
  "curve25519-dalek",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1 0.27.0",
@@ -5511,46 +5343,41 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
- "near-chain-configs 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
- "prometheus",
- "serde",
+ "near-primitives 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "serde_json",
  "thiserror 2.0.12",
  "tokio",
- "tracing",
 ]
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
  "itertools 0.12.1",
  "near-cache",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-chain-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational",
+ "parking_lot 0.12.4",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "rand_hc",
  "serde",
- "serde_json",
- "smart-default 0.7.1",
  "tracing",
 ]
 
@@ -5574,10 +5401,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-primitives-core 2.6.0-rc.1",
+ "near-primitives-core 2.7.0-rc.2",
 ]
 
 [[package]]
@@ -5603,70 +5430,61 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
  "futures",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-client",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-indexer-primitives",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
  "near-store",
  "nearcore",
  "node-runtime",
+ "parking_lot 0.12.4",
  "rocksdb",
- "serde",
- "serde_json",
  "tokio",
  "tracing",
 ]
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "serde",
- "serde_json",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "actix",
  "actix-cors",
  "actix-web",
  "bs58 0.4.0",
- "derive_more 1.0.0",
  "easy-ext",
- "futures",
- "hex",
  "near-async",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-client",
  "near-client-primitives",
  "near-jsonrpc-client-internal",
- "near-jsonrpc-primitives 2.6.0-rc.1",
+ "near-jsonrpc-primitives 2.7.0-rc.2",
  "near-network",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "serde",
  "serde_json",
- "serde_with",
  "tokio",
  "tracing",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -5690,14 +5508,13 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "actix-http",
  "awc",
  "futures",
- "near-jsonrpc-primitives 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
+ "near-jsonrpc-primitives 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
  "serde",
  "serde_json",
 ]
@@ -5721,15 +5538,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -5738,30 +5556,27 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "near-account-id",
- "near-chain-configs 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
  "serde_json",
 ]
 
 [[package]]
 name = "near-network"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "anyhow",
  "arc-swap",
- "async-trait",
  "borsh",
  "bytes",
  "bytesize",
- "chrono",
  "crossbeam-channel",
- "derive_more 1.0.0",
  "enum-map",
  "futures",
  "futures-util",
@@ -5769,14 +5584,14 @@ dependencies = [
  "itertools 0.12.1",
  "lru 0.12.5",
  "near-async",
- "near-chain-configs 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
- "near-fmt 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.2",
+ "near-fmt 2.7.0-rc.2",
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.4",
@@ -5788,36 +5603,33 @@ dependencies = [
  "reed-solomon-erasure",
  "serde",
  "sha2",
- "smart-default 0.7.1",
  "strum 0.24.1",
  "stun",
  "thiserror 2.0.12",
  "time",
  "tokio",
- "tokio-stream",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "near-o11y"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "base64 0.21.7",
  "clap",
- "near-crypto 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
+ "parking_lot 0.12.4",
  "prometheus",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
- "tokio",
  "tracing",
  "tracing-appender",
  "tracing-opentelemetry",
@@ -5864,14 +5676,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-primitives-core 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "num-rational",
  "serde",
  "serde_repr",
@@ -5882,23 +5694,20 @@ dependencies = [
 
 [[package]]
 name = "near-performance-metrics"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
- "bitflags 1.3.2",
- "bytes",
  "futures",
  "libc",
- "tokio",
- "tokio-util",
+ "parking_lot 0.12.4",
  "tracing",
 ]
 
 [[package]]
 name = "near-performance-metrics-macros"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "quote",
  "syn 2.0.103",
@@ -5906,13 +5715,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "rand 0.8.5",
 ]
 
@@ -6000,8 +5809,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -6009,20 +5818,19 @@ dependencies = [
  "borsh",
  "bytes",
  "bytesize",
- "cfg-if 1.0.1",
  "chrono",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "easy-ext",
  "enum-map",
  "hex",
  "itertools 0.12.1",
- "near-crypto 2.6.0-rc.1",
- "near-fmt 2.6.0-rc.1",
- "near-parameters 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-fmt 2.7.0-rc.2",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
  "num-rational",
  "ordered-float",
  "primitive-types 0.10.1",
@@ -6084,17 +5892,17 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
  "borsh",
  "bs58 0.4.0",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "enum-map",
  "near-account-id",
- "near-schema-checker-lib 2.6.0-rc.1",
+ "near-schema-checker-lib 2.7.0-rc.2",
  "num-rational",
  "serde",
  "serde_repr",
@@ -6104,27 +5912,25 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-cors",
- "actix-http",
  "actix-web",
- "awc",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "futures",
  "hex",
  "insta",
  "near-account-id",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
  "node-runtime",
  "paperclip",
  "serde",
@@ -6148,8 +5954,8 @@ checksum = "ed1fbfbc3c53b00aa893f8cb64abc5c12601edb8cecb878baf6f8f00e3184d3d"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -6173,11 +5979,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "near-schema-checker-core 2.6.0-rc.1",
- "near-schema-checker-macro 2.6.0-rc.1",
+ "near-schema-checker-core 2.7.0-rc.2",
+ "near-schema-checker-macro 2.7.0-rc.2",
 ]
 
 [[package]]
@@ -6194,8 +6000,8 @@ checksum = "d191936f902770069255b16c95d1fb8edd6f3c3817c9228933a20ec8466737a3"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-sdk"
@@ -6253,13 +6059,13 @@ checksum = "f292226fd8f4c7c21cf6b1da1c17e9b484ebc1b9aeb4251d69336d28b7917ace"
 
 [[package]]
 name = "near-stdx"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 
 [[package]]
 name = "near-store"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
@@ -6268,24 +6074,25 @@ dependencies = [
  "bytesize",
  "crossbeam",
  "derive-where",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
  "enum-map",
  "hex",
  "itertools 0.12.1",
  "itoa",
  "lru 0.12.5",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-chain-primitives",
- "near-crypto 2.6.0-rc.1",
- "near-fmt 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
+ "near-fmt 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
- "near-time 2.6.0-rc.1",
- "near-vm-runner 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
+ "near-time 2.7.0-rc.2",
+ "near-vm-runner 2.7.0-rc.2",
  "num_cpus",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "rayon",
  "reed-solomon-erasure",
@@ -6298,7 +6105,6 @@ dependencies = [
  "strum 0.24.1",
  "tempfile",
  "thiserror 2.0.12",
- "thread_local",
  "tokio",
  "tracing",
 ]
@@ -6311,8 +6117,8 @@ checksum = "a7d8e0ba9994e4d54cb4b301cd5fa9f2defcb69851148103512b9640a7e91572"
 
 [[package]]
 name = "near-telemetry"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "awc",
@@ -6321,8 +6127,6 @@ dependencies = [
  "near-o11y",
  "near-performance-metrics",
  "near-performance-metrics-macros",
- "near-time 2.6.0-rc.1",
- "openssl",
  "serde",
  "serde_json",
  "tracing",
@@ -6350,9 +6154,10 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
+ "parking_lot 0.12.4",
  "serde",
  "time",
  "tokio",
@@ -6370,14 +6175,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "enumset",
  "finite-wasm",
  "near-vm-types",
  "near-vm-vm",
- "rkyv 0.8.10",
+ "rkyv",
  "target-lexicon 0.12.16",
  "thiserror 2.0.12",
  "tracing",
@@ -6386,15 +6191,14 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
- "dynasm 2.0.0",
- "dynasmrt 2.0.0",
+ "dynasm",
+ "dynasmrt",
  "enumset",
  "finite-wasm",
  "memoffset 0.8.0",
- "more-asserts",
  "near-vm-compiler",
  "near-vm-types",
  "near-vm-vm",
@@ -6406,22 +6210,19 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "backtrace",
- "cfg-if 1.0.1",
- "enumset",
  "finite-wasm",
  "more-asserts",
  "near-vm-compiler",
  "near-vm-types",
  "near-vm-vm",
- "region",
- "rkyv 0.8.10",
+ "parking_lot 0.12.4",
+ "rkyv",
  "rustc-demangle",
  "rustix 1.0.7",
- "target-lexicon 0.12.16",
  "thiserror 2.0.12",
  "tracing",
 ]
@@ -6461,8 +6262,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
  "blst",
@@ -6473,29 +6274,26 @@ dependencies = [
  "finite-wasm",
  "lru 0.12.5",
  "memoffset 0.8.0",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
- "near-schema-checker-lib 2.6.0-rc.1",
- "near-stdx 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
+ "near-schema-checker-lib 2.7.0-rc.2",
+ "near-stdx 2.7.0-rc.2",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
  "near-vm-types",
  "near-vm-vm",
  "num-rational",
- "parity-wasm 0.41.0",
- "parity-wasm 0.42.2",
+ "parking_lot 0.12.4",
  "prefix-sum-vec",
  "prometheus",
- "pwasm-utils",
  "rand 0.8.5",
  "rayon",
  "ripemd",
  "rustix 1.0.7",
  "serde",
- "serde_repr",
  "sha2",
  "sha3",
  "strum 0.24.1",
@@ -6503,14 +6301,6 @@ dependencies = [
  "thiserror 2.0.12",
  "tracing",
  "wasm-encoder 0.224.1",
- "wasmer-compiler-near",
- "wasmer-compiler-singlepass-near",
- "wasmer-engine-near",
- "wasmer-engine-universal-near",
- "wasmer-runtime-core-near",
- "wasmer-runtime-near",
- "wasmer-types-near",
- "wasmer-vm-near",
  "wasmparser 0.78.2",
  "wasmtime",
  "zeropool-bn",
@@ -6518,31 +6308,31 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "indexmap 2.9.0",
  "num-traits",
- "rkyv 0.8.10",
+ "rkyv",
  "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "near-vm-vm"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "backtrace",
  "cc",
  "cfg-if 1.0.1",
  "finite-wasm",
- "indexmap 2.9.0",
  "libc",
  "memoffset 0.8.0",
  "more-asserts",
  "near-vm-types",
+ "parking_lot 0.12.4",
  "region",
- "rkyv 0.8.10",
+ "rkyv",
  "thiserror 2.0.12",
  "tracing",
  "winapi",
@@ -6550,28 +6340,25 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.6.0-rc.1",
- "near-vm-runner 2.6.0-rc.1",
+ "near-primitives-core 2.7.0-rc.2",
+ "near-vm-runner 2.7.0-rc.2",
 ]
 
 [[package]]
 name = "nearcore"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "actix",
  "actix-rt",
  "actix-web",
  "anyhow",
- "awc",
  "borsh",
  "bytesize",
- "chrono",
- "cloud-storage",
  "dirs",
  "easy-ext",
  "futures",
@@ -6582,40 +6369,36 @@ dependencies = [
  "itertools 0.12.1",
  "near-async",
  "near-chain",
- "near-chain-configs 2.6.0-rc.1",
+ "near-chain-configs 2.7.0-rc.2",
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.6.0-rc.1",
- "near-crypto 2.6.0-rc.1",
+ "near-config-utils 2.7.0-rc.2",
+ "near-crypto 2.7.0-rc.2",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-jsonrpc",
- "near-jsonrpc-primitives 2.6.0-rc.1",
+ "near-jsonrpc-primitives 2.7.0-rc.2",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
  "near-performance-metrics",
  "near-pool",
- "near-primitives 2.6.0-rc.1",
+ "near-primitives 2.7.0-rc.2",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 2.7.0-rc.2",
  "node-runtime",
  "num-rational",
+ "object_store",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
- "rayon",
- "regex",
- "reqwest 0.11.27",
- "rlimit",
- "rust-s3",
+ "reqwest 0.12.20",
  "serde",
  "serde_ignored",
  "serde_json",
- "smart-default 0.7.1",
- "strum 0.24.1",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",
@@ -6626,47 +6409,36 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.15.0"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2e0b4f3320ed72aaedb9a5ac838690a8047c7b275da22711fddff4f8a14229"
-dependencies = [
- "bitflags 1.3.2",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
-name = "nix"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa52e972a9a719cecb6864fb88568781eb706bac2cd1d4f04a648542dbf78069"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if 1.0.1",
  "libc",
- "memoffset 0.6.5",
+ "memoffset 0.7.1",
+ "pin-utils",
 ]
 
 [[package]]
 name = "node-runtime"
-version = "2.6.0-rc.1"
-source = "git+https://github.com/near/nearcore?tag=2.6.0-rc.1#26e86307153334be3fd48bc7772563c1d8f6d478"
+version = "2.7.0-rc.2"
+source = "git+https://github.com/near/nearcore?tag=2.7.0-rc.2#a2b961bb745bca63a1da031147369145b9e038eb"
 dependencies = [
  "borsh",
  "bytesize",
  "itertools 0.12.1",
- "near-crypto 2.6.0-rc.1",
+ "near-crypto 2.7.0-rc.2",
  "near-o11y",
- "near-parameters 2.6.0-rc.1",
- "near-primitives 2.6.0-rc.1",
- "near-primitives-core 2.6.0-rc.1",
+ "near-parameters 2.7.0-rc.2",
+ "near-primitives 2.7.0-rc.2",
+ "near-primitives-core 2.7.0-rc.2",
  "near-store",
- "near-vm-runner 2.6.0-rc.1",
+ "near-vm-runner 2.7.0-rc.2",
  "near-wallet-contract",
  "num-bigint 0.3.3",
  "num-traits",
+ "parking_lot 0.12.4",
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rayon",
@@ -6703,17 +6475,6 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "090c7f9998ee0ff65aa5b723e4009f7b217707f1fb5ea551329cc4d6231fb304"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]
@@ -6817,6 +6578,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "object_store"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781f96d79ed0f961a7021424ab01840efbda64ae7a505aaea195efc91eaaec4"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "form_urlencoded",
+ "futures",
+ "http 1.3.1",
+ "http-body-util",
+ "humantime",
+ "hyper 1.6.0",
+ "itertools 0.14.0",
+ "parking_lot 0.12.4",
+ "percent-encoding",
+ "quick-xml",
+ "rand 0.9.1",
+ "reqwest 0.12.20",
+ "ring 0.17.14",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "thiserror 2.0.12",
+ "tokio",
+ "tracing",
+ "url",
+ "walkdir",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "oid-registry"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6876,15 +6673,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
-name = "openssl-src"
-version = "300.5.0+3.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ce546f549326b0e6052b649198487d91320875da901e7bd11a06d1ee3f9c2f"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "openssl-sys"
 version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6892,7 +6680,6 @@ checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
- "openssl-src",
  "pkg-config",
  "vcpkg",
 ]
@@ -7000,16 +6787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
-name = "page_size"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebde548fbbf1ea81a99b128872779c437752fb99f217c45245e1a61dcd9edcd"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "paperclip"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7111,32 +6888,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "parity-wasm"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddfc878dac00da22f8f61e7af3157988424567ab01d9920b962ef7dcbd7cd865"
-
-[[package]]
-name = "parity-wasm"
-version = "0.42.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
-
-[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
-
-[[package]]
-name = "parking_lot"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3a704eb390aafdc107b0e392f56a82b668e3a71366993b5340f5833fd62505e"
-dependencies = [
- "lock_api 0.3.4",
- "parking_lot_core 0.7.3",
-]
 
 [[package]]
 name = "parking_lot"
@@ -7145,7 +6900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
- "lock_api 0.4.13",
+ "lock_api",
  "parking_lot_core 0.8.6",
 ]
 
@@ -7155,22 +6910,8 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
- "lock_api 0.4.13",
+ "lock_api",
  "parking_lot_core 0.9.11",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b93f386bb233083c799e6e642a9d73db98c24a5deeb95ffc85bf281255dffc98"
-dependencies = [
- "cfg-if 0.1.10",
- "cloudabi",
- "libc",
- "redox_syscall 0.1.57",
- "smallvec",
- "winapi",
 ]
 
 [[package]]
@@ -7211,17 +6952,6 @@ name = "peeking_take_while"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
-name = "pem"
-version = "0.8.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd56cbd21fea48d0c440b41cd69c589faacade08c992d9a54e471b79d0fd13eb"
-dependencies = [
- "base64 0.13.1",
- "once_cell",
- "regex",
-]
 
 [[package]]
 name = "pem"
@@ -7733,31 +7463,11 @@ dependencies = [
 
 [[package]]
 name = "ptr_meta"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
-dependencies = [
- "ptr_meta_derive 0.1.4",
-]
-
-[[package]]
-name = "ptr_meta"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe9e76f66d3f9606f44e45598d155cb13ecf09f4a28199e48daf8c8fc937ea90"
 dependencies = [
- "ptr_meta_derive 0.3.0",
-]
-
-[[package]]
-name = "ptr_meta_derive"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
+ "ptr_meta_derive",
 ]
 
 [[package]]
@@ -7783,21 +7493,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "pwasm-utils"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f7a12f176deee919f4ba55326ee17491c8b707d0987aed822682c821b660192"
-dependencies = [
- "byteorder",
- "log",
- "parity-wasm 0.41.0",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "quinn"
@@ -7881,7 +7590,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf5f7161924b9d1cea0e4cabc97c372cea92b5f927fc13c6bca67157a0ad947"
 dependencies = [
- "ptr_meta 0.3.0",
+ "ptr_meta",
 ]
 
 [[package]]
@@ -8009,18 +7718,12 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
 dependencies = [
- "pem 3.0.5",
+ "pem",
  "ring 0.17.14",
  "rustls-pki-types 1.12.0",
  "time",
  "yasna",
 ]
-
-[[package]]
-name = "redox_syscall"
-version = "0.1.57"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_syscall"
@@ -8063,7 +7766,7 @@ dependencies = [
  "lru 0.7.8",
  "parking_lot 0.11.2",
  "smallvec",
- "spin 0.9.8",
+ "spin",
 ]
 
 [[package]]
@@ -8170,20 +7873,11 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rend"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
-dependencies = [
- "bytecheck 0.6.12",
-]
-
-[[package]]
-name = "rend"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a35e8a6bf28cd121053a66aa2e6a2e3eaffad4a60012179f0e864aa5ffeff215"
 dependencies = [
- "bytecheck 0.8.1",
+ "bytecheck",
 ]
 
 [[package]]
@@ -8238,6 +7932,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.10",
@@ -8259,6 +7954,7 @@ dependencies = [
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types 1.12.0",
  "serde",
  "serde_json",
@@ -8297,28 +7993,13 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.9"
 source = "git+https://github.com/mattlockyer/ring#ec827590cd2346a401e0c3cfea6b2fe6a757ce4d"
 dependencies = [
  "cc",
  "cfg-if 1.0.1",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -8332,7 +8013,7 @@ dependencies = [
  "cfg-if 1.0.1",
  "getrandom 0.2.16",
  "libc",
- "untrusted 0.9.0",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -8347,50 +8028,21 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9008cd6385b9e161d8229e1f6549dd23c3d022f132a2ea37ac3a10ac4935779b"
-dependencies = [
- "bitvec",
- "bytecheck 0.6.12",
- "bytes",
- "hashbrown 0.12.3",
- "ptr_meta 0.1.4",
- "rend 0.4.2",
- "rkyv_derive 0.7.45",
- "seahash",
- "tinyvec",
- "uuid",
-]
-
-[[package]]
-name = "rkyv"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e147371c75553e1e2fcdb483944a8540b8438c31426279553b9a8182a9b7b65"
 dependencies = [
- "bytecheck 0.8.1",
+ "bytecheck",
  "bytes",
  "hashbrown 0.15.4",
  "indexmap 2.9.0",
  "munge",
- "ptr_meta 0.3.0",
+ "ptr_meta",
  "rancor",
- "rend 0.5.2",
- "rkyv_derive 0.8.10",
+ "rend",
+ "rkyv_derive",
  "tinyvec",
  "uuid",
-]
-
-[[package]]
-name = "rkyv_derive"
-version = "0.7.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503d1d27590a2b0a3a4ca4c94755aa2875657196ecbf401a42eff41d7de532c0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -8586,15 +8238,6 @@ checksum = "3e75f6a532d0fd9f7f13144f392b6ad56a32696bfcd9c78f797f16bbb6f072d6"
 
 [[package]]
 name = "rustc_version"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
-dependencies = [
- "semver 0.9.0",
-]
-
-[[package]]
-name = "rustc_version"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0dfe2087c51c460008730de8b57e6a320782fbfb312e1f4d520e6c6fae155ee"
@@ -8627,7 +8270,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519165d378b97752ca44bbe15047d5d3409e875f39327546b42ac81d7e18c1b6"
 dependencies = [
  "bitflags 1.3.2",
- "errno 0.3.13",
+ "errno",
  "io-lifetimes",
  "libc",
  "linux-raw-sys 0.3.8",
@@ -8641,7 +8284,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
  "bitflags 2.9.1",
- "errno 0.3.13",
+ "errno",
  "libc",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
@@ -8654,7 +8297,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
  "bitflags 2.9.1",
- "errno 0.3.13",
+ "errno",
  "libc",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
@@ -8673,6 +8316,18 @@ dependencies = [
  "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types 1.12.0",
+ "schannel",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -8718,7 +8373,7 @@ source = "git+https://github.com/mattlockyer/webpki#219c5df474ed26d018a262f6d844
 dependencies = [
  "ring 0.17.9",
  "rustls-pki-types 1.11.0",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -8729,7 +8384,7 @@ checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
  "ring 0.17.14",
  "rustls-pki-types 1.12.0",
- "untrusted 0.9.0",
+ "untrusted",
 ]
 
 [[package]]
@@ -8772,6 +8427,15 @@ name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "same-file"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
+dependencies = [
+ "winapi-util",
+]
 
 [[package]]
 name = "scale-info"
@@ -8865,12 +8529,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "584e070911c7017da6cb2eb0788d09f43d789029b5877d3e5ecc8acf86ceee21"
 
 [[package]]
-name = "seahash"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
-
-[[package]]
 name = "sec1"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8878,7 +8536,7 @@ checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
  "base16ct",
  "der",
- "generic-array 0.14.7",
+ "generic-array",
  "pkcs8",
  "serdect",
  "subtle",
@@ -8945,7 +8603,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
+dependencies = [
+ "bitflags 2.9.1",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -8963,20 +8634,11 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
-dependencies = [
- "semver-parser 0.7.0",
-]
-
-[[package]]
-name = "semver"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f301af10236f6df4160f7c3f04eec6dbc70ace82d23326abad5edee88801c6b6"
 dependencies = [
- "semver-parser 0.10.3",
+ "semver-parser",
 ]
 
 [[package]]
@@ -8984,12 +8646,6 @@ name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
-
-[[package]]
-name = "semver-parser"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 
 [[package]]
 name = "semver-parser"
@@ -9007,16 +8663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
-]
-
-[[package]]
-name = "serde-bench"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d733da87e79faaac25616e33d26299a41143fd4cd42746cbb0e91d8feea243fd"
-dependencies = [
- "byteorder",
- "serde",
 ]
 
 [[package]]
@@ -9039,15 +8685,6 @@ dependencies = [
  "serde",
  "thiserror 1.0.69",
  "xml-rs",
-]
-
-[[package]]
-name = "serde_bytes"
-version = "0.11.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8437fd221bde2d4ca316d61b90e337e9e702b3820b87d63caa9ba6c02bd06d96"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -9296,17 +8933,6 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "simple_asn1"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692ca13de57ce0613a363c8c2f1de925adebc81b04c923ac60c5488bb44abe4b"
-dependencies = [
- "chrono",
- "num-bigint 0.2.6",
- "num-traits",
-]
-
-[[package]]
-name = "simple_asn1"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
@@ -9414,17 +9040,11 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 dependencies = [
- "lock_api 0.4.13",
+ "lock_api",
 ]
 
 [[package]]
@@ -9504,16 +9124,16 @@ dependencies = [
 
 [[package]]
 name = "stun"
-version = "0.4.4"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e94b1ec00bad60e6410e058b52f1c66de3dc5fe4d62d09b3e52bb7d3b73e25"
+checksum = "ea256fb46a13f9204e9dee9982997b2c3097db175a9fddaa8350310d03c4d5a3"
 dependencies = [
- "base64 0.13.1",
+ "base64 0.22.1",
  "crc",
  "lazy_static",
  "md-5",
  "rand 0.8.5",
- "ring 0.16.20",
+ "ring 0.17.14",
  "subtle",
  "thiserror 1.0.69",
  "tokio",
@@ -9609,7 +9229,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.5.0",
 ]
 
@@ -9620,7 +9240,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation",
+ "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
 
@@ -9649,12 +9269,6 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
-
-[[package]]
-name = "target-lexicon"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab0e7238dcc7b40a7be719a25365910f6807bd864f4cce6b2e6b873658e2b19d"
 
 [[package]]
 name = "target-lexicon"
@@ -10282,12 +9896,6 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -10361,12 +9969,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "wait-timeout"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10380,6 +9982,16 @@ name = "waker-fn"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "317211a0dc0ceedd78fb2ca9a44aed3d7b9b26f81870d485c07122b4350673b7"
+
+[[package]]
+name = "walkdir"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
+dependencies = [
+ "same-file",
+ "winapi-util",
+]
 
 [[package]]
 name = "want"
@@ -10507,180 +10119,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
-
-[[package]]
-name = "wasmer-compiler-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46fdae7245128f284476e6db9653ef0a15b011975091bcd7f9d7303132409662"
-dependencies = [
- "enumset",
- "rkyv 0.7.45",
- "smallvec",
- "target-lexicon 0.12.16",
- "thiserror 1.0.69",
- "wasmer-types-near",
- "wasmer-vm-near",
- "wasmparser 0.78.2",
-]
-
-[[package]]
-name = "wasmer-compiler-singlepass-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac4af0e438015585eb27b2c6f6869c58c540bfe27408b686b1778470bf301050"
-dependencies = [
- "byteorder",
- "dynasm 1.2.3",
- "dynasmrt 1.2.3",
- "lazy_static",
- "memoffset 0.6.5",
- "more-asserts",
- "rayon",
- "smallvec",
- "wasmer-compiler-near",
- "wasmer-types-near",
- "wasmer-vm-near",
-]
-
-[[package]]
-name = "wasmer-engine-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4048411cabb2c94c7d8d11d9d0282cc6b15308b61ebc1e122c40e89865ebb5c5"
-dependencies = [
- "backtrace",
- "enumset",
- "lazy_static",
- "memmap2",
- "more-asserts",
- "rustc-demangle",
- "target-lexicon 0.12.16",
- "thiserror 1.0.69",
- "wasmer-compiler-near",
- "wasmer-types-near",
- "wasmer-vm-near",
-]
-
-[[package]]
-name = "wasmer-engine-universal-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f31c3d2850ac7957406d3c9581d9435ea8126a26478709fa7e931b6f562b4d"
-dependencies = [
- "cfg-if 1.0.1",
- "enumset",
- "leb128",
- "region",
- "rkyv 0.7.45",
- "thiserror 1.0.69",
- "wasmer-compiler-near",
- "wasmer-engine-near",
- "wasmer-types-near",
- "wasmer-vm-near",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-runtime-core-near"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af9c54899b847f8bab6d47295487c9827f14cc411bd70b168e87a4ea017ccd7e"
-dependencies = [
- "bincode",
- "blake3",
- "borsh",
- "cc",
- "digest 0.8.1",
- "errno 0.2.8",
- "hex",
- "indexmap 2.9.0",
- "lazy_static",
- "libc",
- "nix 0.15.0",
- "page_size",
- "parking_lot 0.10.2",
- "rustc_version 0.2.3",
- "serde",
- "serde-bench",
- "serde_bytes",
- "serde_derive",
- "smallvec",
- "target-lexicon 0.10.0",
- "wasmparser 0.51.4",
- "winapi",
-]
-
-[[package]]
-name = "wasmer-runtime-near"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158e6fff11e5e1ef805af50637374d5bd43d92017beafa18992cdf7f3f7ae3e4"
-dependencies = [
- "lazy_static",
- "memmap",
- "serde",
- "serde_derive",
- "wasmer-runtime-core-near",
- "wasmer-singlepass-backend-near",
-]
-
-[[package]]
-name = "wasmer-singlepass-backend-near"
-version = "0.18.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9358673d39c3b4a15374fba0536bfe5e50485e7c826de50d2dbef8c96df07674"
-dependencies = [
- "bincode",
- "borsh",
- "byteorder",
- "dynasm 1.2.3",
- "dynasmrt 1.2.3",
- "lazy_static",
- "libc",
- "nix 0.15.0",
- "serde",
- "serde_derive",
- "smallvec",
- "wasmer-runtime-core-near",
-]
-
-[[package]]
-name = "wasmer-types-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ba154adffb0fbd33f5dabd3788a1744d846b43e6e090d44269c7ee8fa5743e4"
-dependencies = [
- "indexmap 1.9.3",
- "rkyv 0.7.45",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "wasmer-vm-near"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a5585596f6e9915d606de944aece51626736fb1191aefb5b2ef108c6f7604a"
-dependencies = [
- "backtrace",
- "cc",
- "cfg-if 1.0.1",
- "indexmap 1.9.3",
- "libc",
- "memoffset 0.6.5",
- "more-asserts",
- "region",
- "rkyv 0.7.45",
- "thiserror 1.0.69",
- "wasmer-types-near",
- "winapi",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.51.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeb1956b19469d1c5e63e459d29e7b5aa0f558d9f16fcef09736f8a265e6c10a"
 
 [[package]]
 name = "wasmparser"
@@ -10935,19 +10373,19 @@ dependencies = [
 
 [[package]]
 name = "webrtc-util"
-version = "0.7.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f1db1727772c05cf7a2cfece52c3aca8045ca1e176cd517d323489aa3c6d87"
+checksum = "1438a8fd0d69c5775afb4a71470af92242dbd04059c61895163aa3c1ef933375"
 dependencies = [
  "async-trait",
  "bitflags 1.3.2",
  "bytes",
- "cc",
  "ipnet",
  "lazy_static",
  "libc",
  "log",
- "nix 0.24.3",
+ "nix",
+ "portable-atomic",
  "rand 0.8.5",
  "thiserror 1.0.69",
  "tokio",

--- a/libs/chain-signatures/contract/Cargo.toml
+++ b/libs/chain-signatures/contract/Cargo.toml
@@ -37,7 +37,7 @@ k256 = { version = "0.13.4", features = [
 dcap-qvl = { git = "https://github.com/mattlockyer/dcap-qvl", rev = "3caedd8fd0f365841abaf1430ff2922fcb09d9db" }
 
 near-gas = { version = "0.2.5", features = ["serde", "borsh", "schemars"] }
-near-account-id = "1"
+near-account-id = "1.1.1"
 thiserror = "1"
 sha3 = "0.10.8"
 hex = "0.4.3"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -58,15 +58,15 @@ x509-parser = "0.16.0"
 
 curve25519-dalek = "4.1.3"
 
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.6.0-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.7.0-rc.2" }
 # todo: update once 1.1.0 is pulbished (though the api did not change)
-legacy-mpc-contract = { package = "mpc-contract", git = "https://github.com/Near-One/mpc/", rev = "1d4954dff28e8eb988fb7762eff414a602a2b124" }
+legacy-mpc-contract = { package = "mpc-contract", git = "https://github.com/near/mpc/", rev = "1d4954dff28e8eb988fb7762eff414a602a2b124" }
 mpc-contract = { path = "../libs/chain-signatures/contract/", features = [
     "dev-utils",
 ] }

--- a/node/src/indexer/mod.rs
+++ b/node/src/indexer/mod.rs
@@ -31,7 +31,7 @@ pub(crate) struct IndexerState {
     /// For querying blockchain sync status.
     client: actix::Addr<near_client::ClientActor>,
     /// For sending txs to the chain.
-    tx_processor: actix::Addr<near_client::TxRequestHandlerActor>,
+    tx_processor: actix::Addr<near_client::RpcHandlerActor>,
     /// AccountId for the mpc contract.
     mpc_contract_id: AccountId,
     /// Stores runtime indexing statistics.
@@ -42,7 +42,7 @@ impl IndexerState {
     pub fn new(
         view_client: actix::Addr<near_client::ViewClientActor>,
         client: actix::Addr<near_client::ClientActor>,
-        tx_processor: actix::Addr<near_client::TxRequestHandlerActor>,
+        tx_processor: actix::Addr<near_client::RpcHandlerActor>,
         mpc_contract_id: AccountId,
     ) -> Self {
         Self {

--- a/pytest/common_lib/shared/__init__.py
+++ b/pytest/common_lib/shared/__init__.py
@@ -204,7 +204,7 @@ def adjust_indexing_shard(near_node: LocalNode):
 
     with open(path, 'r+') as f:
         config = json.load(f)
-        config['tracked_shards'] = [0]
+        config['tracked_shards_config'] = "AllShards"
         f.seek(0)
         json.dump(config, f, indent=2)
         f.truncate()


### PR DESCRIPTION
Closes #614 

Equivalent to https://github.com/near/mpc/pull/603 for `testnet-release`