### PR TITLE
chore: remove "exit 1" that could close ssh session

### DIFF
--- a/docs/running_an_mpc_node_in_tdx_external_guide.md
+++ b/docs/running_an_mpc_node_in_tdx_external_guide.md
@@ -333,7 +333,6 @@ if [[ $ALL_OK -eq 1 ]]; then
     echo "All files verified successfully"
 else
     echo "One or more files did not match"
-    exit 1
 fi
 ```
 


### PR DESCRIPTION
tiny fix (no task associated).
remove "exit 1" that could close ssh session