### PR TITLE
feat: new dtos_contract::PublicKey type

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,7 +1216,6 @@ dependencies = [
  "dcap-qvl",
  "derive_more 2.0.1",
  "dstack-sdk-types",
- "dtos-contract",
  "hex",
  "k256",
  "mpc-primitives",
@@ -9793,6 +9792,7 @@ dependencies = [
  "dtos-contract",
  "hex",
  "mpc-primitives",
+ "near-sdk",
  "serde_json",
  "sha2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4995,7 +4995,6 @@ dependencies = [
  "borsh",
  "bs58 0.5.1",
  "clap",
- "dtos-contract",
  "ed25519-dalek",
  "flume",
  "futures",
@@ -9725,7 +9724,6 @@ dependencies = [
  "backon",
  "derive_more 2.0.1",
  "dstack-sdk",
- "dtos-contract",
  "hex",
  "http 1.3.1",
  "reqwest 0.12.23",
@@ -9795,7 +9793,6 @@ dependencies = [
  "dtos-contract",
  "hex",
  "mpc-primitives",
- "near-sdk",
  "serde_json",
  "sha2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1216,6 +1216,7 @@ dependencies = [
  "dcap-qvl",
  "derive_more 2.0.1",
  "dstack-sdk-types",
+ "dtos-contract",
  "hex",
  "k256",
  "mpc-primitives",
@@ -2884,10 +2885,13 @@ dependencies = [
 name = "dtos-contract"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "borsh",
+ "bs58 0.5.1",
  "derive_more 2.0.1",
  "schemars 0.8.22",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
@@ -4991,6 +4995,7 @@ dependencies = [
  "borsh",
  "bs58 0.5.1",
  "clap",
+ "dtos-contract",
  "ed25519-dalek",
  "flume",
  "futures",
@@ -9720,6 +9725,7 @@ dependencies = [
  "backon",
  "derive_more 2.0.1",
  "dstack-sdk",
+ "dtos-contract",
  "hex",
  "http 1.3.1",
  "reqwest 0.12.23",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2888,6 +2888,7 @@ dependencies = [
  "borsh",
  "bs58 0.5.1",
  "derive_more 2.0.1",
+ "near-sdk",
  "schemars 0.8.22",
  "serde",
  "serde_with",

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -18,7 +18,6 @@ serde_json = { workspace = true }
 sha3 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
-dtos-contract = {workspace = true}
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { workspace = true }
 sha3 = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }
+dtos-contract = {workspace = true}
 
 [dev-dependencies]
 rstest = { workspace = true }

--- a/crates/attestation/src/report_data.rs
+++ b/crates/attestation/src/report_data.rs
@@ -1,6 +1,5 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::Constructor;
-use dtos_contract::Ed25519PublicKey;
 use serde::{Deserialize, Serialize};
 use sha3::{Digest, Sha3_384};
 
@@ -35,7 +34,7 @@ impl ReportDataVersion {
 
 #[derive(Debug, Clone, Constructor)]
 pub struct ReportDataV1 {
-    tls_public_key: Ed25519PublicKey,
+    tls_public_key: near_sdk::PublicKey,
 }
 
 /// report_data_v1: [u8; 64] =
@@ -99,7 +98,7 @@ pub enum ReportData {
 }
 
 impl ReportData {
-    pub fn new(tls_public_key: Ed25519PublicKey) -> Self {
+    pub fn new(tls_public_key: near_sdk::PublicKey) -> Self {
         ReportData::V1(ReportDataV1::new(tls_public_key))
     }
 
@@ -123,7 +122,7 @@ mod tests {
     use crate::report_data::ReportData;
     use alloc::vec::Vec;
     use dcap_qvl::quote::Quote;
-    use test_utils::attestation::{p2p_tls_key, quote};
+    use test_utils::attestation::{near_p2p_tls_key, quote};
 
     #[test]
     fn test_from_str_valid() {
@@ -133,12 +132,12 @@ mod tests {
 
         let td_report = quote.report.as_td10().expect("Should be a TD 1.0 report");
 
-        let p2p_public_key = p2p_tls_key();
+        let p2p_public_key = near_p2p_tls_key();
         let report_data = ReportData::V1(ReportDataV1::new(p2p_public_key));
         assert_eq!(report_data.to_bytes(), td_report.report_data,);
     }
 
-    fn create_test_key() -> Ed25519PublicKey {
+    fn create_test_key() -> near_sdk::PublicKey {
         "ed25519:DcA2MzgpJbrUATQLLceocVckhhAqrkingax4oJ9kZ847"
             .parse()
             .unwrap()

--- a/crates/attestation/src/report_data.rs
+++ b/crates/attestation/src/report_data.rs
@@ -87,7 +87,6 @@ impl ReportDataV1 {
     /// Generates SHA3-384 hash of TLS public key only.
     fn public_keys_hash(&self) -> [u8; Self::PUBLIC_KEYS_HASH_SIZE] {
         let mut hasher = Sha3_384::new();
-        // Skip first byte as it is used for identifier for the curve type.
         let key_data = self.tls_public_key.as_bytes();
         hasher.update(key_data);
         hasher.finalize().into()
@@ -202,9 +201,6 @@ mod tests {
     }
 
     #[test]
-    // This test cannot work now because the key that was being returned from create_test_key
-    // had the wrong type
-    #[ignore]
     fn test_public_key_hash_placement() {
         let tls_key = create_test_key();
         let report_data_v1 = ReportDataV1::new(tls_key.clone());
@@ -218,8 +214,7 @@ mod tests {
         assert_ne!(hash_bytes, &[0u8; ReportDataV1::PUBLIC_KEYS_HASH_SIZE]);
 
         let mut hasher = Sha3_384::new();
-        // Skip first byte as it is used for identifier for the curve type.
-        let key_data = &tls_key.as_bytes()[1..];
+        let key_data = &tls_key.as_bytes();
         hasher.update(key_data);
         let expected: [u8; ReportDataV1::PUBLIC_KEYS_HASH_SIZE] = hasher.finalize().into();
 

--- a/crates/attestation/src/report_data.rs
+++ b/crates/attestation/src/report_data.rs
@@ -86,7 +86,8 @@ impl ReportDataV1 {
     /// Generates SHA3-384 hash of TLS public key only.
     fn public_keys_hash(&self) -> [u8; Self::PUBLIC_KEYS_HASH_SIZE] {
         let mut hasher = Sha3_384::new();
-        let key_data = self.tls_public_key.as_bytes();
+        // Skip first byte as it is used for identifier for the curve type.
+        let key_data = &self.tls_public_key.as_bytes()[1..];
         hasher.update(key_data);
         hasher.finalize().into()
     }
@@ -213,7 +214,8 @@ mod tests {
         assert_ne!(hash_bytes, &[0u8; ReportDataV1::PUBLIC_KEYS_HASH_SIZE]);
 
         let mut hasher = Sha3_384::new();
-        let key_data = &tls_key.as_bytes();
+        // Skip first byte as it is used for identifier for the curve type.
+        let key_data = &tls_key.as_bytes()[1..];
         hasher.update(key_data);
         let expected: [u8; ReportDataV1::PUBLIC_KEYS_HASH_SIZE] = hasher.finalize().into();
 

--- a/crates/attestation/tests/test_attestation_verification.rs
+++ b/crates/attestation/tests/test_attestation_verification.rs
@@ -5,7 +5,7 @@ use attestation::{
 use mpc_primitives::hash::{LauncherDockerComposeHash, MpcDockerImageHash};
 use rstest::rstest;
 use test_utils::attestation::{
-    image_digest, launcher_compose_digest, mock_dstack_attestation, p2p_tls_key,
+    image_digest, launcher_compose_digest, mock_dstack_attestation, near_p2p_tls_key,
 };
 
 #[rstest]
@@ -31,7 +31,7 @@ fn test_mock_attestation_verify(
 #[test]
 fn test_verify_method_signature() {
     let attestation = mock_dstack_attestation();
-    let tls_key = p2p_tls_key();
+    let tls_key = near_p2p_tls_key();
 
     let report_data = ReportData::V1(ReportDataV1::new(tls_key));
     let timestamp_s = 1755186041_u64;

--- a/crates/attestation/tests/test_attestation_verification.rs
+++ b/crates/attestation/tests/test_attestation_verification.rs
@@ -3,7 +3,6 @@ use attestation::{
     report_data::{ReportData, ReportDataV1},
 };
 use mpc_primitives::hash::{LauncherDockerComposeHash, MpcDockerImageHash};
-use near_sdk::PublicKey;
 use rstest::rstest;
 use test_utils::attestation::{
     image_digest, launcher_compose_digest, mock_dstack_attestation, p2p_tls_key,
@@ -32,7 +31,7 @@ fn test_mock_attestation_verify(
 #[test]
 fn test_verify_method_signature() {
     let attestation = mock_dstack_attestation();
-    let tls_key: PublicKey = p2p_tls_key();
+    let tls_key = p2p_tls_key();
 
     let report_data = ReportData::V1(ReportDataV1::new(tls_key));
     let timestamp_s = 1755186041_u64;

--- a/crates/contract/src/crypto_shared/types.rs
+++ b/crates/contract/src/crypto_shared/types.rs
@@ -296,7 +296,7 @@ pub mod ed25519_types {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use super::*;
     use rstest::rstest;
     use serde_json::json;

--- a/crates/contract/src/dto_mapping.rs
+++ b/crates/contract/src/dto_mapping.rs
@@ -316,7 +316,9 @@ impl IntoDtoType<dtos_contract::Ed25519PublicKey> for &CompressedEdwardsY {
     }
 }
 
-// These are temporary conversions to avoid breaking the contract API
+// These are temporary conversions to avoid breaking the contract API.
+// Once we complete the migration from near_sdk::PublicKey they should not be
+// needed anymore
 
 impl IntoDtoType<Result<dtos_contract::Ed25519PublicKey>> for &near_sdk::PublicKey {
     fn into_dto_type(self) -> Result<dtos_contract::Ed25519PublicKey> {

--- a/crates/contract/src/dto_mapping.rs
+++ b/crates/contract/src/dto_mapping.rs
@@ -298,7 +298,6 @@ impl IntoDtoType<dtos_contract::Secp256k1PublicKey> for &k256_types::PublicKey {
 
 // This is not yet used, but will be necessary once we complete the migration from near_sdk::PublicKey
 impl IntoContractType<Result<k256_types::PublicKey>> for dtos_contract::Secp256k1PublicKey {
-    // This is not handling errors just to keep the status quo, might be worth doing it
     fn into_contract_type(self) -> Result<k256_types::PublicKey> {
         let mut bytes = [0u8; 65];
         bytes[1..].copy_from_slice(&self.0);

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -19,7 +19,7 @@ use std::{collections::BTreeMap, time::Duration};
 
 use crate::{
     crypto_shared::{near_public_key_to_affine_point, types::CKDResponse},
-    dto_mapping::{IntoContractType, IntoDtoType},
+    dto_mapping::{IntoContractType, IntoDtoType, TryIntoDtoType},
     errors::{Error, RequestError},
     primitives::ckd::{CKDRequest, CKDRequestArgs},
     storage_keys::StorageKey,
@@ -1782,7 +1782,11 @@ mod tests {
             MockAttestation::Invalid
         };
 
-        let dto_public_key = participant_info.sign_pk.clone().into_dto_type().unwrap();
+        let dto_public_key = participant_info
+            .sign_pk
+            .clone()
+            .try_into_dto_type()
+            .unwrap();
 
         let participant_context = VMContextBuilder::new()
             .signer_account_id(account_id.clone())
@@ -2138,7 +2142,7 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type()
+                    .try_into_dto_type()
                     .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk,
@@ -2198,7 +2202,7 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type()
+                    .try_into_dto_type()
                     .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk.clone(),
@@ -2232,7 +2236,7 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type()
+                    .try_into_dto_type()
                     .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk,
@@ -2262,7 +2266,7 @@ mod tests {
                 .destination_node_info
                 .sign_pk
                 .clone()
-                .into_dto_type()
+                .try_into_dto_type()
                 .unwrap(),
             signer_account_id: non_participant_account_id.clone(),
             signer_account_pk: destination_node_info.signer_account_pk,
@@ -2287,7 +2291,7 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type()
+                    .try_into_dto_type()
                     .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk,

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1782,7 +1782,7 @@ mod tests {
             MockAttestation::Invalid
         };
 
-        let dto_public_key = participant_info.sign_pk.clone().into_dto_type();
+        let dto_public_key = participant_info.sign_pk.clone().into_dto_type().unwrap();
 
         let participant_context = VMContextBuilder::new()
             .signer_account_id(account_id.clone())
@@ -2138,7 +2138,8 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type(),
+                    .into_dto_type()
+                    .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk,
                 expected_error_kind: None,
@@ -2197,7 +2198,8 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type(),
+                    .into_dto_type()
+                    .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk.clone(),
                 expected_error_kind: Some(ErrorKind::NodeMigrationError(
@@ -2230,7 +2232,8 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type(),
+                    .into_dto_type()
+                    .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk,
                 expected_error_kind: Some(ErrorKind::NodeMigrationError(
@@ -2259,7 +2262,8 @@ mod tests {
                 .destination_node_info
                 .sign_pk
                 .clone()
-                .into_dto_type(),
+                .into_dto_type()
+                .unwrap(),
             signer_account_id: non_participant_account_id.clone(),
             signer_account_pk: destination_node_info.signer_account_pk,
             expected_error_kind: Some(ErrorKind::InvalidState(InvalidState::NotParticipant)),
@@ -2283,7 +2287,8 @@ mod tests {
                     .destination_node_info
                     .sign_pk
                     .clone()
-                    .into_dto_type(),
+                    .into_dto_type()
+                    .unwrap(),
                 signer_account_id: account_id.clone(),
                 signer_account_pk: destination_node_info.signer_account_pk,
                 expected_error_kind: Some(ErrorKind::InvalidState(

--- a/crates/contract/src/node_migrations.rs
+++ b/crates/contract/src/node_migrations.rs
@@ -1,6 +1,7 @@
 use std::collections::BTreeMap;
 
-use near_sdk::{near, store::IterableMap, AccountId, PublicKey};
+use dtos_contract::Ed25519PublicKey;
+use near_sdk::{near, store::IterableMap, AccountId};
 
 use crate::{primitives::participants::ParticipantInfo, storage_keys::StorageKey};
 
@@ -87,15 +88,15 @@ impl NodeMigrations {
 #[derive(Debug, PartialEq, PartialOrd, Clone)]
 #[near(serializers=[borsh, json])]
 pub struct BackupServiceInfo {
-    pub public_key: PublicKey,
+    pub public_key: Ed25519PublicKey,
 }
 
 #[derive(Debug, Clone, PartialEq, PartialOrd)]
 #[near(serializers=[borsh, json])]
 pub struct DestinationNodeInfo {
-    /// the public key used by the node to sign transactions to the contrat
+    /// the public key used by the node to sign transactions to the contract
     /// this key is different from the TLS key called `sign_pk` and stored in `ParticipantInfo`.
-    pub signer_account_pk: PublicKey,
+    pub signer_account_pk: near_sdk::PublicKey,
     // the participant info for the node
     pub destination_node_info: ParticipantInfo,
 }
@@ -107,13 +108,16 @@ mod tests {
 
     use crate::{
         node_migrations::{BackupServiceInfo, DestinationNodeInfo, NodeMigrations},
-        primitives::test_utils::{bogus_ed25519_near_public_key, gen_account_id, gen_participant},
+        primitives::test_utils::{
+            bogus_ed25519_near_public_key, bogus_ed25519_public_key, gen_account_id,
+            gen_participant,
+        },
     };
 
     #[test]
     fn test_set_backup_service_info() {
         let mut migrations = NodeMigrations::default();
-        let backup_service_pk = bogus_ed25519_near_public_key();
+        let backup_service_pk = bogus_ed25519_public_key();
 
         let account_id = gen_account_id();
         let info = BackupServiceInfo {
@@ -205,7 +209,7 @@ mod tests {
         let mut migrations = NodeMigrations::default();
         let (account_id, participant_info) = gen_participant(0);
         let signer_account_pk = bogus_ed25519_near_public_key();
-        let backup_service_pk = bogus_ed25519_near_public_key();
+        let backup_service_pk = bogus_ed25519_public_key();
 
         let info = BackupServiceInfo {
             public_key: backup_service_pk,

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -21,7 +21,7 @@ use std::{collections::HashSet, time::Duration};
 pub struct NodeId {
     /// Operator account
     pub account_id: AccountId,
-    /// TLS public key
+    /// TLS public key, MUST BE of type Ed25519
     pub tls_public_key: near_sdk::PublicKey,
 }
 
@@ -130,9 +130,12 @@ impl TeeState {
             return TeeQuoteStatus::Invalid;
         };
 
-        let expected_report_data = ReportData::V1(ReportDataV1::new(
-            node_id.tls_public_key.clone().into_dto_type(),
-        ));
+        let tls_public_key = match node_id.tls_public_key.clone().into_dto_type() {
+            Ok(value) => value,
+            Err(_) => return TeeQuoteStatus::Invalid,
+        };
+
+        let expected_report_data = ReportData::V1(ReportDataV1::new(tls_public_key));
         let time_stamp_seconds = Self::current_time_seconds();
 
         let quote_result = participant_attestation.verify(

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -4,14 +4,16 @@ use crate::{
     tee::proposal::{
         AllowedDockerImageHashes, AllowedMpcDockerImage, CodeHashesVotes, MpcDockerImageHash,
     },
+    IntoDtoType,
 };
 use attestation::{
     attestation::{Attestation, MockAttestation},
     report_data::{ReportData, ReportDataV1},
 };
 use borsh::{BorshDeserialize, BorshSerialize};
+use dtos_contract::Ed25519PublicKey;
 use mpc_primitives::hash::LauncherDockerComposeHash;
-use near_sdk::{env, near, store::IterableMap, AccountId, PublicKey};
+use near_sdk::{env, near, store::IterableMap, AccountId};
 use std::{collections::HashSet, time::Duration};
 
 #[near(serializers=[borsh, json])]
@@ -20,7 +22,7 @@ pub struct NodeId {
     /// Operator account
     pub account_id: AccountId,
     /// TLS public key
-    pub tls_public_key: PublicKey,
+    pub tls_public_key: near_sdk::PublicKey,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -95,7 +97,7 @@ impl TeeState {
     pub(crate) fn verify_proposed_participant_attestation(
         &mut self,
         attestation: &Attestation,
-        tls_public_key: PublicKey,
+        tls_public_key: Ed25519PublicKey,
         tee_upgrade_deadline_duration: Duration,
     ) -> TeeQuoteStatus {
         let expected_report_data = ReportData::V1(ReportDataV1::new(tls_public_key));
@@ -128,8 +130,9 @@ impl TeeState {
             return TeeQuoteStatus::Invalid;
         };
 
-        let expected_report_data =
-            ReportData::V1(ReportDataV1::new(node_id.tls_public_key.clone()));
+        let expected_report_data = ReportData::V1(ReportDataV1::new(
+            node_id.tls_public_key.clone().into_dto_type(),
+        ));
         let time_stamp_seconds = Self::current_time_seconds();
 
         let quote_result = participant_attestation.verify(

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -4,7 +4,7 @@ use crate::{
     tee::proposal::{
         AllowedDockerImageHashes, AllowedMpcDockerImage, CodeHashesVotes, MpcDockerImageHash,
     },
-    IntoDtoType,
+    IntoContractType, IntoDtoType,
 };
 use attestation::{
     attestation::{Attestation, MockAttestation},
@@ -100,7 +100,8 @@ impl TeeState {
         tls_public_key: Ed25519PublicKey,
         tee_upgrade_deadline_duration: Duration,
     ) -> TeeQuoteStatus {
-        let expected_report_data = ReportData::V1(ReportDataV1::new(tls_public_key));
+        let expected_report_data =
+            ReportData::V1(ReportDataV1::new(tls_public_key.into_contract_type()));
         let is_valid = attestation.verify(
             expected_report_data,
             Self::current_time_seconds(),
@@ -135,7 +136,8 @@ impl TeeState {
             Err(_) => return TeeQuoteStatus::Invalid,
         };
 
-        let expected_report_data = ReportData::V1(ReportDataV1::new(tls_public_key));
+        let expected_report_data =
+            ReportData::V1(ReportDataV1::new(tls_public_key.into_contract_type()));
         let time_stamp_seconds = Self::current_time_seconds();
 
         let quote_result = participant_attestation.verify(

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -4,7 +4,7 @@ use crate::{
     tee::proposal::{
         AllowedDockerImageHashes, AllowedMpcDockerImage, CodeHashesVotes, MpcDockerImageHash,
     },
-    IntoContractType, IntoDtoType,
+    IntoContractType, TryIntoDtoType,
 };
 use attestation::{
     attestation::{Attestation, MockAttestation},
@@ -131,7 +131,7 @@ impl TeeState {
             return TeeQuoteStatus::Invalid;
         };
 
-        let tls_public_key = match node_id.tls_public_key.clone().into_dto_type() {
+        let tls_public_key = match node_id.tls_public_key.clone().try_into_dto_type() {
             Ok(value) => value,
             Err(_) => return TeeQuoteStatus::Invalid,
         };

--- a/crates/contract/tests/inprocess/expired_attestation.rs
+++ b/crates/contract/tests/inprocess/expired_attestation.rs
@@ -1,4 +1,4 @@
-use dtos_contract::{Attestation, Ed25519PublicKey, MockAttestation};
+use dtos_contract::{Attestation, MockAttestation};
 use mpc_contract::{
     config::InitConfig,
     crypto_shared::types::PublicKeyExtended,
@@ -15,11 +15,10 @@ use mpc_contract::{
 };
 
 use assert_matches::assert_matches;
-use near_sdk::{
-    test_utils::VMContextBuilder, testing_env, AccountId, CurveType, NearToken, PublicKey,
-    VMContext,
-};
+use near_sdk::{test_utils::VMContextBuilder, testing_env, AccountId, NearToken, VMContext};
 use std::time::Duration;
+
+use crate::sandbox::common::IntoDtoType;
 
 const SECOND: Duration = Duration::from_secs(1);
 const NANOS_IN_SECOND: u64 = SECOND.as_nanos() as u64;
@@ -41,8 +40,11 @@ impl TestSetup {
                 vec![KeyForDomain {
                     domain_id: DomainId::default(),
                     key: PublicKeyExtended::Secp256k1 {
-                        near_public_key: PublicKey::from_parts(CurveType::SECP256K1, vec![1u8; 64])
-                            .unwrap(),
+                        near_public_key: near_sdk::PublicKey::from_parts(
+                            near_sdk::CurveType::SECP256K1,
+                            vec![1u8; 64],
+                        )
+                        .unwrap(),
                     },
                     attempt: AttemptId::new(),
                 }],
@@ -72,9 +74,8 @@ impl TestSetup {
     ) -> Result<(), mpc_contract::errors::Error> {
         let context = create_context_for_participant(&node_id.account_id);
         testing_env!(context);
-        let tls_key_bytes: [u8; 32] = node_id.tls_public_key.as_bytes()[1..].try_into().unwrap();
         self.contract
-            .submit_participant_info(attestation, Ed25519PublicKey::from(tls_key_bytes))
+            .submit_participant_info(attestation, node_id.tls_public_key.clone().into_dto_type())
     }
 
     /// Switches testing context to a given participant at a specific timestamp

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -384,7 +384,7 @@ pub fn new_ed25519() -> (dtos_contract::PublicKey, KeygenOutput) {
     let compressed_key = public_key.to_element().compress().as_bytes().to_vec();
     let mut bytes = [0u8; 32];
     bytes.copy_from_slice(&compressed_key);
-    let pk = dtos_contract::PublicKey::Ed25519(dtos_contract::Ed25519PublicKey(bytes));
+    let pk = dtos_contract::PublicKey::Ed25519(dtos_contract::Ed25519PublicKey::from(bytes));
 
     (pk, keygen_output)
 }
@@ -1109,7 +1109,6 @@ impl IntoDtoType<dtos_contract::Ed25519PublicKey> for &near_sdk::PublicKey {
 
 impl IntoContractType<near_sdk::PublicKey> for &dtos_contract::Ed25519PublicKey {
     fn into_contract_type(self) -> near_sdk::PublicKey {
-        // If the original data is correct, this will never panic
         near_sdk::PublicKey::from_parts(near_sdk::CurveType::ED25519, self.0.into()).unwrap()
     }
 }
@@ -1132,6 +1131,5 @@ impl IntoContractType<near_sdk::PublicKey> for &dtos_contract::PublicKey {
                 .unwrap()
             }
         }
-        // If the original data is correct, this will never panic
     }
 }

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -1087,7 +1087,9 @@ pub async fn vote_for_hash(
     Ok(())
 }
 
-// These are temporary conversions to avoid breaking the contract API
+// These are temporary conversions to avoid breaking the contract API.
+// Once we complete the migration from near_sdk::PublicKey they should not be
+// needed anymore
 
 pub(crate) trait IntoDtoType<DtoType> {
     fn into_dto_type(self) -> DtoType;

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use digest::{Digest, FixedOutput};
-use dtos_contract::{Attestation, MockAttestation};
+use dtos_contract::{Attestation, Ed25519PublicKey, MockAttestation};
 use ecdsa::signature::Verifier;
 use fs2::FileExt;
 use k256::{
@@ -36,7 +36,7 @@ use mpc_contract::{
     crypto_shared::k256_types::SerializableAffinePoint,
     primitives::signature::{Payload, SignRequestArgs},
 };
-use near_sdk::{log, CurveType, Gas, PublicKey};
+use near_sdk::{log, Gas};
 use near_workspaces::{
     network::Sandbox,
     operations::TransactionStatus,
@@ -241,7 +241,7 @@ pub async fn init() -> (Worker<Sandbox>, Contract) {
 
 /// Initializes the contract with `pks` as public keys, a set of participants and a threshold.
 pub async fn init_with_candidates(
-    pks: Vec<near_sdk::PublicKey>,
+    pks: Vec<dtos_contract::PublicKey>,
 ) -> (Worker<Sandbox>, Contract, Vec<Account>) {
     let (worker, contract) = init().await;
     let (accounts, participants) = gen_accounts(&worker, PARTICIPANT_LEN).await;
@@ -256,11 +256,11 @@ pub async fn init_with_candidates(
             .enumerate()
             .map(|(i, pk)| {
                 let domain_id = DomainId((i as u64) * 2);
-                let scheme = match pk.curve_type() {
-                    CurveType::ED25519 => SignatureScheme::Ed25519,
-                    CurveType::SECP256K1 => SignatureScheme::Secp256k1,
+                let scheme = match pk {
+                    dtos_contract::PublicKey::Ed25519(_) => SignatureScheme::Ed25519,
+                    dtos_contract::PublicKey::Secp256k1(_) => SignatureScheme::Secp256k1,
                 };
-                let key = pk.try_into().unwrap();
+                let key = pk.into_contract_type().try_into().unwrap();
 
                 (
                     DomainConfig {
@@ -302,7 +302,7 @@ pub async fn init_with_candidates(
             account,
             &contract,
             &Attestation::Mock(MockAttestation::Valid),
-            &participant.sign_pk,
+            &participant.sign_pk.into_dto_type(),
         )
         .await;
 
@@ -323,15 +323,17 @@ pub enum SharedSecretKey {
 }
 
 pub fn new_secp256k1() -> (
-    near_sdk::PublicKey,
+    dtos_contract::PublicKey,
     k256::elliptic_curve::SecretKey<k256::Secp256k1>,
 ) {
     let secret_key = k256::SecretKey::random(&mut rand::thread_rng());
     let public_key = secret_key.public_key();
 
-    let compressed_key = public_key.as_affine().to_encoded_point(false).as_bytes()[1..65].to_vec();
-
-    let public_key = near_sdk::PublicKey::from_parts(CurveType::SECP256K1, compressed_key).unwrap();
+    let compressed_key = public_key.as_affine().to_encoded_point(false);
+    let mut bytes = [0u8; 64];
+    bytes.copy_from_slice(&compressed_key.as_bytes()[1..]);
+    let public_key =
+        dtos_contract::PublicKey::Secp256k1(dtos_contract::Secp256k1PublicKey::from(bytes));
 
     (public_key, secret_key)
 }
@@ -355,7 +357,7 @@ pub async fn init_env_secp256k1(
 
 pub fn make_key_for_domain(
     domain_scheme: SignatureScheme,
-) -> (near_sdk::PublicKey, SharedSecretKey) {
+) -> (dtos_contract::PublicKey, SharedSecretKey) {
     match domain_scheme {
         SignatureScheme::Secp256k1 | SignatureScheme::CkdSecp256k1 => {
             let (pk, sk) = new_secp256k1();
@@ -368,7 +370,7 @@ pub fn make_key_for_domain(
     }
 }
 
-pub fn new_ed25519() -> (near_sdk::PublicKey, KeygenOutput) {
+pub fn new_ed25519() -> (dtos_contract::PublicKey, KeygenOutput) {
     let scalar = curve25519_dalek::Scalar::random(&mut OsRng);
     let private_share = SigningShare::new(scalar);
     let public_key_element = Ed25519Group::generator() * scalar;
@@ -380,7 +382,9 @@ pub fn new_ed25519() -> (near_sdk::PublicKey, KeygenOutput) {
     };
 
     let compressed_key = public_key.to_element().compress().as_bytes().to_vec();
-    let pk = near_sdk::PublicKey::from_parts(CurveType::ED25519, compressed_key).unwrap();
+    let mut bytes = [0u8; 32];
+    bytes.copy_from_slice(&compressed_key);
+    let pk = dtos_contract::PublicKey::Ed25519(dtos_contract::Ed25519PublicKey(bytes));
 
     (pk, keygen_output)
 }
@@ -601,7 +605,7 @@ pub async fn sign_and_validate(
     Ok(())
 }
 
-pub fn example_secp256k1_point() -> PublicKey {
+pub fn example_secp256k1_point() -> near_sdk::PublicKey {
     "secp256k1:4Ls3DBDeFDaf5zs2hxTBnJpKnfsnjNahpKU9HwQvij8fTXoCP9y5JQqQpe273WgrKhVVj1EH73t5mMJKDFMsxoEd".parse().unwrap()
 }
 
@@ -807,13 +811,11 @@ pub async fn submit_participant_info(
     account: &Account,
     contract: &Contract,
     attestation: &Attestation,
-    tls_key: &PublicKey,
+    tls_key: &Ed25519PublicKey,
 ) -> anyhow::Result<bool> {
-    let dto_tls_key_bytes: [u8; 32] = tls_key.as_bytes()[1..].try_into().unwrap();
-
     let result = account
         .call(contract.id(), "submit_participant_info")
-        .args_json((attestation, dto_tls_key_bytes))
+        .args_json((attestation, tls_key.as_bytes()))
         .max_gas()
         .transact()
         .await?;
@@ -822,15 +824,13 @@ pub async fn submit_participant_info(
 
 pub async fn get_participant_attestation(
     contract: &Contract,
-    tls_key: &PublicKey,
+    tls_key: &Ed25519PublicKey,
 ) -> anyhow::Result<Option<Attestation>> {
-    let dto_tls_key_bytes: [u8; 32] = tls_key.as_bytes()[1..].try_into().unwrap();
-
     let result = contract
         .as_account()
         .call(contract.id(), "get_attestation")
         .args_json(json!({
-            "tls_public_key": dto_tls_key_bytes
+            "tls_public_key": tls_key.as_bytes()
         }))
         .max_gas()
         .transact()
@@ -862,9 +862,13 @@ pub async fn submit_tee_attestations(
     for (account, node_id) in env_accounts.iter().zip(node_ids) {
         assert_eq!(*account.id(), node_id.account_id, "AccountId mismatch");
         let attestation = Attestation::Mock(MockAttestation::Valid); // todo #1109, add TLS key.
-        let result =
-            submit_participant_info(account, contract, &attestation, &node_id.tls_public_key)
-                .await?;
+        let result = submit_participant_info(
+            account,
+            contract,
+            &attestation,
+            &node_id.tls_public_key.into_dto_type(),
+        )
+        .await?;
         assert!(result);
     }
     Ok(())
@@ -946,7 +950,7 @@ pub async fn call_contract_key_generation<const N: usize>(
                 "domain_id": domain.id,
                 "attempt_id": 0,
             },
-            "public_key": public_key,
+            "public_key": public_key.into_contract_type(),
         });
 
         for account in accounts {
@@ -1081,4 +1085,53 @@ pub async fn vote_for_hash(
             .await?,
     );
     Ok(())
+}
+
+// These are temporary conversions to avoid breaking the contract API
+
+pub(crate) trait IntoDtoType<DtoType> {
+    fn into_dto_type(self) -> DtoType;
+}
+
+pub(crate) trait IntoContractType<ContractType> {
+    fn into_contract_type(self) -> ContractType;
+}
+
+impl IntoDtoType<dtos_contract::Ed25519PublicKey> for &near_sdk::PublicKey {
+    fn into_dto_type(self) -> dtos_contract::Ed25519PublicKey {
+        // This function should not be called with any other type
+        assert!(self.curve_type() == near_sdk::CurveType::ED25519);
+        let mut bytes = [0u8; 32];
+        bytes.copy_from_slice(&self.as_bytes()[1..]);
+        dtos_contract::Ed25519PublicKey::from(bytes)
+    }
+}
+
+impl IntoContractType<near_sdk::PublicKey> for &dtos_contract::Ed25519PublicKey {
+    fn into_contract_type(self) -> near_sdk::PublicKey {
+        // If the original data is correct, this will never panic
+        near_sdk::PublicKey::from_parts(near_sdk::CurveType::ED25519, self.0.into()).unwrap()
+    }
+}
+
+impl IntoContractType<near_sdk::PublicKey> for &dtos_contract::PublicKey {
+    fn into_contract_type(self) -> near_sdk::PublicKey {
+        match self {
+            dtos_contract::PublicKey::Secp256k1(secp256k1_public_key) => {
+                near_sdk::PublicKey::from_parts(
+                    near_sdk::CurveType::SECP256K1,
+                    secp256k1_public_key.as_bytes().to_vec(),
+                )
+                .unwrap()
+            }
+            dtos_contract::PublicKey::Ed25519(ed25519_public_key) => {
+                near_sdk::PublicKey::from_parts(
+                    near_sdk::CurveType::ED25519,
+                    ed25519_public_key.as_bytes().to_vec(),
+                )
+                .unwrap()
+            }
+        }
+        // If the original data is correct, this will never panic
+    }
 }

--- a/crates/contract/tests/sandbox/integration_tee_cleanup_after_resharing.rs
+++ b/crates/contract/tests/sandbox/integration_tee_cleanup_after_resharing.rs
@@ -6,7 +6,7 @@ use serde_json::json;
 use crate::sandbox::common::{
     assert_running_return_participants, check_call_success, check_call_success_all_receipts,
     gen_accounts, get_tee_accounts, init_env_secp256k1, submit_participant_info,
-    submit_tee_attestations,
+    submit_tee_attestations, IntoDtoType,
 };
 use mpc_contract::{
     primitives::{
@@ -64,7 +64,7 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
         &env_accounts[0],
         &contract,
         &attestation,
-        &new_uid.tls_public_key,
+        &new_uid.tls_public_key.into_dto_type(),
     )
     .await?;
 

--- a/crates/contract/tests/sandbox/vote.rs
+++ b/crates/contract/tests/sandbox/vote.rs
@@ -1,5 +1,5 @@
 use crate::sandbox::common::{
-    check_call_success, gen_accounts, init_env_secp256k1, submit_participant_info,
+    check_call_success, gen_accounts, init_env_secp256k1, submit_participant_info, IntoDtoType,
     GAS_FOR_VOTE_RESHARED,
 };
 use assert_matches::assert_matches;
@@ -165,7 +165,7 @@ async fn test_resharing() -> anyhow::Result<()> {
         new_account,
         &contract,
         &dtos_contract::Attestation::Mock(dtos_contract::MockAttestation::Valid),
-        &new_p.2.sign_pk,
+        &new_p.2.sign_pk.into_dto_type(),
     )
     .await
     .expect("Attestation submission for new account must succeed.");
@@ -263,7 +263,7 @@ async fn test_repropose_resharing() -> anyhow::Result<()> {
         new_account,
         &contract,
         &dtos_contract::Attestation::Mock(dtos_contract::MockAttestation::Valid),
-        &new_p.2.sign_pk,
+        &new_p.2.sign_pk.into_dto_type(),
     )
     .await
     .expect("Attestation submission for new account must succeed.");
@@ -360,7 +360,7 @@ async fn setup_resharing_state() -> ResharingTestContext {
         &new_account,
         &contract,
         &dtos_contract::Attestation::Mock(dtos_contract::MockAttestation::Valid),
-        &new_participant_info.sign_pk,
+        &new_participant_info.sign_pk.into_dto_type(),
     )
     .await
     .expect("Attestation submission for new account must succeed.");

--- a/crates/devnet/Cargo.toml
+++ b/crates/devnet/Cargo.toml
@@ -24,7 +24,6 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 near-sdk = { workspace = true }
-dtos-contract = {workspace = true}
 
 # TODO: #657 use workspace versions.
 # https://github.com/near/mpc/issues/657 

--- a/crates/devnet/Cargo.toml
+++ b/crates/devnet/Cargo.toml
@@ -24,6 +24,7 @@ serde_yaml = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 near-sdk = { workspace = true }
+dtos-contract = {workspace = true}
 
 # TODO: #657 use workspace versions.
 # https://github.com/near/mpc/issues/657 

--- a/crates/dtos_contract/Cargo.toml
+++ b/crates/dtos_contract/Cargo.toml
@@ -7,6 +7,9 @@ edition = "2024"
 borsh = { workspace = true }
 derive_more = { workspace = true }
 serde = { workspace = true }
+serde_with = { workspace = true }
+bs58 = { workspace = true }
+anyhow = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { workspace = true, optional = true }

--- a/crates/dtos_contract/Cargo.toml
+++ b/crates/dtos_contract/Cargo.toml
@@ -4,15 +4,17 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+anyhow = { workspace = true }
 borsh = { workspace = true }
+bs58 = { workspace = true, optional = true }
 derive_more = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
-bs58 = { workspace = true }
-anyhow = { workspace = true }
+
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { workspace = true, optional = true }
 
 [features]
 abi = ["schemars"]
+test-utils = ["bs58"]

--- a/crates/dtos_contract/Cargo.toml
+++ b/crates/dtos_contract/Cargo.toml
@@ -11,6 +11,8 @@ derive_more = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 
+[dev-dependencies]
+near-sdk = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { workspace = true, optional = true }

--- a/crates/dtos_contract/src/crypto.rs
+++ b/crates/dtos_contract/src/crypto.rs
@@ -80,8 +80,8 @@ impl schemars::JsonSchema for Secp256k1PublicKey {
         schemars::schema::SchemaObject {
             instance_type: Some(schemars::schema::InstanceType::Array.into()),
             array: Some(Box::new(schemars::schema::ArrayValidation {
-                min_items: Some(SECP256K1_PUBLIC_KEY_SIZE),
-                max_items: Some(SECP256K1_PUBLIC_KEY_SIZE),
+                min_items: Some(SECP256K1_PUBLIC_KEY_SIZE as u32),
+                max_items: Some(SECP256K1_PUBLIC_KEY_SIZE as u32),
                 items: Some(generator.subschema_for::<u8>().into()),
                 ..Default::default()
             })),

--- a/crates/dtos_contract/src/crypto.rs
+++ b/crates/dtos_contract/src/crypto.rs
@@ -117,6 +117,9 @@ impl AsRef<[u8]> for Secp256k1PublicKey {
     }
 }
 
+// These conversions are only used in tests
+
+#[cfg(feature = "test-utils")]
 impl std::str::FromStr for PublicKey {
     type Err = anyhow::Error;
 
@@ -134,6 +137,7 @@ impl std::str::FromStr for PublicKey {
     }
 }
 
+#[cfg(feature = "test-utils")]
 impl std::str::FromStr for Secp256k1PublicKey {
     type Err = anyhow::Error;
 
@@ -156,6 +160,7 @@ impl std::str::FromStr for Secp256k1PublicKey {
     }
 }
 
+#[cfg(feature = "test-utils")]
 impl std::str::FromStr for Ed25519PublicKey {
     type Err = anyhow::Error;
 

--- a/crates/dtos_contract/src/crypto.rs
+++ b/crates/dtos_contract/src/crypto.rs
@@ -25,6 +25,7 @@ use serde_with::serde_as;
 pub enum PublicKey {
     Secp256k1(Secp256k1PublicKey),
     Ed25519(Ed25519PublicKey),
+    // TODO(#1212): Add BLS types
 }
 
 #[derive(

--- a/crates/dtos_contract/src/crypto.rs
+++ b/crates/dtos_contract/src/crypto.rs
@@ -67,23 +67,17 @@ pub struct Ed25519PublicKey(pub [u8; 32]);
 pub struct Secp256k1PublicKey(#[serde_as(as = "[_; 64]")] pub [u8; 64]);
 
 #[cfg(all(feature = "abi", not(target_arch = "wasm32")))]
-use schemars::{
-    JsonSchema,
-    schema::{ArrayValidation, InstanceType, Schema, SchemaObject},
-};
-
-// This should be done better
-#[cfg(all(feature = "abi", not(target_arch = "wasm32")))]
-impl JsonSchema for Secp256k1PublicKey {
+impl schemars::JsonSchema for Secp256k1PublicKey {
     fn schema_name() -> String {
         "Secp256k1PublicKey".into()
     }
 
-    fn json_schema(generator: &mut schemars::SchemaGenerator) -> Schema {
-        SchemaObject {
-            instance_type: Some(InstanceType::Array.into()),
-            array: Some(Box::new(ArrayValidation {
-                unique_items: Some(true),
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::schema::Schema {
+        schemars::schema::SchemaObject {
+            instance_type: Some(schemars::schema::InstanceType::Array.into()),
+            array: Some(Box::new(schemars::schema::ArrayValidation {
+                min_items: Some(64),
+                max_items: Some(64),
                 items: Some(generator.subschema_for::<u8>().into()),
                 ..Default::default()
             })),

--- a/crates/dtos_contract/src/crypto.rs
+++ b/crates/dtos_contract/src/crypto.rs
@@ -1,14 +1,75 @@
+use borsh::BorshDeserialize;
+use borsh::BorshSerialize;
 use derive_more::{Deref, From};
 use serde::{Deserialize, Serialize};
+use serde_with::Bytes;
+use serde_with::serde_as;
 
 #[derive(
-    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Deref, From, Serialize, Deserialize,
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    From,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema)
+)]
+pub enum PublicKey {
+    Secp256k1(Secp256k1PublicKey),
+    Ed25519(Ed25519PublicKey),
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Deref,
+    From,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
 pub struct Ed25519PublicKey(pub [u8; 32]);
+
+#[serde_as]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Deref,
+    From,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema)
+)]
+pub struct Secp256k1PublicKey(#[serde_as(as = "Bytes")] pub [u8; 64]);
 
 impl Ed25519PublicKey {
     pub fn as_bytes(&self) -> &[u8; 32] {
@@ -19,5 +80,78 @@ impl Ed25519PublicKey {
 impl AsRef<[u8]> for Ed25519PublicKey {
     fn as_ref(&self) -> &[u8] {
         &self.0
+    }
+}
+
+impl Secp256k1PublicKey {
+    pub fn as_bytes(&self) -> &[u8; 64] {
+        &self.0
+    }
+}
+
+impl AsRef<[u8]> for Secp256k1PublicKey {
+    fn as_ref(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl std::str::FromStr for PublicKey {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if let Some(idx) = value.find(':') {
+            let (prefix, _) = value.split_at(idx);
+            match prefix {
+                "ed25519" => Ok(Self::Ed25519(Ed25519PublicKey::from_str(value)?)),
+                "secp256k1" => Ok(Self::Secp256k1(Secp256k1PublicKey::from_str(value)?)),
+                _ => anyhow::bail!("Unknown prefix"),
+            }
+        } else {
+            anyhow::bail!("Separator not found")
+        }
+    }
+}
+
+impl std::str::FromStr for Secp256k1PublicKey {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut bytes = [0u8; 64];
+        if let Some(idx) = value.find(':') {
+            let (prefix, key_data) = value.split_at(idx);
+            match prefix {
+                "secp256k1" => {
+                    let data = bs58::decode(&key_data[1..]).into_vec()?;
+                    anyhow::ensure!(data.len() == 64);
+                    bytes.copy_from_slice(&data);
+                    Ok(Self(bytes))
+                }
+                _ => anyhow::bail!("Unknown prefix"),
+            }
+        } else {
+            anyhow::bail!("Separator not found")
+        }
+    }
+}
+
+impl std::str::FromStr for Ed25519PublicKey {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let mut bytes = [0u8; 32];
+        if let Some(idx) = value.find(':') {
+            let (prefix, key_data) = value.split_at(idx);
+            match prefix {
+                "ed25519" => {
+                    let data = bs58::decode(&key_data[1..]).into_vec()?;
+                    anyhow::ensure!(data.len() == 32);
+                    bytes.copy_from_slice(&data);
+                    Ok(Self(bytes))
+                }
+                _ => anyhow::bail!("Unknown prefix"),
+            }
+        } else {
+            anyhow::bail!("Separator not found")
+        }
     }
 }

--- a/crates/dtos_contract/src/lib.rs
+++ b/crates/dtos_contract/src/lib.rs
@@ -4,4 +4,5 @@ mod crypto;
 pub use attestation::{
     AppCompose, Attestation, Collateral, DstackAttestation, EventLog, MockAttestation, TcbInfo,
 };
-pub use crypto::Ed25519PublicKey;
+
+pub use crypto::{Ed25519PublicKey, PublicKey, Secp256k1PublicKey};

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::config::{CKDConfig, PersistentSecrets, RespondConfig};
 use crate::indexer::tx_sender::TransactionSender;
-use crate::providers::PublicKeyConversion;
+use crate::trait_extensions::convert_to_contract_dto::IntoDtoType;
 use crate::web::{DebugRequest, StaticWebData};
 use crate::{
     config::{
@@ -241,7 +241,7 @@ impl StartCmd {
         // Generate attestation
         let tee_authority = TeeAuthority::try_from(self.tee_authority.clone())?;
         let tls_public_key = &secrets.persistent_secrets.p2p_private_key.verifying_key();
-        let report_data = ReportData::new(tls_public_key.clone().to_near_sdk_public_key()?);
+        let report_data = ReportData::new(tls_public_key.into_dto_type());
         let attestation = tee_authority.generate_attestation(report_data).await?;
 
         // Create communication channels and runtime

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -1,6 +1,6 @@
 use crate::config::{CKDConfig, PersistentSecrets, RespondConfig};
 use crate::indexer::tx_sender::TransactionSender;
-use crate::trait_extensions::convert_to_contract_dto::IntoDtoType;
+use crate::providers::PublicKeyConversion;
 use crate::web::{DebugRequest, StaticWebData};
 use crate::{
     config::{
@@ -241,7 +241,7 @@ impl StartCmd {
         // Generate attestation
         let tee_authority = TeeAuthority::try_from(self.tee_authority.clone())?;
         let tls_public_key = &secrets.persistent_secrets.p2p_private_key.verifying_key();
-        let report_data = ReportData::new(tls_public_key.into_dto_type());
+        let report_data = ReportData::new(tls_public_key.to_near_sdk_public_key()?);
         let attestation = tee_authority.generate_attestation(report_data).await?;
 
         // Create communication channels and runtime

--- a/crates/node/src/indexer/types.rs
+++ b/crates/node/src/indexer/types.rs
@@ -11,7 +11,6 @@ use mpc_contract::{
 };
 use near_indexer_primitives::types::Gas;
 use near_sdk::AccountId;
-use near_sdk::PublicKey;
 use serde::{Deserialize, Serialize};
 use threshold_signatures::ecdsa::Signature;
 use threshold_signatures::frost_ed25519;
@@ -141,7 +140,7 @@ pub struct GetAttestationArgs {
 #[derive(Serialize, Debug)]
 pub struct ChainVotePkArgs {
     pub key_event_id: KeyEventId,
-    pub public_key: PublicKey,
+    pub public_key: near_sdk::PublicKey,
 }
 
 #[derive(Serialize, Debug)]

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -247,8 +247,13 @@ async fn resharing_computation_inner(
             .await?;
             KeyshareData::CkdSecp256k1(res)
         }
-        // Note that once we add the BLS type to dtos_contract::PublicKey this might not be needed
-        _ => unreachable!(),
+        (public_key, scheme) => {
+            return Err(anyhow::anyhow!(
+                "Unexpected pair of ({:?}, {:?})",
+                public_key,
+                scheme
+            ));
+        }
     };
     tracing::info!("Key resharing attempt {:?}: committing keyshare.", key_id);
     keyshare_handle

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -247,6 +247,7 @@ async fn resharing_computation_inner(
             .await?;
             KeyshareData::CkdSecp256k1(res)
         }
+        // Note that once we add the BLS type to dtos_contract::PublicKey this might not be needed
         _ => unreachable!(),
     };
     tracing::info!("Key resharing attempt {:?}: committing keyshare.", key_id);

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -7,9 +7,9 @@ use crate::network::MeshNetworkClient;
 use crate::providers::eddsa::{EddsaSignatureProvider, EddsaTaskId};
 use crate::providers::EcdsaTaskId;
 use crate::tracking::AutoAbortTaskCollection;
-use crate::trait_extensions::convert_to_contract_dto::IntoContractType;
-use crate::trait_extensions::convert_to_contract_dto::IntoDtoType;
-use crate::trait_extensions::convert_to_contract_dto::IntoNodeType;
+use crate::trait_extensions::convert_to_contract_dto::{
+    IntoContractType, IntoDtoType, IntoNodeType,
+};
 use crate::{
     config::ParticipantsConfig,
     indexer::{

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -5,8 +5,11 @@ use crate::indexer::types::{
 };
 use crate::network::MeshNetworkClient;
 use crate::providers::eddsa::{EddsaSignatureProvider, EddsaTaskId};
-use crate::providers::{EcdsaTaskId, PublicKeyConversion};
+use crate::providers::EcdsaTaskId;
 use crate::tracking::AutoAbortTaskCollection;
+use crate::trait_extensions::convert_to_contract_dto::IntoContractType;
+use crate::trait_extensions::convert_to_contract_dto::IntoDtoType;
+use crate::trait_extensions::convert_to_contract_dto::IntoNodeType;
 use crate::{
     config::ParticipantsConfig,
     indexer::{
@@ -21,7 +24,7 @@ use mpc_contract::primitives::domain::{DomainConfig, SignatureScheme};
 use mpc_contract::primitives::key_state::{KeyEventId, KeyForDomain, Keyset};
 use std::sync::Arc;
 use std::time::Duration;
-use threshold_signatures::{frost_ed25519, frost_secp256k1};
+use threshold_signatures::frost_ed25519;
 use tokio::sync::{mpsc, watch};
 use tokio::time::timeout;
 use tracing::{error, info};
@@ -54,19 +57,19 @@ pub async fn keygen_computation_inner(
         SignatureScheme::Secp256k1 => {
             let keyshare =
                 EcdsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
-            let public_key = keyshare.public_key.to_near_sdk_public_key()?;
+            let public_key = keyshare.public_key.into_dto_type();
             (KeyshareData::Secp256k1(keyshare), public_key)
         }
         SignatureScheme::Ed25519 => {
             let keyshare =
                 EddsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
-            let public_key = keyshare.public_key.to_near_sdk_public_key()?;
+            let public_key = keyshare.public_key.into_dto_type();
             (KeyshareData::Ed25519(keyshare), public_key)
         }
         SignatureScheme::CkdSecp256k1 => {
             let keyshare =
                 EcdsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
-            let public_key = keyshare.public_key.to_near_sdk_public_key()?;
+            let public_key = keyshare.public_key.into_dto_type();
             (KeyshareData::CkdSecp256k1(keyshare), public_key)
         }
     };
@@ -85,7 +88,7 @@ pub async fn keygen_computation_inner(
     chain_txn_sender
         .send(ChainSendTransactionRequest::VotePk(ChainVotePkArgs {
             key_event_id: key_id,
-            public_key,
+            public_key: public_key.into_contract_type(),
         }))
         .await?;
     Ok(())
@@ -185,12 +188,11 @@ async fn resharing_computation_inner(
         .public_key(key_id.domain_id)
         .map_err(|_| anyhow::anyhow!("Previous keyset does not contain key for {:?}", key_id))?;
 
-    let near_public_key = previous_public_key.as_ref();
+    let public_key = near_sdk::PublicKey::from(previous_public_key.clone()).into_dto_type();
 
-    let keyshare_data = match domain.scheme {
-        SignatureScheme::Secp256k1 => {
-            let public_key =
-                frost_secp256k1::VerifyingKey::from_near_sdk_public_key(near_public_key)?;
+    let keyshare_data = match (public_key, domain.scheme) {
+        (dtos_contract::PublicKey::Secp256k1(inner_public_key), SignatureScheme::Secp256k1) => {
+            let public_key = inner_public_key.into_node_type()?;
             let my_share = existing_keyshare
                 .map(|keyshare| match keyshare.data {
                     KeyshareData::Secp256k1(data) => Ok(data.private_share),
@@ -207,9 +209,10 @@ async fn resharing_computation_inner(
             .await?;
             KeyshareData::Secp256k1(res)
         }
-        SignatureScheme::Ed25519 => {
-            let public_key =
-                frost_ed25519::VerifyingKey::from_near_sdk_public_key(near_public_key)?;
+        (dtos_contract::PublicKey::Ed25519(inner_public_key), SignatureScheme::Ed25519) => {
+            let public_key: Result<frost_ed25519::VerifyingKey, _> =
+                inner_public_key.into_node_type();
+            let public_key = public_key?;
             let my_share = existing_keyshare
                 .map(|keyshare| match keyshare.data {
                     KeyshareData::Ed25519(data) => Ok(data.private_share),
@@ -226,9 +229,8 @@ async fn resharing_computation_inner(
             .await?;
             KeyshareData::Ed25519(res)
         }
-        SignatureScheme::CkdSecp256k1 => {
-            let public_key =
-                frost_secp256k1::VerifyingKey::from_near_sdk_public_key(near_public_key)?;
+        (dtos_contract::PublicKey::Secp256k1(inner_public_key), SignatureScheme::CkdSecp256k1) => {
+            let public_key = inner_public_key.into_node_type()?;
             let my_share = existing_keyshare
                 .map(|keyshare| match keyshare.data {
                     KeyshareData::CkdSecp256k1(data) => Ok(data.private_share),
@@ -245,6 +247,7 @@ async fn resharing_computation_inner(
             .await?;
             KeyshareData::CkdSecp256k1(res)
         }
+        _ => unreachable!(),
     };
     tracing::info!("Key resharing attempt {:?}: committing keyshare.", key_id);
     keyshare_handle

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -8,7 +8,7 @@ use crate::providers::eddsa::{EddsaSignatureProvider, EddsaTaskId};
 use crate::providers::EcdsaTaskId;
 use crate::tracking::AutoAbortTaskCollection;
 use crate::trait_extensions::convert_to_contract_dto::{
-    IntoContractType, IntoDtoType, IntoNodeType,
+    IntoContractType, IntoDtoType, TryIntoNodeType,
 };
 use crate::{
     config::ParticipantsConfig,
@@ -192,7 +192,7 @@ async fn resharing_computation_inner(
 
     let keyshare_data = match (public_key, domain.scheme) {
         (dtos_contract::PublicKey::Secp256k1(inner_public_key), SignatureScheme::Secp256k1) => {
-            let public_key = inner_public_key.into_node_type()?;
+            let public_key = inner_public_key.try_into_node_type()?;
             let my_share = existing_keyshare
                 .map(|keyshare| match keyshare.data {
                     KeyshareData::Secp256k1(data) => Ok(data.private_share),
@@ -211,7 +211,7 @@ async fn resharing_computation_inner(
         }
         (dtos_contract::PublicKey::Ed25519(inner_public_key), SignatureScheme::Ed25519) => {
             let public_key: Result<frost_ed25519::VerifyingKey, _> =
-                inner_public_key.into_node_type();
+                inner_public_key.try_into_node_type();
             let public_key = public_key?;
             let my_share = existing_keyshare
                 .map(|keyshare| match keyshare.data {
@@ -230,7 +230,7 @@ async fn resharing_computation_inner(
             KeyshareData::Ed25519(res)
         }
         (dtos_contract::PublicKey::Secp256k1(inner_public_key), SignatureScheme::CkdSecp256k1) => {
-            let public_key = inner_public_key.into_node_type()?;
+            let public_key = inner_public_key.try_into_node_type()?;
             let my_share = existing_keyshare
                 .map(|keyshare| match keyshare.data {
                     KeyshareData::CkdSecp256k1(data) => Ok(data.private_share),

--- a/crates/node/src/keyshare.rs
+++ b/crates/node/src/keyshare.rs
@@ -6,7 +6,7 @@ mod temporary;
 #[cfg(test)]
 pub mod test_utils;
 
-use crate::providers::PublicKeyConversion;
+use crate::trait_extensions::convert_to_contract_dto::IntoDtoType;
 use anyhow::Context;
 use mpc_contract::primitives::key_state::Keyset;
 use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain};
@@ -29,11 +29,11 @@ pub struct Keyshare {
 }
 
 impl Keyshare {
-    pub fn public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
+    pub fn public_key(&self) -> anyhow::Result<dtos_contract::PublicKey> {
         match &self.data {
-            KeyshareData::Secp256k1(data) => data.public_key.to_near_sdk_public_key(),
-            KeyshareData::Ed25519(data) => data.public_key.to_near_sdk_public_key(),
-            KeyshareData::CkdSecp256k1(data) => data.public_key.to_near_sdk_public_key(),
+            KeyshareData::Secp256k1(data) => Ok(data.public_key.into_dto_type()),
+            KeyshareData::Ed25519(data) => Ok(data.public_key.into_dto_type()),
+            KeyshareData::CkdSecp256k1(data) => Ok(data.public_key.into_dto_type()),
         }
     }
 
@@ -46,7 +46,8 @@ impl Keyshare {
                 key_id
             );
         }
-        if self.public_key()? != key.key.clone().into() {
+        let near_sdk_public_key: near_sdk::PublicKey = key.key.clone().into();
+        if self.public_key()? != near_sdk_public_key.into_dto_type() {
             anyhow::bail!(
                 "Keyshare has incorrect public key {:?}, should be {:?}",
                 self.public_key()?,

--- a/crates/node/src/keyshare/test_utils.rs
+++ b/crates/node/src/keyshare/test_utils.rs
@@ -1,6 +1,7 @@
 use super::permanent::PermanentKeyshareData;
 use super::{Keyshare, KeyshareData};
 use crate::tests::TestGenerators;
+use crate::trait_extensions::convert_to_contract_dto::IntoContractType;
 use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::{EpochId, KeyEventId, KeyForDomain, Keyset};
 use threshold_signatures::ecdsa::KeygenOutput;
@@ -39,10 +40,13 @@ fn keyset_from_permanent_keyshare(permanent: &PermanentKeyshareData) -> Keyset {
     let keys = permanent
         .keyshares
         .iter()
-        .map(|keyshare| KeyForDomain {
-            domain_id: keyshare.key_id.domain_id,
-            key: keyshare.public_key().unwrap().try_into().unwrap(),
-            attempt: keyshare.key_id.attempt_id,
+        .map(|keyshare| {
+            let near_sdk_public_key = keyshare.public_key().unwrap().into_contract_type();
+            KeyForDomain {
+                domain_id: keyshare.key_id.domain_id,
+                key: near_sdk_public_key.try_into().unwrap(),
+                attempt: keyshare.key_id.attempt_id,
+            }
         })
         .collect();
     Keyset::new(permanent.epoch_id, keys)

--- a/crates/node/src/providers.rs
+++ b/crates/node/src/providers.rs
@@ -79,7 +79,6 @@ pub trait HasParticipants {
 
 /// Helper functions to convert back and forth public key types
 pub trait PublicKeyConversion: Sized {
-    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey>;
     fn from_near_sdk_public_key(public_key: &near_sdk::PublicKey) -> anyhow::Result<Self>;
 }

--- a/crates/node/src/providers.rs
+++ b/crates/node/src/providers.rs
@@ -79,8 +79,7 @@ pub trait HasParticipants {
 
 /// Helper functions to convert back and forth public key types
 pub trait PublicKeyConversion: Sized {
-    // This is needed now because this method is only used in tests
-    #[allow(unused)]
+    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey>;
     fn from_near_sdk_public_key(public_key: &near_sdk::PublicKey) -> anyhow::Result<Self>;
 }

--- a/crates/node/src/providers.rs
+++ b/crates/node/src/providers.rs
@@ -79,6 +79,8 @@ pub trait HasParticipants {
 
 /// Helper functions to convert back and forth public key types
 pub trait PublicKeyConversion: Sized {
+    // This is needed now because this method is only used in tests
+    #[allow(unused)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey>;
     fn from_near_sdk_public_key(public_key: &near_sdk::PublicKey) -> anyhow::Result<Self>;
 }

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -22,9 +22,7 @@ use crate::tracking;
 use crate::types::SignatureId;
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
-use k256::elliptic_curve::sec1::FromEncodedPoint;
-#[cfg(test)]
-use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::elliptic_curve::sec1::{FromEncodedPoint as _, ToEncodedPoint as _};
 use k256::{AffinePoint, EncodedPoint};
 use mpc_contract::primitives::domain::DomainId;
 use near_time::Clock;
@@ -257,7 +255,6 @@ impl SignatureProvider for EcdsaSignatureProvider {
 }
 
 impl PublicKeyConversion for VerifyingKey {
-    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let bytes = self.to_element().to_encoded_point(false).to_bytes();
         anyhow::ensure!(bytes[0] == 0x04);

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -23,6 +23,7 @@ use crate::types::SignatureId;
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
 use k256::elliptic_curve::sec1::FromEncodedPoint;
+#[cfg(test)]
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::{AffinePoint, EncodedPoint};
 use mpc_contract::primitives::domain::DomainId;
@@ -256,6 +257,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
 }
 
 impl PublicKeyConversion for VerifyingKey {
+    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let bytes = self.to_element().to_encoded_point(false).to_bytes();
         anyhow::ensure!(bytes[0] == 0x04);

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -289,7 +289,7 @@ impl PublicKeyConversion for VerifyingKey {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use threshold_signatures::frost_secp256k1;
 
     use crate::{

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -18,10 +18,12 @@ use crate::primitives::{MpcTaskId, UniqueId};
 use crate::providers::{PublicKeyConversion, SignatureProvider};
 use crate::storage::SignRequestStorage;
 use crate::tracking;
+
 use crate::types::SignatureId;
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
-use k256::elliptic_curve::sec1::{FromEncodedPoint, ToEncodedPoint};
+use k256::elliptic_curve::sec1::FromEncodedPoint;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
 use k256::{AffinePoint, EncodedPoint};
 use mpc_contract::primitives::domain::DomainId;
 use near_time::Clock;
@@ -287,23 +289,31 @@ impl PublicKeyConversion for VerifyingKey {
     }
 }
 
-#[test]
-fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
-    use crate::tests::TestGenerators;
-    let x = TestGenerators::new(4, 3)
-        .make_ecdsa_keygens()
-        .values()
-        .next()
-        .unwrap()
-        .clone();
-    x.public_key.to_near_sdk_public_key()?;
-    Ok(())
-}
+#[cfg(test)]
+mod test {
+    use threshold_signatures::frost_secp256k1;
 
-#[test]
-fn check_conversion_from_sdk() -> anyhow::Result<()> {
-    let near_sdk: near_sdk::PublicKey = "secp256k1:5TJSTQwYwe3MgTCep9DbLxLT6UjB6LFn3SStpBMgdfGjBopNjxL7mpNK92R6cdyByjz7vUQdRgtLiu9w84kopNqn"
+    use crate::{
+        providers::PublicKeyConversion, trait_extensions::convert_to_contract_dto::IntoDtoType,
+    };
+    #[test]
+    fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
+        use crate::tests::TestGenerators;
+        let x = TestGenerators::new(4, 3)
+            .make_ecdsa_keygens()
+            .values()
+            .next()
+            .unwrap()
+            .clone();
+        x.public_key.into_dto_type();
+        Ok(())
+    }
+
+    #[test]
+    fn check_conversion_from_sdk() -> anyhow::Result<()> {
+        let near_sdk: near_sdk::PublicKey = "secp256k1:5TJSTQwYwe3MgTCep9DbLxLT6UjB6LFn3SStpBMgdfGjBopNjxL7mpNK92R6cdyByjz7vUQdRgtLiu9w84kopNqn"
                 .parse()?;
-    let _ = VerifyingKey::from_near_sdk_public_key(&near_sdk)?;
-    Ok(())
+        let _ = frost_secp256k1::VerifyingKey::from_near_sdk_public_key(&near_sdk)?;
+        Ok(())
+    }
 }

--- a/crates/node/src/providers/eddsa.rs
+++ b/crates/node/src/providers/eddsa.rs
@@ -167,7 +167,7 @@ impl PublicKeyConversion for ed25519_dalek::VerifyingKey {
 }
 
 #[cfg(test)]
-mod test {
+mod tests {
     use threshold_signatures::frost_ed25519::VerifyingKey;
 
     use crate::{

--- a/crates/node/src/providers/eddsa.rs
+++ b/crates/node/src/providers/eddsa.rs
@@ -124,7 +124,6 @@ impl SignatureProvider for EddsaSignatureProvider {
 }
 
 impl PublicKeyConversion for VerifyingKey {
-    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let data = self.serialize()?;
         let data: [u8; 32] = data
@@ -148,7 +147,6 @@ impl PublicKeyConversion for VerifyingKey {
     }
 }
 impl PublicKeyConversion for ed25519_dalek::VerifyingKey {
-    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let data: [u8; 32] = self.to_bytes();
         near_sdk::PublicKey::from_parts(near_sdk::CurveType::ED25519, data.to_vec())

--- a/crates/node/src/providers/eddsa.rs
+++ b/crates/node/src/providers/eddsa.rs
@@ -7,6 +7,7 @@ use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::MpcTaskId;
 use crate::providers::{PublicKeyConversion, SignatureProvider};
 use crate::storage::SignRequestStorage;
+
 use crate::types::SignatureId;
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -165,24 +166,32 @@ impl PublicKeyConversion for ed25519_dalek::VerifyingKey {
     }
 }
 
-#[test]
-fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
-    use crate::tests::TestGenerators;
-    let x = TestGenerators::new(4, 3)
-        .make_eddsa_keygens()
-        .values()
-        .next()
-        .unwrap()
-        .clone();
-    x.public_key.to_near_sdk_public_key()?;
-    Ok(())
-}
+#[cfg(test)]
+mod test {
+    use threshold_signatures::frost_ed25519::VerifyingKey;
 
-#[test]
-fn check_pubkey_conversion_from_sdk() -> anyhow::Result<()> {
-    use std::str::FromStr;
-    let near_sdk =
-        near_sdk::PublicKey::from_str("ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp")?;
-    let _ = VerifyingKey::from_near_sdk_public_key(&near_sdk)?;
-    Ok(())
+    use crate::{
+        providers::PublicKeyConversion, trait_extensions::convert_to_contract_dto::IntoDtoType,
+    };
+    #[test]
+    fn check_pubkey_conversion_to_sdk() -> anyhow::Result<()> {
+        use crate::tests::TestGenerators;
+        let x = TestGenerators::new(4, 3)
+            .make_eddsa_keygens()
+            .values()
+            .next()
+            .unwrap()
+            .clone();
+        x.public_key.into_dto_type();
+        Ok(())
+    }
+
+    #[test]
+    fn check_pubkey_conversion_from_sdk() -> anyhow::Result<()> {
+        use std::str::FromStr;
+        let near_sdk =
+            near_sdk::PublicKey::from_str("ed25519:6E8sCci9badyRkXb3JoRpBj5p8C6Tw41ELDZoiihKEtp")?;
+        let _ = VerifyingKey::from_near_sdk_public_key(&near_sdk)?;
+        Ok(())
+    }
 }

--- a/crates/node/src/providers/eddsa.rs
+++ b/crates/node/src/providers/eddsa.rs
@@ -7,13 +7,11 @@ use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::MpcTaskId;
 use crate::providers::{PublicKeyConversion, SignatureProvider};
 use crate::storage::SignRequestStorage;
-
 use crate::types::SignatureId;
 use anyhow::Context;
 use borsh::{BorshDeserialize, BorshSerialize};
 use mpc_contract::primitives::domain::DomainId;
 use mpc_contract::primitives::key_state::KeyEventId;
-use near_sdk::CurveType;
 use std::collections::HashMap;
 use std::sync::Arc;
 use threshold_signatures::eddsa::KeygenOutput;
@@ -126,13 +124,15 @@ impl SignatureProvider for EddsaSignatureProvider {
 }
 
 impl PublicKeyConversion for VerifyingKey {
+    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let data = self.serialize()?;
         let data: [u8; 32] = data
             .try_into()
             .or_else(|_| anyhow::bail!("Serialized public key is not 32 bytes."))?;
 
-        near_sdk::PublicKey::from_parts(CurveType::ED25519, data.to_vec()).context("Infallible.")
+        near_sdk::PublicKey::from_parts(near_sdk::CurveType::ED25519, data.to_vec())
+            .context("Infallible.")
     }
 
     fn from_near_sdk_public_key(public_key: &near_sdk::PublicKey) -> anyhow::Result<Self> {
@@ -148,9 +148,11 @@ impl PublicKeyConversion for VerifyingKey {
     }
 }
 impl PublicKeyConversion for ed25519_dalek::VerifyingKey {
+    #[cfg(test)]
     fn to_near_sdk_public_key(&self) -> anyhow::Result<near_sdk::PublicKey> {
         let data: [u8; 32] = self.to_bytes();
-        near_sdk::PublicKey::from_parts(CurveType::ED25519, data.to_vec()).context("Infallible.")
+        near_sdk::PublicKey::from_parts(near_sdk::CurveType::ED25519, data.to_vec())
+            .context("Infallible.")
     }
 
     fn from_near_sdk_public_key(public_key: &near_sdk::PublicKey) -> anyhow::Result<Self> {

--- a/crates/node/src/tee/remote_attestation.rs
+++ b/crates/node/src/tee/remote_attestation.rs
@@ -12,6 +12,7 @@ use crate::{
         tx_sender::{TransactionSender, TransactionStatus},
         types::{ChainSendTransactionRequest, SubmitParticipantInfoArgs},
     },
+    providers::PublicKeyConversion,
     trait_extensions::convert_to_contract_dto::IntoDtoType,
 };
 
@@ -110,7 +111,7 @@ async fn periodic_attestation_submission_with_interval<T: TransactionSender + Cl
     loop {
         interval_ticker.tick().await;
 
-        let tls_sdk_public_key = tls_public_key.into_dto_type();
+        let tls_sdk_public_key = tls_public_key.to_near_sdk_public_key()?;
         let report_data = ReportData::new(tls_sdk_public_key);
         let fresh_attestation = match tee_authority.generate_attestation(report_data).await {
             Ok(attestation) => attestation,

--- a/crates/node/src/tee/remote_attestation.rs
+++ b/crates/node/src/tee/remote_attestation.rs
@@ -12,7 +12,6 @@ use crate::{
         tx_sender::{TransactionSender, TransactionStatus},
         types::{ChainSendTransactionRequest, SubmitParticipantInfoArgs},
     },
-    providers::PublicKeyConversion,
     trait_extensions::convert_to_contract_dto::IntoDtoType,
 };
 
@@ -111,8 +110,8 @@ async fn periodic_attestation_submission_with_interval<T: TransactionSender + Cl
     loop {
         interval_ticker.tick().await;
 
-        let tls_sdk_public_key = tls_public_key.to_near_sdk_public_key()?;
-        let report_data = ReportData::new(tls_sdk_public_key.clone());
+        let tls_sdk_public_key = tls_public_key.into_dto_type();
+        let report_data = ReportData::new(tls_sdk_public_key);
         let fresh_attestation = match tee_authority.generate_attestation(report_data).await {
             Ok(attestation) => attestation,
             Err(error) => {

--- a/crates/node/src/trait_extensions/convert_to_contract_dto.rs
+++ b/crates/node/src/trait_extensions/convert_to_contract_dto.rs
@@ -22,8 +22,9 @@ pub(crate) trait IntoDtoType<DtoType> {
     fn into_dto_type(self) -> DtoType;
 }
 
-pub(crate) trait IntoNodeType<NodeType> {
-    fn into_node_type(self) -> NodeType;
+pub(crate) trait TryIntoNodeType<NodeType> {
+    type Error;
+    fn try_into_node_type(self) -> Result<NodeType, Self::Error>;
 }
 
 impl IntoDtoType<dtos_contract::Ed25519PublicKey> for &ed25519_dalek::VerifyingKey {
@@ -182,10 +183,11 @@ impl IntoDtoType<dtos_contract::PublicKey>
     }
 }
 
-impl IntoNodeType<Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError>>
+impl TryIntoNodeType<threshold_signatures::frost_ed25519::VerifyingKey>
     for dtos_contract::Ed25519PublicKey
 {
-    fn into_node_type(
+    type Error = ParsePublicKeyError;
+    fn try_into_node_type(
         self,
     ) -> Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError> {
         threshold_signatures::frost_ed25519::VerifyingKey::deserialize(self.as_bytes())
@@ -193,10 +195,11 @@ impl IntoNodeType<Result<threshold_signatures::frost_ed25519::VerifyingKey, Pars
     }
 }
 
-impl IntoNodeType<Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError>>
+impl TryIntoNodeType<threshold_signatures::frost_secp256k1::VerifyingKey>
     for dtos_contract::Secp256k1PublicKey
 {
-    fn into_node_type(
+    type Error = ParsePublicKeyError;
+    fn try_into_node_type(
         self,
     ) -> Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError> {
         let mut bytes = [0u8; 65];
@@ -212,10 +215,9 @@ impl IntoNodeType<Result<threshold_signatures::frost_secp256k1::VerifyingKey, Pa
     }
 }
 
-impl IntoNodeType<Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError>>
-    for dtos_contract::Ed25519PublicKey
-{
-    fn into_node_type(self) -> Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError> {
+impl TryIntoNodeType<ed25519_dalek::VerifyingKey> for dtos_contract::Ed25519PublicKey {
+    type Error = ParsePublicKeyError;
+    fn try_into_node_type(self) -> Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError> {
         ed25519_dalek::VerifyingKey::from_bytes(self.as_bytes()).map_err(|_| ParsePublicKeyError {})
     }
 }

--- a/crates/node/src/trait_extensions/convert_to_contract_dto.rs
+++ b/crates/node/src/trait_extensions/convert_to_contract_dto.rs
@@ -32,61 +32,6 @@ impl IntoDtoType<dtos_contract::Ed25519PublicKey> for &ed25519_dalek::VerifyingK
     }
 }
 
-impl IntoDtoType<dtos_contract::PublicKey> for &threshold_signatures::frost_ed25519::VerifyingKey {
-    fn into_dto_type(self) -> dtos_contract::PublicKey {
-        dtos_contract::PublicKey::Ed25519(dtos_contract::Ed25519PublicKey::from(
-            self.to_element().to_bytes(),
-        ))
-    }
-}
-
-impl IntoDtoType<dtos_contract::PublicKey>
-    for &threshold_signatures::frost_secp256k1::VerifyingKey
-{
-    fn into_dto_type(self) -> dtos_contract::PublicKey {
-        let mut bytes = [0u8; 64];
-        bytes.copy_from_slice(&self.to_element().to_encoded_point(false).to_bytes()[1..]);
-        dtos_contract::PublicKey::Secp256k1(dtos_contract::Secp256k1PublicKey::from(bytes))
-    }
-}
-
-impl IntoNodeType<Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError>>
-    for dtos_contract::Ed25519PublicKey
-{
-    fn into_node_type(
-        self,
-    ) -> Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError> {
-        threshold_signatures::frost_ed25519::VerifyingKey::deserialize(self.as_bytes())
-            .map_err(|_| ParsePublicKeyError {})
-    }
-}
-
-impl IntoNodeType<Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError>>
-    for dtos_contract::Secp256k1PublicKey
-{
-    fn into_node_type(
-        self,
-    ) -> Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError> {
-        let mut bytes = [0u8; 65];
-        bytes[0] = 0x4;
-        bytes[1..].copy_from_slice(&self.0);
-        let point = EncodedPoint::from_bytes(bytes).map_err(|_| ParsePublicKeyError {})?;
-        Ok(threshold_signatures::frost_secp256k1::VerifyingKey::new(
-            k256::ProjectivePoint::from_encoded_point(&point)
-                .into_option()
-                .ok_or(ParsePublicKeyError {})?,
-        ))
-    }
-}
-
-impl IntoNodeType<Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError>>
-    for dtos_contract::Ed25519PublicKey
-{
-    fn into_node_type(self) -> Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError> {
-        ed25519_dalek::VerifyingKey::from_bytes(self.as_bytes()).map_err(|_| ParsePublicKeyError {})
-    }
-}
-
 impl IntoDtoType<dtos_contract::Attestation> for Attestation {
     fn into_dto_type(self) -> dtos_contract::Attestation {
         match self {
@@ -218,16 +163,71 @@ impl IntoDtoType<dtos_contract::EventLog> for EventLog {
     }
 }
 
-// This is only needed temporarily
+impl IntoDtoType<dtos_contract::PublicKey> for &threshold_signatures::frost_ed25519::VerifyingKey {
+    fn into_dto_type(self) -> dtos_contract::PublicKey {
+        dtos_contract::PublicKey::Ed25519(dtos_contract::Ed25519PublicKey::from(
+            self.to_element().to_bytes(),
+        ))
+    }
+}
 
-// This is needed as it is only used in tests
-#[allow(dead_code)]
+impl IntoDtoType<dtos_contract::PublicKey>
+    for &threshold_signatures::frost_secp256k1::VerifyingKey
+{
+    fn into_dto_type(self) -> dtos_contract::PublicKey {
+        let mut bytes = [0u8; 64];
+        // The first byte is the curve type
+        bytes.copy_from_slice(&self.to_element().to_encoded_point(false).to_bytes()[1..]);
+        dtos_contract::PublicKey::Secp256k1(dtos_contract::Secp256k1PublicKey::from(bytes))
+    }
+}
+
+impl IntoNodeType<Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError>>
+    for dtos_contract::Ed25519PublicKey
+{
+    fn into_node_type(
+        self,
+    ) -> Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError> {
+        threshold_signatures::frost_ed25519::VerifyingKey::deserialize(self.as_bytes())
+            .map_err(|_| ParsePublicKeyError {})
+    }
+}
+
+impl IntoNodeType<Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError>>
+    for dtos_contract::Secp256k1PublicKey
+{
+    fn into_node_type(
+        self,
+    ) -> Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError> {
+        let mut bytes = [0u8; 65];
+        // The first byte is the curve representation, in this case uncompressed
+        bytes[0] = 0x4;
+        bytes[1..].copy_from_slice(&self.0);
+        let point = EncodedPoint::from_bytes(bytes).map_err(|_| ParsePublicKeyError {})?;
+        Ok(threshold_signatures::frost_secp256k1::VerifyingKey::new(
+            k256::ProjectivePoint::from_encoded_point(&point)
+                .into_option()
+                .ok_or(ParsePublicKeyError {})?,
+        ))
+    }
+}
+
+impl IntoNodeType<Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError>>
+    for dtos_contract::Ed25519PublicKey
+{
+    fn into_node_type(self) -> Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError> {
+        ed25519_dalek::VerifyingKey::from_bytes(self.as_bytes()).map_err(|_| ParsePublicKeyError {})
+    }
+}
+
+// This is only needed temporarily, until we finish the migration from near_sdk::PublicKey
+
 pub(crate) trait IntoContractType<ContractType> {
     fn into_contract_type(self) -> ContractType;
 }
 
 impl IntoContractType<near_sdk::PublicKey> for &dtos_contract::PublicKey {
-    // If the original data is correct, this will never panic
+    // This will never panic, because the key sizes match
     fn into_contract_type(self) -> near_sdk::PublicKey {
         match self {
             dtos_contract::PublicKey::Secp256k1(secp256k1_public_key) => {
@@ -249,16 +249,18 @@ impl IntoContractType<near_sdk::PublicKey> for &dtos_contract::PublicKey {
 }
 
 impl IntoDtoType<dtos_contract::PublicKey> for &near_sdk::PublicKey {
-    // If the original data is correct, this will never panic
+    // This will never panic, because the key sizes match
     fn into_dto_type(self) -> dtos_contract::PublicKey {
         match self.curve_type() {
             near_sdk::CurveType::SECP256K1 => {
                 let mut bytes = [0u8; 64];
+                // The first byte is the curve type
                 bytes.copy_from_slice(&self.as_bytes()[1..]);
                 dtos_contract::PublicKey::from(dtos_contract::Secp256k1PublicKey::from(bytes))
             }
             near_sdk::CurveType::ED25519 => {
                 let mut bytes = [0u8; 32];
+                // The first byte is the curve type
                 bytes.copy_from_slice(&self.as_bytes()[1..]);
                 dtos_contract::PublicKey::from(dtos_contract::Ed25519PublicKey::from(bytes))
             }

--- a/crates/node/src/trait_extensions/convert_to_contract_dto.rs
+++ b/crates/node/src/trait_extensions/convert_to_contract_dto.rs
@@ -9,14 +9,81 @@ use attestation::{
     collateral::{Collateral, QuoteCollateralV3},
     EventLog, TcbInfo,
 };
+use derive_more::Display;
+use k256::elliptic_curve::sec1::FromEncodedPoint;
+use k256::elliptic_curve::sec1::ToEncodedPoint;
+use k256::{elliptic_curve::group::GroupEncoding, EncodedPoint};
+
+#[derive(Debug, Display)]
+pub struct ParsePublicKeyError {}
+impl std::error::Error for ParsePublicKeyError {}
 
 pub(crate) trait IntoDtoType<DtoType> {
     fn into_dto_type(self) -> DtoType;
 }
 
+pub(crate) trait IntoNodeType<NodeType> {
+    fn into_node_type(self) -> NodeType;
+}
+
 impl IntoDtoType<dtos_contract::Ed25519PublicKey> for &ed25519_dalek::VerifyingKey {
     fn into_dto_type(self) -> dtos_contract::Ed25519PublicKey {
         dtos_contract::Ed25519PublicKey::from(self.to_bytes())
+    }
+}
+
+impl IntoDtoType<dtos_contract::PublicKey> for &threshold_signatures::frost_ed25519::VerifyingKey {
+    fn into_dto_type(self) -> dtos_contract::PublicKey {
+        dtos_contract::PublicKey::Ed25519(dtos_contract::Ed25519PublicKey::from(
+            self.to_element().to_bytes(),
+        ))
+    }
+}
+
+impl IntoDtoType<dtos_contract::PublicKey>
+    for &threshold_signatures::frost_secp256k1::VerifyingKey
+{
+    fn into_dto_type(self) -> dtos_contract::PublicKey {
+        let mut bytes = [0u8; 64];
+        bytes.copy_from_slice(&self.to_element().to_encoded_point(false).to_bytes()[1..]);
+        dtos_contract::PublicKey::Secp256k1(dtos_contract::Secp256k1PublicKey::from(bytes))
+    }
+}
+
+impl IntoNodeType<Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError>>
+    for dtos_contract::Ed25519PublicKey
+{
+    fn into_node_type(
+        self,
+    ) -> Result<threshold_signatures::frost_ed25519::VerifyingKey, ParsePublicKeyError> {
+        threshold_signatures::frost_ed25519::VerifyingKey::deserialize(self.as_bytes())
+            .map_err(|_| ParsePublicKeyError {})
+    }
+}
+
+impl IntoNodeType<Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError>>
+    for dtos_contract::Secp256k1PublicKey
+{
+    fn into_node_type(
+        self,
+    ) -> Result<threshold_signatures::frost_secp256k1::VerifyingKey, ParsePublicKeyError> {
+        let mut bytes = [0u8; 65];
+        bytes[0] = 0x4;
+        bytes[1..].copy_from_slice(&self.0);
+        let point = EncodedPoint::from_bytes(bytes).map_err(|_| ParsePublicKeyError {})?;
+        Ok(threshold_signatures::frost_secp256k1::VerifyingKey::new(
+            k256::ProjectivePoint::from_encoded_point(&point)
+                .into_option()
+                .ok_or(ParsePublicKeyError {})?,
+        ))
+    }
+}
+
+impl IntoNodeType<Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError>>
+    for dtos_contract::Ed25519PublicKey
+{
+    fn into_node_type(self) -> Result<ed25519_dalek::VerifyingKey, ParsePublicKeyError> {
+        ed25519_dalek::VerifyingKey::from_bytes(self.as_bytes()).map_err(|_| ParsePublicKeyError {})
     }
 }
 
@@ -147,6 +214,54 @@ impl IntoDtoType<dtos_contract::EventLog> for EventLog {
             digest,
             event,
             event_payload,
+        }
+    }
+}
+
+// This is only needed temporarily
+
+// This is needed as it is only used in tests
+#[allow(dead_code)]
+pub(crate) trait IntoContractType<ContractType> {
+    fn into_contract_type(self) -> ContractType;
+}
+
+impl IntoContractType<near_sdk::PublicKey> for &dtos_contract::PublicKey {
+    // If the original data is correct, this will never panic
+    fn into_contract_type(self) -> near_sdk::PublicKey {
+        match self {
+            dtos_contract::PublicKey::Secp256k1(secp256k1_public_key) => {
+                near_sdk::PublicKey::from_parts(
+                    near_sdk::CurveType::SECP256K1,
+                    secp256k1_public_key.as_bytes().to_vec(),
+                )
+                .unwrap()
+            }
+            dtos_contract::PublicKey::Ed25519(ed25519_public_key) => {
+                near_sdk::PublicKey::from_parts(
+                    near_sdk::CurveType::ED25519,
+                    ed25519_public_key.as_bytes().to_vec(),
+                )
+                .unwrap()
+            }
+        }
+    }
+}
+
+impl IntoDtoType<dtos_contract::PublicKey> for &near_sdk::PublicKey {
+    // If the original data is correct, this will never panic
+    fn into_dto_type(self) -> dtos_contract::PublicKey {
+        match self.curve_type() {
+            near_sdk::CurveType::SECP256K1 => {
+                let mut bytes = [0u8; 64];
+                bytes.copy_from_slice(&self.as_bytes()[1..]);
+                dtos_contract::PublicKey::from(dtos_contract::Secp256k1PublicKey::from(bytes))
+            }
+            near_sdk::CurveType::ED25519 => {
+                let mut bytes = [0u8; 32];
+                bytes.copy_from_slice(&self.as_bytes()[1..]);
+                dtos_contract::PublicKey::from(dtos_contract::Ed25519PublicKey::from(bytes))
+            }
         }
     }
 }

--- a/crates/tee_authority/Cargo.toml
+++ b/crates/tee_authority/Cargo.toml
@@ -25,4 +25,3 @@ tokio = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
 test_utils = { workspace = true }
-dtos-contract = {workspace = true}

--- a/crates/tee_authority/Cargo.toml
+++ b/crates/tee_authority/Cargo.toml
@@ -18,9 +18,11 @@ reqwest = { workspace = true }
 serde = { workspace = true }
 tracing = { workspace = true }
 
+
 [dev-dependencies]
 hex = { workspace = true }
 tokio = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
 test_utils = { workspace = true }
+dtos-contract = {workspace = true}

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -8,6 +8,6 @@ attestation = { workspace = true }
 mpc-primitives = { workspace = true }
 dstack-sdk-types = { workspace = true }
 hex = { workspace = true }
-dtos-contract = { workspace = true }
+dtos-contract = { workspace = true, features = ["test-utils"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -8,7 +8,6 @@ attestation = { workspace = true }
 mpc-primitives = { workspace = true }
 dstack-sdk-types = { workspace = true }
 hex = { workspace = true }
-near-sdk = { workspace = true }
 dtos-contract = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/crates/test_utils/Cargo.toml
+++ b/crates/test_utils/Cargo.toml
@@ -11,3 +11,4 @@ hex = { workspace = true }
 dtos-contract = { workspace = true, features = ["test-utils"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
+near-sdk = { workspace = true }

--- a/crates/test_utils/src/attestation.rs
+++ b/crates/test_utils/src/attestation.rs
@@ -51,6 +51,11 @@ pub fn p2p_tls_key() -> Ed25519PublicKey {
     key_file.parse().expect("File contains a valid public key")
 }
 
+pub fn near_p2p_tls_key() -> near_sdk::PublicKey {
+    let key_file = include_str!("../assets/near_p2p_public_key.pub");
+    key_file.parse().expect("File contains a valid public key")
+}
+
 pub fn mock_dstack_attestation() -> Attestation {
     let quote = quote();
     let collateral_json_string = include_str!("../assets/collateral.json");

--- a/crates/test_utils/src/attestation.rs
+++ b/crates/test_utils/src/attestation.rs
@@ -3,8 +3,8 @@ use attestation::{
     quote::QuoteBytes,
 };
 use dstack_sdk_types::dstack::TcbInfo as DstackTcbInfo;
+use dtos_contract::Ed25519PublicKey;
 use mpc_primitives::hash::{LauncherDockerComposeHash, MpcDockerImageHash};
-use near_sdk::PublicKey;
 use serde_json::Value;
 use sha2::{Digest, Sha256};
 
@@ -46,7 +46,7 @@ pub fn quote() -> QuoteBytes {
         .expect("Quote collateral file is a valid json.")
 }
 
-pub fn p2p_tls_key() -> PublicKey {
+pub fn p2p_tls_key() -> Ed25519PublicKey {
     let key_file = include_str!("../assets/near_p2p_public_key.pub");
     key_file.parse().expect("File contains a valid public key")
 }


### PR DESCRIPTION
Closes #1220 

- The new `dtos_contract::PublicKey` substitutes `near_sdk::PublicKey` where it is possible to do so without breaking the contract API.
- I am using explicitly `near_sdk::PublicKey` instead of `PublicKey` so that removing it later becomes easier
- A few temporary conversion functions were needed