### PR TITLE
chore: PoC for http based disaster recovery API

### DIFF
--- a/libs/http-disaster-poc/Cargo.toml
+++ b/libs/http-disaster-poc/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "http-disaster-poc"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+aes-gcm = "0.10"
+array-bytes = "9.3.0"
+axum = "0.8"
+secp256k1 = { version = "0.31", features = ["serde", "rand", "global-context"] }
+tokio = { version = "1.0", features = ["full"] }
+rand = "0.8"
+reqwest = "0.12"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/libs/http-disaster-poc/src/bin/client.rs
+++ b/libs/http-disaster-poc/src/bin/client.rs
@@ -1,0 +1,54 @@
+#[tokio::main]
+async fn main() {
+    println!("Getting original secret");
+    let secret = get_secret().await;
+    println!("Secret: {secret}\n");
+
+    let new_secret = "Build projects around motivated individuals.
+Give them the environment and support they need,
+and trust them to get the job done.";
+
+    println!("Setting a new secret: {new_secret}\n");
+    set_secret(new_secret).await;
+
+    let latest_secret = get_secret().await;
+    println!("Latest secret: {latest_secret}\n");
+}
+
+async fn get_secret() -> String {
+    let client = reqwest::Client::new();
+
+    let secret = client
+        .get("http://localhost:3000/encrypted_secret")
+        .header("Authorization", format!("Bearer {}", dummy::BEARER_TOKEN))
+        .send()
+        .await
+        .expect("get request should succeed if server is running")
+        .text()
+        .await
+        .expect("secret response should contain text");
+
+    dummy::CLIENT_KEYPAIR
+        .secret_key()
+        .decrypt_from(dummy::SERVER_KEYPAIR.public_key(), &secret)
+}
+
+async fn set_secret(secret: &str) {
+    let encrypted = dummy::CLIENT_KEYPAIR
+        .secret_key()
+        .encrypt_to(dummy::SERVER_KEYPAIR.public_key(), secret);
+
+    let client = reqwest::Client::new();
+    client
+        .put("http://localhost:3000/encrypted_secret")
+        .body(encrypted)
+        .header("Authorization", format!("Bearer {}", dummy::BEARER_TOKEN))
+        .send()
+        .await
+        .expect("put request should succeed if server is running");
+}
+
+use http_disaster_poc::dummy;
+
+use http_disaster_poc::encrypt::DecryptFrom as _;
+use http_disaster_poc::encrypt::EncryptTo as _;

--- a/libs/http-disaster-poc/src/bin/server.rs
+++ b/libs/http-disaster-poc/src/bin/server.rs
@@ -1,0 +1,98 @@
+#[tokio::main]
+async fn main() {
+    let app_state = AppState::default();
+
+    let app = Router::new()
+        .route("/encrypted_secret", get(get_encrypted_secret))
+        .route("/encrypted_secret", put(put_encrypted_secret))
+        .with_state(app_state);
+
+    let listener = TcpListener::bind("0.0.0.0:3000").await.unwrap();
+
+    println!("Server running on http://0.0.0.0:3000");
+    axum::serve(listener, app).await.unwrap();
+}
+
+#[derive(Clone)]
+struct AppState {
+    encrypted_secret: Arc<Mutex<String>>,
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        let secret = "Working software is the primary measure of progress.";
+        let encrypted_secret = Arc::new(Mutex::new(
+            dummy::SERVER_KEYPAIR
+                .secret_key()
+                .encrypt_to(dummy::CLIENT_KEYPAIR.public_key(), secret),
+        ));
+        Self { encrypted_secret }
+    }
+}
+
+async fn get_encrypted_secret(_auth: BearerToken, State(state): State<AppState>) -> String {
+    state.encrypted_secret.lock().unwrap().clone()
+}
+
+async fn put_encrypted_secret(
+    _auth: BearerToken,
+    State(state): State<AppState>,
+    new_secret: String,
+) -> StatusCode {
+    let mut secret = state.encrypted_secret.lock().unwrap();
+
+    let decrypted = dummy::SERVER_KEYPAIR
+        .secret_key()
+        .decrypt_from(dummy::CLIENT_KEYPAIR.public_key(), &new_secret);
+
+    println!("Received secret: {decrypted}");
+
+    *secret = new_secret;
+    StatusCode::OK
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct PublicKeyResponse {
+    key: PublicKey,
+}
+
+struct BearerToken;
+
+impl<S> FromRequestParts<S> for BearerToken
+where
+    S: Send + Sync,
+{
+    type Rejection = StatusCode;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let headers = &parts.headers;
+
+        if let Some(auth_header) = headers.get("authorization") {
+            if let Ok(auth_str) = auth_header.to_str() {
+                if let Some(token) = auth_str.strip_prefix("Bearer ") {
+                    if token == dummy::BEARER_TOKEN {
+                        return Ok(BearerToken);
+                    }
+                }
+            }
+        }
+
+        Err(StatusCode::UNAUTHORIZED)
+    }
+}
+
+use axum::{
+    Router,
+    extract::{FromRequestParts, State},
+    http::{StatusCode, request::Parts},
+    routing::{get, put},
+};
+use secp256k1::PublicKey;
+use serde::{Deserialize, Serialize};
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+
+use http_disaster_poc::dummy;
+
+use http_disaster_poc::encrypt::DecryptFrom as _;
+use http_disaster_poc::encrypt::EncryptTo as _;

--- a/libs/http-disaster-poc/src/dummy.rs
+++ b/libs/http-disaster-poc/src/dummy.rs
@@ -1,0 +1,9 @@
+pub const BEARER_TOKEN: &str = "secret_bearer_token_123";
+pub static SERVER_KEYPAIR: LazyLock<Keypair> =
+    LazyLock::new(|| Keypair::new_global(&mut secp256k1::rand::rngs::StdRng::seed_from_u64(42)));
+pub static CLIENT_KEYPAIR: LazyLock<Keypair> =
+    LazyLock::new(|| Keypair::new_global(&mut secp256k1::rand::rngs::StdRng::seed_from_u64(1337)));
+
+use std::sync::LazyLock;
+
+use secp256k1::{Keypair, rand::SeedableRng as _};

--- a/libs/http-disaster-poc/src/encrypt.rs
+++ b/libs/http-disaster-poc/src/encrypt.rs
@@ -1,0 +1,73 @@
+pub trait EncryptTo {
+    fn encrypt_to(&self, recipient: PublicKey, msg: &str) -> String;
+}
+
+pub trait DecryptFrom {
+    fn decrypt_from(&self, sender: PublicKey, msg: &str) -> String;
+}
+
+impl EncryptTo for SecretKey {
+    fn encrypt_to(&self, recipient: PublicKey, msg: &str) -> String {
+        let shared_secret: [u8; 32] = SharedSecret::new(&recipient, self).secret_bytes();
+        let cipher = Aes256Gcm::new(&shared_secret.into());
+        let nonce = Aes256Gcm::generate_nonce(rand::rngs::StdRng::seed_from_u64(1337));
+
+        let encrypted = cipher
+            .encrypt(&nonce, msg.as_bytes())
+            .expect("should be able to encrypt message");
+
+        encrypted.hexify()
+    }
+}
+
+impl DecryptFrom for SecretKey {
+    fn decrypt_from(&self, sender: PublicKey, secret: &str) -> String {
+        let shared_secret: [u8; 32] = SharedSecret::new(&sender, self).secret_bytes();
+        let cipher = Aes256Gcm::new(&shared_secret.into());
+        let nonce = Aes256Gcm::generate_nonce(rand::rngs::StdRng::seed_from_u64(1337));
+
+        let msg_bytes = <Vec<u8>>::dehexify(secret).expect("secret should be hex encoded");
+
+        let decrypted = cipher
+            .decrypt(&nonce, msg_bytes.as_slice())
+            .expect("should be able to decrypt message bytes");
+
+        String::from_utf8(decrypted).expect("decrypted message should be valid UTF8")
+    }
+}
+
+use aes_gcm::{AeadCore, Aes256Gcm, KeyInit as _, aead::Aead};
+use array_bytes::{Dehexify, Hexify};
+use rand::SeedableRng as _;
+use secp256k1::{PublicKey, SecretKey, ecdh::SharedSecret};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use secp256k1::{Keypair, rand::SeedableRng};
+
+    #[test]
+    fn recipient_should_be_able_to_decrypt_encrypted_message() {
+        let mut rng = secp256k1::rand::rngs::StdRng::seed_from_u64(1337);
+
+        // Given
+        let sender_keypair = Keypair::new_global(&mut rng);
+        let recipient_keypair = Keypair::new_global(&mut rng);
+        let msg = "Simplicity--the art of maximizing the amount
+of work not done--is essential. ";
+
+        // When
+        let encrypted = sender_keypair
+            .secret_key()
+            .encrypt_to(recipient_keypair.public_key(), msg);
+
+        let decrypted = recipient_keypair
+            .secret_key()
+            .decrypt_from(sender_keypair.public_key(), &encrypted);
+
+        // Then
+        assert_ne!(msg, encrypted);
+        assert_eq!(msg, decrypted);
+    }
+}

--- a/libs/http-disaster-poc/src/lib.rs
+++ b/libs/http-disaster-poc/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod dummy;
+pub mod encrypt;


### PR DESCRIPTION
Closes #917 

This is a Proof of Concept illustrating a HTTP based disaster recovery API. It consists of a server and a client.

### Server
The server holds a secret that can be obtained and modified by the client, and serves it over the HTTP API. It uses bearer based authentication to prevent unauthorized entities from accessing the encrypted secret.

### Client
The client is just a hard-coded script illustrating requests to this API.

### Public key distribution
The server is assumed to already know the public key of the Client, and vice versa - as this will be provided through the blockchain in the production system.

### Encryption
The secret is always encrypted when stored and in-flight. For this PoC I'm using a plain Diffie-Hellman key exchange using Secp256k1 to act as a simple baseline, but the same principle should work with more sophisticated schemes as well.

### Note on crypto libraries
I chose Secp256k1 because it's one of the libraries I'm already pretty familiar with. I'm not advocating for it in particular, but I found it surprisingly hard to find decent libraries providing the relevant primitives.