### PR TITLE
fix: redundant secure_time validation for app compose

### DIFF
--- a/crates/attestation/src/attestation.rs
+++ b/crates/attestation/src/attestation.rs
@@ -314,7 +314,6 @@ impl Attestation {
             && app_compose.allowed_envs.is_empty()
             && app_compose.no_instance_id
             && app_compose.secure_time == Some(true)
-            && app_compose.secure_time == Some(true)
             && app_compose.pre_launch_script.is_none()
     }
 


### PR DESCRIPTION
There's an extra validation for validating `secure_time` in app compose which seems not necessary.