### PR TITLE
chore: Enable running with dstack TEE authority in start.sh

### DIFF
--- a/deployment/start.sh
+++ b/deployment/start.sh
@@ -111,5 +111,11 @@ else
     echo "Using provided MPC_SECRET_STORE_KEY from environment"
 fi
 
+if [ -n "$DSTACK_ENDPOINT" ]; then
+    tee_authority=dstack
+else
+    tee_authority=local
+fi
+
 echo "Starting mpc node..."
-/app/mpc-node start local
+/app/mpc-node start $tee_authority


### PR DESCRIPTION
closes #1009

Unfortunately I don't know a simple way to test this right now. Open to suggestions, but improving our ability to test the system as a whole is also a current ongoing effort.