### PR TITLE
fix: path to store latest mpc node image hashes in devnet

### DIFF
--- a/crates/devnet/README.md
+++ b/crates/devnet/README.md
@@ -31,7 +31,7 @@ The CLI can be installed using `cargo install`. Open a terminal in
 the devnet directory and run the following.
 
 ```shell
-cargo install --path .
+cargo install --path . --locked
 ```
 
 Once completed, you should have the `mpc-devnet` command available in your shell.

--- a/crates/devnet/src/terraform.rs
+++ b/crates/devnet/src/terraform.rs
@@ -144,7 +144,7 @@ async fn export_terraform_vars(
             mpc_contract_signer: contract,
             ssd: mpc_setup.ssd,
             image_hash,
-            latest_allowed_hash_file: "/mnt/shared/image-digest.bin".to_string(), // should match value in launcher.py
+            latest_allowed_hash_file: "latest_hash.txt".to_string(),
         };
         serde_json::to_string_pretty(&terraform_file).unwrap()
     };


### PR DESCRIPTION
Closes #1222 

Some [context](https://nearone.slack.com/archives/C07UW93JVQ8/p1762774926650819)