### PR TITLE
fix: Adjust invariant checks when selecting participants

### DIFF
--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -1095,7 +1095,7 @@ mod tests {
     }
 
     #[test]
-    fn foo() {
+    fn test_random_participant_selection() {
         let num_participants = 4;
         let participant_ids =
             TestGenerators::new(num_participants, num_participants).participant_ids();

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -1095,7 +1095,7 @@ mod tests {
     }
 
     #[test]
-    fn test_random_participant_selection() {
+    fn select_random_active_participants_including_me_should_return_error_when_peers_to_consider_is_empty() {
         let num_participants = 4;
         let participant_ids =
             TestGenerators::new(num_participants, num_participants).participant_ids();

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -1095,7 +1095,7 @@ mod tests {
     }
 
     #[test]
-    fn select_random_active_participants_including_me_should_return_error_when_peers_to_consider_is_empty() {
+    fn select_random_active_participants_including_me_should_return_not_enough_active_participants_when_peers_to_consider_is_empty() {
         let num_participants = 4;
         let participant_ids =
             TestGenerators::new(num_participants, num_participants).participant_ids();
@@ -1113,9 +1113,17 @@ mod tests {
             channels.clone(),
             indexer_heights.clone(),
         );
-        let result = mesh_network_client
-            .select_random_active_participants_including_me(num_participants, &[]);
-        assert!(result.is_err())
+
+        let err = mesh_network_client
+            .select_random_active_participants_including_me(num_participants, &[])
+            .unwrap_err();
+
+        let err_msg = err.to_string();
+        assert!(
+            err_msg.starts_with("Not enough active participants"),
+            "unexpected error message: {}",
+            err_msg
+        );
     }
 }
 

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -1095,7 +1095,8 @@ mod tests {
     }
 
     #[test]
-    fn select_random_active_participants_including_me_should_return_not_enough_active_participants_when_peers_to_consider_is_empty() {
+    fn select_random_active_participants_including_me_should_return_not_enough_active_participants_when_peers_to_consider_is_empty(
+    ) {
         let num_participants = 4;
         let participant_ids =
             TestGenerators::new(num_participants, num_participants).participant_ids();

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -205,17 +205,10 @@ impl MeshNetworkClient {
     ) -> anyhow::Result<Vec<ParticipantId>> {
         let me = self.my_participant_id();
         let participants = self.all_alive_participant_ids();
-
-        if participants.len() < total {
-            anyhow::bail!(
-                "Not enough active participants: need {}, got {}",
-                total,
-                participants.len()
-            );
-        }
-        if !participants.contains(&me) {
-            anyhow::bail!("There's no `me` in active participants");
-        }
+        anyhow::ensure!(
+            participants.contains(&me),
+            "There's no `me` in active participants"
+        );
 
         let mut res = participants
             .into_iter()
@@ -226,6 +219,14 @@ impl MeshNetworkClient {
             })
             .choose_multiple(&mut rand::thread_rng(), total - 1);
         res.push(me);
+
+        anyhow::ensure!(
+            res.len() == total,
+            "Not enough active participants: need {}, got {}",
+            total,
+            res.len()
+        );
+
         Ok(res)
     }
 


### PR DESCRIPTION
## Context
The function: 
```
pub fn select_random_active_participants_including_me(
        &self,
        total: usize,
        peers_to_consider: &[ParticipantId],
    ) -> anyhow::Result<Vec<ParticipantId>>
```
Should return `total` number of online participants amongst `peers_to_consider`, including the caller participant. 

This function has two usages:
1. In generation of triples
2. In generation eddsa signatures

## Bug
This function behaves incorrectly, when the size of `peers_to_consider` is insufficient, to make up for `total` participants.
Extrapolated example: if we pass empty `peers_to_consider`. In that case `[me]` will be returned, because `me` is getting appended regardless. The error should be returned instead.

`IteratorRandom::choose_multiple(_, amount)` silently returns less than `amount` elements, if there are not enough.

## Solution

Make invariant check on return value

## Effect 

This has no practical effect at the moment, because `all_participants_from_config` is being passed into `select_random_active_participants_including_me` 

