### PR TITLE
chore: index nodes by account id & TLS key in TEE State

### DIFF
--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -50,7 +50,7 @@ use primitives::{
 use state::{running::RunningContractState, ProtocolContractState};
 use tee::{
     proposal::MpcDockerImageHash,
-    tee_state::{NodeUid, TeeValidationResult},
+    tee_state::{NodeId, TeeValidationResult},
 };
 
 /// Gas required for a sign request
@@ -739,7 +739,7 @@ impl VersionedMpcContract {
 
         // Add the participant information to the contract state
         let is_new_attestation = mpc_contract.tee_state.add_participant(
-            NodeUid {
+            NodeId {
                 account_id: account_id.clone(),
                 tls_public_key,
             },
@@ -1116,7 +1116,7 @@ impl VersionedMpcContract {
     /// Returns all accounts that have TEE attestations stored in the contract.
     /// Note: This includes both current protocol participants and accounts that may have
     /// submitted TEE information but are not currently part of the active participant set.
-    pub fn get_tee_accounts(&self) -> Vec<NodeUid> {
+    pub fn get_tee_accounts(&self) -> Vec<NodeId> {
         log!("get_tee_accounts: signer={}", env::signer_account_id());
         match self {
             Self::V2(contract) => contract.tee_state.get_tee_accounts(),

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -738,7 +738,7 @@ impl VersionedMpcContract {
         }
 
         // Add the participant information to the contract state
-        mpc_contract.tee_state.add_participant(
+        let is_new_attestation = mpc_contract.tee_state.add_participant(
             NodeUid {
                 account_id: account_id.clone(),
                 tls_public_key,
@@ -748,7 +748,7 @@ impl VersionedMpcContract {
 
         // Both participants and non-participants can propose. Non-participants must pay for the
         // storage they use; participants do not.
-        if self.voter_account().is_err() {
+        if self.voter_account().is_err() || is_new_attestation {
             let storage_used = env::storage_usage() - initial_storage;
             let cost = env::storage_byte_cost().saturating_mul(storage_used as u128);
             let attached = env::attached_deposit();

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1184,7 +1184,7 @@ impl VersionedMpcContract {
                     contract.protocol_state = ProtocolContractState::Resharing(resharing);
                 }
 
-                Ok(false)
+                Ok(true)
             }
         }
     }

--- a/crates/contract/src/primitives/participants.rs
+++ b/crates/contract/src/primitives/participants.rs
@@ -1,6 +1,10 @@
 use crate::errors::{Error, InvalidCandidateSet, InvalidParameters};
+
 use near_sdk::{near, AccountId, PublicKey};
 use std::{collections::BTreeSet, fmt::Display};
+
+#[cfg(any(test, feature = "test-utils"))]
+use crate::tee::tee_state::NodeUid;
 
 pub mod hpke {
     pub type PublicKey = [u8; 32];
@@ -198,6 +202,16 @@ impl Participants {
             }
         }
         Err(crate::errors::InvalidState::NotParticipant.into())
+    }
+
+    pub fn get_node_uids(&self) -> BTreeSet<NodeUid> {
+        self.participants()
+            .iter()
+            .map(|(account_id, _, p_info)| NodeUid {
+                account_id: account_id.clone(),
+                tls_public_key: p_info.sign_pk.clone(),
+            })
+            .collect()
     }
 }
 

--- a/crates/contract/src/primitives/participants.rs
+++ b/crates/contract/src/primitives/participants.rs
@@ -4,7 +4,7 @@ use near_sdk::{near, AccountId, PublicKey};
 use std::{collections::BTreeSet, fmt::Display};
 
 #[cfg(any(test, feature = "test-utils"))]
-use crate::tee::tee_state::NodeUid;
+use crate::tee::tee_state::NodeId;
 
 pub mod hpke {
     pub type PublicKey = [u8; 32];
@@ -204,10 +204,10 @@ impl Participants {
         Err(crate::errors::InvalidState::NotParticipant.into())
     }
 
-    pub fn get_node_uids(&self) -> BTreeSet<NodeUid> {
+    pub fn get_node_ids(&self) -> BTreeSet<NodeId> {
         self.participants()
             .iter()
-            .map(|(account_id, _, p_info)| NodeUid {
+            .map(|(account_id, _, p_info)| NodeId {
                 account_id: account_id.clone(),
                 tls_public_key: p_info.sign_pk.clone(),
             })

--- a/crates/contract/src/primitives/participants.rs
+++ b/crates/contract/src/primitives/participants.rs
@@ -130,6 +130,12 @@ impl Participants {
             participants,
         }
     }
+    pub fn info(&self, account_id: &AccountId) -> Option<&ParticipantInfo> {
+        self.participants
+            .iter()
+            .find(|(a_id, _, _)| a_id == account_id)
+            .map(|(_, _, info)| info)
+    }
 }
 
 #[cfg(any(test, feature = "test-utils"))]
@@ -140,13 +146,6 @@ impl Participants {
             .find(|(a_id, _, _)| a_id == account_id)
             .map(|(_, p_id, _)| p_id.clone())
             .ok_or_else(|| crate::errors::InvalidState::NotParticipant.into())
-    }
-
-    pub fn info(&self, account_id: &AccountId) -> Option<&ParticipantInfo> {
-        self.participants
-            .iter()
-            .find(|(a_id, _, _)| a_id == account_id)
-            .map(|(_, _, info)| info)
     }
 
     pub fn account_id(&self, id: &ParticipantId) -> Result<AccountId, Error> {

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -209,7 +209,7 @@ impl TeeState {
             .collect();
 
         // Collect accounts to remove (can't remove while iterating)
-        let accounts_to_remove: Vec<NodeUid> = self
+        let nodes_to_remove: Vec<NodeUid> = self
             .participants_attestations
             .keys()
             .filter(|node_uid| !participant_accounts.contains(node_uid))
@@ -217,8 +217,8 @@ impl TeeState {
             .collect();
 
         // Remove non-participant TEE information
-        for account_id in &accounts_to_remove {
-            self.participants_attestations.remove(account_id);
+        for node_uid in &nodes_to_remove {
+            self.participants_attestations.remove(node_uid);
         }
     }
 

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -153,9 +153,19 @@ impl TeeState {
         }
     }
 
-    pub fn add_participant(&mut self, node_uid: NodeUid, proposed_tee_participant: Attestation) {
+    /// Adds a participant attestation for the given node.
+    ///
+    /// Returns:
+    /// - `true` if this is the first attestation for the node (i.e., a new participant was added).
+    /// - `false` if the node already had an attestation (the existing one was replaced).
+    pub fn add_participant(
+        &mut self,
+        node_uid: NodeUid,
+        proposed_tee_participant: Attestation,
+    ) -> bool {
         self.participants_attestations
-            .insert(node_uid, proposed_tee_participant);
+            .insert(node_uid, proposed_tee_participant)
+            .is_none()
     }
 
     pub fn vote(

--- a/crates/contract/tests/common.rs
+++ b/crates/contract/tests/common.rs
@@ -28,7 +28,7 @@ use mpc_contract::{
         thresholds::{Threshold, ThresholdParameters},
     },
     state::ProtocolContractState,
-    tee::tee_state::NodeUid,
+    tee::tee_state::NodeId,
     update::UpdateId,
 };
 use mpc_contract::{
@@ -658,14 +658,14 @@ pub fn check_call_success_all_receipts(result: ExecutionFinalResult) {
 }
 
 /// Helper function to get TEE participants from contract.
-pub async fn get_tee_accounts(contract: &Contract) -> anyhow::Result<BTreeSet<NodeUid>> {
+pub async fn get_tee_accounts(contract: &Contract) -> anyhow::Result<BTreeSet<NodeId>> {
     Ok(contract
         .call("get_tee_accounts")
         .args_json(serde_json::json!({}))
         .max_gas()
         .transact()
         .await?
-        .json::<Vec<NodeUid>>()?
+        .json::<Vec<NodeId>>()?
         .into_iter()
         .collect())
 }
@@ -703,14 +703,14 @@ pub async fn assert_running_return_participants(
 pub async fn submit_tee_attestations(
     contract: &Contract,
     env_accounts: &mut [Account],
-    node_uids: &BTreeSet<NodeUid>,
+    node_ids: &BTreeSet<NodeId>,
 ) -> anyhow::Result<()> {
     env_accounts.sort_by_key(|account| account.id().clone());
-    for (account, node_uid) in env_accounts.iter().zip(node_uids) {
-        assert_eq!(*account.id(), node_uid.account_id, "AccountId mismatch");
+    for (account, node_id) in env_accounts.iter().zip(node_ids) {
+        assert_eq!(*account.id(), node_id.account_id, "AccountId mismatch");
         let attestation = Attestation::Mock(MockAttestation::Valid); // todo #1109, add TLS key.
         let result =
-            submit_participant_info(account, contract, &attestation, &node_uid.tls_public_key)
+            submit_participant_info(account, contract, &attestation, &node_id.tls_public_key)
                 .await?;
         assert!(result);
     }

--- a/crates/contract/tests/common.rs
+++ b/crates/contract/tests/common.rs
@@ -24,8 +24,10 @@ use mpc_contract::{
         key_state::{AttemptId, EpochId, KeyForDomain, Keyset},
         participants::{ParticipantInfo, Participants},
         signature::{Bytes, SignatureRequest, Tweak},
+        test_utils::bogus_ed25519_near_public_key,
         thresholds::{Threshold, ThresholdParameters},
     },
+    tee::tee_state::NodeUid,
     update::UpdateId,
 };
 use mpc_contract::{
@@ -48,7 +50,6 @@ use std::{
     io::{Read, Write},
     path::Path,
     process::Command,
-    str::FromStr,
     sync::OnceLock,
     time::{SystemTime, UNIX_EPOCH},
 };
@@ -80,10 +81,7 @@ pub fn candidates(names: Option<Vec<AccountId>>) -> Participants {
             account_id.clone(),
             ParticipantInfo {
                 url: "127.0.0.1".into(),
-                sign_pk: near_sdk::PublicKey::from_str(
-                    "ed25519:J75xXmF7WUPS3xCm3hy2tgwLCKdYM1iJd4BWF8sWVnae",
-                )
-                .unwrap(),
+                sign_pk: bogus_ed25519_near_public_key(),
             },
         );
     }
@@ -649,7 +647,7 @@ pub fn check_call_success(result: ExecutionFinalResult) {
 }
 
 /// Helper function to get TEE participants from contract.
-pub async fn get_tee_accounts(contract: &Contract) -> anyhow::Result<Vec<AccountId>> {
+pub async fn get_tee_accounts(contract: &Contract) -> anyhow::Result<Vec<NodeUid>> {
     Ok(contract
         .call("get_tee_accounts")
         .args_json(serde_json::json!({}))

--- a/crates/contract/tests/common.rs
+++ b/crates/contract/tests/common.rs
@@ -705,7 +705,7 @@ pub async fn submit_tee_attestations(
     env_accounts: &mut [Account],
     node_uids: &BTreeSet<NodeUid>,
 ) -> anyhow::Result<()> {
-    env_accounts.sort_by(|a, b| a.id().cmp(b.id()));
+    env_accounts.sort_by_key(|account| account.id().clone());
     for (account, node_uid) in env_accounts.iter().zip(node_uids) {
         assert_eq!(*account.id(), node_uid.account_id, "AccountId mismatch");
         let attestation = Attestation::Mock(MockAttestation::Valid); // todo #1109, add TLS key.

--- a/crates/contract/tests/common.rs
+++ b/crates/contract/tests/common.rs
@@ -705,7 +705,7 @@ pub async fn submit_tee_attestations(
     env_accounts: &mut [Account],
     node_ids: &BTreeSet<NodeId>,
 ) -> anyhow::Result<()> {
-    env_accounts.sort_by_key(|account| account.id().clone());
+    env_accounts.sort_by(|left, right| left.id().cmp(right.id()));
     for (account, node_id) in env_accounts.iter().zip(node_ids) {
         assert_eq!(*account.id(), node_id.account_id, "AccountId mismatch");
         let attestation = Attestation::Mock(MockAttestation::Valid); // todo #1109, add TLS key.

--- a/crates/contract/tests/expired_attestation.rs
+++ b/crates/contract/tests/expired_attestation.rs
@@ -100,8 +100,8 @@ fn test_participant_kickout_after_expiration() {
     let participant_nodes: Vec<NodeId> = setup
         .participants_list
         .iter()
-        .cloned()
         .take(2)
+        .cloned()
         .map(|(account_id, _, participant_info)| NodeId {
             account_id,
             tls_public_key: participant_info.sign_pk,
@@ -199,8 +199,8 @@ fn test_clean_tee_status_removes_non_participants() {
     let participant_nodes: Vec<NodeId> = setup
         .participants_list
         .iter()
-        .cloned()
         .take(2)
+        .cloned()
         .map(|(account_id, _, participant_info)| NodeId {
             account_id,
             tls_public_key: participant_info.sign_pk,

--- a/crates/contract/tests/expired_attestation.rs
+++ b/crates/contract/tests/expired_attestation.rs
@@ -135,7 +135,7 @@ fn test_participant_kickout_after_expiration() {
         .block_timestamp(EXPIRED_TIMESTAMP)
         .build());
 
-    assert!(!setup.contract.verify_tee().unwrap());
+    assert!(setup.contract.verify_tee().unwrap());
 
     let resharing_state = match setup.contract.state() {
         ProtocolContractState::Resharing(r) => r,

--- a/crates/contract/tests/integration_tee_cleanup_after_resharing.rs
+++ b/crates/contract/tests/integration_tee_cleanup_after_resharing.rs
@@ -3,8 +3,6 @@ use anyhow::Result;
 use attestation::attestation::{Attestation, MockAttestation};
 use near_workspaces::{Account, Contract};
 use serde_json::json;
-use std::time::Duration;
-use tokio::time;
 
 use common::{
     assert_running_return_participants, check_call_success, check_call_success_all_receipts,
@@ -123,7 +121,6 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
     // Verify only the new participants remain
     assert_eq!(final_participants_node_uids, expected_tee_post_resharing);
     // Verify TEE participants are properly cleaned up
-    time::sleep(Duration::from_secs(1)).await;
     let tee_participants_after_cleanup = get_tee_accounts(&contract).await.unwrap();
 
     // Verify that the remaining TEE participants match exactly the new contract participants
@@ -161,7 +158,6 @@ async fn do_resharing(
     };
 
     for domain_id in domain_ids {
-        // Use hardcoded key event ID for test simplicity
         let key_event_id = json!({
             "epoch_id": prospective_epoch_id.get(),
             "domain_id": domain_id.0,

--- a/crates/contract/tests/tee.rs
+++ b/crates/contract/tests/tee.rs
@@ -5,17 +5,13 @@ use anyhow::Result;
 use assert_matches::assert_matches;
 use attestation::attestation::{Attestation, MockAttestation};
 use common::{
-    check_call_success, get_tee_accounts, init_env_ed25519, init_env_secp256k1,
-    submit_participant_info,
+    assert_running_return_participants, check_call_success, get_tee_accounts, init_env_ed25519,
+    init_env_secp256k1, submit_participant_info, submit_tee_attestations,
 };
-use mpc_contract::{
-    errors::InvalidState, primitives::test_utils::bogus_ed25519_near_public_key,
-    state::ProtocolContractState, tee::tee_state::NodeUid,
-};
+use mpc_contract::{errors::InvalidState, state::ProtocolContractState};
 use mpc_primitives::hash::MpcDockerImageHash;
 use near_sdk::PublicKey;
 use near_workspaces::{Account, Contract};
-use std::collections::BTreeSet;
 use test_utils::attestation::{image_digest, mock_dstack_attestation, p2p_tls_key};
 
 /// Tests the basic TEE verification functionality when no TEE accounts are present.
@@ -336,56 +332,31 @@ async fn test_clean_tee_status_denies_external_account_access() -> Result<()> {
 /// TEE data for accounts that are no longer participants. Uses the test method to populate initial TEE state.
 #[tokio::test]
 async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<()> {
-    let (worker, contract, accounts, _) = init_env_secp256k1(1).await;
+    let (worker, contract, mut accounts, _) = init_env_secp256k1(1).await;
 
     // Initially should have no TEE participants
     assert_eq!(get_tee_accounts(&contract).await?.len(), 0);
 
-    // extract initial participants:
-    // Get current state to extract participant info
-    let state: ProtocolContractState = contract.view("state").await?.json()?;
-    let running_state = match state {
-        ProtocolContractState::Running(running_state) => running_state,
-        _ => panic!("Contract should be in running state initially"),
-    };
-
-    // Get current participants to construct proper ThresholdParameters
-    let init_participants = running_state.parameters.participants().clone();
-
-    let mut expected_participants = BTreeSet::new();
-    for account in &accounts {
-        let attestation = Attestation::Mock(MockAttestation::Valid); // todo #1109, add TLS key.
-        let tls_key = init_participants
-            .info(account.id())
-            .unwrap()
-            .sign_pk
-            .clone();
-        let success = submit_participant_info(account, &contract, &attestation, &tls_key).await?;
-        expected_participants.insert(NodeUid {
-            account_id: account.id().clone(),
-            tls_public_key: tls_key,
-        });
-        assert!(success);
-    }
+    let participant_uids = assert_running_return_participants(&contract)
+        .await?
+        .get_node_uids();
+    submit_tee_attestations(&contract, &mut accounts, &participant_uids).await?;
 
     // Verify current participants have TEE data
-    assert_eq!(get_tee_accounts(&contract).await?.len(), accounts.len());
+    assert_eq!(get_tee_accounts(&contract).await?, participant_uids);
 
     // Create additional accounts (non-participants) and submit TEE info for them
     const NUM_ADDITIONAL_ACCOUNTS: usize = 2;
-    let additional_accounts = gen_accounts(&worker, NUM_ADDITIONAL_ACCOUNTS).await.0;
-    for account in &additional_accounts {
-        let tls_key = bogus_ed25519_near_public_key();
-        let attestation = Attestation::Mock(MockAttestation::Valid); // todo #1109, add TLS key.
-        let success = submit_participant_info(account, &contract, &attestation, &tls_key).await?;
-        assert!(success);
-    }
+    let (mut additional_accounts, additional_participants) =
+        gen_accounts(&worker, NUM_ADDITIONAL_ACCOUNTS).await;
+    let additional_uids = additional_participants.get_node_uids();
+    submit_tee_attestations(&contract, &mut additional_accounts, &additional_uids).await?;
 
     // Verify we have TEE data for all accounts before cleanup
     let tee_participants_before = get_tee_accounts(&contract).await?;
     assert_eq!(
-        tee_participants_before.len(),
-        accounts.len() + additional_accounts.len()
+        tee_participants_before,
+        &additional_uids | &participant_uids
     );
 
     // Contract should be able to call clean_tee_status on itself
@@ -401,10 +372,7 @@ async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<(
     // Verify cleanup worked: only current participants should have TEE data
     let tee_participants_after = get_tee_accounts(&contract).await?;
     assert_eq!(tee_participants_after.len(), accounts.len());
-
-    let actual_participants: BTreeSet<_> = tee_participants_after.into_iter().collect();
-
-    assert_eq!(expected_participants, actual_participants);
+    assert_eq!(participant_uids, tee_participants_after);
 
     Ok(())
 }

--- a/crates/contract/tests/tee.rs
+++ b/crates/contract/tests/tee.rs
@@ -339,7 +339,7 @@ async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<(
 
     let participant_uids = assert_running_return_participants(&contract)
         .await?
-        .get_node_uids();
+        .get_node_ids();
     submit_tee_attestations(&contract, &mut accounts, &participant_uids).await?;
 
     // Verify current participants have TEE data
@@ -349,7 +349,7 @@ async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<(
     const NUM_ADDITIONAL_ACCOUNTS: usize = 2;
     let (mut additional_accounts, additional_participants) =
         gen_accounts(&worker, NUM_ADDITIONAL_ACCOUNTS).await;
-    let additional_uids = additional_participants.get_node_uids();
+    let additional_uids = additional_participants.get_node_ids();
     submit_tee_attestations(&contract, &mut additional_accounts, &additional_uids).await?;
 
     // Verify we have TEE data for all accounts before cleanup


### PR DESCRIPTION
Resolves #1084, #1119 and #1145

Introduces `NodeUid` as a unique identifier for participants nodes.
```rust
pub struct NodeUid {
    /// Operator account
    pub account_id: AccountId,
    /// TLS public key
    pub tls_public_key: PublicKey,
}
```

Reasonable assumptions about the network state are:

1. Each node operator is uniquely identified by their `AccountId` (existing assumption).
2. A node operator may only have one participating node at any point in time (enforced by the `Participants` struct).
3. A node operator may have multiple nodes submitting an attestation to the contract (enabled by this PR);
4. Each node is uniquely identified by their `tls_public_key` (not really enforceable on the contract).

Note that the following give probabilistic guarantees for point 4, if nodes run inside TEEs:
- a new node must generate a new TLS key upon startup;
- the TLS key is measured and included in the attestation.


Uncovered issues:
- https://github.com/near/mpc/issues/1118
- https://github.com/near/mpc/issues/1109
- https://github.com/near/mpc/issues/1144
