### PR TITLE
chore: Move MPC node modules to `lib.rs`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,7 +92,7 @@ tracing-subscriber = { version = "0.3.18", features = [
 url = "2"
 x509-parser = "0.16.0"
 
-
+mpc-node = { path = "node" }
 # MPC Contract
 mpc-contract = { path = "libs/chain-signatures/contract/", features = [
     "dev-utils",

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,0 +1,30 @@
+mod assets;
+#[cfg(test)]
+mod async_testing;
+mod background;
+pub mod cli;
+mod config;
+mod coordinator;
+mod db;
+mod indexer;
+mod key_events;
+mod keyshare;
+mod metrics;
+mod mpc_client;
+mod network;
+mod p2p;
+pub mod primitives;
+mod protocol;
+mod protocol_version;
+mod providers;
+mod runtime;
+mod sign_request;
+pub mod signing;
+pub mod tracing;
+mod tracking;
+pub mod web;
+
+#[cfg(feature = "tee")]
+mod tee;
+#[cfg(test)]
+mod tests;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,39 +1,8 @@
 use clap::Parser;
-use tracing::init_logging;
-
-mod assets;
-#[cfg(test)]
-mod async_testing;
-mod background;
-mod cli;
-mod config;
-mod coordinator;
-mod db;
-mod indexer;
-mod key_events;
-mod keyshare;
-mod metrics;
-mod mpc_client;
-mod network;
-mod p2p;
-mod primitives;
-mod protocol;
-mod protocol_version;
-mod providers;
-mod runtime;
-mod sign_request;
-pub mod signing;
-mod tracing;
-mod tracking;
-mod web;
-
-#[cfg(feature = "tee")]
-mod tee;
-#[cfg(test)]
-mod tests;
+use mpc_node::cli;
 
 fn main() -> anyhow::Result<()> {
     let cli = cli::Cli::parse();
-    init_logging(cli.log_format);
+    mpc_node::tracing::init_logging(cli.log_format);
     futures::executor::block_on(cli.run())
 }


### PR DESCRIPTION
Closes #719

This PR simply moves the definition of all crates in `main.rs` to `lib.rs`. We can definitely iterate further on the distinction between the two, but this at least enables reusing MPC node modules outside of the binary for e.g. the Devnet CLI and potentially other benchmarks or external integration tests.