### PR TITLE
chore(deployment): gcp start bash script: avoid unnecessary warning

### DIFF
--- a/deployment/gcp-start.sh
+++ b/deployment/gcp-start.sh
@@ -24,14 +24,15 @@ json.dump(config, open("$NEAR_NODE_CONFIG_FILE", 'w'), indent=2)
 EOF
 }
 
-if [ -n "$MPC_RESPONDER_ID" ]; then
-    responder_id="$MPC_RESPONDER_ID"
-else
-    echo "WARNING: \$MPC_RESPONDER_ID is not set, falling back to \$MPC_ACCOUNT_ID"
-    responder_id="$MPC_ACCOUNT_ID"
-fi
-
 initialize_mpc_config() {
+
+    if [ -n "$MPC_RESPONDER_ID" ]; then
+        responder_id="$MPC_RESPONDER_ID"
+    else
+        echo "WARNING: \$MPC_RESPONDER_ID is not set, falling back to \$MPC_ACCOUNT_ID"
+        responder_id="$MPC_ACCOUNT_ID"
+    fi
+
     cat <<EOF >"$1"
 # Configuration File
 my_near_account_id: $MPC_ACCOUNT_ID


### PR DESCRIPTION
When executing the bash script in devnet, we get this warning:
```
WARNING: $MPC_RESPONDER_ID is not set, falling back to $MPC_ACCOUNT_ID
```
The warning suggests that the node would set `near_responder_account_id` to `$MPC_ACCOUNT_ID`, but this only happens in case if the mpc config file does not already exist.

In our devnet test suite, terraform provides the mpc config file, thus, the fallback does not apply. In that context, this error message is slightly confusing, because it insinuates that the variable `near_responder_account_id` set by the devnet test suite would be ignored.

This PR moves the parsing of the variable inside the function where it is actually used, thus ensuring that the warning will only show in case no mpc config is found on disk.