### PR TITLE
ci: remove redundant and duplicate clippy check for `devnet` crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,14 +52,14 @@ jobs:
           -e MPC_IMAGE_HASH=5ba283860c0efa3d4c3e08a76a2b77fab4725baad4f48504eac858e04af7fd64 \
           -e MPC_LATEST_ALLOWED_HASH_FILE=/tmp/image-digest.bin \
           -e MPC_ENV=mainnet test_image_tag_ci)
-          
+
           if [ -z "$CONTAINER_ID" ]; then
             echo "❌ Failed to start container"
             exit 1
           fi
-          
+
           echo "Container started: $CONTAINER_ID"
-          
+
           # Check if container is actually running
           sleep 60
           if [ -z "$(docker ps --filter "id=$CONTAINER_ID" --format "{{.ID}}")" ]; then
@@ -67,7 +67,7 @@ jobs:
             echo "❌ Container cannot initialize/start properly"
             exit 1
           fi
-          
+
           echo "✅ Container started successfully"
 
   clippy-mpc-node:
@@ -160,38 +160,6 @@ jobs:
       - name: Run Cargo fmt
         run: |
           cd libs/chain-signatures
-          cargo fmt -- --check
-
-  clippy-mpc-devnet:
-    name: "MPC Devnet: clippy and format"
-    runs-on: warp-ubuntu-2204-x64-8x
-    timeout-minutes: 60
-    permissions:
-      contents: read
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Initialize submodules
-        run: git submodule update --init --recursive
-
-      - name: Cache Rust dependencies
-        uses: WarpBuilds/rust-cache@v2
-        with:
-          cache-on-failure: true
-          cache-all-crates: true
-
-      - name: Run Clippy fmt
-        run: |
-          cd devnet
-          CARGO_TARGET_DIR="target/clippy" \
-          RUSTFLAGS="-D warnings" \
-          cargo clippy --all-features --all-targets --locked
-
-      - name: Run Cargo fmt
-        run: |
-          cd devnet
           cargo fmt -- --check
 
   mpc-unittests:
@@ -306,7 +274,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libudev-dev
           cargo install cargo-near --locked
-      
+
       - name: Install wasm-opt from crates.io
         run: |
           cargo install wasm-opt --locked


### PR DESCRIPTION
closes #1107 