### PR TITLE
chore: fix cargo-near install failure in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y libudev-dev
-          cargo install cargo-near
+          cargo install cargo-near --locked
 
       - name: Setup python
         uses: actions/setup-python@v4


### PR DESCRIPTION
No issue closed sorry, this is just a quick fix that should avoid the currently broken CI