### PR TITLE
chore: remove default features prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5659,7 +5659,7 @@ dependencies = [
  "opentelemetry",
  "parking_lot 0.12.4",
  "pin-project 1.1.10",
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-codegen",
  "rand 0.8.5",
  "rayon",
@@ -7387,7 +7387,6 @@ dependencies = [
  "lazy_static",
  "memchr",
  "parking_lot 0.12.4",
- "protobuf 2.28.0",
  "thiserror 1.0.69",
 ]
 
@@ -7500,12 +7499,6 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
-
-[[package]]
-name = "protobuf"
 version = "3.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
@@ -7523,7 +7516,7 @@ checksum = "5d3976825c0014bbd2f3b34f0001876604fe87e0c86cd8fa54251530f1544ace"
 dependencies = [
  "anyhow",
  "once_cell",
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-parse",
  "regex",
  "tempfile",
@@ -7539,7 +7532,7 @@ dependencies = [
  "anyhow",
  "indexmap 2.10.0",
  "log",
- "protobuf 3.7.2",
+ "protobuf",
  "protobuf-support",
  "tempfile",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ near-sdk = { version = "5.15.1", features = [
     "unit-testing",
     "unstable",
 ] }
-prometheus = "0.13.4"
+prometheus = {version = "0.13.4", default-features = false }
 rand = "0.8.5"
 rand_xorshift = "0.3"
 rcgen = "0.13.1"


### PR DESCRIPTION
This contributes with #741
It should avoid depending on protobuf v2.*, fixing https://github.com/near/mpc/security/dependabot/18