### PR TITLE
feat: indexer fetches migration state from contract and displays it on a web-endpoint

### DIFF
--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1305,6 +1305,7 @@ impl MpcContract {
 /// Methods for Migration service
 #[near_bindgen]
 impl MpcContract {
+    // todo: [#1248](https://github.com/near/mpc/issues/1248), we might want to delete this one
     pub fn my_migration_info(
         &self,
     ) -> (

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -26,6 +26,7 @@ use mpc_contract::state::ProtocolContractState;
 use near_indexer_primitives::types::Finality;
 use near_sdk::AccountId;
 use near_time::Clock;
+use std::collections::BTreeMap;
 use std::{
     path::PathBuf,
     sync::OnceLock,
@@ -260,6 +261,8 @@ impl StartCmd {
         let (protocol_state_sender, protocol_state_receiver) =
             watch::channel(ProtocolContractState::NotInitialized);
 
+        let (migration_state_sender, migration_state_receiver) =
+            watch::channel((0, BTreeMap::new()));
         let web_server = root_runtime
             .block_on(start_web_server(
                 root_task_handle.clone(),
@@ -267,6 +270,7 @@ impl StartCmd {
                 config.web_ui.clone(),
                 static_web_data(&secrets, Some(attestation.clone())),
                 protocol_state_receiver,
+                migration_state_receiver,
             ))
             .context("Failed to create web server.")?;
 
@@ -282,6 +286,8 @@ impl StartCmd {
             respond_config,
             indexer_exit_sender,
             protocol_state_sender,
+            migration_state_sender,
+            *tls_public_key,
         );
 
         let (shutdown_signal_sender, mut shutdown_signal_receiver) = mpsc::channel(1);

--- a/crates/node/src/indexer.rs
+++ b/crates/node/src/indexer.rs
@@ -1,3 +1,5 @@
+use crate::migration_service::types::MigrationInfo;
+
 use self::stats::IndexerStats;
 use handler::ChainBlockUpdate;
 use mpc_contract::tee::{proposal::MpcDockerImageHash, tee_state::NodeId};
@@ -13,14 +15,14 @@ pub mod balances;
 pub mod configs;
 pub mod handler;
 pub mod lib;
+pub mod migrations;
 pub mod participants;
 pub mod real;
 pub mod stats;
+pub mod tee;
 pub mod tx_sender;
 pub mod tx_signer;
 pub mod types;
-
-pub mod tee;
 
 #[cfg(test)]
 pub mod fake;
@@ -78,4 +80,7 @@ pub struct IndexerAPI<TransactionSender> {
     pub allowed_docker_images_receiver: watch::Receiver<Vec<MpcDockerImageHash>>,
     /// Watcher that tracks node IDs that have TEE attestations in the contract.
     pub attested_nodes_receiver: watch::Receiver<Vec<NodeId>>,
+
+    #[allow(dead_code)] // todo: [#1249](https://github.com/near/mpc/issues/1249): remove `allow`
+    pub my_migration_info_receiver: watch::Receiver<MigrationInfo>,
 }

--- a/crates/node/src/indexer/lib.rs
+++ b/crates/node/src/indexer/lib.rs
@@ -14,9 +14,12 @@ use serde::Deserialize;
 use std::time::Duration;
 use tokio::time;
 
+use super::migrations::ContractMigrationInfo;
+
 const INTERVAL: Duration = Duration::from_millis(500);
 const ALLOWED_IMAGE_HASHES_ENDPOINT: &str = "allowed_docker_image_hashes";
 const TEE_ACCOUNTS_ENDPOINT: &str = "get_tee_accounts";
+pub const MIGRATION_INFO_ENDPOINT: &str = "migration_info";
 const CONTRACT_STATE_ENDPOINT: &str = "state";
 
 pub(crate) async fn wait_for_full_sync(client: &Addr<ClientActor>) {
@@ -90,6 +93,13 @@ pub(crate) async fn get_mpc_tee_accounts(
     client: &actix::Addr<near_client::ViewClientActor>,
 ) -> anyhow::Result<(u64, Vec<NodeId>)> {
     get_mpc_state(mpc_contract_id, client, TEE_ACCOUNTS_ENDPOINT).await
+}
+
+pub(crate) async fn get_mpc_migration_info(
+    mpc_contract_id: AccountId,
+    client: &actix::Addr<near_client::ViewClientActor>,
+) -> anyhow::Result<(u64, ContractMigrationInfo)> {
+    get_mpc_state(mpc_contract_id, client, MIGRATION_INFO_ENDPOINT).await
 }
 
 pub(crate) async fn get_account_balance(

--- a/crates/node/src/indexer/migrations.rs
+++ b/crates/node/src/indexer/migrations.rs
@@ -1,0 +1,98 @@
+use std::{collections::BTreeMap, sync::Arc};
+
+use ed25519_dalek::VerifyingKey;
+use mpc_contract::node_migrations::{BackupServiceInfo, DestinationNodeInfo};
+use near_sdk::AccountId;
+use tokio::sync::watch;
+
+use crate::{
+    indexer::{
+        lib::{get_mpc_migration_info, wait_for_full_sync},
+        IndexerState,
+    },
+    migration_service::types::MigrationInfo,
+};
+
+pub type ContractMigrationInfo =
+    BTreeMap<AccountId, (Option<BackupServiceInfo>, Option<DestinationNodeInfo>)>;
+
+const MIGRATION_INFO_REFRESH_INTERVAL: std::time::Duration = std::time::Duration::from_secs(1);
+
+/// Blocks until the indexer has a current view of the blockchain.
+/// Spawns a monitoring task to fetch the migration info from the contract.
+/// Returns a tokio watch channel on which the latest migration state can be watched.
+///
+/// The interval checking for new values is defined by [`MIGRATION_INFO_REFRESH_INTERVAL`]
+pub async fn monitor_migrations(
+    indexer_state: Arc<IndexerState>,
+
+    migration_state_sender: watch::Sender<(u64, ContractMigrationInfo)>,
+    my_near_account_id: AccountId,
+    my_tls_p2p_key: VerifyingKey,
+) -> watch::Receiver<MigrationInfo> {
+    let init_response = fetch_migrations_once(indexer_state.clone()).await;
+    let init_migration_state =
+        MigrationInfo::from_contract_state(&my_near_account_id, &my_tls_p2p_key, &init_response.1);
+
+    let (sender, receiver) = watch::channel(init_migration_state);
+
+    tokio::spawn({
+        let mut interval = tokio::time::interval(MIGRATION_INFO_REFRESH_INTERVAL);
+        async move {
+            loop {
+                interval.tick().await;
+                let response = fetch_migrations_once(indexer_state.clone()).await;
+                tracing::debug!(target: "indexer", "fetched mpc migration state {:?}", response);
+                migration_state_sender.send_if_modified(|watched_state| {
+                    if *watched_state != response {
+                        tracing::info!("contract migration state changed: {:?}", response);
+                        *watched_state = response.clone();
+                        true
+                    } else {
+                        false
+                    }
+                });
+                let my_migration_state = MigrationInfo::from_contract_state(
+                    &my_near_account_id,
+                    &my_tls_p2p_key,
+                    &response.1,
+                );
+                sender.send_if_modified(|watched_state| {
+                    if *watched_state != my_migration_state {
+                        tracing::info!("my migration state changed: {:?}", my_migration_state);
+                        *watched_state = my_migration_state;
+                        true
+                    } else {
+                        false
+                    }
+                });
+            }
+        }
+    });
+
+    receiver
+}
+
+async fn fetch_migrations_once(indexer_state: Arc<IndexerState>) -> (u64, ContractMigrationInfo) {
+    loop {
+        tracing::debug!(target: "indexer", "awaiting indexer full sync to read mpc contract state");
+        wait_for_full_sync(&indexer_state.client).await;
+
+        tracing::debug!(target: "indexer", "querying migration state");
+
+        match get_mpc_migration_info(
+            indexer_state.mpc_contract_id.clone(),
+            &indexer_state.view_client,
+        )
+        .await
+        {
+            Ok(res) => {
+                return res;
+            }
+            Err(e) => {
+                tracing::error!(target: "mpc", "error reading config from chain: {:?}", e);
+                tokio::time::sleep(MIGRATION_INFO_REFRESH_INTERVAL).await;
+            }
+        }
+    }
+}

--- a/crates/node/src/indexer/tx_sender.rs
+++ b/crates/node/src/indexer/tx_sender.rs
@@ -333,7 +333,8 @@ async fn observe_tx_result(
         | VotePk(_)
         | VoteReshared(_)
         | VoteAbortKeyEventInstance(_)
-        | VerifyTee() => Ok(TransactionStatus::Unknown),
+        | VerifyTee()
+        | ConcludeNodeMigration(_) => Ok(TransactionStatus::Unknown),
     }
 }
 

--- a/crates/node/src/indexer/types.rs
+++ b/crates/node/src/indexer/types.rs
@@ -7,7 +7,11 @@ use k256::{
 };
 use mpc_contract::{
     crypto_shared::CKDResponse,
-    primitives::{domain::DomainId, key_state::KeyEventId, signature::Tweak},
+    primitives::{
+        domain::DomainId,
+        key_state::{KeyEventId, Keyset},
+        signature::Tweak,
+    },
 };
 use near_indexer_primitives::types::Gas;
 use near_sdk::AccountId;
@@ -169,6 +173,10 @@ pub struct SubmitParticipantInfoArgs {
     pub tls_public_key: dtos_contract::Ed25519PublicKey,
 }
 
+#[derive(Serialize, Debug)]
+pub struct ConcludeNodeMigrationArgs {
+    pub keyset: Keyset,
+}
 /// Request to send a transaction to the contract on chain.
 #[derive(Serialize, Debug)]
 #[serde(untagged)]
@@ -188,6 +196,9 @@ pub(crate) enum ChainSendTransactionRequest {
     // For more info see clippy lint:
     // https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant
     SubmitParticipantInfo(Box<SubmitParticipantInfoArgs>),
+
+    #[allow(dead_code)] // todo: [1249](https://github.com/near/mpc/issues/1249) use it
+    ConcludeNodeMigration(ConcludeNodeMigrationArgs),
 }
 
 impl ChainSendTransactionRequest {
@@ -204,6 +215,7 @@ impl ChainSendTransactionRequest {
             }
             ChainSendTransactionRequest::VerifyTee() => "verify_tee",
             ChainSendTransactionRequest::SubmitParticipantInfo(_) => "submit_participant_info",
+            ChainSendTransactionRequest::ConcludeNodeMigration(_) => "conclude_node_migration",
         }
     }
 
@@ -219,6 +231,7 @@ impl ChainSendTransactionRequest {
             // This is too high in most settings, see https://github.com/near/mpc/issues/166
             | Self::VerifyTee() => 300 * TGAS,
             Self::SubmitParticipantInfo(_) => 300 * TGAS,
+            Self::ConcludeNodeMigration(_) => 300 * TGAS,
         }
     }
 }

--- a/crates/node/src/lib.rs
+++ b/crates/node/src/lib.rs
@@ -29,6 +29,7 @@ mod indexer;
 mod key_events;
 mod keyshare;
 pub mod metrics;
+mod migration_service;
 mod mpc_client;
 mod network;
 mod p2p;

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -7,6 +7,7 @@ pub static MPC_NUM_TRIPLES_GENERATED: LazyLock<prometheus::IntCounter> = LazyLoc
     )
     .unwrap()
 });
+
 pub static MPC_TRIPLES_GENERATION_TIME_ELAPSED: LazyLock<prometheus::Histogram> =
     LazyLock::new(|| {
         near_o11y::metrics::try_create_histogram(
@@ -15,6 +16,7 @@ pub static MPC_TRIPLES_GENERATION_TIME_ELAPSED: LazyLock<prometheus::Histogram> 
         )
         .unwrap()
     });
+
 pub static MPC_PRE_SIGNATURE_TIME_ELAPSED: LazyLock<prometheus::Histogram> = LazyLock::new(|| {
     near_o11y::metrics::try_create_histogram(
         "near_mpc_pre_signature_time_elapsed",
@@ -22,6 +24,7 @@ pub static MPC_PRE_SIGNATURE_TIME_ELAPSED: LazyLock<prometheus::Histogram> = Laz
     )
     .unwrap()
 });
+
 pub static MPC_SIGNATURE_TIME_ELAPSED: LazyLock<prometheus::Histogram> = LazyLock::new(|| {
     near_o11y::metrics::try_create_histogram(
         "near_mpc_signature_time_elapsed",
@@ -73,6 +76,7 @@ pub static MPC_OWNED_NUM_PRESIGNATURES_AVAILABLE: LazyLock<prometheus::IntGauge>
         )
         .unwrap()
     });
+
 pub static MPC_OWNED_NUM_PRESIGNATURES_ONLINE: LazyLock<prometheus::IntGauge> =
     LazyLock::new(|| {
         prometheus::register_int_gauge!(
@@ -82,6 +86,7 @@ pub static MPC_OWNED_NUM_PRESIGNATURES_ONLINE: LazyLock<prometheus::IntGauge> =
         )
         .unwrap()
     });
+
 pub static MPC_OWNED_NUM_PRESIGNATURES_WITH_OFFLINE_PARTICIPANT: LazyLock<prometheus::IntGauge> =
     LazyLock::new(|| {
         prometheus::register_int_gauge!(
@@ -91,6 +96,7 @@ pub static MPC_OWNED_NUM_PRESIGNATURES_WITH_OFFLINE_PARTICIPANT: LazyLock<promet
         )
         .unwrap()
     });
+
 pub static MPC_INDEXER_NUM_RECEIPT_EXECUTION_OUTCOMES: LazyLock<prometheus::IntCounter> =
     LazyLock::new(|| {
         prometheus::register_int_counter!(
@@ -197,6 +203,7 @@ pub static MPC_OUTGOING_TRANSACTION_OUTCOMES: LazyLock<prometheus::IntCounterVec
         )
         .unwrap()
     });
+
 pub static MPC_INDEXER_LATEST_BLOCK_HEIGHT: LazyLock<prometheus::IntGauge> = LazyLock::new(|| {
     prometheus::register_int_gauge!(
         "mpc_indexer_latest_block_height",
@@ -213,6 +220,7 @@ pub static MPC_ACCESS_KEY_NONCE: LazyLock<prometheus::IntGauge> = LazyLock::new(
     )
     .unwrap()
 });
+
 pub static MPC_CURRENT_JOB_STATE: LazyLock<prometheus::IntGaugeVec> = LazyLock::new(|| {
     prometheus::register_int_gauge_vec!(
         "mpc_current_job_state",
@@ -221,6 +229,7 @@ pub static MPC_CURRENT_JOB_STATE: LazyLock<prometheus::IntGaugeVec> = LazyLock::
     )
     .unwrap()
 });
+
 pub static SIGN_REQUEST_CHANNEL_FAILED: LazyLock<prometheus::IntCounter> = LazyLock::new(|| {
     prometheus::register_int_counter!(
         "sign_request_channel_failed",

--- a/crates/node/src/migration_service.rs
+++ b/crates/node/src/migration_service.rs
@@ -1,0 +1,1 @@
+pub mod types;

--- a/crates/node/src/migration_service/types.rs
+++ b/crates/node/src/migration_service/types.rs
@@ -1,0 +1,55 @@
+use ed25519_dalek::VerifyingKey;
+use mpc_contract::node_migrations::{BackupServiceInfo, DestinationNodeInfo};
+use near_sdk::AccountId;
+
+use crate::{indexer::migrations::ContractMigrationInfo, providers::PublicKeyConversion};
+
+#[derive(PartialEq, Debug, Clone)]
+pub struct MigrationInfo {
+    pub backup_service_info: Option<BackupServiceInfo>,
+    pub active_migration: bool,
+}
+
+impl MigrationInfo {
+    pub fn from_contract_state(
+        my_account_id: &AccountId,
+        my_p2p_tls_key: &VerifyingKey,
+        contract_state: &ContractMigrationInfo,
+    ) -> Self {
+        infer_migration_info(my_account_id, my_p2p_tls_key, contract_state)
+    }
+}
+
+fn infer_migration_status(
+    my_p2p_tls_key: &VerifyingKey,
+    destination_node_info: &Option<DestinationNodeInfo>,
+) -> bool {
+    destination_node_info
+        .as_ref()
+        .map(|info| {
+            ed25519_dalek::VerifyingKey::from_near_sdk_public_key(
+                &info.destination_node_info.sign_pk,
+            )
+            .inspect_err(|_| tracing::warn!(target: "Migration Service", "Error parsing public key from chain."))
+            .is_ok_and(|key| key == *my_p2p_tls_key)
+        })
+        .unwrap_or(false)
+}
+
+fn infer_migration_info(
+    my_account_id: &AccountId,
+    my_p2p_tls_key: &VerifyingKey,
+    contract_state: &ContractMigrationInfo,
+) -> MigrationInfo {
+    let (backup_service_info, active_migration) = match contract_state.get(my_account_id) {
+        Some((backup_service_info, destination_node_info)) => (
+            backup_service_info.clone(),
+            infer_migration_status(my_p2p_tls_key, destination_node_info),
+        ),
+        None => (None, false),
+    };
+    MigrationInfo {
+        backup_service_info,
+        active_migration,
+    }
+}

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -3,7 +3,7 @@ use k256::{AffinePoint, Scalar};
 use mpc_contract::primitives::key_state::Keyset;
 use mpc_contract::state::ProtocolContractState;
 use rand::rngs::OsRng;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use threshold_signatures::ecdsa::ot_based_ecdsa::triples::TripleGenerationOutput;
 use threshold_signatures::ecdsa::ot_based_ecdsa::PresignOutput;
 use threshold_signatures::ecdsa::ot_based_ecdsa::{PresignArguments, RerandomizedPresignOutput};
@@ -273,12 +273,15 @@ impl OneNodeTestConfig {
 
                 let (_, dummy_protocol_state_receiver) =
                     watch::channel(ProtocolContractState::NotInitialized);
+                // todo: use it for testing [(#1249)](https://github.com/near/mpc/issues/1249)
+                let (_, dummy_migration_state_receiver) = watch::channel((0, BTreeMap::new()));
                 let web_server = start_web_server(
                     root_task.into(),
                     debug_request_sender.clone(),
                     self.config.web_ui.clone(),
                     static_web_data(&self.secrets, None),
                     dummy_protocol_state_receiver,
+                    dummy_migration_state_receiver,
                 )
                 .await?;
                 let _web_server = tracking::spawn_checked("web server", web_server);

--- a/pytest/common_lib/contracts.py
+++ b/pytest/common_lib/contracts.py
@@ -110,3 +110,8 @@ class ContractMethod(str, Enum):
     VOTE_ADD_DOMAINS = "vote_add_domains"
     PROPOSE_UPDATE = "propose_update"
     VOTE_UPDATE = "vote_update"
+    GET_TEE_ACCOUNTS = "get_tee_accounts"
+    MIGRATION_INFO = "migration_info"
+    STATE = "state"
+    REGISTER_BACKUP_SERVICE = "register_backup_service"
+    START_NODE_MIGRATION = "start_node_migration"

--- a/pytest/common_lib/migration_state.py
+++ b/pytest/common_lib/migration_state.py
@@ -1,0 +1,50 @@
+from dataclasses import dataclass
+from typing import Any, Optional, Dict
+
+
+@dataclass
+class ParticipantInfo:
+    url: str
+    sign_pk: str
+
+
+@dataclass
+class DestinationNodeInfo:
+    signer_account_pk: str
+    destination_node_info: ParticipantInfo
+
+
+@dataclass
+class BackupServiceInfo:
+    public_key: list[int]  # 32 integers
+
+
+@dataclass
+class AccountEntry:
+    backup_service_info: Optional[BackupServiceInfo]
+    destination_node_info: Optional[DestinationNodeInfo]
+
+
+@dataclass
+class MigrationState:
+    state_by_account: Dict[str, AccountEntry]
+
+
+def parse_migration_state(contract_btree_map: Any) -> MigrationState:
+    state_by_account: Dict[str, AccountEntry] = {}
+
+    for account_id, (backup_raw, dest_raw) in contract_btree_map.items():
+        backup = BackupServiceInfo(**backup_raw) if backup_raw else None
+        dest = (
+            DestinationNodeInfo(
+                signer_account_pk=dest_raw["signer_account_pk"],
+                destination_node_info=ParticipantInfo(
+                    **dest_raw["destination_node_info"]
+                ),
+            )
+            if dest_raw
+            else None
+        )
+        state_by_account[account_id] = AccountEntry(backup, dest)
+
+    return MigrationState(state_by_account=state_by_account)

--- a/pytest/common_lib/shared/mpc_node.py
+++ b/pytest/common_lib/shared/mpc_node.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 import pathlib
 import sys
 import time
@@ -7,6 +8,8 @@ from key import Key
 from ruamel.yaml import YAML
 
 from common_lib.constants import LISTEN_BLOCKS_FILE, MPC_BINARY_PATH
+from common_lib.contracts import ContractMethod
+from common_lib.migration_state import BackupServiceInfo, DestinationNodeInfo
 from common_lib.shared import metrics
 from common_lib.shared.metrics import DictMetricName, FloatMetricName, IntMetricName
 from common_lib.shared.near_account import NearAccount
@@ -200,3 +203,23 @@ class MpcNode(NearAccount):
             DictMetricName.MPC_PEERS_INDEXER_BLOCK_HEIGHTS
         )
         return {int(a["participant"]): int(b) for a, b in res}
+
+    def set_backup_service_info(
+        self, contract: str, backup_service_info: BackupServiceInfo
+    ):
+        tx = self.sign_tx(
+            contract,
+            ContractMethod.REGISTER_BACKUP_SERVICE,
+            {"backup_service_info": asdict(backup_service_info)},
+        )
+        return self.send_txn_and_check_success(tx)
+
+    def start_node_migration(
+        self, contract: str, destination_node_info: DestinationNodeInfo
+    ):
+        tx = self.sign_tx(
+            contract,
+            ContractMethod.START_NODE_MIGRATION,
+            {"destination_node_info": asdict(destination_node_info)},
+        )
+        return self.send_txn_and_check_success(tx)

--- a/pytest/tests/test_web_endpoints.py
+++ b/pytest/tests/test_web_endpoints.py
@@ -3,9 +3,22 @@
 Sanity checks that all web endpoints are properly served.
 """
 
+import json
 import sys
 import pathlib
+import time
 import requests
+
+from common_lib.migration_state import (
+    AccountEntry,
+    BackupServiceInfo,
+    DestinationNodeInfo,
+    MigrationState,
+    ParticipantInfo,
+    parse_migration_state,
+)
+from common_lib.shared.mpc_cluster import MpcCluster
+from common_lib.shared.mpc_node import MpcNode
 
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from common_lib import shared
@@ -22,6 +35,8 @@ def test_web_endpoints():
     cluster.send_and_await_ckd_requests(1)
 
     # ports are hardcoded... they come from PortSeed::CLI_FOR_PYTEST.web_port(i)
+
+    expected_migrations = MigrationState(state_by_account={})
     for port in range(20000, 20000 + number_nodes):
         response = requests.get(f"http://localhost:{port}/health")
         assert response.status_code == 200, response.status_code
@@ -47,3 +62,77 @@ def test_web_endpoints():
 
         response = requests.get(f"http://localhost:{port}/debug/contract")
         assert "Contract is in Running state" in response.text, response.text
+
+        verify_migration_endpoint(cluster, port, expected_migrations)
+
+
+def verify_migration_endpoint(
+    cluster: MpcCluster, port: int, expected_migrations: MigrationState
+):
+    contract_migrations = cluster.get_migrations()
+    assert contract_migrations == expected_migrations, (
+        f"expected {expected_migrations}, found {contract_migrations}"
+    )
+
+    response = requests.get(f"http://localhost:{port}/debug/migrations")
+    (_, contract_btree_map) = json.loads(response.text)
+    res = parse_migration_state(contract_btree_map)
+    assert expected_migrations == res, f"expected {expected_migrations}, found {res}"
+
+    # it does not matter which node we take here, as long as we end up taking all of them
+    node_id = port - 20000
+    node: MpcNode = cluster.mpc_nodes[node_id]
+    # we just need a bogus key
+    bogus_backup_service = BackupServiceInfo(public_key=[node_id] * 32)
+    node.set_backup_service_info(cluster.mpc_contract_account(), bogus_backup_service)
+
+    expected_migrations.state_by_account[node.account_id()] = AccountEntry(
+        backup_service_info=bogus_backup_service, destination_node_info=None
+    )
+    assert_contract_match(cluster, expected_migrations)
+    assert_web_endpiont_match(port, expected_migrations)
+
+    participant_info = ParticipantInfo(url="bogus_url", sign_pk=node.p2p_public_key)
+    bogus_destination_node_info = DestinationNodeInfo(
+        signer_account_pk=node._signer_key.pk,
+        destination_node_info=participant_info,
+    )
+    node.start_node_migration(
+        cluster.mpc_contract_account(), bogus_destination_node_info
+    )
+    expected_migrations.state_by_account[node.account_id()] = AccountEntry(
+        backup_service_info=bogus_backup_service,
+        destination_node_info=bogus_destination_node_info,
+    )
+
+    assert_contract_match(cluster, expected_migrations)
+
+    assert_web_endpiont_match(port, expected_migrations)
+
+
+def assert_web_endpiont_match(port: int, expected_migrations: MigrationState):
+    max_attempts: int = 10
+    for attempt in range(max_attempts):
+        response = requests.get(f"http://localhost:{port}/debug/migrations")
+        (_, contract_btree_map) = json.loads(response.text)
+        res = parse_migration_state(contract_btree_map)
+        if res == expected_migrations:
+            break
+        else:
+            assert attempt + 1 < max_attempts, (
+                f"Expected {expected_migrations}, found: {response.text}"
+            )
+            time.sleep(1)
+
+
+def assert_contract_match(cluster: MpcCluster, expected_migrations: MigrationState):
+    max_attempts: int = 10
+    for attempt in range(max_attempts):
+        contract_migrations = cluster.get_migrations()
+        if expected_migrations == contract_migrations:
+            break
+        else:
+            assert attempt + 1 < max_attempts, (
+                f"Failed to get expected migrations state expected: {expected_migrations}, found: {contract_migrations}"
+            )
+            time.sleep(1)


### PR DESCRIPTION
This PR:
- integrates the contract migration logic with the indexer
- adds debug web-endpoints to display the current view the node has on the migration state in the contract
- tests the aforementioned logic in a comprehensive pytest, verifying that debug endpoint and indexer work as expected.

 We also hook-up the fake indexer with the migration state logic, which will be useful for when we work on #1249 .

Note that part of the indexer integration follows the existing, concerning pattern  of spawning channels without a true separation of concerns. While working on this, I also, initially, resolved https://github.com/near/mpc/issues/1184, but found the PR would become quite a bit too large and lose focus, which led to a reversion of the refactor and a minimal diff seen herein.

Some observations about working with the indexer and a proposal for abstraction have been added [here](https://github.com/near/mpc/issues/1184#issuecomment-3378017936) 