### PR TITLE
refactor: Consistent usage of SerializableEdwardsPoint in crypto_shared/types.rs

### DIFF
--- a/libs/chain-signatures/contract/src/crypto_shared/types.rs
+++ b/libs/chain-signatures/contract/src/crypto_shared/types.rs
@@ -48,14 +48,6 @@ pub enum PublicKeyExtended {
         /// Serialized compressed Edwards-y point.
         near_public_key_compressed: near_sdk::PublicKey,
         /// Decompressed Edwards point used for curve arithmetic operations.
-        #[cfg_attr(
-            all(feature = "abi", not(target_arch = "wasm32")),
-            schemars(with = "[u8; 32]"),
-            borsh(schema(with_funcs(
-                declaration = "<[u8; 32] as ::borsh::BorshSchema>::declaration",
-                definitions = "<[u8; 32] as ::borsh::BorshSchema>::add_definitions_recursively"
-            ),))
-        )]
         edwards_point: SerializableEdwardsPoint,
     },
 }

--- a/libs/chain-signatures/contract/src/crypto_shared/types/serializable.rs
+++ b/libs/chain-signatures/contract/src/crypto_shared/types/serializable.rs
@@ -64,13 +64,12 @@ impl BorshDeserialize for SerializableEdwardsPoint {
     fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
         let bytes: [u8; 32] = BorshDeserialize::deserialize_reader(reader)?;
 
-        EdwardsPoint::from_bytes(&bytes)
+        SerializableEdwardsPoint::from_bytes(&bytes)
             .into_option()
             .ok_or(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 "The provided bytes is not a valid edwards point.",
             ))
-            .map(SerializableEdwardsPoint)
     }
 }
 

--- a/libs/chain-signatures/contract/src/crypto_shared/types/serializable.rs
+++ b/libs/chain-signatures/contract/src/crypto_shared/types/serializable.rs
@@ -1,0 +1,82 @@
+//! Module that adds implementation of [`BorshSerialize`] and [`BorshDeserialize`] for
+//! [`PublicKeyExtended`].
+
+use borsh::{BorshDeserialize, BorshSerialize};
+use curve25519_dalek::EdwardsPoint;
+#[cfg(any(test, feature = "test-utils"))]
+use k256::elliptic_curve::Group as _;
+use k256::elliptic_curve::{group::GroupEncoding, subtle::CtOption};
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(::near_sdk::schemars::JsonSchema),
+    derive(::borsh::BorshSchema)
+)]
+#[derive(
+    Debug,
+    PartialEq,
+    Serialize,
+    Deserialize,
+    Eq,
+    Clone,
+    Copy,
+    derive_more::From,
+    derive_more::AsRef,
+    derive_more::Deref,
+)]
+pub struct SerializableEdwardsPoint(
+    #[cfg_attr(
+        all(feature = "abi", not(target_arch = "wasm32")),
+        schemars(with = "[u8; 32]"),
+        borsh(schema(with_funcs(
+            declaration = "<[u8; 32] as ::borsh::BorshSchema>::declaration",
+            definitions = "<[u8; 32] as ::borsh::BorshSchema>::add_definitions_recursively"
+        ),))
+    )]
+    EdwardsPoint,
+);
+
+impl GroupEncoding for SerializableEdwardsPoint {
+    type Repr = [u8; 32];
+
+    fn from_bytes(bytes: &Self::Repr) -> CtOption<Self> {
+        EdwardsPoint::from_bytes(bytes).map(Into::into)
+    }
+
+    fn from_bytes_unchecked(bytes: &Self::Repr) -> CtOption<Self> {
+        Self::from_bytes(bytes)
+    }
+
+    fn to_bytes(&self) -> Self::Repr {
+        self.compress().to_bytes()
+    }
+}
+
+impl BorshSerialize for SerializableEdwardsPoint {
+    fn serialize<W: std::io::prelude::Write>(&self, writer: &mut W) -> std::io::Result<()> {
+        let bytes = self.0.to_bytes();
+        BorshSerialize::serialize(&bytes, writer)
+    }
+}
+
+impl BorshDeserialize for SerializableEdwardsPoint {
+    fn deserialize_reader<R: std::io::prelude::Read>(reader: &mut R) -> std::io::Result<Self> {
+        let bytes: [u8; 32] = BorshDeserialize::deserialize_reader(reader)?;
+
+        EdwardsPoint::from_bytes(&bytes)
+            .into_option()
+            .ok_or(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "The provided bytes is not a valid edwards point.",
+            ))
+            .map(SerializableEdwardsPoint)
+    }
+}
+
+#[cfg(any(test, feature = "test-utils"))]
+impl SerializableEdwardsPoint {
+    pub fn random(rng: impl rand::RngCore) -> Self {
+        Self(EdwardsPoint::random(rng))
+    }
+}

--- a/libs/chain-signatures/contract/src/primitives/test_utils.rs
+++ b/libs/chain-signatures/contract/src/primitives/test_utils.rs
@@ -1,19 +1,17 @@
 use crate::{
-    crypto_shared::types::PublicKeyExtended,
+    crypto_shared::types::{serializable::SerializableEdwardsPoint, PublicKeyExtended},
     primitives::{
         participants::{ParticipantInfo, Participants},
         thresholds::{Threshold, ThresholdParameters},
     },
 };
-use curve25519_dalek::EdwardsPoint;
-use k256::elliptic_curve::Group;
 use near_sdk::{AccountId, CurveType, PublicKey};
 use rand::{distributions::Uniform, Rng};
 use std::collections::BTreeMap;
 
 pub fn bogus_ed25519_public_key_extended() -> PublicKeyExtended {
     let rng = rand::thread_rng();
-    let edwards_point = EdwardsPoint::random(rng);
+    let edwards_point = SerializableEdwardsPoint::random(rng);
     let compressed_edwards_point = edwards_point.compress();
     let near_public_key_compressed = PublicKey::from_parts(
         CurveType::ED25519,


### PR DESCRIPTION
Closes #757 

This PR simplifies the serialization trait implementations for `PublicKeyExtended` by using `SerializableEdwardsPoint` consistently throughout the module. Additionally, I've broken out the `serialize` submodule to a separate file and implemented more useful traits on the `SerializableEdwardsPoint` type to make using it more ergonomic.

Note: I considered replacing other usages of `EdwardsPoint` with `SerializableEdwardsPoint` in the rest of the code base but I don't see the (Edwards) point of doing that, so I let it be for now.