### PR TITLE
chore(node): use one key pair for both TLS AND near access key

### DIFF
--- a/crates/contract/src/primitives/participants.rs
+++ b/crates/contract/src/primitives/participants.rs
@@ -3,9 +3,6 @@ use crate::errors::{Error, InvalidCandidateSet, InvalidParameters};
 use near_sdk::{near, AccountId, PublicKey};
 use std::{collections::BTreeSet, fmt::Display};
 
-#[cfg(any(test, feature = "test-utils"))]
-use crate::tee::tee_state::NodeId;
-
 pub mod hpke {
     pub type PublicKey = [u8; 32];
 }
@@ -204,13 +201,10 @@ impl Participants {
         }
     }
 
-    pub fn get_node_ids(&self) -> BTreeSet<NodeId> {
+    pub fn get_public_keys(&self) -> BTreeSet<PublicKey> {
         self.participants()
             .iter()
-            .map(|(account_id, _, p_info)| NodeId {
-                account_id: account_id.clone(),
-                tls_public_key: p_info.sign_pk.clone(),
-            })
+            .map(|(_, _, p_info)| p_info.sign_pk.clone())
             .collect()
     }
 }

--- a/crates/contract/tests/sandbox/integration_tee_cleanup_after_resharing.rs
+++ b/crates/contract/tests/sandbox/integration_tee_cleanup_after_resharing.rs
@@ -39,7 +39,7 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
 
     // extract initial participants:
     let initial_participants = assert_running_return_participants(&contract).await?;
-    let expected_node_ids = initial_participants.get_node_ids();
+    let expected_node_ids = initial_participants.get_public_keys();
 
     // submit attestations
     submit_tee_attestations(&contract, &mut env_accounts, &expected_node_ids).await?;
@@ -51,7 +51,7 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
     // Add two prospective Participants
     // Note: this test fails if `vote_reshared` needs to clean up more than 3 attestations
     let (mut env_non_participant_accounts, non_participants) = gen_accounts(&worker, 1).await;
-    let non_participant_uids = non_participants.get_node_ids();
+    let non_participant_uids = non_participants.get_public_keys();
     submit_tee_attestations(
         &contract,
         &mut env_non_participant_accounts,
@@ -95,7 +95,7 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
             .expect("Failed to insert participant");
     }
 
-    let expected_tee_post_resharing = new_participants.get_node_ids();
+    let expected_tee_post_resharing = new_participants.get_public_keys();
     let new_threshold_parameters =
         ThresholdParameters::new(new_participants, Threshold::new(2)).unwrap();
 
@@ -116,7 +116,7 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
         .expect("Expected contract to be in Running state after resharing.");
 
     // Get current participants to compare
-    let final_participants_node_ids = final_participants.get_node_ids();
+    let final_participants_node_ids = final_participants.get_public_keys();
     // Verify only the new participants remain
     assert_eq!(final_participants_node_ids, expected_tee_post_resharing);
     // Verify TEE participants are properly cleaned up

--- a/crates/contract/tests/sandbox/tee.rs
+++ b/crates/contract/tests/sandbox/tee.rs
@@ -336,7 +336,7 @@ async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<(
 
     let participant_uids = assert_running_return_participants(&contract)
         .await?
-        .get_node_ids();
+        .get_public_keys();
     submit_tee_attestations(&contract, &mut accounts, &participant_uids).await?;
 
     // Verify current participants have TEE data
@@ -346,7 +346,7 @@ async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<(
     const NUM_ADDITIONAL_ACCOUNTS: usize = 2;
     let (mut additional_accounts, additional_participants) =
         gen_accounts(&worker, NUM_ADDITIONAL_ACCOUNTS).await;
-    let additional_uids = additional_participants.get_node_ids();
+    let additional_uids = additional_participants.get_public_keys();
     submit_tee_attestations(&contract, &mut additional_accounts, &additional_uids).await?;
 
     // Verify we have TEE data for all accounts before cleanup

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -239,7 +239,7 @@ impl StartCmd {
             home_dir.clone(),
             config.indexer.clone(),
             config.my_near_account_id.clone(),
-            persistent_secrets.near_signer_key.clone(),
+            persistent_secrets.node_signing_key.clone(),
             respond_config,
             web_contract_sender,
             indexer_exit_sender,
@@ -325,13 +325,13 @@ impl StartCmd {
 
         let (debug_request_sender, _) = tokio::sync::broadcast::channel(10);
 
-        let tls_public_key = secrets
+        let node_public_key = secrets
             .persistent_secrets
-            .p2p_private_key
+            .node_signing_key
             .verifying_key()
             .to_near_sdk_public_key()?;
 
-        let report_data = ReportData::new(tls_public_key);
+        let report_data = ReportData::new(node_public_key);
         let tee_authority = TeeAuthority::try_from(self.tee_authority)?;
         let attestation = tee_authority.generate_attestation(report_data).await?;
         let web_server = start_web_server(
@@ -366,7 +366,7 @@ impl StartCmd {
 
         // submit remote attestation
         {
-            let account_public_key = secrets.persistent_secrets.near_signer_key.verifying_key();
+            let account_public_key = secrets.persistent_secrets.node_signing_key.verifying_key();
 
             submit_remote_attestation(
                 indexer_api.txn_sender.clone(),
@@ -472,7 +472,7 @@ impl Cli {
                     &subdir,
                     desired_responder_keys_per_participant,
                 )
-                .map(|secret| secret.p2p_private_key)
+                .map(|secret| secret.node_signing_key)
             })
             .collect::<Result<Vec<_>, _>>()?;
         let configs = generate_test_p2p_configs(

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -240,8 +240,7 @@ impl SecretsConfig {
 /// from outside.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct PersistentSecrets {
-    pub p2p_private_key: SigningKey,
-    pub near_signer_key: SigningKey,
+    pub node_signing_key: SigningKey,
     pub near_responder_keys: Vec<SigningKey>,
 }
 
@@ -270,15 +269,13 @@ impl PersistentSecrets {
 
         let mut os_rng = rand::rngs::OsRng;
         let p2p_secret = SigningKey::generate(&mut os_rng);
-        let near_signer_key = SigningKey::generate(&mut os_rng);
 
         let near_responder_keys = (0..number_of_responder_keys)
             .map(|_| SigningKey::generate(&mut os_rng))
             .collect::<Vec<_>>();
 
         let secrets = PersistentSecrets {
-            p2p_private_key: p2p_secret,
-            near_signer_key,
+            node_signing_key: p2p_secret,
             near_responder_keys,
         };
 
@@ -374,8 +371,8 @@ mod tests {
         let actual_secrets = PersistentSecrets::generate_or_get_existing(temp_dir_path, 424)?;
 
         assert_eq!(
-            actual_secrets.p2p_private_key,
-            expected_secrets.p2p_private_key
+            actual_secrets.node_signing_key,
+            expected_secrets.node_signing_key
         );
         assert_eq!(
             actual_secrets.near_signer_key,

--- a/crates/node/src/coordinator.rs
+++ b/crates/node/src/coordinator.rs
@@ -268,7 +268,7 @@ where
         chain_txn_sender: TransactionSender,
         key_event_receiver: watch::Receiver<ContractKeyEventInstance>,
     ) -> anyhow::Result<MpcJobResult> {
-        let p2p_key = &secrets.persistent_secrets.p2p_private_key;
+        let p2p_key = &secrets.persistent_secrets.node_signing_key;
         let Some(mpc_config) = MpcConfig::from_participants_with_near_account_id(
             participants,
             &config_file.my_near_account_id,
@@ -359,7 +359,7 @@ where
             .participants
             .retain(|p| participants_config.participants.contains(p));
 
-        let p2p_key = &secrets.persistent_secrets.p2p_private_key;
+        let p2p_key = &secrets.persistent_secrets.node_signing_key;
         let Some(mpc_config) = MpcConfig::from_participants_with_near_account_id(
             participants_config,
             &config_file.my_near_account_id,

--- a/crates/node/src/indexer/real.rs
+++ b/crates/node/src/indexer/real.rs
@@ -46,7 +46,7 @@ pub fn spawn_real_indexer(
     home_dir: PathBuf,
     indexer_config: IndexerConfig,
     my_near_account_id: AccountId,
-    account_secret_key: SigningKey,
+    node_signing_key: SigningKey,
     respond_config: RespondConfig,
     protocol_state_sender: watch::Sender<ProtocolContractState>,
     indexer_exit_sender: oneshot::Sender<anyhow::Result<()>>,
@@ -81,7 +81,7 @@ pub fn spawn_real_indexer(
 
             let txn_sender_result = TransactionProcessorHandle::start_transaction_processor(
                 my_near_account_id_clone,
-                account_secret_key.clone(),
+                node_signing_key.clone(),
                 respond_config_clone,
                 Arc::clone(&indexer_state),
             );

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -351,7 +351,7 @@ impl IntegrationTestSetup {
             };
             let secrets = SecretsConfig {
                 persistent_secrets: PersistentSecrets {
-                    p2p_private_key: p2p_key,
+                    node_signing_key: p2p_key,
                     near_signer_key: ed25519_dalek::SigningKey::generate(&mut OsRng),
                     near_responder_keys: vec![ed25519_dalek::SigningKey::generate(&mut OsRng)],
                 },

--- a/crates/node/src/web.rs
+++ b/crates/node/src/web.rs
@@ -122,27 +122,22 @@ async fn third_party_licenses() -> Html<&'static str> {
 
 #[derive(Clone, Serialize)]
 pub struct StaticWebData {
-    pub near_signer_public_key: VerifyingKey,
-    pub near_p2p_public_key: VerifyingKey,
+    pub node_public_key: VerifyingKey,
     pub near_responder_public_keys: Vec<VerifyingKey>,
     pub tee_participant_info: Option<Attestation>,
 }
 
 struct PublicKeys {
-    near_signer_public_key: VerifyingKey,
-    near_p2p_public_key: VerifyingKey,
+    node_public_key: VerifyingKey,
     near_responder_public_keys: Vec<VerifyingKey>,
 }
 
 fn get_public_keys(secrets_config: &SecretsConfig) -> PublicKeys {
-    let near_signer_public_key = secrets_config
+    let node_verifying_key = secrets_config
         .persistent_secrets
-        .near_signer_key
+        .node_signing_key
         .verifying_key();
-    let near_p2p_public_key = secrets_config
-        .persistent_secrets
-        .p2p_private_key
-        .verifying_key();
+
     let near_responder_public_keys = secrets_config
         .persistent_secrets
         .near_responder_keys
@@ -151,8 +146,7 @@ fn get_public_keys(secrets_config: &SecretsConfig) -> PublicKeys {
         .collect();
 
     PublicKeys {
-        near_signer_public_key,
-        near_p2p_public_key,
+        node_public_key: node_verifying_key,
         near_responder_public_keys,
     }
 }
@@ -161,8 +155,7 @@ impl StaticWebData {
     pub fn new(value: &SecretsConfig, tee_participant_info: Option<Attestation>) -> Self {
         let public_keys = get_public_keys(value);
         Self {
-            near_signer_public_key: public_keys.near_signer_public_key,
-            near_p2p_public_key: public_keys.near_p2p_public_key,
+            node_public_key: public_keys.node_public_key,
             near_responder_public_keys: public_keys.near_responder_public_keys,
             tee_participant_info,
         }


### PR DESCRIPTION
Proof of concept PR to
- merge the two key pairs generated on the ndoe, TLS and Account key, into one key: https://nearone.slack.com/archives/C07UW93JVQ8/p1759043700318139
- remove`NodeId`struct and its usage as a unique identifier for attestations, and only rely on the nodes' public keys as identifiers as they are assumed to be unique: 


Remaining work:
- Pytests and integration tests will also have to be updated and simplified to not rely on `NodeId` struct.
- Pytests must be simplified to only fetch a single key from the web endpoint.