### PR TITLE
fix: node ignores peers lagging 50 blocks behind

### DIFF
--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -122,7 +122,7 @@ impl MeshNetworkClient {
     }
     /// The maximum height difference that we are willing to accept.
     /// This is used to filter out participants that are too far behind in the indexer height.
-    const MAX_HEIGHT_DIFF: u64 = 100;
+    const MAX_HEIGHT_DIFF: u64 = 50;
 
     /// Primary functionality for the MeshNetworkClient: returns a channel for the given
     /// new MPC task. It is expected that the caller is the leader of this MPC task.


### PR DESCRIPTION
Cherry picking fix for https://github.com/near/mpc/issues/801 introduced to main in https://github.com/near/mpc/pull/802