### PR TITLE
fix: display error message when participant list is empty in mpc-node generate-test-configs

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -73,7 +73,7 @@ pub enum CliCommand {
     GenerateTestConfigs {
         #[arg(long)]
         output_dir: String,
-        #[arg(long, value_delimiter = ',')]
+        #[arg(long, value_delimiter = ',', required = true)]
         /// Near signer account for each participant
         participants: Vec<AccountId>,
         /// Near responder account for each participant. Refer to `indexer/real.rs` for more details.
@@ -396,10 +396,6 @@ impl Cli {
                 anyhow::ensure!(
                     participants.len() == responders.len(),
                     "Number of participants must match number of responders"
-                );
-                anyhow::ensure!(
-                    !participants.is_empty(),
-                    "Number of participants must be greater than 0"
                 );
                 self.run_generate_test_configs(
                     output_dir,


### PR DESCRIPTION
Closes #716 