### PR TITLE
chore(contract): remove stale log of random seed in contract

### DIFF
--- a/libs/chain-signatures/contract/src/lib.rs
+++ b/libs/chain-signatures/contract/src/lib.rs
@@ -355,8 +355,6 @@ impl VersionedMpcContract {
             env::panic_str(&TeeError::TeeValidationFailed.to_string())
         }
 
-        env::log_str(&serde_json::to_string(&near_sdk::env::random_seed_array()).unwrap());
-
         let promise_index = env::promise_yield_create(
             "return_signature_and_clean_state_on_success",
             &serde_json::to_vec(&(&request,)).unwrap(),


### PR DESCRIPTION
Resolves #918 


This log has been introduced in this PR: https://github.com/near/mpc_old/pull/401. In that PR, the indexers behavior was changed s.t. it would pick up the random seed [from the logs](https://github.com/near/mpc_old/pull/401/files#diff-2fc98148c22be5e311dc92c77f7f3817bdad8d1233de4ed678e9e42092d500b3R94), use it [to derive delta](https://github.com/near/mpc_old/pull/401/files#diff-2fc98148c22be5e311dc92c77f7f3817bdad8d1233de4ed678e9e42092d500b3R104) and stored with the Signature request [here](https://github.com/near/mpc_old/pull/401/files#diff-2fc98148c22be5e311dc92c77f7f3817bdad8d1233de4ed678e9e42092d500b3R113).


The entropy would later be used to [chose a random subset of participants for signature generation](https://github.com/near/mpc_old/blob/4ab556981830d1633d2f00927cd0e7933722641a/node/src/protocol/signature.rs#L52).

What the `delta` was used for is not entirely clear to me (I see it being used somewhere in pre-sign), but I am pretty certain it is irrelevant at this point, as with the current design, the indexer does not read this log from chain.
