### PR TITLE
fix: Separate build workflows for launcher and node

### DIFF
--- a/.github/workflows/docker_build_launcher.yml
+++ b/.github/workflows/docker_build_launcher.yml
@@ -1,4 +1,4 @@
-name: Build Docker Images on Main
+name: Build Docker Launcher Image
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -12,7 +12,7 @@ on:
 
 jobs:
   build-and-push-images:
-    name: "Build and push Docker images with commit hash"
+    name: "Build and push Docker launcher image with commit hash"
     runs-on: warp-ubuntu-2404-x64-8x
     permissions:
       contents: read
@@ -29,19 +29,12 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Install repro-env
-        run: |
-          wget 'https://github.com/kpcyrd/repro-env/releases/download/v0.4.3/repro-env'
-          echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
-          sudo install -m755 repro-env -t /usr/bin
-
       - name: Install skopeo
         run: |
           sudo apt-get update
           sudo apt-get install -y skopeo
 
-      - name: Build and push both images
+      - name: Build and push launcher image
         run: |
-          export NODE_IMAGE_NAME=mpc-node
           export LAUNCHER_IMAGE_NAME=mpc-launcher
-          ./deployment/build-images.sh --node --launcher --push
+          ./deployment/build-images.sh --launcher --push

--- a/.github/workflows/docker_build_node.yml
+++ b/.github/workflows/docker_build_node.yml
@@ -1,0 +1,41 @@
+name: Build Docker Node Image
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-push-images:
+    name: "Build and push Docker node image with commit hash"
+    runs-on: warp-ubuntu-2204-x64-8x
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef # v3.6.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Install repro-env
+        run: |
+          wget 'https://github.com/kpcyrd/repro-env/releases/download/v0.4.3/repro-env'
+          echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
+          sudo install -m755 repro-env -t /usr/bin
+
+      - name: Build and push node image
+        run: |
+          export NODE_IMAGE_NAME=mpc-node
+          ./deployment/build-images.sh --node --push


### PR DESCRIPTION
fixes #1465

This was a tricky one. It seems like buildkit fails on the `warp-ubuntu-2404` image whereas skopeo doesn't work on the `-2204` image. While it would be nice to find a better solution long-term, splitting the builds seems like the best short-term fix.