### PR TITLE
fix: Add missing bs58 dependency in contract_history crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2079,7 +2079,7 @@ dependencies = [
 name = "contract_history"
 version = "0.1.0"
 dependencies = [
- "base64 0.22.1",
+ "bs58 0.5.1",
  "clap",
  "reqwest 0.12.23",
  "serde",

--- a/crates/contract_history/Cargo.toml
+++ b/crates/contract_history/Cargo.toml
@@ -11,7 +11,7 @@ path = "src/bin/export_contracts.rs"
 clap.workspace = true
 
 [dev-dependencies]
-base64.workspace = true
+bs58.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true


### PR DESCRIPTION
Closes #1039 