### PR TITLE
chore(ci): split ci-tests into multiple jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           CARGO_TARGET_DIR="target/clippy" \
           RUSTFLAGS="-D warnings" \
-          cargo clippy --locked
+          cargo clippy --all-targets --locked
 
       - name: Run Cargo fmt
         run: |
@@ -85,7 +85,7 @@ jobs:
         run: |
           CARGO_TARGET_DIR="target/clippy" \
           RUSTFLAGS="-D warnings" \
-          cargo clippy --features "tee" --locked
+          cargo clippy --all-targets --features "tee" --locked
 
       - name: Run Cargo fmt
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,8 @@ jobs:
           profile-name: "mpc-image-builder"
           file: deployment/Dockerfile-gcp
 
-  ci-tests:
-    name: "Run tests"
+  clippy-mpc-node:
+    name: "MPC Node: clippy and format"
     runs-on: warp-ubuntu-2204-x64-8x
     timeout-minutes: 60
     permissions:
@@ -55,31 +55,125 @@ jobs:
         run: |
           CARGO_TARGET_DIR="target/clippy" \
           RUSTFLAGS="-D warnings" \
-          cargo clippy --all-features --all-targets --locked
-
-          cd devnet
-          CARGO_TARGET_DIR="target/clippy" \
-          RUSTFLAGS="-D warnings" \
-          cargo clippy --all-features --all-targets --locked
-          cd ..
-
-          cd libs/chain-signatures
-          CARGO_TARGET_DIR="target/clippy" \
-          RUSTFLAGS="-D warnings" \
-          cargo clippy --all-features --all-targets --locked
-          cd ../..
+          cargo clippy --locked
 
       - name: Run Cargo fmt
         run: |
           cargo fmt -- --check
 
-          cd devnet
-          cargo fmt -- --check
-          cd ..
+  clippy-mpc-node-tee:
+    name: "MPC Node (TEE): clippy and format"
+    runs-on: warp-ubuntu-2204-x64-8x
+    timeout-minutes: 60
+    permissions:
+      contents: read
 
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+
+      - name: Cache Rust dependencies
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Run Clippy fmt
+        run: |
+          CARGO_TARGET_DIR="target/clippy" \
+          RUSTFLAGS="-D warnings" \
+          cargo clippy --features "tee" --locked
+
+      - name: Run Cargo fmt
+        run: |
+          cargo fmt -- --check
+
+  clippy-mpc-contract:
+    name: "MPC Contract: clippy and format"
+    runs-on: warp-ubuntu-2204-x64-8x
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+
+      - name: Cache Rust dependencies
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Run Clippy fmt
+        run: |
+          cd libs/chain-signatures
+          CARGO_TARGET_DIR="target/clippy" \
+          RUSTFLAGS="-D warnings" \
+          cargo clippy --all-features --all-targets --locked
+
+      - name: Run Cargo fmt
+        run: |
           cd libs/chain-signatures
           cargo fmt -- --check
-          cd ../..
+
+  clippy-mpc-devnet:
+    name: "MPC Devnet: clippy and format"
+    runs-on: warp-ubuntu-2204-x64-8x
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+
+      - name: Cache Rust dependencies
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Run Clippy fmt
+        run: |
+          cd devnet
+          CARGO_TARGET_DIR="target/clippy" \
+          RUSTFLAGS="-D warnings" \
+          cargo clippy --all-features --all-targets --locked
+
+      - name: Run Cargo fmt
+        run: |
+          cd devnet
+          cargo fmt -- --check
+
+  mpc-tee-unittests:
+    name: "MPC Node (TEE): unittests"
+    runs-on: warp-ubuntu-2204-x64-8x
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+
+      - name: Cache Rust dependencies
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
 
       - name: Install cargo-nextest
         run: cargo install cargo-nextest
@@ -89,19 +183,84 @@ jobs:
           cargo install wasm-opt --locked
           echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
       
-      - name: Install cargo-near
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libudev-dev
-          cargo install cargo-near
+      - name: Run cargo-nextest
+        run: cargo nextest run --release --locked --features "tee"
+
+  mpc-unittests:
+    name: "MPC Node: unittests"
+    runs-on: warp-ubuntu-2204-x64-8x
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+
+      - name: Cache Rust dependencies
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest
 
       - name: Run cargo-nextest
-        run: cargo nextest run --release --locked --all-features
+        run: cargo nextest run --release --locked
 
+  mpc-contract-unittests:
+    name: "MPC Contract: unittests"
+    runs-on: warp-ubuntu-2204-x64-8x
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Cache Rust dependencies
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
+
+      - name: Install cargo-nextest
+        run: cargo install cargo-nextest
+
+      - name: Install wasm-opt from crates.io
+        run: |
+          cargo install wasm-opt --locked
+          echo "${HOME}/.cargo/bin" >> $GITHUB_PATH
+      
       - name: Run contract tests
         run: |
           cd libs/chain-signatures
           cargo nextest run -p mpc-contract --release --locked
+
+  mpc-pytests:
+    name: "MPC Node: pytests"
+    runs-on: warp-ubuntu-2204-x64-8x
+    timeout-minutes: 60
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize submodules
+        run: git submodule update --init --recursive
+      
+      - name: Cache Rust dependencies
+        uses: WarpBuilds/rust-cache@v2
+        with:
+          cache-on-failure: true
+          cache-all-crates: true
 
       - name: Download near core binary from S3
         id: download-neard
@@ -134,6 +293,12 @@ jobs:
       - name: Build mpc node
         run: cargo build -p mpc-node --release --features=network-hardship-simulation
 
+      - name: Install cargo-near
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libudev-dev
+          cargo install cargo-near
+
       - name: Setup python
         uses: actions/setup-python@v4
         with:
@@ -153,7 +318,7 @@ jobs:
           pytest -m "not ci_excluded" -s -x
 
   tee-launcher-tests:
-    name: "Run TEE Launcher pytests"
+    name: "TEE Launcher: pytests"
     runs-on: warp-ubuntu-2204-x64-8x
     timeout-minutes: 60
     permissions:


### PR DESCRIPTION
Resolves https://github.com/near/mpc/issues/696

Reduces CI time by approx. 20 minutes.

Additionally, we now also unittest the build without the tee flag.


@andrei-near I think we need to change the branch protection rules to allow this PR to pass (c.f. [this thread](https://github.com/orgs/community/discussions/26698#discussioncomment-3252954))

