### PR TITLE
chore: Fix failing CI for TEE Launcher build

### DIFF
--- a/.github/workflows/tee_launcher.yml
+++ b/.github/workflows/tee_launcher.yml
@@ -6,19 +6,17 @@ concurrency:
 
 on:
   push:
-    branches:
-      - main
-
+    branches: [ main ]
   workflow_dispatch:
     inputs:
       build-ref:
-        default: 'main'
-        description: "The branch, tag or SHA to build the launcher Docker image from. Default to latest commit on main branch."
+        description: "Branch, tag or SHA to build the launcher Docker image from"
         type: string
+        default: "main"
 
 jobs:
   docker-image-build:
-    name: "Build and push Tee Launcher image"
+    name: Build and push TEE Launcher image
     runs-on: warp-ubuntu-2204-x64-2x
     permissions:
       contents: read
@@ -27,19 +25,21 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.build-ref }}
+          ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-ref || github.ref }}
 
-      - name: Get short SHA
+      - name: Compute tags meta
+        id: meta
         shell: bash
         run: |
-          echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_ENV"
+          RAW_REF="${{ github.event_name == 'workflow_dispatch' && github.event.inputs.build-ref || github.ref_name }}"
+          SANITIZED_REF=$(echo "$RAW_REF" \
+            | tr '[:upper:]' '[:lower:]' \
+            | sed 's/[^a-z0-9_.-]/-/g; s/^-*//; s/-*$//')
+          SHA_SHORT="${GITHUB_SHA::7}"
 
-      - name: Sanitize build-ref for Docker tags
-        shell: bash
-        run: |
-          # Replace forward slashes with hyphens to create valid Docker tags
-          sanitized_ref=$(echo "${{ github.event.inputs.build-ref }}" | sed 's/\//-/g')
-          echo "sanitized_ref=$sanitized_ref" >> "$GITHUB_ENV"
+          echo "sanitized_ref=$SANITIZED_REF" >> "$GITHUB_ENV"
+          echo "sha_short=$SHA_SHORT"         >> "$GITHUB_ENV"
+          echo "raw_ref=$RAW_REF"             >> "$GITHUB_OUTPUT"
 
       - name: Initialize submodules
         run: git submodule update --init --recursive
@@ -50,11 +50,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and push Tee Launcher image to Docker Hub
+      - name: Build and push TEE Launcher image to Docker Hub
         uses: Warpbuilds/build-push-action@v6
         with:
           context: tee_launcher/
-          profile-name: "mpc-image-builder"
+          profile-name: mpc-image-builder
           push: true
           file: tee_launcher/development/Dockerfile.launcher
-          tags: nearone/mpc-tee-launcher:latest,nearone/mpc-tee-launcher:${{ env.sanitized_ref }},nearone/mpc-tee-launcher:${{ env.sanitized_ref }}-${{ env.sha_short }}
+          tags: |
+            nearone/mpc-tee-launcher:latest
+            nearone/mpc-tee-launcher:${{ env.sanitized_ref }}
+            nearone/mpc-tee-launcher:${{ env.sanitized_ref }}-${{ env.sha_short }}

--- a/tee_launcher/development/Dockerfile.launcher
+++ b/tee_launcher/development/Dockerfile.launcher
@@ -1,6 +1,7 @@
 FROM debian:bookworm-slim@sha256:4b44499bc2a6c78d726f3b281e6798009c0ae1f034b0bfaf6a227147dcff928b
 
-ARG SNAP=20250714T202759Z
+# https://snapshot.debian.org/archive/debian/20241201T025825Z/
+ARG SNAP=20241201T025825Z
 
 RUN set -eux; \
   echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot; \
@@ -8,6 +9,7 @@ RUN set -eux; \
 deb http://snapshot.debian.org/archive/debian/${SNAP} bookworm main contrib non-free-firmware
 deb http://snapshot.debian.org/archive/debian/${SNAP} bookworm-updates main contrib non-free-firmware
 deb http://snapshot.debian.org/archive/debian-security/${SNAP} bookworm-security main contrib non-free-firmware
+deb http://snapshot.debian.org/archive/debian-debug/${SNAP} bookworm-debug main
 EOF
 
 # Install packages with exact versions for reproducibility

--- a/tee_launcher/development/Dockerfile.launcher
+++ b/tee_launcher/development/Dockerfile.launcher
@@ -1,5 +1,15 @@
 FROM debian:bookworm-slim@sha256:4b44499bc2a6c78d726f3b281e6798009c0ae1f034b0bfaf6a227147dcff928b
 
+ARG SNAP=20250714T202759Z
+
+RUN set -eux; \
+  echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99snapshot; \
+  cat > /etc/apt/sources.list <<EOF
+deb http://snapshot.debian.org/archive/debian/${SNAP} bookworm main contrib non-free-firmware
+deb http://snapshot.debian.org/archive/debian/${SNAP} bookworm-updates main contrib non-free-firmware
+deb http://snapshot.debian.org/archive/debian-security/${SNAP} bookworm-security main contrib non-free-firmware
+EOF
+
 # Install packages with exact versions for reproducibility
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \


### PR DESCRIPTION
#685 follow-up
This PR: 
1. Pins debian package repository, otherwise you can't build it as of now
2. Fixes how git refs are handled in ci, because it didn't get propagated on a push 
