### PR TITLE
feat: Make python formatter apply for the whole repo

### DIFF
--- a/.github/workflows/black-formatter.yml
+++ b/.github/workflows/black-formatter.yml
@@ -13,5 +13,5 @@ jobs:
       - name: Check Python code formatting with Black
         uses: psf/black@stable
         with:
-          options: "--check --diff --verbose"
-          src: "./pytest"
+          options: "--check --diff --verbose --extend-exclude libs/nearcore"
+          src: "."

--- a/tee_launcher/launcher.py
+++ b/tee_launcher/launcher.py
@@ -73,7 +73,6 @@ ALLOWED_ENV_VARS = {
     "RUST_BACKTRACE",  # Enables backtraces for Rust errors
     "RUST_LOG",  # Logging level for Rust code
     "MPC_RESPONDER_ID",  # Unique responder ID for MPC communication
-   
 }
 
 # Regex: hostnames must be alphanum + dash/dot, IPs must be valid IPv4

--- a/tee_launcher/test_launcher.py
+++ b/tee_launcher/test_launcher.py
@@ -8,20 +8,24 @@ class TestLauncher(unittest.TestCase):
     def test_get_manifest_digest(self):
 
         # Use a recent (at the time of writing) tag/image digest/manifest digest combination for testing
-        registry_url = 'registry.hub.docker.com'
-        image_name = 'nearone/mpc-node-gcp'
-        image_hash = 'sha256:7e5a6bcb6707d134fc479cc293830c05ce45891f0977d467362cbb7f55cde46b'
-        expected_manifest_digest = 'sha256:005943bccdd401e71c5408d65cf301eeb8bfc3926fe346023912412aafda2490'
-        tags = ['8805536ab98d924d980a58ecc0518a8c90204bec']
-        image = ResolvedImage(ImageSpec(tags=tags,
-                                        image_name=image_name,
-                                        registry=registry_url),
-                              digest=image_hash)
-        result = get_manifest_digest(image,
-                                     rpc_request_interval_secs=0.5,
-                                     rpc_max_attempts=10)
+        registry_url = "registry.hub.docker.com"
+        image_name = "nearone/mpc-node-gcp"
+        image_hash = (
+            "sha256:7e5a6bcb6707d134fc479cc293830c05ce45891f0977d467362cbb7f55cde46b"
+        )
+        expected_manifest_digest = (
+            "sha256:005943bccdd401e71c5408d65cf301eeb8bfc3926fe346023912412aafda2490"
+        )
+        tags = ["8805536ab98d924d980a58ecc0518a8c90204bec"]
+        image = ResolvedImage(
+            ImageSpec(tags=tags, image_name=image_name, registry=registry_url),
+            digest=image_hash,
+        )
+        result = get_manifest_digest(
+            image, rpc_request_interval_secs=0.5, rpc_max_attempts=10
+        )
         self.assertEqual(result, expected_manifest_digest)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
resolves: #681 

This PR: 
1. Applies formatter to the `/tee_launcher` code
2. Makes python linter to be applied to every python code in the repo, except for the `libs/nearcore`