### PR TITLE
chore: unify rand by downgrading

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4849,7 +4849,7 @@ dependencies = [
  "near-jsonrpc-primitives 0.28.0",
  "near-primitives 0.28.0",
  "near-sdk",
- "rand 0.9.2",
+ "rand 0.8.5",
  "reqwest 0.12.22",
  "serde",
  "serde_json",

--- a/devnet/Cargo.toml
+++ b/devnet/Cargo.toml
@@ -13,8 +13,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 legacy-mpc-contract = { workspace = true }
 mpc-contract = { workspace = true, features = ["test-utils", "dev-utils"] }
-# TODO: #658 use workspace version
-rand = "0.9.0"
+rand = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/devnet/src/contracts.rs
+++ b/devnet/src/contracts.rs
@@ -6,7 +6,7 @@ use mpc_contract::primitives::{
 };
 use near_primitives::action::Action;
 use near_sdk::AccountId;
-use rand::RngCore;
+use rand::{Rng, RngCore};
 use serde::Serialize;
 
 #[derive(Clone)]
@@ -131,9 +131,9 @@ fn make_payload(scheme: SignatureScheme) -> Payload {
             Payload::Ecdsa(Bytes::new(rand::random::<[u8; 32]>().to_vec()).unwrap())
         }
         SignatureScheme::Ed25519 => {
-            let len = rand::random_range(32..=1232);
+            let len = rand::thread_rng().gen_range(32..=1232);
             let mut payload = vec![0; len];
-            rand::rng().fill_bytes(&mut payload);
+            rand::thread_rng().fill_bytes(&mut payload);
             Payload::Eddsa(Bytes::new(payload).unwrap())
         }
     }


### PR DESCRIPTION
Closes #658

The move from rand 0.8 to rand 0.9 breaks other deps in node, and rand was just minimally used in devnet. Therefore, I opted to downgrade rand in devnet to use the same version  as in the workspace. We can leave the update of rand for the future when our crypto deps also update.