### PR TITLE
chore: Bump crate versions to 3.0.4 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,45 @@ All notable changes to this project will be documented in this file.
 
 This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## [3.0.4] - 2025-11-18
+
+### 🚀 Features
+
+- [#1428](https://github.com/near/mpc/pull/1428)(@barakeinav1): *(verification)* Allow RTMR2 to match production or dev measurements (#1428)
+
+- [#1438](https://github.com/near/mpc/pull/1438)(@gilcu3): Add support for abi snapshots (#1438)
+
+- [#1459](https://github.com/near/mpc/pull/1459)(@gilcu3): Add pytest with CKD private verification (#1459)
+
+- [#1468](https://github.com/near/mpc/pull/1468)(@gilcu3): Group compatible pytests to use shared cluster (#1468)
+
+
+### 🐛 Bug Fixes
+
+- [#1448](https://github.com/near/mpc/pull/1448)(@barakeinav1): *(localnet)* Ensure MPC node can sync after delay by updating neard retention policy (#1448)
+
+- [#1446](https://github.com/near/mpc/pull/1446)(@gilcu3): Align waiting time with number of added domains (#1446)
+
+- [#1463](https://github.com/near/mpc/pull/1463)(@gilcu3): Update snapshot after recent contract ABI changes (#1463)
+
+- [#1469](https://github.com/near/mpc/pull/1469)(@netrome): Separate build workflows for launcher and node (#1469)
+
+- [#1471](https://github.com/near/mpc/pull/1471)(@gilcu3): Make sure cargo-near is installed from binary release (#1471)
+
+- [#1480](https://github.com/near/mpc/pull/1480)(@gilcu3): Fetch mpc secret store key and add gcp image (#1480)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- [#1451](https://github.com/near/mpc/pull/1451)(@gilcu3): Update testnet contract (#1451)
+
+- [#1454](https://github.com/near/mpc/pull/1454)(@gilcu3): Update contract readme wrt CKD (#1454)
+
+- [#1460](https://github.com/near/mpc/pull/1460)(@netrome): Improved docker workflows for node and launcher image (#1460)
+
+- [#1464](https://github.com/near/mpc/pull/1464)(@gilcu3): Extend localnet guide to include eddsa and ckd examples as well (#1464)
+
+
 ## [3.0.3] - 2025-11-12
 
 ### 🐛 Bug Fixes
@@ -17,6 +56,8 @@ This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conv
 - [#1434](https://github.com/near/mpc/pull/1434)(@barakeinav1): Fix key names in localnet guide (#1434)
 
 - [#1444](https://github.com/near/mpc/pull/1444)(@netrome): Bump nearcore to include 2.9.1 (#1444)
+
+- [#1445](https://github.com/near/mpc/pull/1445)(@netrome): Bump crate versions to 3.0.3 and update changelog (#1445)
 
 
 ## [3.0.2] - 2025-11-11

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1175,7 +1175,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "borsh",
  "dcap-qvl",
@@ -1463,7 +1463,7 @@ dependencies = [
 
 [[package]]
 name = "backup-cli"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2183,7 +2183,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-interface"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "borsh",
  "bs58 0.5.1",
@@ -2197,7 +2197,7 @@ dependencies = [
 
 [[package]]
 name = "contract_history"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "bs58 0.5.1",
  "clap",
@@ -5017,7 +5017,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mpc-contract"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5061,7 +5061,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-devnet"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5089,7 +5089,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "actix",
  "aes-gcm",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "borsh",
  "derive_more 2.0.1",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-tls"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -6900,7 +6900,7 @@ dependencies = [
 
 [[package]]
 name = "node-types"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "attestation",
@@ -9819,7 +9819,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tee_authority"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "anyhow",
  "attestation",
@@ -9867,7 +9867,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-migration-contract"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "borsh",
  "near-sdk",
@@ -9875,7 +9875,7 @@ dependencies = [
 
 [[package]]
 name = "test-parallel-contract"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "blstrs",
  "borsh",
@@ -9890,7 +9890,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "3.0.3"
+version = "3.0.4"
 dependencies = [
  "attestation",
  "contract-interface",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.3"
+version = "3.0.4"
 edition = "2024"
 license = "MIT"
 

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -1,12 +1,13 @@
 ---
 source: crates/contract/tests/abi.rs
+assertion_line: 48
 expression: abi
 ---
 {
   "schema_version": "0.4.0",
   "metadata": {
     "name": "mpc-contract",
-    "version": "3.0.3",
+    "version": "3.0.4",
     "build": {
       "compiler": "rustc 1.86.0",
       "builder": "cargo-near cargo-near-build 0.9.0"


### PR DESCRIPTION
part of #1483 