### PR TITLE
fix: CI get docker manifest timeouts

### DIFF
--- a/tee_launcher/launcher.py
+++ b/tee_launcher/launcher.py
@@ -420,7 +420,6 @@ def request_until_success(
             continue
         else:
             return manifest_resp
-        
 
     raise RuntimeError(
         f"Failed to get succesful response from {url} after {rpc_max_attempts} attempts."


### PR DESCRIPTION
Closes #927 

This was actually a bug. The function doing the retries was doing a single retry, throwing an exception on the first failure.