### PR TITLE
chore(pytest): improve test_lost_assets.py performance and coverage

### DIFF
--- a/pytest/common_lib/constants.py
+++ b/pytest/common_lib/constants.py
@@ -15,3 +15,6 @@ TGAS = 10**12
 GAS_FOR_SIGN_CALL = 10
 # Deposit in Yoctonear required for a sign call.
 SIGNATURE_DEPOSIT = 1
+# maximum block delay an MPC node is allowed to communicated before being labeled offline
+# defined in https://github.com/near/mpc/blob/cf53eadb8a9a5ad73da07efc0e8cb206af6fb48f/node/src/network.rs#L103
+INDEXER_MAX_HEIGHT_DIFF = 50

--- a/pytest/common_lib/contract_state.py
+++ b/pytest/common_lib/contract_state.py
@@ -1,7 +1,13 @@
 from dataclasses import dataclass
+from enum import Enum
 from typing import Dict, List, Literal, Optional
 
-ProtocolState = Literal["Initializing", "Running", "Resharing"]
+
+class ProtocolState(str, Enum):
+    INITIALIZING = "Initializing"
+    RUNNING = "Running"
+    RESHARING = "Resharing"
+
 
 SignatureScheme = Literal["Secp256k1", "Ed25519"]
 
@@ -423,9 +429,9 @@ class InitializingProtocolState:
 
 class ContractState:
     def get_running_domains(self) -> List[Domain]:
-        if self.state == "Running":
+        if self.state == ProtocolState.RUNNING:
             return self.protocol_state.domains.domains
-        elif self.state == "Resharing":
+        elif self.state == ProtocolState.RESHARING:
             return self.protocol_state.previous_running_state.domains.domains
 
         assert False, "expected running state"
@@ -436,15 +442,15 @@ class ContractState:
     def __init__(self, data):
         state, state_data = next(iter(data.items()))
         self.state: ProtocolState = state
-        if self.state == "Running":
+        if self.state == ProtocolState.RUNNING:
             self.protocol_state = RunningProtocolState.from_json(state_data)
-        elif self.state == "Resharing":
+        elif self.state == ProtocolState.RESHARING:
             self.protocol_state = ResharingProtocolState.from_json(state_data)
-        elif self.state == "Initializing":
+        elif self.state == ProtocolState.INITIALIZING:
             self.protocol_state = InitializingProtocolState.from_json(state_data)
 
     def keyset(self) -> Keyset | None:
-        if self.state == "Running":
+        if self.state == ProtocolState.RUNNING:
             return self.protocol_state.keyset
         return None
 

--- a/pytest/common_lib/shared/metrics.py
+++ b/pytest/common_lib/shared/metrics.py
@@ -17,3 +17,4 @@ class IntMetricName(str, Enum):
 
 class DictMetricName(str, Enum):
     MPC_PEERS_INDEXER_BLOCK_HEIGHTS = "mpc_peers_indexer_block_heights"
+    MPC_NETWORK_LIVE_CONNECTIONS = "mpc_network_live_connections"

--- a/pytest/common_lib/shared/mpc_cluster.py
+++ b/pytest/common_lib/shared/mpc_cluster.py
@@ -214,7 +214,7 @@ class MpcCluster:
             args.update(additional_init_args)
         tx = self.contract_node.sign_tx(self.contract_node.account_id(), "init", args)
         self.contract_node.send_txn_and_check_success(tx)
-        assert self.wait_for_state("Running"), "expected running state"
+        assert self.wait_for_state(ProtocolState.RUNNING), "expected running state"
 
     def wait_for_state(self, state: ProtocolState):
         """
@@ -241,7 +241,7 @@ class MpcCluster:
         )
         state = self.contract_state()
         state.print()
-        assert state.is_state("Running"), "require running state"
+        assert state.is_state(ProtocolState.RUNNING), "require running state"
         domains_to_add = []
         next_domain_id = state.protocol_state.next_domain_id()
         for scheme in signature_schemes:
@@ -262,9 +262,9 @@ class MpcCluster:
             args=args,
         )
 
-        assert self.wait_for_state("Initializing"), "failed to initialize"
+        assert self.wait_for_state(ProtocolState.INITIALIZING), "failed to initialize"
         if wait_for_running:
-            assert self.wait_for_state("Running"), "failed to run"
+            assert self.wait_for_state(ProtocolState.RUNNING), "failed to run"
 
     def do_resharing(
         self,
@@ -282,7 +282,7 @@ class MpcCluster:
             "proposal": self.make_threshold_parameters(new_threshold),
         }
         state = self.contract_state()
-        assert state.is_state("Running"), "Require running state"
+        assert state.is_state(ProtocolState.RUNNING), "Require running state"
 
         self.parallel_contract_calls(
             method=ContractMethod.VOTE_NEW_PARAMETERS,
@@ -298,9 +298,11 @@ class MpcCluster:
             args=args,
         )
 
-        assert self.wait_for_state("Resharing"), "failed to start resharing"
+        assert self.wait_for_state(ProtocolState.RESHARING), "failed to start resharing"
         if wait_for_running:
-            assert self.wait_for_state("Running"), "failed to conclude resharing"
+            assert self.wait_for_state(ProtocolState.RUNNING), (
+                "failed to conclude resharing"
+            )
             self.update_participant_status()
 
     def get_contract_state(self):

--- a/pytest/common_lib/shared/mpc_cluster.py
+++ b/pytest/common_lib/shared/mpc_cluster.py
@@ -11,6 +11,7 @@ from common_lib import signature
 from common_lib.constants import TGAS
 from common_lib.contract_state import ContractState, ProtocolState, SignatureScheme
 from common_lib.contracts import ContractMethod
+from common_lib.shared import metrics
 from common_lib.shared.metrics import FloatMetricName, IntMetricName
 from common_lib.shared.mpc_node import MpcNode
 from common_lib.shared.near_account import NearAccount
@@ -19,7 +20,7 @@ from common_lib.signature import generate_sign_args
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional, Set, cast
 
 from transaction import sign_deploy_contract_tx
 
@@ -27,18 +28,37 @@ from transaction import sign_deploy_contract_tx
 class MpcCluster:
     """Helper class"""
 
+    # todo: add description. What does this class hold?
+
     def run_all(self):
         for node in self.nodes:
             node.run()
 
     def kill_all(self):
-        for node in self.mpc_nodes:
+        for node in self.active_mpc_nodes:
             node.kill(False)
 
+    def kill_nodes(self, node_idxs: List[int], gentle=True):
+        for node_idx in node_idxs:
+            self.active_mpc_nodes[node_idx].kill(gentle)
+
+    def run_nodes(self, node_idxs: List[int]):
+        for node_idx in node_idxs:
+            self.active_mpc_nodes[node_idx].run()
+
+    def set_block_ingestion(self, node_idxs: List[int], active: bool):
+        for node_idx in node_idxs:
+            self.active_mpc_nodes[node_idx].set_block_ingestion(active)
+
+    def reset_mpc_data(self, node_idxs: List[int]):
+        for node_idx in node_idxs:
+            self.active_mpc_nodes[node_idx].reset_mpc_data()
+
     def __init__(self, main: NearAccount, secondary: NearAccount):
-        self.mpc_nodes: List[MpcNode] = []
+        # todo: these are only the active nodes. You probably also want to keep track of inactive ones.
+        self.active_mpc_nodes: List[MpcNode] = []
         # Note: Refer to signing schemas and key resharing
-        self.next_participant_id = 0
+        self.next_participant_id: int = 0
         # Main account where Chain Signatures contract is deployed
         self.contract_node = main
         # In some tests we may need another CS contract.
@@ -47,13 +67,13 @@ class MpcCluster:
         self.sign_request_node = secondary
 
     def print_cluster_status(self):
-        status_list = [node.print() for node in self.mpc_nodes]
+        status_list = [node.print() for node in self.active_mpc_nodes]
         print("Cluster status:", " ".join(status_list))
 
     def get_voters(self):
         voters = [
             node
-            for node in self.mpc_nodes
+            for node in self.active_mpc_nodes
             if node.is_running
             and (
                 node.status == MpcNode.NodeStatus.OLD_PARTICIPANT
@@ -69,13 +89,24 @@ class MpcCluster:
     def get_float_metric_value(
         self, metric_name: FloatMetricName
     ) -> List[Optional[float]]:
-        return [node.get_float_metric_value(metric_name) for node in self.mpc_nodes]
+        return [
+            node.get_float_metric_value(metric_name) for node in self.active_mpc_nodes
+        ]
 
     def get_int_metric_value(self, metric_name: IntMetricName) -> List[Optional[int]]:
-        return [node.get_int_metric_value(metric_name) for node in self.mpc_nodes]
+        return [
+            node.get_int_metric_value(metric_name) for node in self.active_mpc_nodes
+        ]
+
+    def require_int_metric_values(self, metric_name: IntMetricName) -> List[int]:
+        return [
+            node.require_int_metric_value(metric_name) for node in self.active_mpc_nodes
+        ]
 
     def get_int_metric_value_for_node(self, metric_name, node_index):
-        return self.mpc_nodes[node_index].metrics.get_int_metric_value(metric_name)
+        return self.active_mpc_nodes[node_index].metrics.get_int_metric_value(
+            metric_name
+        )
 
     def parallel_contract_calls(
         self,
@@ -129,19 +160,19 @@ class MpcCluster:
         initializes the contract with `participants` and `threshold`.
         Adds `Secp256k1` to the contract domains.
         """
-        self.define_candidate_set(participants)
+        self.set_active_nodes(participants)
         self.update_participant_status(
             assert_contract=False
         )  # do not assert when contract is not initialized
         self.init_contract(threshold=threshold)
         self.add_domains(domains)
 
-    def define_candidate_set(self, mpc_nodes: List[MpcNode]):
+    def set_active_nodes(self, mpc_nodes: List[MpcNode]):
         """
         Labels mpc_nodes as a candidate. Any node that is currently a participant but not in `mpc_nodes` will be labeled a `old_participant`
         """
         for node in mpc_nodes:
-            if node not in self.mpc_nodes:
+            if node not in self.active_mpc_nodes:
                 node.participant_id = self.next_participant_id
                 node.status = MpcNode.NodeStatus.NEW_PARTICIPANT
                 print(
@@ -149,12 +180,12 @@ class MpcCluster:
                 )
                 self.next_participant_id += 1
 
-        for node in self.mpc_nodes:
+        for node in self.active_mpc_nodes:
             if node not in mpc_nodes:
                 print(f"MpcCluster: Kicking out node {node.account_id()}")
                 node.participant_id = None
                 node.status = MpcNode.NodeStatus.OLD_PARTICIPANT
-        self.mpc_nodes = mpc_nodes
+        self.active_mpc_nodes = mpc_nodes
         self.print_cluster_status()
 
     def update_participant_status(self, assert_contract=True):
@@ -164,7 +195,7 @@ class MpcCluster:
         if assert_contract is True, then it ensures the set is consistent with the contract
         """
         nodes = []
-        for node in self.mpc_nodes:
+        for node in self.active_mpc_nodes:
             if node.status == MpcNode.NodeStatus.OLD_PARTICIPANT:
                 node.status = MpcNode.NodeStatus.IDLE
             elif node.status == MpcNode.NodeStatus.NEW_PARTICIPANT:
@@ -177,8 +208,8 @@ class MpcCluster:
             contract_state = self.contract_state()
             assert len(
                 contract_state.protocol_state.parameters.participants.participants
-            ) == len(self.mpc_nodes)
-            for p in self.mpc_nodes:
+            ) == len(self.active_mpc_nodes)
+            for p in self.active_mpc_nodes:
                 assert contract_state.protocol_state.parameters.participants.is_participant(
                     p.account_id()
                 )
@@ -199,7 +230,7 @@ class MpcCluster:
                             "url": node.url,
                         },
                     ]
-                    for node in self.mpc_nodes
+                    for node in self.active_mpc_nodes
                 ],
             },
         }
@@ -273,7 +304,7 @@ class MpcCluster:
         prospective_epoch_id: int,
         wait_for_running=True,
     ):
-        self.define_candidate_set(new_participants)
+        self.set_active_nodes(new_participants)
         print(
             f"\033[91m(Vote Resharing) Voting to reshare with new threshold: \033[93m{new_threshold}\033[0m"
         )
@@ -377,7 +408,7 @@ class MpcCluster:
         )
 
     def propose_update(self, args):
-        participant = self.mpc_nodes[0]
+        participant = self.active_mpc_nodes[0]
         tx = participant.sign_tx(
             self.mpc_contract_account(),
             ContractMethod.PROPOSE_UPDATE,
@@ -420,7 +451,7 @@ class MpcCluster:
         assert hash_expected == hash_deployed, "invalid contract deployed"
 
     def get_config(self, node_id=0):
-        node = self.mpc_nodes[node_id]
+        node = self.active_mpc_nodes[node_id]
         tx = node.sign_tx(self.mpc_contract_account(), "config", {})
         res = node.send_txn_and_check_success(tx)
         return json.dumps(

--- a/pytest/pytest.ini
+++ b/pytest/pytest.ini
@@ -2,3 +2,5 @@
 markers =
     slow: marks tests as slow (deselect with '-m "not slow"')
     ci_excluded: marks tests that should be excluded from ci
+    no_atexit_cleanup: Skip the autouse atexit cleanup fixture for this test
+

--- a/pytest/tests/conftest.py
+++ b/pytest/tests/conftest.py
@@ -19,13 +19,16 @@ from common_lib import constants, contracts
 
 
 @pytest.fixture(autouse=True, scope="function")
-def run_atexit_cleanup():
+def run_atexit_cleanup(request):
     """
     Runs atexit BEFORE the pytest concludes.
     Without the -s flag, pytest redirects the output of stdout and stderr,
     but closes those pipes BEFORE executing atexit,
     resulting in a failed test in case atexit attempts to write to stdout or stderr.
     """
+    if "no_atexit_cleanup" in request.keywords:
+        yield
+        return
     yield
     atexit._run_exitfuncs()
 

--- a/pytest/tests/test_cancellation_of_key_resharing.py
+++ b/pytest/tests/test_cancellation_of_key_resharing.py
@@ -9,6 +9,7 @@ from common_lib.shared.transaction_status import assert_txn_execution_error
 from common_lib import shared
 from common_lib.contracts import load_mpc_contract
 from common_lib.contract_state import (
+    ProtocolState,
     RunningProtocolState,
 )
 
@@ -85,7 +86,7 @@ def test_cancellation_of_key_resharing():
         running_node.send_txn_and_check_success(tx)
 
     # Assert cancellation works.
-    assert cluster.wait_for_state("Running"), (
+    assert cluster.wait_for_state(ProtocolState.RUNNING), (
         "Contract should transition to running state after threshold running nodes voted for cancellation."
     )
 

--- a/pytest/tests/test_contract_update.py
+++ b/pytest/tests/test_contract_update.py
@@ -43,7 +43,7 @@ def test_update_from_current():
 def test_update_to_current(fetch_contract):
     current = fetch_contract()
     cluster, mpc_nodes = shared.start_cluster_with_mpc(4, 4, 1, current)
-    cluster.set_active_nodes(mpc_nodes)
+    cluster.define_candidate_set(mpc_nodes)
     cluster.update_participant_status(assert_contract=False)
     cluster.init_contract(threshold=3)
     cluster.add_domains(signature_schemes=["Secp256k1", "Ed25519"])
@@ -54,7 +54,7 @@ def test_update_to_current(fetch_contract):
 
     cluster.parallel_contract_calls(
         method=ContractMethod.VOTE_NEW_PARAMETERS,
-        nodes=cluster.active_mpc_nodes[0:2],
+        nodes=cluster.mpc_nodes[0:2],
         args=args,
     )
     cluster.contract_state().print()

--- a/pytest/tests/test_contract_update.py
+++ b/pytest/tests/test_contract_update.py
@@ -43,7 +43,7 @@ def test_update_from_current():
 def test_update_to_current(fetch_contract):
     current = fetch_contract()
     cluster, mpc_nodes = shared.start_cluster_with_mpc(4, 4, 1, current)
-    cluster.define_candidate_set(mpc_nodes)
+    cluster.set_active_nodes(mpc_nodes)
     cluster.update_participant_status(assert_contract=False)
     cluster.init_contract(threshold=3)
     cluster.add_domains(signature_schemes=["Secp256k1", "Ed25519"])
@@ -54,7 +54,7 @@ def test_update_to_current(fetch_contract):
 
     cluster.parallel_contract_calls(
         method=ContractMethod.VOTE_NEW_PARAMETERS,
-        nodes=cluster.mpc_nodes[0:2],
+        nodes=cluster.active_mpc_nodes[0:2],
         args=args,
     )
     cluster.contract_state().print()

--- a/pytest/tests/test_contract_update.py
+++ b/pytest/tests/test_contract_update.py
@@ -12,6 +12,8 @@ import time
 import pathlib
 import pytest
 
+from common_lib.contract_state import ProtocolState
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from common_lib import shared
 from common_lib.contracts import (
@@ -62,6 +64,6 @@ def test_update_to_current(fetch_contract):
     cluster.vote_update(nodes=cluster.get_voters()[0:3], update_id=0)
     time.sleep(2)
     cluster.assert_is_deployed(new_contract.code())
-    cluster.wait_for_state("Running")
+    cluster.wait_for_state(ProtocolState.RUNNING)
     cluster.contract_state().print()
     cluster.send_and_await_signature_requests(1)

--- a/pytest/tests/test_key_event.py
+++ b/pytest/tests/test_key_event.py
@@ -11,6 +11,8 @@ import sys
 
 import pytest
 
+from common_lib.contract_state import ProtocolState
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from common_lib import shared
 from common_lib.contracts import load_mpc_contract
@@ -55,7 +57,7 @@ def test_single_domain():
         wait_for_running=False,
     )
 
-    assert cluster.wait_for_state("Running"), "failed to start running"
+    assert cluster.wait_for_state(ProtocolState.RUNNING), "failed to start running"
     cluster.update_participant_status()
     cluster.send_and_await_signature_requests(1)
 
@@ -89,7 +91,7 @@ def test_multi_domain():
     cluster.add_domains(
         ["Secp256k1", "Ed25519", "Secp256k1", "Ed25519"], wait_for_running=False
     )
-    cluster.wait_for_state("Running")
+    cluster.wait_for_state(ProtocolState.RUNNING)
     ## two new nodes join, increase threshold
     cluster.do_resharing(
         new_participants=mpc_nodes[:4], new_threshold=3, prospective_epoch_id=1
@@ -107,7 +109,7 @@ def test_multi_domain():
         }
         tx = node.sign_tx(cluster.mpc_contract_account(), "vote_cancel_keygen", args)
         node.send_txn_and_check_success(tx)
-    cluster.wait_for_state("Running")
+    cluster.wait_for_state(ProtocolState.RUNNING)
     with pytest.raises(KeyError):
         cluster.contract_state().keyset().get_key(6)
     assert cluster.contract_state().protocol_state.next_domain_id() == 7

--- a/pytest/tests/test_lost_assets.py
+++ b/pytest/tests/test_lost_assets.py
@@ -11,6 +11,7 @@ import pathlib
 from typing import List
 import requests
 
+from common_lib.contract_state import ProtocolState
 from common_lib.shared import MpcCluster, MpcNode, metrics
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
@@ -78,7 +79,7 @@ def test_lost_assets():
         presignatures_to_buffer=PRESIGNATURES_TO_BUFFER,
     )
     cluster.init_cluster(participants=mpc_nodes, threshold=2)
-    cluster.wait_for_state("Running")
+    cluster.wait_for_state(ProtocolState.RUNNING)
 
     # Wait for nodes to have assets with everyone else
     wait_for_presignatures_to_buffer(cluster)
@@ -126,7 +127,7 @@ def test_signature_pause_block_ingestion():
         presignatures_to_buffer=PRESIGNATURES_TO_BUFFER,
     )
     cluster.init_cluster(mpc_nodes, 2)
-    cluster.wait_for_state("Running")
+    cluster.wait_for_state(ProtocolState.RUNNING)
 
     # Wait for nodes to have assets with everyone else
     wait_for_presignatures_to_buffer(cluster)

--- a/pytest/tests/test_lost_assets.py
+++ b/pytest/tests/test_lost_assets.py
@@ -6,13 +6,16 @@ Restarts the node and verifies that signature requests succeed.
 """
 
 import sys
+from cluster import atexit
+import pytest
 import time
+import random
 import pathlib
 from typing import List
 import requests
 
-from common_lib.contract_state import ProtocolState
-from common_lib.shared import MpcCluster, MpcNode, metrics
+from common_lib.contract_state import ContractState, ProtocolState
+from common_lib.shared import MpcCluster, metrics
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from common_lib import shared
@@ -22,102 +25,10 @@ from common_lib.constants import TIMEOUT
 PRESIGNATURES_TO_BUFFER = 8
 
 
-def wait_for_presignatures_to_buffer(cluster: MpcCluster):
-    started = time.time()
-    while True:
-        assert time.time() - started < TIMEOUT, "Waiting for presignatures"
-        try:
-            presignature_count = cluster.get_int_metric_value(
-                metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE
-            )
-            print("Owned presignatures:", presignature_count)
-            if all(x and x == PRESIGNATURES_TO_BUFFER for x in presignature_count):
-                break
-        except requests.exceptions.ConnectionError:
-            pass
-        time.sleep(1)
-
-
-def wait_for_asset_cleanup(mpc_nodes: List[MpcNode]):
-    started = time.time()
-    while True:
-        assert time.time() - started < TIMEOUT, "Waiting for asset cleanup"
-        try:
-            cleanup_done = True
-            for node in mpc_nodes:
-                available = node.get_int_metric_value(
-                    metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE
-                )
-                online = node.get_int_metric_value(
-                    metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_ONLINE
-                )
-                offline = node.get_int_metric_value(
-                    metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_WITH_OFFLINE_PARTICIPANT
-                )
-                print(
-                    f"node {node.print()} has owned presignatures available={available} online={online} with_offline_participant={offline}"
-                )
-                peers_indexer_block_heights = node.get_peers_block_height_metric_value()
-                print(
-                    f"node {node.print()} has following peer block heights: {peers_indexer_block_heights}"
-                )
-                if not (online == PRESIGNATURES_TO_BUFFER and offline == 0):
-                    cleanup_done = False
-            if cleanup_done:
-                break
-        except requests.exceptions.ConnectionError:
-            pass
-        time.sleep(1)
-
-
-def test_lost_assets():
-    cluster, mpc_nodes = shared.start_cluster_with_mpc(
-        2,
-        3,
-        1,
-        load_mpc_contract(),
-        presignatures_to_buffer=PRESIGNATURES_TO_BUFFER,
-    )
-    cluster.init_cluster(participants=mpc_nodes, threshold=2)
-    cluster.wait_for_state(ProtocolState.RUNNING)
-
-    # Wait for nodes to have assets with everyone else
-    wait_for_presignatures_to_buffer(cluster)
-
-    # Stop mpc node 0 and wipe its database. Any assets generated before this point
-    # which included node 0 are now unusable because node 0 has lost its share.
-    cluster.mpc_nodes[0].kill(gentle=True)
-    cluster.mpc_nodes[0].reset_mpc_data()
-
-    # Let the other nodes notice that node 0 is offline;
-    # we don't want to check the presignature metrics too early
-    cluster.mpc_nodes[1].wait_for_connection_count(2)
-    cluster.mpc_nodes[2].wait_for_connection_count(2)
-
-    # Wait for nodes 1 and 2 to clean up assets involving node 0
-    wait_for_asset_cleanup(cluster.mpc_nodes[1:])
-
-    # Start node 0 again
-    cluster.mpc_nodes[0].run()
-    cluster.mpc_nodes[1].wait_for_connection_count(3)
-    cluster.mpc_nodes[2].wait_for_connection_count(3)
-
-    # Send some signature requests as a sanity check. Ideally we would like the entire
-    # presignature stores in nodes 1 and 2 to be used up here.
-    # However, it is tricky to guarantee because we cannot control which nodes
-    # are assigned as leaders for the requests.
-
-    presignatures_available = sum(
-        cluster.get_int_metric_value(
-            metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE
-        )
-    )
-    cluster.send_and_await_signature_requests(presignatures_available // 4)
-
-
-def test_signature_pause_block_ingestion():
+@pytest.fixture(scope="module")
+def lost_assets_cluster():
     """
-    This test requires the MPC binary to be compiled with the feature flag "network-hardship-simulation"
+    Spins up a cluster with three nodes, initializes contract and adds domains. Retuns the cluster in a running state.
     """
     cluster, mpc_nodes = shared.start_cluster_with_mpc(
         2,
@@ -129,36 +40,223 @@ def test_signature_pause_block_ingestion():
     cluster.init_cluster(mpc_nodes, 2)
     cluster.wait_for_state(ProtocolState.RUNNING)
 
-    # Wait for nodes to have assets with everyone else
-    wait_for_presignatures_to_buffer(cluster)
+    yield cluster
 
-    # Simulate node 0's indexer falling behind
-    mpc_nodes[0].set_block_ingestion(False)
+    atexit._run_exitfuncs()
 
+
+def assert_num_presignatures_available(
+    cluster: MpcCluster, expected_num_presignatures_available: int, timeout: int
+):
+    """
+    Asserts that each node owns `expected_number_of_presignatures` presignatures.
+    Panics in case of a timeout
+    """
     started = time.time()
     while True:
-        peers_indexer_block_heights = mpc_nodes[0].get_peers_block_height_metric_value()
-        print(
-            f"node {mpc_nodes[0].print()} has following peer block heights = {peers_indexer_block_heights}"
-        )
-        assert time.time() - started < 120, "Waiting for presignatures"
+        assert time.time() - started < timeout, "Waiting for presignatures"
         try:
-            block_heights = cluster.get_int_metric_value(
-                metrics.IntMetricName.MPC_INDEXER_LATEST_BLOCK_HEIGHT
+            presignature_count: List[int] = cluster.require_int_metric_values(
+                metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE
             )
-            print("block heights:", block_heights)
-            if (block_heights[0] + 10 < block_heights[1]) and (
-                block_heights[0] + 10 < block_heights[2]
+            print("Owned presignatures:", presignature_count)
+            if all(
+                x == expected_num_presignatures_available for x in presignature_count
             ):
                 break
         except requests.exceptions.ConnectionError:
             pass
-        time.sleep(5)
+        time.sleep(1)
+
+
+def assert_num_offline_online_presignatures(
+    cluster: MpcCluster,
+    node_idxs_alive: List[int],
+    expected_num_presignatures_online: int,
+    expected_num_presignaturse_offline: int,
+    verbose: bool = True,
+):
+    """
+    ensures that
+    """
+    started = time.time()
+    while True:
+        assert time.time() - started < TIMEOUT, "Waiting for asset cleanup"
+
+        try:
+            cleanup_done = all(
+                (
+                    node.require_int_metric_value(
+                        metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_ONLINE
+                    )
+                    == expected_num_presignatures_online
+                    and node.require_int_metric_value(
+                        metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_WITH_OFFLINE_PARTICIPANT
+                    )
+                    == expected_num_presignaturse_offline
+                )
+                for node in (cluster.active_mpc_nodes[i] for i in node_idxs_alive)
+            )
+            if verbose:
+                for node in (cluster.active_mpc_nodes[i] for i in node_idxs_alive):
+                    node_name = node.print()
+                    peers_block_heights = node.get_peers_block_height_metric_value()
+                    print(f"node {node_name} peer block heights: {peers_block_heights}")
+
+                    online = node.require_int_metric_value(
+                        metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_ONLINE
+                    )
+                    offline = node.require_int_metric_value(
+                        metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_WITH_OFFLINE_PARTICIPANT
+                    )
+                    available = node.require_int_metric_value(
+                        metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE
+                    )
+                    print(
+                        f"node {node_name} available={available} online={online} offline_participant={offline}"
+                    )
+            if cleanup_done:
+                print(f"time for cleanup: {time.time() - started:.2f} s")
+                return
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(1)
+
+
+def assert_num_live_connections(
+    cluster: MpcCluster, node_idxs: List[int], expected_num_connected: int, timeout: int
+):
+    """
+    Asserts that each node in node_idx is connected to exactly `expected_num_connected` peers.
+    """
+    for node_idx in node_idxs:
+        cluster.active_mpc_nodes[node_idx].assert_num_live_connections(
+            expected_num_connected, timeout
+        )
+
+
+def assert_indexer_lag(
+    cluster: MpcCluster,
+    faulty_node_idx: int,
+    active_node_idxs: List[int],
+    min_lag: int = 10,
+    timeout: int = 120,
+    verbose: bool = True,
+):
+    """
+    This function:
+        - asserts that the nodes correctly expose the `metrics.IntMetricName.MPC_INDEXER_LATEST_BLOCK_HEIGHT` metric
+        - returns only after the indexer of the node with `faulty_node_idx` lags at least `min_lag` behind every active nodes.
+    Raises an exception if the timeout is exceeded or if there is no valid metric
+    """
+    started = time.time()
+    while True:
+        assert time.time() - started < timeout, "Waiting for indexer lag"
+        try:
+            block_heights: List[int] = cluster.require_int_metric_values(
+                metrics.IntMetricName.MPC_INDEXER_LATEST_BLOCK_HEIGHT
+            )
+            if verbose:
+                print(f"Block heights: {block_heights}")
+            stalled_node_height: int = block_heights[faulty_node_idx]
+            if all(
+                [
+                    stalled_node_height + min_lag < block_heights[active_node_idx]
+                    for active_node_idx in active_node_idxs
+                ]
+            ):
+                break
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(1)
+
+
+@pytest.mark.no_atexit_cleanup
+def test_cleanup_dead_node(lost_assets_cluster: MpcCluster):
+    """
+    Expect an initialized cluster of at least 3 nodes running.
+    This function tests if the asset cleanup mechanism works if a node is dead.
+    """
+    assert len(lost_assets_cluster.active_mpc_nodes) == 3, (
+        "expected cluster with three nodes"
+    )
+    contract: ContractState = lost_assets_cluster.contract_state()
+    assert contract.is_state(ProtocolState.RUNNING), "expect cluster in running state"
+    assert len(contract.get_running_domains()) > 0, (
+        "expect cluster with at least one domain"
+    )
+
+    # Wait for nodes to have assets with everyone else
+    assert_num_presignatures_available(
+        lost_assets_cluster, PRESIGNATURES_TO_BUFFER, TIMEOUT
+    )
+
+    # Stop mpc node 0 and wipe its database. Any assets generated before this point
+    # which included node 0 are now unusable because node 0 has lost its share.
+    faulty_node_idx = random.randint(0, 2)
+    node_idxs_alive = [i for i in range(0, 3) if i != faulty_node_idx]
+    lost_assets_cluster.kill_nodes([faulty_node_idx])
+    lost_assets_cluster.reset_mpc_data([faulty_node_idx])
+
+    # Assert that node is noticed as offline
+    assert_num_live_connections(lost_assets_cluster, node_idxs_alive, 2, TIMEOUT)
+
+    # Wait for alive nodes to clean up assets involving dead node
+    assert_num_offline_online_presignatures(
+        lost_assets_cluster,
+        node_idxs_alive,
+        expected_num_presignatures_online=PRESIGNATURES_TO_BUFFER,
+        expected_num_presignaturse_offline=0,
+    )
+
+    # Start node 0 again
+    lost_assets_cluster.run_nodes([faulty_node_idx])
+    assert_num_live_connections(lost_assets_cluster, node_idxs_alive, 3, TIMEOUT)
+
+    # Send some signature requests as a sanity check.
+    presignatures_available = sum(
+        lost_assets_cluster.require_int_metric_values(
+            metrics.IntMetricName.MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE
+        )
+    )
+    lost_assets_cluster.send_and_await_signature_requests(presignatures_available // 4)
+
+
+# requires network network-hardship-simulation
+@pytest.mark.no_atexit_cleanup
+def test_cleanup_lagging_node(lost_assets_cluster: MpcCluster):
+    """
+    This test requires the MPC binary to be compiled with the feature flag "network-hardship-simulation"
+    """
+    assert len(lost_assets_cluster.active_mpc_nodes) == 3, (
+        "expected cluster with three nodes"
+    )
+    contract: ContractState = lost_assets_cluster.contract_state()
+    assert contract.is_state(ProtocolState.RUNNING), "expect cluster in running state"
+    assert len(contract.get_running_domains()) > 0, (
+        "expect cluster with at least one domain"
+    )
+    # Wait for nodes to have assets with everyone else
+    assert_num_presignatures_available(
+        lost_assets_cluster, PRESIGNATURES_TO_BUFFER, TIMEOUT
+    )
+
+    # Simulate node 0's indexer falling behind
+    faulty_node_idx = random.randint(0, 2)
+    node_idxs_alive = [i for i in range(0, 3) if i != faulty_node_idx]
+    lost_assets_cluster.set_block_ingestion([faulty_node_idx], False)
+
+    assert_indexer_lag(lost_assets_cluster, faulty_node_idx, node_idxs_alive, 50)
 
     # we wait for the other nodes to cleanup
-    wait_for_asset_cleanup(cluster.mpc_nodes[1:])
+    assert_num_offline_online_presignatures(
+        lost_assets_cluster,
+        node_idxs_alive,
+        expected_num_presignatures_online=PRESIGNATURES_TO_BUFFER,
+        expected_num_presignaturse_offline=0,
+    )
 
-    cluster.send_and_await_signature_requests(5)
+    lost_assets_cluster.send_and_await_signature_requests(5)
 
     # re-enable block ingestion, in case any tests run afterwards
-    mpc_nodes[0].set_block_ingestion(True)
+    lost_assets_cluster.set_block_ingestion([faulty_node_idx], True)

--- a/pytest/tests/test_signature_request_during_resharing.py
+++ b/pytest/tests/test_signature_request_during_resharing.py
@@ -2,6 +2,8 @@
 import pathlib
 import sys
 
+from common_lib.contract_state import ProtocolState
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from common_lib import shared
 from common_lib.contracts import load_mpc_contract
@@ -39,13 +41,13 @@ def test_threshold_from_previous_running_state_is_maintained():
     mpc_nodes[3].kill()
 
     # sanity check
-    assert cluster.wait_for_state("Resharing"), (
+    assert cluster.wait_for_state(ProtocolState.RESHARING), (
         "State should still be in resharing. 4th node was killed."
     )
 
     cluster.send_and_await_signature_requests(3)
 
     # sanity check
-    assert cluster.wait_for_state("Resharing"), (
+    assert cluster.wait_for_state(ProtocolState.RESHARING), (
         "State should still be in resharing. 4th node was killed."
     )


### PR DESCRIPTION
Resolves #808

This Pull Request aims to improve pytest code, test coverage and test time. Changes:

**Refactor:**
- contract state is now an enum, improving code readability and our linter
-  created or renamed existing helper functions inside `test_lost_assets.py` to better reflect what they are doing

**Coverage:**
- For the sanity checks, we now deplete the entire asset queues of the alive MPC nodes, further reducing the chance of false negatives.

**Performance:**
- Even though this PR adds significant coverage to the aforementioned tests, the total execution time of `test_lost_assets.py` is reduced by over 33% (tested locally on my machine, from over 2min 46s to 1min 51s).
