### PR TITLE
chore: test for new docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,8 @@ jobs:
           # Check if container is actually running
           sleep 60
           if [ -z "$(docker ps --filter "id=$CONTAINER_ID" --format "{{.ID}}")" ]; then
-            echo "❌ Container failed configuration validation or startup. Checking logs..."
             docker logs "$CONTAINER_ID" 2>&1 | head -50
-            echo "❌ Container cannot start properly - this indicates a real problem"
+            echo "❌ Container cannot initialize/start properly"
             exit 1
           fi
           

--- a/deployment/Dockerfile-mpc
+++ b/deployment/Dockerfile-mpc
@@ -1,4 +1,4 @@
-FROM rust:latest AS builder
+FROM rust:1.85 AS builder
 RUN apt-get update -y && apt-get install -y --no-install-recommends clang  # needed for rocksdb
 
 WORKDIR /app


### PR DESCRIPTION
Adding a CI test for resulting Docker image.
This will try to start a generic docker mpc container and report back if it fails.
Example failure run: https://github.com/near/mpc/actions/runs/17494915394/job/49693182812?pr=1036