### PR TITLE
feat: import keyshares into empty keyshare storage

### DIFF
--- a/crates/contract/src/primitives/key_state.rs
+++ b/crates/contract/src/primitives/key_state.rs
@@ -11,7 +11,7 @@ use std::fmt::Display;
 /// Locally on each node, each keyshare is uniquely identified by the tuple
 /// (EpochId, DomainId, AttemptId).
 #[near(serializers=[borsh, json])]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
 pub struct EpochId(u64);
 
 impl EpochId {
@@ -33,7 +33,7 @@ impl Display for EpochId {
 }
 
 #[near(serializers=[borsh, json])]
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Hash, PartialOrd, Ord)]
 pub struct AttemptId(u64);
 
 impl AttemptId {
@@ -70,7 +70,7 @@ impl Display for AttemptId {
 ///               yielded partially valid results. This is incremented for each attempt within the
 ///               same epoch and domain.
 #[near(serializers=[borsh, json])]
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash, PartialOrd, Ord)]
 pub struct KeyEventId {
     pub epoch_id: EpochId,
     pub domain_id: DomainId,

--- a/crates/node/src/keyshare.rs
+++ b/crates/node/src/keyshare.rs
@@ -307,13 +307,13 @@ impl KeyshareStorage {
             &contract_keyset.domains,
         )?;
         if backup.len() != contract_keyset.domains.len() {
-            anyhow::bail!("Require backup keyshares to be an exact match for the contract keyset.")
+            anyhow::bail!("backup keyshares is not an exact match for the contract keyset")
         }
 
         // Ensure we import into an empty Keystore
         let permanent = self.permanent.load().await?;
         if permanent.is_some() {
-            anyhow::bail!("Require permanent keyshare storage to be empty");
+            anyhow::bail!("permanent keyshare storage isn't empty");
         }
 
         self._store_new_permanent_keyset_data_delete_temporary(

--- a/crates/node/src/keyshare.rs
+++ b/crates/node/src/keyshare.rs
@@ -110,7 +110,7 @@ impl KeyshareStorage {
         let epoch_id = key_id_to_generate.epoch_id;
         let num_permanent_keys_same_epoch = if let Some(permanent) = permanent {
             if permanent.epoch_id == epoch_id {
-                self.verify_existing_keyshares_are_prefix_of_keyset(
+                Self::verify_existing_keyshares_are_prefix_of_keyset(
                     &permanent.keyshares,
                     epoch_id,
                     already_generated_keys,
@@ -168,15 +168,8 @@ impl KeyshareStorage {
             .await
     }
 
-    /// Ensures that the given keyset is in permanent key storage, and then returns them. The order
-    /// the keys are given and returned are both in increasing order of DomainId.
-    ///
-    /// Since this is only expected to be called when we already know which attempt to use, this
-    /// function also deletes keyshares in temporary storage that are below the keyset's epoch ID.
-    /// (We could also delete attempts in the same epoch ID but this is not necessary from a
-    /// security perspective, since the same epoch ID corresponds to the same set of participants
-    /// and the threshold value.)
-    pub async fn load_keyset(&self, keyset: &Keyset) -> anyhow::Result<Vec<Keyshare>> {
+    /// Loads
+    async fn _load_prefix_from_permanent(&self, keyset: &Keyset) -> anyhow::Result<Vec<Keyshare>> {
         let permanent = self.permanent.load().await?;
         let existing_keyshares = if let Some(permanent) = permanent {
             if permanent.epoch_id == keyset.epoch_id {
@@ -187,12 +180,37 @@ impl KeyshareStorage {
         } else {
             Vec::new()
         };
-        self.verify_existing_keyshares_are_prefix_of_keyset(
+        Self::verify_existing_keyshares_are_prefix_of_keyset(
             &existing_keyshares,
             keyset.epoch_id,
             &keyset.domains,
         )?;
+        Ok(existing_keyshares)
+    }
 
+    async fn _store_new_permanent_keyset_data_delete_temporary(
+        &self,
+        epoch_id: EpochId,
+        keyshares: Vec<Keyshare>,
+    ) -> anyhow::Result<()> {
+        let new_permanent_keyshare = PermanentKeyshareData::new(epoch_id, keyshares)?;
+        self.permanent.store(&new_permanent_keyshare).await?;
+        self.temporary
+            .delete_keyshares_prior_to_epoch_id(epoch_id)
+            .await?;
+        Ok(())
+    }
+
+    /// Ensures that the given keyset is in permanent key storage, and then returns them. The order
+    /// the keys are given and returned are both in increasing order of DomainId.
+    ///
+    /// Since this is only expected to be called when we already know which attempt to use, this
+    /// function also deletes keyshares in temporary storage that are below the keyset's epoch ID.
+    /// (We could also delete attempts in the same epoch ID but this is not necessary from a
+    /// security perspective, since the same epoch ID corresponds to the same set of participants
+    /// and the threshold value.)
+    pub async fn load_keyset(&self, keyset: &Keyset) -> anyhow::Result<Vec<Keyshare>> {
+        let existing_keyshares = self._load_prefix_from_permanent(keyset).await?;
         if existing_keyshares.len() == keyset.domains.len() {
             return Ok(existing_keyshares);
         }
@@ -207,14 +225,13 @@ impl KeyshareStorage {
                 .ok_or_else(|| anyhow::anyhow!("Missing temporary keyshare {:?}", key_id))?;
             new_keyshares.push(keyshare);
         }
-        let new_permanent_keyshare = PermanentKeyshareData {
-            epoch_id: keyset.epoch_id,
-            keyshares: new_keyshares.clone(),
-        };
-        self.permanent.store(&new_permanent_keyshare).await?;
-        self.temporary
-            .delete_keyshares_prior_to_epoch_id(keyset.epoch_id)
-            .await?;
+
+        self._store_new_permanent_keyset_data_delete_temporary(
+            keyset.epoch_id,
+            new_keyshares.clone(),
+        )
+        .await?;
+
         Ok(new_keyshares)
     }
 
@@ -222,7 +239,6 @@ impl KeyshareStorage {
     /// of the expected keyset, i.e. there are no extra keyshares, and each keyshare matches the
     /// keyset entry at the same index.
     fn verify_existing_keyshares_are_prefix_of_keyset(
-        &self,
         existing_keyshares: &[Keyshare],
         epoch_id: EpochId,
         expected_keys: &[KeyForDomain],
@@ -267,25 +283,46 @@ impl KeyshareStorage {
             .with_context(|| format!("Keyshare loaded from temporary storage for {:?}", key_id))?;
         Ok(keyshare)
     }
-}
 
-#[cfg(test)]
-pub mod recovery_test_utils {
-    use crate::keyshare::permanent::PermanentKeyshareData;
-    use crate::keyshare::Keyshare;
-    use crate::keyshare::KeyshareStorage;
-
-    /// Do NOT use this for production
-    pub async fn put_keyshares(
-        keyshare_storage: &KeyshareStorage,
-        keyshares: Vec<Keyshare>,
+    /// Imports keyshares from the provided backup into permanent storages.
+    ///
+    /// # Errors
+    /// Returns an error if:
+    /// - The backup does not match the contract keyset’s epoch or domains,
+    /// - The permanent keyshare storage is not empty.
+    ///
+    /// # Returns
+    /// * `Ok(())` if the backup was successfully imported and stored permanently.
+    /// * `Err(anyhow::Error)` if any validation or storage step fails.
+    #[allow(dead_code)] // todo: remove after integration with onboarding function
+    pub async fn import_backup(
+        &mut self,
+        backup: Vec<Keyshare>,
+        contract_keyset: &Keyset,
     ) -> anyhow::Result<()> {
-        let epoch_id = keyshares.first().unwrap().key_id.epoch_id;
-        let keyshare_data = &PermanentKeyshareData {
-            epoch_id,
-            keyshares,
-        };
-        keyshare_storage.permanent.store(keyshare_data).await
+        // Ensure that the backup is a perfect match for the contract keyset
+        Self::verify_existing_keyshares_are_prefix_of_keyset(
+            &backup,
+            contract_keyset.epoch_id,
+            &contract_keyset.domains,
+        )?;
+        if backup.len() != contract_keyset.domains.len() {
+            anyhow::bail!("Require backup keyshares to be an exact match for the contract keyset.")
+        }
+
+        // Ensure we import into an empty Keystore
+        let permanent = self.permanent.load().await?;
+        if permanent.is_some() {
+            anyhow::bail!("Require permanent keyshare storage to be empty");
+        }
+
+        self._store_new_permanent_keyset_data_delete_temporary(
+            contract_keyset.epoch_id,
+            backup.clone(),
+        )
+        .await?;
+
+        Ok(())
     }
 }
 
@@ -329,11 +366,19 @@ impl KeyStorageConfig {
 
 #[cfg(test)]
 mod tests {
-    use super::KeyStorageConfig;
-    use crate::keyshare::test_utils::{generate_dummy_keyshare, KeysetBuilder};
+    use mpc_contract::primitives::{
+        domain::DomainId,
+        key_state::{AttemptId, EpochId, KeyEventId},
+    };
+    use tempfile::TempDir;
 
-    #[tokio::test]
-    async fn test_key_storage() {
+    use super::{KeyStorageConfig, KeyshareStorage};
+    use crate::keyshare::{
+        test_utils::{generate_dummy_keyshare, generate_dummy_keyshares, KeysetBuilder},
+        Keyshare,
+    };
+
+    async fn generate_key_storage() -> (KeyshareStorage, TempDir) {
         let tempdir = tempfile::tempdir().unwrap();
         let home_dir = tempdir.path().to_path_buf();
         let local_encryption_key = [3; 16];
@@ -345,6 +390,12 @@ mod tests {
         .create()
         .await
         .unwrap();
+        (storage, tempdir)
+    }
+
+    #[tokio::test]
+    async fn test_key_storage() {
+        let (storage, _tempdir) = generate_key_storage().await;
 
         let mut keyset = KeysetBuilder::new(0);
 
@@ -353,56 +404,56 @@ mod tests {
         assert!(&loaded0.is_empty());
 
         // Store some keyshares.
-        let key1 = generate_dummy_keyshare(0, 1, 1);
-        let key2 = generate_dummy_keyshare(0, 1, 2);
-        let key3 = generate_dummy_keyshare(0, 2, 1);
-        let key4 = generate_dummy_keyshare(0, 2, 2);
+        let key_1_epoch_0_non_final = generate_dummy_keyshare(0, 1, 1);
+        let (key_1_epoch_0, key_1_epoch_0_alternate) = generate_dummy_keyshares(0, 1, 2);
+        let (key_2_epoch_0, key_2_epoch_0_alternate) = generate_dummy_keyshares(0, 2, 1);
+        let key_2_epoch_0_final = generate_dummy_keyshare(0, 2, 2);
 
         {
             // Before starting the good path, let's test that start_generating_key fails if called
             // when already-generated keys don't exist.
-            let bad_keyset = KeysetBuilder::from_keyshares(0, &[key1.clone()]);
+            let bad_keyset = KeysetBuilder::from_keyshares(0, &[key_1_epoch_0_non_final.clone()]);
             assert!(storage
-                .start_generating_key(&bad_keyset.generated(), key1.key_id)
+                .start_generating_key(&bad_keyset.generated(), key_1_epoch_0_non_final.key_id)
                 .await
                 .is_err());
         }
 
         storage
-            .start_generating_key(&keyset.generated(), key1.key_id)
+            .start_generating_key(&keyset.generated(), key_1_epoch_0_non_final.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key1.clone())
+            .commit_keyshare(key_1_epoch_0_non_final.clone())
             .await
             .unwrap();
         storage
-            .start_generating_key(&keyset.generated(), key2.key_id)
+            .start_generating_key(&keyset.generated(), key_1_epoch_0.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key2.clone())
+            .commit_keyshare(key_1_epoch_0.clone())
             .await
             .unwrap();
-        keyset.add_keyshare(key2.clone());
+        keyset.add_keyshare(key_1_epoch_0.clone());
         storage
-            .start_generating_key(&keyset.generated(), key3.key_id)
+            .start_generating_key(&keyset.generated(), key_2_epoch_0.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key3.clone())
+            .commit_keyshare(key_2_epoch_0.clone())
             .await
             .unwrap();
-        keyset.add_keyshare(key3.clone());
+        keyset.add_keyshare(key_2_epoch_0.clone());
         storage
-            .start_generating_key(&keyset.generated(), key4.key_id)
+            .start_generating_key(&keyset.generated(), key_2_epoch_0_final.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key4.clone())
+            .commit_keyshare(key_2_epoch_0_final.clone())
             .await
             .unwrap();
 
         {
             // Check that we cannot start generating the same key again.
             assert!(storage
-                .start_generating_key(&keyset.generated(), key4.key_id)
+                .start_generating_key(&keyset.generated(), key_2_epoch_0_final.key_id)
                 .await
                 .is_err());
         }
@@ -412,7 +463,10 @@ mod tests {
         assert_eq!(&loaded1, &keyset.keyshares());
 
         // Load a conflicting keyset; this should fail.
-        let conflicting_keyset = KeysetBuilder::from_keyshares(0, &[key1.clone(), key4.clone()]);
+        let conflicting_keyset = KeysetBuilder::from_keyshares(
+            0,
+            &[key_1_epoch_0_non_final.clone(), key_2_epoch_0_final.clone()],
+        );
         assert!(storage
             .load_keyset(&conflicting_keyset.keyset())
             .await
@@ -423,63 +477,75 @@ mod tests {
         assert_eq!(&loaded1, &keyset.keyshares());
 
         // Store some more keyshares as part of resharing, for epoch 1.
-        let key5 = generate_dummy_keyshare(1, 1, 1);
-        let key6 = generate_dummy_keyshare(1, 1, 2);
-        let key7 = generate_dummy_keyshare(1, 2, 1);
-        let key8 = generate_dummy_keyshare(1, 2, 2);
+        let key_1_epoch_1 = Keyshare {
+            key_id: KeyEventId::new(EpochId::new(1), DomainId(1), AttemptId::new().next()),
+            data: key_1_epoch_0_alternate.data.clone(),
+        };
+        let key_1_epoch_1_invalid = generate_dummy_keyshare(1, 1, 2);
+        let key_2_epoch_1_invalid = generate_dummy_keyshare(1, 2, 1);
+        let key_2_epoch_1 = Keyshare {
+            key_id: KeyEventId::new(EpochId::new(1), DomainId(2), AttemptId::new().next().next()),
+            data: key_2_epoch_0_alternate.data.clone(),
+        };
 
         let old_keyset = keyset;
 
         {
             // Before starting the good path, let's test that start_resharing fails if called
             // when already-reshared keys don't exist.
-            let bad_keyset = KeysetBuilder::from_keyshares(1, &[key5.clone()]);
+            let bad_keyset = KeysetBuilder::from_keyshares(1, &[key_1_epoch_1.clone()]);
             assert!(storage
-                .start_resharing_key(&bad_keyset.generated(), key5.key_id)
+                .start_resharing_key(&bad_keyset.generated(), key_1_epoch_1.key_id)
                 .await
                 .is_err());
         }
 
         let mut keyset = KeysetBuilder::from_keyshares(1, &[]);
         storage
-            .start_resharing_key(&keyset.generated(), key5.key_id)
+            .start_resharing_key(&keyset.generated(), key_1_epoch_1.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key5.clone())
+            .commit_keyshare(key_1_epoch_1.clone())
+            .await
+            .unwrap();
+        keyset.add_keyshare(key_1_epoch_1.clone());
+        storage
+            .start_resharing_key(&keyset.generated(), key_1_epoch_1_invalid.key_id)
+            .await
+            .unwrap()
+            .commit_keyshare(key_1_epoch_1_invalid.clone())
             .await
             .unwrap();
         storage
-            .start_resharing_key(&keyset.generated(), key6.key_id)
+            .start_resharing_key(&keyset.generated(), key_2_epoch_1_invalid.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key6.clone())
-            .await
-            .unwrap();
-        keyset.add_keyshare(key5.clone());
-        storage
-            .start_resharing_key(&keyset.generated(), key7.key_id)
-            .await
-            .unwrap()
-            .commit_keyshare(key7.clone())
+            .commit_keyshare(key_2_epoch_1_invalid.clone())
             .await
             .unwrap();
         storage
-            .start_resharing_key(&keyset.generated(), key8.key_id)
+            .start_resharing_key(&keyset.generated(), key_2_epoch_1.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key8.clone())
+            .commit_keyshare(key_2_epoch_1.clone())
             .await
             .unwrap();
 
         {
             // Check that we cannot start resharing the same key again.
             assert!(storage
-                .start_resharing_key(&keyset.generated(), key8.key_id)
+                .start_resharing_key(&keyset.generated(), key_2_epoch_1.key_id)
                 .await
                 .is_err());
         }
 
-        keyset.add_keyshare(key8.clone());
+        {
+            // Check that finalizing an invalid key is not possible
+            let mut invalid_keyset = keyset.clone();
+            invalid_keyset.add_keyshare(key_2_epoch_1_invalid);
+            assert!(storage.load_keyset(&keyset.keyset()).await.is_err());
+        }
+        keyset.add_keyshare(key_2_epoch_1.clone());
 
         // Finalize two keys from epoch 1.
         let loaded3 = storage.load_keyset(&keyset.keyset()).await.unwrap();
@@ -489,16 +555,76 @@ mod tests {
         assert!(storage.load_keyset(&old_keyset.keyset()).await.is_err());
 
         // Add another key to the same epoch via key generation; this is fine.
-        let key9 = generate_dummy_keyshare(1, 3, 1);
+        let key_3_epoch_1 = generate_dummy_keyshare(1, 3, 1);
         storage
-            .start_generating_key(&keyset.generated(), key9.key_id)
+            .start_generating_key(&keyset.generated(), key_3_epoch_1.key_id)
             .await
             .unwrap()
-            .commit_keyshare(key9.clone())
+            .commit_keyshare(key_3_epoch_1.clone())
             .await
             .unwrap();
-        keyset.add_keyshare(key9.clone());
+        keyset.add_keyshare(key_3_epoch_1.clone());
         let loaded4 = storage.load_keyset(&keyset.keyset()).await.unwrap();
         assert_eq!(&loaded4, &keyset.keyshares());
+    }
+
+    async fn populate_permanent_keystore(
+        keyshare: Keyshare,
+        keyset: &mut KeysetBuilder,
+        storage: &KeyshareStorage,
+    ) {
+        storage
+            .start_generating_key(&keyset.generated(), keyshare.key_id)
+            .await
+            .unwrap()
+            .commit_keyshare(keyshare.clone())
+            .await
+            .unwrap();
+        keyset.add_keyshare(keyshare.clone());
+        let loaded = storage.load_keyset(&keyset.keyset()).await.unwrap();
+        assert_eq!(&loaded, &keyset.keyshares());
+    }
+
+    /// Import keyshares into an empty KeyshareStorage.
+    #[tokio::test]
+    async fn test_import_backup_success_empty() {
+        let epoch_id = 1;
+        let key_1 = generate_dummy_keyshare(epoch_id, 1, 0);
+        let key_2 = generate_dummy_keyshare(epoch_id, 2, 3);
+        let keyset = KeysetBuilder::from_keyshares(epoch_id, &[key_1, key_2]);
+
+        let (mut storage, _tempdir) = generate_key_storage().await;
+        assert!(storage
+            .import_backup(keyset.keyshares().to_vec(), &keyset.keyset())
+            .await
+            .is_ok());
+
+        let loaded = storage.load_keyset(&keyset.keyset()).await.unwrap();
+        assert_eq!(&loaded, &keyset.keyshares());
+    }
+
+    /// Fail to import keyshares into a populated KeyshareStorage.
+    #[tokio::test]
+    async fn test_import_backup_failure_populated() {
+        let epoch_id = 1;
+
+        let (mut storage, _tempdir) = generate_key_storage().await;
+        let existing_key = generate_dummy_keyshare(epoch_id, 2, 3);
+        let mut existing_keyset = KeysetBuilder::from_keyshares(epoch_id, &[]);
+        populate_permanent_keystore(existing_key, &mut existing_keyset, &storage).await;
+
+        let key_1 = generate_dummy_keyshare(epoch_id, 1, 0);
+        let keyset = KeysetBuilder::from_keyshares(epoch_id, &[key_1]);
+
+        assert!(storage
+            .import_backup(keyset.keyshares().to_vec(), &keyset.keyset())
+            .await
+            .is_err());
+
+        let loaded = storage
+            .load_keyset(&existing_keyset.keyset())
+            .await
+            .unwrap();
+        assert_eq!(&loaded, &existing_keyset.keyshares());
     }
 }

--- a/crates/node/src/keyshare/permanent.rs
+++ b/crates/node/src/keyshare/permanent.rs
@@ -132,8 +132,8 @@ impl PermanentKeyStorage {
                 );
             }
             let is_same_epoch_id = existing.epoch_id.get() == keyshare_data.epoch_id.get();
-            let same_number_of_domains = existing.keyshares.len() >= keyshare_data.keyshares.len();
-            if is_same_epoch_id && same_number_of_domains {
+            let does_not_extend_keyset = existing.keyshares.len() >= keyshare_data.keyshares.len();
+            if is_same_epoch_id && does_not_extend_keyset {
                 anyhow::bail!(
                     "Refusing to overwrite existing permanent keyshares of epoch {} with new permanent keyshares of same epoch but equal number of domains",
                     existing.epoch_id.get(),

--- a/crates/node/src/keyshare/permanent.rs
+++ b/crates/node/src/keyshare/permanent.rs
@@ -20,7 +20,8 @@ impl PermanentKeyshareData {
             keyshares: vec![Keyshare::from_legacy(legacy)],
         }
     }
-    // todo: move this to a separate crate, s.t. we are forced to use the constructor
+
+    // [todo #1217](https://github.com/near/mpc/issues/1217): Move this to a separate crate, s.t. we are forced to use the constructor
     pub fn new(epoch_id: EpochId, keyshares: Vec<Keyshare>) -> anyhow::Result<Self> {
         let is_consistent = keyshares.windows(2).all(|w| {
             w[0].key_id.epoch_id == w[1].key_id.epoch_id

--- a/crates/node/src/keyshare/permanent.rs
+++ b/crates/node/src/keyshare/permanent.rs
@@ -1,7 +1,7 @@
 use super::Keyshare;
 use anyhow::Context;
 use k256::{AffinePoint, Scalar};
-use mpc_contract::primitives::key_state::EpochId;
+use mpc_contract::primitives::key_state::{EpochId, KeyEventId};
 use serde::{Deserialize, Serialize};
 
 /// The single object we persist to permanent key storage.
@@ -19,6 +19,31 @@ impl PermanentKeyshareData {
             epoch_id: EpochId::new(legacy.epoch),
             keyshares: vec![Keyshare::from_legacy(legacy)],
         }
+    }
+    // todo: move this to a separate crate, s.t. we are forced to use the constructor
+    pub fn new(epoch_id: EpochId, keyshares: Vec<Keyshare>) -> anyhow::Result<Self> {
+        let is_consistent = keyshares.windows(2).all(|w| {
+            w[0].key_id.epoch_id == w[1].key_id.epoch_id
+                && w[0].key_id.domain_id < w[1].key_id.domain_id
+        });
+        if !is_consistent {
+            let key_ids: Vec<KeyEventId> = keyshares.iter().map(|share| share.key_id).collect();
+            anyhow::bail!("Inconsistent key ids: {:?}", key_ids);
+        }
+        let Some(first) = keyshares.first() else {
+            anyhow::bail!("Keyshares must not be empty");
+        };
+        if first.key_id.epoch_id != epoch_id {
+            anyhow::bail!(
+                "Inconsistent epoch id. Keyshares are of epoch id {}, but epoch id is  {}",
+                first.key_id.epoch_id,
+                epoch_id
+            );
+        }
+        Ok(PermanentKeyshareData {
+            epoch_id,
+            keyshares,
+        })
     }
 }
 
@@ -48,7 +73,9 @@ impl PermanentKeyStorage {
         let existing_data = ret.backend.load().await?;
         if let Some(data) = existing_data {
             if serde_json::from_slice::<PermanentKeyshareData>(&data).is_err() {
-                tracing::info!("Existing permanent keyshare data is not in the expected format, attempting to migrate...");
+                tracing::info!(
+                    "Existing permanent keyshare data is not in the expected format, attempting to migrate..."
+                );
                 let legacy_data = serde_json::from_slice::<LegacyRootKeyshareData>(&data)?;
                 let new_data = PermanentKeyshareData::from_legacy(&legacy_data);
                 ret.store_unchecked(&new_data).await?;
@@ -62,25 +89,91 @@ impl PermanentKeyStorage {
         Ok(data.map(|data| serde_json::from_slice(&data)).transpose()?)
     }
 
+    /// Attempts to store the given [`PermanentKeyshareData`] in persistent storage,
+    /// replacing existing data only if the new keyset is considered valid.
+    ///
+    /// Validation is performed against the latest stored keyset to prevent
+    /// accidental downgrades or mismatches.
+    ///
+    /// # Validation rules
+    /// The new keyset is **rejected** for any of the following reasons:
+    /// - It has a **lower epoch id** than the existing keyset.
+    /// - It does not contain keshares for existing domains and public keys.
+    /// - If has the **same epoch id** as the existing keyset, but **does not** extend the keyset.
+    ///
+    /// Only if all checks succeed will the new keyset be stored via [`store_unchecked`].
+    ///
+    /// # Errors
+    /// Returns an [`anyhow::Error`] if validation fails or if persistence fails.
+    ///
+    /// # Returns
+    /// * `Ok(())` if the keyset was successfully stored.
+    /// * `Err(anyhow::Error)` otherwise.
     pub async fn store(&self, keyshare_data: &PermanentKeyshareData) -> anyhow::Result<()> {
         let existing = self.load().await.context("Checking existing keyshare")?;
         if let Some(existing) = existing {
-            if existing.epoch_id.get() > keyshare_data.epoch_id.get() {
-                return Err(anyhow::anyhow!(
-                    "Refusing to overwrite existing permanent keyshare of epoch {} with new permanent keyshare of older epoch {}",
+            let existing_keyset_is_more_recent =
+                existing.epoch_id.get() > keyshare_data.epoch_id.get();
+            if existing_keyset_is_more_recent {
+                anyhow::bail!(
+                    "Refusing to overwrite existing permanent keyshares of epoch {} with new permanent keyshares of older epoch {}",
                     existing.epoch_id.get(),
                     keyshare_data.epoch_id.get(),
-                ));
-            } else if existing.epoch_id.get() == keyshare_data.epoch_id.get()
-                && existing.keyshares.len() >= keyshare_data.keyshares.len()
-            {
-                return Err(anyhow::anyhow!(
-                    "Refusing to overwrite existing permanent keyshare of epoch {} with new permanent keyshare of same epoch but equal or fewer domains",
+                );
+            }
+            let existing_keset_has_more_domains =
+                existing.keyshares.len() > keyshare_data.keyshares.len();
+            if existing_keset_has_more_domains {
+                anyhow::bail!(
+                    "Refusing to overwrite existing permanent keyshares for {} domains with new permanent keyshares for fewer domains {}",
+                    existing.keyshares.len(),
+                    keyshare_data.keyshares.len()
+                );
+            }
+            let is_same_epoch_id = existing.epoch_id.get() == keyshare_data.epoch_id.get();
+            let same_number_of_domains = existing.keyshares.len() >= keyshare_data.keyshares.len();
+            if is_same_epoch_id && same_number_of_domains {
+                anyhow::bail!(
+                    "Refusing to overwrite existing permanent keyshares of epoch {} with new permanent keyshares of same epoch but equal number of domains",
                     existing.epoch_id.get(),
-                ));
+                );
+            }
+            for (existing_keyshare, new_keyshare) in
+                existing.keyshares.iter().zip(&keyshare_data.keyshares)
+            {
+                let domain_ids_match =
+                    existing_keyshare.key_id.domain_id == new_keyshare.key_id.domain_id;
+                if !domain_ids_match {
+                    anyhow::bail!(
+                        "Refusing to overwrite existing permanent keyshare for domain id {:?} with new permanent keyshare for different domain id {:?}",
+                        existing_keyshare.key_id,
+                        new_keyshare.key_id
+                    );
+                }
+
+                let key_ids_match = existing_keyshare.key_id == new_keyshare.key_id;
+                if is_same_epoch_id && !key_ids_match {
+                    anyhow::bail!(
+                        "Refusing to overwrite existing permanent keyshare of key id {:?} with new permanent keyshare of different key id {:?} for the same epoch.",
+                        existing_keyshare.key_id,
+                        new_keyshare.key_id
+                    );
+                }
+
+                let public_keys_match =
+                    existing_keyshare.public_key()? == new_keyshare.public_key()?;
+                if !public_keys_match {
+                    anyhow::bail!(
+                        "Refusing to overwrite existing permanent keyshare of key id {:?} with new permanent keyshare of same domin id  {:?} but different public key.\
+                            Existing public key: {:?}, new public key: {:?}",
+                        existing_keyshare.key_id,
+                        new_keyshare.key_id,
+                        existing_keyshare.public_key(),
+                        new_keyshare.public_key()
+                    );
+                }
             }
         }
-
         self.store_unchecked(keyshare_data).await
     }
 
@@ -110,8 +203,10 @@ mod tests {
     use crate::keyshare::permanent::{
         LegacyRootKeyshareData, PermanentKeyStorage, PermanentKeyStorageBackend,
     };
-    use crate::keyshare::test_utils::{generate_dummy_keyshare, KeysetBuilder};
-    use crate::keyshare::KeyshareData;
+    use crate::keyshare::test_utils::{
+        generate_dummy_keyshare, generate_dummy_keyshares, make_key_id, KeysetBuilder,
+    };
+    use crate::keyshare::{Keyshare, KeyshareData};
     use k256::elliptic_curve::Field;
     use k256::{AffinePoint, Scalar};
     use mpc_contract::primitives::key_state::EpochId;
@@ -129,10 +224,9 @@ mod tests {
         let storage = PermanentKeyStorage::new(Box::new(backend)).await.unwrap();
         assert!(storage.load().await.unwrap().is_none());
 
-        let keys = vec![
-            generate_dummy_keyshare(1, 0, 1),
-            generate_dummy_keyshare(1, 2, 4),
-        ];
+        let (key_1, key_1_alternate) = generate_dummy_keyshares(1, 0, 1);
+        let (key_2, key_2_alternate) = generate_dummy_keyshares(1, 2, 4);
+        let keys = vec![key_1.clone(), key_2];
         let permanent_keyshare = PermanentKeyshareData {
             epoch_id: EpochId::new(1),
             keyshares: keys.clone(),
@@ -145,33 +239,43 @@ mod tests {
         // Cannot store the same permanent keyshare twice.
         assert!(storage.store(&permanent_keyshare).await.is_err());
         // Cannot store current epoch with fewer domains.
-        let keys = vec![generate_dummy_keyshare(1, 0, 1)];
+        let keys = vec![key_1];
         let permanent_keyshare = KeysetBuilder::from_keyshares(1, &keys).permanent_key_data();
         assert!(storage.store(&permanent_keyshare).await.is_err());
         // Cannot store older epoch than current.
         let keys = vec![
-            generate_dummy_keyshare(0, 0, 1),
-            generate_dummy_keyshare(0, 2, 2),
+            Keyshare {
+                key_id: make_key_id(0, 0, 1),
+                data: key_1_alternate.data.clone(),
+            },
+            Keyshare {
+                key_id: make_key_id(0, 2, 4),
+                data: key_2_alternate.data.clone(),
+            },
         ];
         let permanent_keyshare = KeysetBuilder::from_keyshares(0, &keys).permanent_key_data();
         assert!(storage.store(&permanent_keyshare).await.is_err());
 
         // Can store newer epoch than current.
         let keys = vec![
-            generate_dummy_keyshare(2, 0, 1),
-            generate_dummy_keyshare(2, 2, 2),
+            Keyshare {
+                key_id: make_key_id(2, 0, 8),
+                data: key_1_alternate.data.clone(),
+            },
+            Keyshare {
+                key_id: make_key_id(2, 2, 10),
+                data: key_2_alternate.data.clone(),
+            },
         ];
+
         let permanent_keyshare = KeysetBuilder::from_keyshares(2, &keys).permanent_key_data();
         storage.store(&permanent_keyshare).await.unwrap();
         let loaded = storage.load().await.unwrap().unwrap();
         assert_eq!(loaded, permanent_keyshare);
 
         // Can store current epoch with more domains.
-        let keys = vec![
-            generate_dummy_keyshare(2, 0, 1),
-            generate_dummy_keyshare(2, 2, 2),
-            generate_dummy_keyshare(2, 3, 5),
-        ];
+        let mut keys = keys;
+        keys.extend(vec![generate_dummy_keyshare(2, 3, 5)]);
         let permanent_keyshare = KeysetBuilder::from_keyshares(2, &keys).permanent_key_data();
         storage.store(&permanent_keyshare).await.unwrap();
         let loaded = storage.load().await.unwrap().unwrap();

--- a/crates/node/src/keyshare/test_utils.rs
+++ b/crates/node/src/keyshare/test_utils.rs
@@ -5,6 +5,47 @@ use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain, Keyset};
 use threshold_signatures::ecdsa::KeygenOutput;
 
+pub fn make_key_id(epoch_id: u64, domain_id: u64, attempt_id: u64) -> KeyEventId {
+    KeyEventId::new(
+        EpochId::new(epoch_id),
+        DomainId(domain_id),
+        serde_json::from_str(&format!("{}", attempt_id)).unwrap(),
+    )
+}
+/// returns two shares for the same key
+pub fn generate_dummy_keyshares(
+    epoch_id: u64,
+    domain_id: u64,
+    attempt_id: u64,
+) -> (Keyshare, Keyshare) {
+    let keyshares = TestGenerators::new(2, 2).make_ecdsa_keygens();
+    let mut iter = keyshares.into_iter().map(|share| {
+        let key = share.1;
+
+        Keyshare {
+            key_id: make_key_id(epoch_id, domain_id, attempt_id),
+            data: KeyshareData::Secp256k1(KeygenOutput {
+                private_share: key.private_share,
+                public_key: key.public_key,
+            }),
+        }
+    });
+    (iter.next().unwrap(), iter.next().unwrap())
+}
+
+#[test]
+pub fn test_generate_dummy_keyshares() {
+    let (keyshare, alternate_keyshare) = generate_dummy_keyshares(0, 1, 0);
+    assert_ne!(alternate_keyshare, keyshare);
+    // ensure that the keyshares are different
+    assert_ne!(alternate_keyshare.data, keyshare.data);
+    // ensure that the keyshares are for the same public key
+    assert_eq!(
+        alternate_keyshare.public_key().unwrap(),
+        keyshare.public_key().unwrap()
+    );
+}
+
 pub fn generate_dummy_keyshare(epoch_id: u64, domain_id: u64, attempt_id: u64) -> Keyshare {
     let key = TestGenerators::new(2, 2)
         .make_ecdsa_keygens()
@@ -13,11 +54,7 @@ pub fn generate_dummy_keyshare(epoch_id: u64, domain_id: u64, attempt_id: u64) -
         .unwrap()
         .1;
     Keyshare {
-        key_id: KeyEventId::new(
-            EpochId::new(epoch_id),
-            DomainId(domain_id),
-            serde_json::from_str(&format!("{}", attempt_id)).unwrap(),
-        ),
+        key_id: make_key_id(epoch_id, domain_id, attempt_id),
         data: KeyshareData::Secp256k1(KeygenOutput {
             private_share: key.private_share,
             public_key: key.public_key,
@@ -48,6 +85,7 @@ fn keyset_from_permanent_keyshare(permanent: &PermanentKeyshareData) -> Keyset {
     Keyset::new(permanent.epoch_id, keys)
 }
 
+#[derive(Clone)]
 pub struct KeysetBuilder {
     epoch_id: u64,
     keys: Vec<Keyshare>,

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -19,7 +19,6 @@ use crate::db::SecretDB;
 use crate::indexer::fake::FakeIndexerManager;
 use crate::indexer::handler::{CKDArgs, CKDRequestFromChain, SignArgs, SignatureRequestFromChain};
 use crate::indexer::IndexerAPI;
-use crate::keyshare;
 use crate::keyshare::{KeyStorageConfig, Keyshare};
 use crate::p2p::testing::{generate_test_p2p_configs, PortSeed};
 use crate::primitives::ParticipantId;
@@ -229,17 +228,6 @@ pub async fn get_keyshares(
     let key_storage_config = make_key_storage_config(home_dir, local_encryption_key);
     let keystore = key_storage_config.create().await.unwrap();
     keystore.load_keyset(keyset).await
-}
-
-pub async fn put_keyshares(
-    home_dir: PathBuf,
-    keyshares: Vec<Keyshare>,
-    local_encryption_key: [u8; 16],
-) -> anyhow::Result<()> {
-    std::fs::create_dir_all(&home_dir)?;
-    let key_storage_config = make_key_storage_config(home_dir, local_encryption_key);
-    let keystore = key_storage_config.create().await?;
-    keyshare::recovery_test_utils::put_keyshares(&keystore, keyshares).await
 }
 
 impl OneNodeTestConfig {

--- a/crates/node/src/tests/changing_participant_details.rs
+++ b/crates/node/src/tests/changing_participant_details.rs
@@ -1,11 +1,11 @@
 use crate::indexer::fake::participant_info_from_config;
 use crate::indexer::participants::ContractState;
 use crate::p2p::testing::PortSeed;
-use crate::tests::DEFAULT_BLOCK_TIME;
 use crate::tests::{
-    get_keyshares, put_keyshares, request_signature_and_await_response, IntegrationTestSetup,
+    get_keyshares, request_signature_and_await_response, IntegrationTestSetup,
     DEFAULT_MAX_PROTOCOL_WAIT_TIME,
 };
+use crate::tests::{make_key_storage_config, DEFAULT_BLOCK_TIME};
 use crate::tracking::AutoAbortTask;
 use mpc_contract::primitives::domain::{DomainConfig, DomainId, SignatureScheme};
 use mpc_contract::state::ProtocolContractState;
@@ -18,7 +18,7 @@ use near_time::Clock;
 /// After the conclusion of the key initialization and passing of a sanity check, the participant
 /// set will be forcefully changed.
 #[tokio::test]
-async fn test_changing_participant_set() {
+async fn test_changing_participant_set_test_keyshare_import() {
     init_integration_logger();
     const NUM_PARTICIPANTS: usize = 2;
     const THRESHOLD: usize = 2;
@@ -95,9 +95,12 @@ async fn test_changing_participant_set() {
         let keyshares = get_keyshares(home_dir_first, local_encryption_key_first, keyset)
             .await
             .unwrap();
-        put_keyshares(home_dir_last, keyshares, local_encryption_key_last)
-            .await
-            .unwrap();
+
+        // test keyshare import
+        std::fs::create_dir_all(&home_dir_last).unwrap();
+        let key_storage_config = make_key_storage_config(home_dir_last, local_encryption_key_last);
+        let mut keystore = key_storage_config.create().await.unwrap();
+        keystore.import_backup(keyshares, keyset).await.unwrap();
     }
 
     // finally, change the participant info. Remove the first node and insert the last node.


### PR DESCRIPTION
**Resolves #1213**

This PR includes additional improvements as outlined below (valid on their own, but pretty necessary with #1214 in mind).

**Enforce consistency of keyshares in `PermanentKeyStorage` across different epochs:**
This PR fixes a slight oversight in `PermanentKeyStorage::store()`. Until now, it was possible to have inconsistent keyshares in `PermanentKeyStorage`, e.g. to have two keyshares for the same domain (but different epoch), that have different public keys.

It was not a real issue, because we only store the keyshares to the permanent keyset when the contract enters a running or resharing state. But nonetheless, it seemed diligent to add a consistency check to the `PermanentKeyStorage`, to enforce local consistency.

**Make implicit assumptions on `PermanentKeyshareData` more explicit:**
The node assumes, in multiple places, that the keyshares are ordered with respect to the `DomainId` (c.f. examples below).

This PR adds a constructor for `PermanentKeyshareData`, which verifies that the given keyshares respect the assumption.
This should be followed-up by moving `PermanentKeyshareData` into its own crate and making its fields private.

Note that the node *assumes* the contract will generate / reshare keys in increasing order of `DomainId`. This is currently the case, but it's something worth keeping an eye on, as it might turn into a footgun.

Examples:
https://github.com/near/mpc/blob/36a940ebede06ce2e857be48ac9363c19d397d1a/crates/node/src/keyshare.rs#L172
https://github.com/near/mpc/blob/36a940ebede06ce2e857be48ac9363c19d397d1a/crates/node/src/keyshare.rs#L238-L248
https://github.com/near/mpc/blob/36a940ebede06ce2e857be48ac9363c19d397d1a/crates/node/src/keyshare.rs#L113


