### PR TITLE
docs: Getting lasted MPC hash from the contract

### DIFF
--- a/docs/running_an_mpc_node_in_tdx_external_guide.md
+++ b/docs/running_an_mpc_node_in_tdx_external_guide.md
@@ -235,7 +235,7 @@ near contract call-function as-transaction \
   attached-deposit '0 NEAR' \
   sign-as <your-account-id> \
   network-config testnet \
-  sign-with-plaintext-private-key <your-private-key> \
+  sign-with-keychain \
   send
 ```
 


### PR DESCRIPTION
fixes #898