### PR TITLE
refactor: Send indexer state as arg instead of oneshot

### DIFF
--- a/node/src/indexer/real.rs
+++ b/node/src/indexer/real.rs
@@ -68,18 +68,6 @@ pub fn spawn_real_indexer(
             // We have this indirection of using a oneshot for sending the sender,
             // as we can't block the main thread for waiting on the `txn_sender`.
             // Thus we instead initialize a `txn_sender`, which runs as a spawned task, to await on the indexer state being ready.
-            let (indexer_state_sender, indexer_state_receiver) = oneshot::channel();
-            let txn_sender = start_transaction_processor(
-                my_near_account_id_clone,
-                account_secret_key.clone(),
-                respond_config_clone,
-                indexer_state_receiver,
-            );
-
-            if txn_sender_sender.send(txn_sender).is_err() {
-                tracing::error!("Failed to send txn_sender back to main thread.")
-            };
-
             let indexer =
                 near_indexer::Indexer::new(indexer_config.to_near_indexer_config(home_dir.clone()))
                     .expect("Failed to initialize the Indexer");
@@ -92,7 +80,16 @@ pub fn spawn_real_indexer(
                 indexer_config.mpc_contract_id.clone(),
             ));
 
-            let _ = indexer_state_sender.send(indexer_state.clone());
+            let txn_sender = start_transaction_processor(
+                my_near_account_id_clone,
+                account_secret_key.clone(),
+                respond_config_clone,
+                Arc::clone(&indexer_state),
+            );
+
+            if txn_sender_sender.send(txn_sender).is_err() {
+                tracing::error!("Failed to send txn_sender back to main thread.")
+            };
 
             #[cfg(feature = "network-hardship-simulation")]
             let process_blocks_receiver = {

--- a/node/src/indexer/tx_sender.rs
+++ b/node/src/indexer/tx_sender.rs
@@ -96,7 +96,7 @@ pub(crate) fn start_transaction_processor(
     owner_account_id: AccountId,
     owner_secret_key: SigningKey,
     config: RespondConfig,
-    indexer_state_receiver: oneshot::Receiver<Arc<IndexerState>>,
+    indexer_state: Arc<IndexerState>,
 ) -> impl TransactionSender {
     let mut signers = TransactionSigners::new(config, owner_account_id, owner_secret_key)
         .expect("Failed to initialize transaction signers");
@@ -105,10 +105,6 @@ pub(crate) fn start_transaction_processor(
         mpsc::channel::<TransactionSenderSubmission>(TRANSACTION_PROCESSOR_CHANNEL_SIZE);
 
     tokio::spawn(async move {
-        let indexer_state = indexer_state_receiver
-            .await
-            .expect("Indexer must be running");
-
         while let Some(transaction_submission) = transaction_receiver.recv().await {
             let tx_request = transaction_submission.transaction;
 


### PR DESCRIPTION
From PR conversation: https://github.com/near/mpc/pull/1101#discussion_r2348748429