### PR TITLE
chore: added rerun for flaky test

### DIFF
--- a/pytest/tests/test_key_event.py
+++ b/pytest/tests/test_key_event.py
@@ -17,6 +17,7 @@ from common_lib import shared
 from common_lib.contracts import load_mpc_contract
 
 
+@pytest.mark.flaky(reruns=3, only_rerun=["AssertionError"])
 def test_single_domain():
     """
     Tests single-domain key generation and resharing.


### PR DESCRIPTION
This mitigates #641 . We were installing `pytest-rerunfailures` already in the virtualenv but were not using it.

The reason I am opening this now is that this test failed again for me, this time locally.