### PR TITLE
chore: use the right `protocol_state` type for MpcContractV1 state

### DIFF
--- a/libs/chain-signatures/contract/src/v0_state/mod.rs
+++ b/libs/chain-signatures/contract/src/v0_state/mod.rs
@@ -9,12 +9,13 @@
 use near_account_id::AccountId;
 use near_sdk::store::IterableMap;
 use near_sdk::{env, near, store::LookupMap};
-use std::collections::{BTreeMap, HashSet};
+use std::collections::HashSet;
 
 use crate::legacy_contract_state::ConfigV1;
+use crate::primitives::votes::ThresholdParametersVotes;
 use crate::primitives::{
     domain::{AddDomainsVotes, DomainRegistry},
-    key_state::{AuthenticatedParticipantId, KeyForDomain, Keyset},
+    key_state::{KeyForDomain, Keyset},
     thresholds::ThresholdParameters,
 };
 use crate::state::{initializing::InitializingContractState, key_event::KeyEvent};
@@ -33,13 +34,6 @@ pub struct ResharingContractState {
     pub previous_running_state: RunningContractState,
     pub reshared_keys: Vec<KeyForDomain>,
     pub resharing_key: KeyEvent,
-}
-
-#[near(serializers=[borsh, json])]
-#[derive(Debug, Default, PartialEq)]
-#[cfg_attr(feature = "dev-utils", derive(Clone))]
-pub struct ThresholdParametersVotes {
-    proposal_by_account: BTreeMap<AuthenticatedParticipantId, ThresholdParameters>,
 }
 
 #[near(serializers=[borsh, json])]

--- a/libs/chain-signatures/contract/src/v0_state/mod.rs
+++ b/libs/chain-signatures/contract/src/v0_state/mod.rs
@@ -114,7 +114,7 @@ impl From<TeeState> for crate::TeeState {
 #[near(serializers=[borsh])]
 #[derive(Debug)]
 pub struct MpcContractV1 {
-    protocol_state: crate::state::ProtocolContractState,
+    protocol_state: ProtocolContractState,
     pending_requests: LookupMap<SignatureRequest, YieldIndex>,
     proposed_updates: crate::update::ProposedUpdates,
     config: Config,
@@ -147,7 +147,7 @@ impl From<ProtocolContractState> for crate::ProtocolContractState {
 impl From<MpcContractV1> for MpcContract {
     fn from(value: MpcContractV1) -> Self {
         Self {
-            protocol_state: value.protocol_state,
+            protocol_state: value.protocol_state.into(),
             pending_requests: value.pending_requests,
             proposed_updates: value.proposed_updates,
             config: value.config,

--- a/libs/chain-signatures/contract/tests/updates.rs
+++ b/libs/chain-signatures/contract/tests/updates.rs
@@ -31,7 +31,7 @@ pub fn invalid_contract() -> ProposeUpdateArgs {
 /// This is the current deposit required for a contract deploy. This is subject to change but make
 /// sure that it's not larger than 2mb. We can go up to 4mb technically but our contract should
 /// not be getting that big.
-const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(9700);
+const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(9750);
 
 #[tokio::test]
 async fn test_propose_contract_max_size_upload() {

--- a/pytest/common_lib/shared/mpc_cluster.py
+++ b/pytest/common_lib/shared/mpc_cluster.py
@@ -440,7 +440,7 @@ class MpcCluster:
         tx = participant.sign_tx(self.mpc_contract_account(),
                                  'propose_update',
                                  args,
-                                 deposit=9624860000000000000000000)
+                                 deposit=9750000000000000000000000)
         res = participant.send_txn_and_check_success(tx, timeout=30)
         return int(
             base64.b64decode(res['result']['status']['SuccessValue']).decode(

--- a/pytest/common_lib/shared/mpc_cluster.py
+++ b/pytest/common_lib/shared/mpc_cluster.py
@@ -440,7 +440,7 @@ class MpcCluster:
         tx = participant.sign_tx(self.mpc_contract_account(),
                                  'propose_update',
                                  args,
-                                 deposit=9750000000000000000000000)
+                                 deposit=9753060000000000000000000)
         res = participant.send_txn_and_check_success(tx, timeout=30)
         return int(
             base64.b64decode(res['result']['status']['SuccessValue']).decode(


### PR DESCRIPTION
closes #668 