### PR TITLE
fix(devnet): compatibility with upcoming mpc node version 3.0.0

### DIFF
--- a/devnet/README.md
+++ b/devnet/README.md
@@ -43,7 +43,7 @@ edit it:
   * The CLI will utilize all available RPC nodes by aggregating their
     available throughput.
 * Set the directory of your local clone of the infra-ops repository.
-  This is used for Terraform deployment of the test cluster.
+  This is used for Terraform deployment of the test cluster. To avoid any errors, it is advised to ensure the local repo is up to date.
 * Set `rpcs` to point to your RPC endpoints
 * (Optional) Configure a `funding_account` to use a specific account for funding operations:
   ```yaml
@@ -87,14 +87,10 @@ independent nonce.
 
 Then, deploy the contract.
 ```
-mpc-devnet mpc my-test deploy-contract \
-  --init-participants 2 --threshold 2
+mpc-devnet mpc my-test deploy-contract 
 ```
-
-The `--init-participants` can be fewer than the total number of participants,
-if we wish to have fewer participants join the network at the beginning.
-
 The path of the contract binary can be overridden via `--path`.
+
 
 We can now deploy the infra with Terraform:
 ```
@@ -106,6 +102,9 @@ the Nomad server UI shows up, we can then deploy the MPC nodes:
 ```
 mpc-devnet mpc my-test deploy-nomad
 ```
+The docker image to be deployed can be change with the `--docker-image` flag.
+By default, devnet assumes that a legacy docker image is deployed (with node version strictly older than 2.2.0).
+For newer versions, one must pass the `--not-legacy` flag, because they require different terraform varibles (todo: remove the flag [(#710)](https://github.com/near/mpc/issues/710)).
 
 Both the `deploy-infra` and `deploy-nomad` commands can be repeated as 
 needed.
@@ -114,6 +113,26 @@ The Terraform deployments use the Terraform Workspaces feature, where
 the workspace name is the same as the MPC network name. The Terraform
 state is stored in S3, which is why this workspace name needs to be
 unique in the team.
+
+
+Now, wait for the nodes to spin-up and start syncing. Once the `public_data` endpoint is accessible, run
+```
+mpc-devnet my-test add-keys
+```
+
+Finally, initialize the contract
+```
+mpc-devnet mpc my-test init-contract \
+  --init-participants 2 --threshold 2
+```
+
+(todo: [(#710)](https://github.com/near/mpc/issues/710) merge these two steps)
+
+The `--init-participants` can be fewer than the total number of participants,
+if we wish to have fewer participants join the network at the beginning.
+
+The path of the contract binary can be overridden via `--path`.
+
 
 ### Generating Keys
 

--- a/devnet/src/account.rs
+++ b/devnet/src/account.rs
@@ -281,6 +281,11 @@ impl OperatingAccessKey {
 }
 
 impl OperatingAccount {
+    pub async fn add_access_key(&mut self, new_key: PublicKey) {
+        let key = self.keys.first().unwrap().clone();
+        let mut key = key.lock().await;
+        key.add_access_key(new_key).await;
+    }
     /// In log(N) serial steps, ensure that this account has at least the desired number of access
     /// keys. Internally, what this does is it uses each access key to add another key to the
     /// account, doubling the number of keys every time up to the desired limit.

--- a/devnet/src/cli.rs
+++ b/devnet/src/cli.rs
@@ -63,6 +63,9 @@ impl Cli {
                     MpcNetworkSubCmd::Describe(cmd) => {
                         cmd.run(&name, config).await;
                     }
+                    MpcNetworkSubCmd::AddKeys(cmd) => {
+                        cmd.run(&name, config).await;
+                    }
                 }
             }
             Cli::Loadtest(cmd) => {
@@ -122,6 +125,9 @@ pub struct MpcNetworkCmd {
 }
 
 #[derive(clap::Parser)]
+pub struct MpcAddKeysCmd {}
+
+#[derive(clap::Parser)]
 pub enum MpcNetworkSubCmd {
     /// Create a new MPC network.
     New(NewMpcNetworkCmd),
@@ -131,6 +137,8 @@ pub enum MpcNetworkSubCmd {
     DeployContract(MpcDeployContractCmd),
     /// Initialize the MPC contract, initializing it to the specified parameters.
     InitContract(MpcInitContractCmd),
+    /// fetch data from `get_public_data` and add the keys.
+    AddKeys(MpcAddKeysCmd),
     /// Remove the MPC contract from the local state, so a fresh one can be deployed.
     RemoveContract(RemoveContractCmd),
     /// View the contract state.
@@ -211,10 +219,6 @@ pub struct UpdateMpcNetworkCmd {
 
 #[derive(clap::Parser)]
 pub struct MpcInitContractCmd {
-    /// File path that contains the contract code.
-    /// If not set, then the contract from TESTNET_CONTRACT_ACCOUNT_ID is fetched and deployed.
-    #[clap(long)]
-    pub path: Option<String>,
     /// The number of participants to initialize with; the participants will be from 0 to
     /// init_participants-1.
     #[clap(long)]
@@ -222,13 +226,6 @@ pub struct MpcInitContractCmd {
     /// The threshold to initialize with.
     #[clap(long)]
     pub threshold: u64,
-    /// The number of NEAR to deposit into the contract account, for storage deposit.
-    #[clap(long, default_value = "20")]
-    pub deposit_near: u128,
-    /// Maximum number of requests to remove per signature request; reduce this to
-    /// optimize gas cost for signature requests.
-    #[clap(long)]
-    pub max_requests_to_remove: Option<u32>,
 }
 
 #[derive(clap::Parser)]
@@ -313,6 +310,11 @@ pub struct MpcTerraformDeployNomadCmd {
     /// The default is `constants::DEFAULT_MPC_DOCKER_IMAGE`.
     #[clap(long)]
     pub docker_image: Option<String>,
+    /// By default, we deploy the default docker image, which is a legacy node, requiring secret
+    /// shares.
+    /// Set this flag if you deploy a newer node that generates its secrets on its own.
+    #[clap(long)]
+    pub not_legacy: bool, // todo: remove [(#710)](https://github.com/near/mpc/issues/710)
 }
 
 #[derive(clap::Parser)]

--- a/devnet/src/cli.rs
+++ b/devnet/src/cli.rs
@@ -30,6 +30,9 @@ impl Cli {
                     MpcNetworkSubCmd::DeployContract(cmd) => {
                         cmd.run(&name, config).await;
                     }
+                    MpcNetworkSubCmd::InitContract(cmd) => {
+                        cmd.run(&name, config).await;
+                    }
                     MpcNetworkSubCmd::RemoveContract(cmd) => {
                         cmd.run(&name, config).await;
                     }
@@ -124,8 +127,10 @@ pub enum MpcNetworkSubCmd {
     New(NewMpcNetworkCmd),
     /// Update the parameters of an existing MPC network, including refilling accounts.
     Update(UpdateMpcNetworkCmd),
-    /// Deploy the MPC contract, initializing it to a number of participants.
+    /// Deploy the MPC contract code (without initializing it).
     DeployContract(MpcDeployContractCmd),
+    /// Initialize the MPC contract, initializing it to the specified parameters.
+    InitContract(MpcInitContractCmd),
     /// Remove the MPC contract from the local state, so a fresh one can be deployed.
     RemoveContract(RemoveContractCmd),
     /// View the contract state.
@@ -205,7 +210,7 @@ pub struct UpdateMpcNetworkCmd {
 }
 
 #[derive(clap::Parser)]
-pub struct MpcDeployContractCmd {
+pub struct MpcInitContractCmd {
     /// File path that contains the contract code.
     /// If not set, then the contract from TESTNET_CONTRACT_ACCOUNT_ID is fetched and deployed.
     #[clap(long)]
@@ -224,6 +229,17 @@ pub struct MpcDeployContractCmd {
     /// optimize gas cost for signature requests.
     #[clap(long)]
     pub max_requests_to_remove: Option<u32>,
+}
+
+#[derive(clap::Parser)]
+pub struct MpcDeployContractCmd {
+    /// File path that contains the contract code.
+    /// If not set, then the contract from TESTNET_CONTRACT_ACCOUNT_ID is fetched and deployed.
+    #[clap(long)]
+    pub path: Option<String>,
+    /// The number of NEAR to deposit into the contract account, for storage deposit.
+    #[clap(long, default_value = "20")]
+    pub deposit_near: u128,
 }
 
 #[derive(clap::Parser)]

--- a/devnet/src/mpc.rs
+++ b/devnet/src/mpc.rs
@@ -825,7 +825,7 @@ pub async fn read_contract_state(
         Err(JsonRpcError::ServerError(JsonRpcServerError::HandlerError(
             RpcQueryError::ContractExecutionError { vm_error, .. },
         ))) if vm_error.contains("Calling default not allowed.") => {
-            return ProtocolContractState::NotInitialized;
+            ProtocolContractState::NotInitialized
         }
         Err(err) => {
             panic!("Unexpected error: {:?}", err);

--- a/devnet/src/types.rs
+++ b/devnet/src/types.rs
@@ -1,5 +1,5 @@
 use crate::rpc::NearRpcClients;
-use near_crypto::SecretKey;
+use near_crypto::{PublicKey, SecretKey};
 use near_sdk::AccountId;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -30,9 +30,10 @@ pub enum NearAccountKind {
 /// Locally stored MPC participant keys and other info.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct MpcParticipantSetup {
-    pub p2p_private_key: SecretKey,
+    pub p2p_private_key: SecretKey, // todo: this can eventually be removed [(#710)](https://github.com/near/mpc/issues/710)
     /// The account this participant uses to respond to signature requests.
     pub responding_account_id: AccountId,
+    pub p2p_public_key: Option<PublicKey>, // todo: this can eventually be made non-optional [(#710)](https://github.com/near/mpc/issues/710)
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -279,6 +279,7 @@ impl PersistentSecrets {
         );
         let secrets = if let Some(secrets) = Self::maybe_get_existing(home_dir)? {
             tracing::debug!("p2p and near account secret key already exists. Using existing.");
+            // todo: add keys if necessary
             secrets
         } else {
             tracing::debug!("p2p and near account secret key not found. Generating...");

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -279,7 +279,7 @@ impl PersistentSecrets {
         );
         let secrets = if let Some(secrets) = Self::maybe_get_existing(home_dir)? {
             tracing::debug!("p2p and near account secret key already exists. Using existing.");
-            // todo: add keys if necessary
+            // todo: consistent number of keys [(#534)](https://github.com/near/mpc/issues/534)
             secrets
         } else {
             tracing::debug!("p2p and near account secret key not found. Generating...");


### PR DESCRIPTION
resolves #521 
requires https://github.com/Near-One/infra-ops/pull/503
related follow-ups:
- https://github.com/near/mpc/issues/710
- https://github.com/near/mpc/issues/712

changes:
- `deploy-contract` command is now split into two commands `deploy-contract` (deploy the code) and `init-contract` (initialize the contract).
- `add-keys` method, adding the public keys generated by the nodes to the mpc and responder accounts (signer and responder keys).
- unused `--max-requests-to-remove` argument has been removed from the contract commands
- devnet no longer panics upon calling `describe` in case the contract is not initialized:
```
thread 'main' panicked at devnet/src/mpc.rs:812:10:
Expected rpc node to respond: ServerError(HandlerError(ContractExecutionError { vm_error: "wasm execution failed with error: HostError(GuestPanic { panic_msg: \"Calling default not allowed.\" })", block_height: 206548722, block_hash: 2LPrNt4BEv2MU6GVRRCZLYXvD1dCUYFRymr5mXtdYWZC }))
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

