### PR TITLE
chore: port mainnet fixes to testnet branch

### DIFF
--- a/node/src/indexer/configs.rs
+++ b/node/src/indexer/configs.rs
@@ -9,7 +9,7 @@ impl IndexerConfig {
         near_indexer::IndexerConfig {
             home_dir,
             sync_mode: self.sync_mode.clone().into(),
-            await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::WaitForFullSync,
+            await_for_node_synced: near_indexer::AwaitForNodeSyncedEnum::StreamWhileSyncing,
             finality: self.finality.clone(),
             validate_genesis: self.validate_genesis,
         }

--- a/node/src/metrics.rs
+++ b/node/src/metrics.rs
@@ -227,3 +227,13 @@ pub fn init_build_info_metric() {
         .with_label_values(&[version, build_time, rustc_version, commit])
         .set(1);
 }
+
+lazy_static! {
+    pub static ref PEERS_INDEXER_HEIGHTS: prometheus::IntGaugeVec =
+        prometheus::register_int_gauge_vec!(
+            "mpc_peers_indexer_block_heights",
+            "Latest known block height of peers",
+            &["participant"]
+        )
+        .unwrap();
+}

--- a/node/src/network.rs
+++ b/node/src/network.rs
@@ -354,8 +354,6 @@ impl MeshNetworkClient {
             .send_indexer_height(IndexerHeightMessage { height });
     }
 
-    // TODO(#226): Use.
-    #[allow(dead_code)]
     pub fn get_indexer_heights(&self) -> HashMap<ParticipantId, u64> {
         self.indexer_heights.get_heights()
     }


### PR DESCRIPTION
The goal of this PR is to port all fixes deployed to mainnet release branch over to the testnet release:
* https://github.com/near/mpc/pull/743

 
 
**Methodology:**
Since we don't have a list of when which fixes where applied, I looked at the commit history of testnet-release and mainnet-release branch

https://github.com/near/mpc/commits/testnet-release/  and https://github.com/near/mpc/commits/mainnent-release/

**Mainnet fixes not on main and not on testnet-release:**
* https://github.com/near/mpc/pull/556
    * included in testnet with https://github.com/near/mpc/pull/600
* https://github.com/near/mpc/pull/803
    * included in testnet with https://github.com/near/mpc/pull/804
* https://github.com/near/mpc/pull/554
    * included in tesnet with https://github.com/near/mpc/pull/371/files
* https://github.com/near/mpc/pull/608
    * included in testnet with https://github.com/near/mpc/pull/600
* https://github.com/near/mpc/pull/609
     * included with https://github.com/near/mpc/pull/403

**nearcore changes** (irrelevant?)
* use nearcore version from ignore-announce-accounts branch for better MPC node stability https://github.com/near/mpc/commit/38e70b3071b9b20048980966741499163f62f882
* fix 1 from nearcore: https://github.com/near/mpc/commit/9307e5432e452477488d807bc1cd3fbe0945e72e
* near 256 https://github.com/near/mpc/commit/3b7f5ad9cffdd0fb3035ca6ceabfd6e9d5ca959c


I suppose the nearcore changes are not relevant if we bump the nearcore version, right?

