### PR TITLE
chore: Bump crate versions to 3.0.5 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ All notable changes to this project will be documented in this file.
 
 This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## [3.0.5] - 2025-11-21
+
+### 🚀 Features
+
+- [#1505](https://github.com/near/mpc/pull/1505)(@andrei-near): Periodic mpc build workflow (#1505)
+
+- [#1506](https://github.com/near/mpc/pull/1506)(@kevindeforth): Contract allows querying update proposals (#1506)
+
+- [#1510](https://github.com/near/mpc/pull/1510)(@gilcu3): Sandbox tests support for any number of participants (#1510)
+
+
+### 🐛 Bug Fixes
+
+- [#1488](https://github.com/near/mpc/pull/1488)(@kevindeforth): *(contract)* Fix ProposeUpdate vote method and add unit test (#1488)
+
+- [#1490](https://github.com/near/mpc/pull/1490)(@gilcu3): Remove balance checks (#1490)
+
+- [#1492](https://github.com/near/mpc/pull/1492)(@barakeinav1): *(test)* Enable and update test_from_str_valid (#1492)
+
+- [#1509](https://github.com/near/mpc/pull/1509)(@andrei-near): Nightly build MPC workflow (#1509)
+
+
+### 🧪 Testing
+
+- [#1498](https://github.com/near/mpc/pull/1498)(@pbeza): Add unit tests for `do_update` function in `contract.rs` (#1498)
+
+- [#1504](https://github.com/near/mpc/pull/1504)(@barakeinav1): Update attestation test and refresh asset extraction files (#1504)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- [#1503](https://github.com/near/mpc/pull/1503)(@DSharifi): Update mainnet to use 3_0_2 release for backwards compatibilit… (#1503)
+
+- [#1511](https://github.com/near/mpc/pull/1511)(@DSharifi): Bump nearcore dependency to `2.10.0-rc.3` (#1511)
+
+
 ## [3.0.4] - 2025-11-18
 
 ### 🚀 Features
@@ -42,6 +78,8 @@ This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conv
 - [#1460](https://github.com/near/mpc/pull/1460)(@netrome): Improved docker workflows for node and launcher image (#1460)
 
 - [#1464](https://github.com/near/mpc/pull/1464)(@gilcu3): Extend localnet guide to include eddsa and ckd examples as well (#1464)
+
+- [#1487](https://github.com/near/mpc/pull/1487)(@netrome): Bump crate versions to 3.0.4 and update changelog (#1487)
 
 
 ## [3.0.3] - 2025-11-12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "borsh",
  "dcap-qvl",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "backup-cli"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -1785,7 +1785,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-interface"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "borsh",
  "bs58 0.5.1",
@@ -1799,7 +1799,7 @@ dependencies = [
 
 [[package]]
 name = "contract_history"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "bs58 0.5.1",
  "clap",
@@ -4634,7 +4634,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mpc-contract"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4679,7 +4679,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-devnet"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4709,7 +4709,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4777,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "borsh",
  "derive_more 2.0.1",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-tls"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -6575,7 +6575,7 @@ dependencies = [
 
 [[package]]
 name = "node-types"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "attestation",
@@ -9402,7 +9402,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tee_authority"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "anyhow",
  "attestation",
@@ -9450,7 +9450,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-migration-contract"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "borsh",
  "near-sdk",
@@ -9458,7 +9458,7 @@ dependencies = [
 
 [[package]]
 name = "test-parallel-contract"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "blstrs",
  "borsh",
@@ -9473,7 +9473,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "attestation",
  "contract-interface",
@@ -10189,7 +10189,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utilities"
-version = "3.0.4"
+version = "3.0.5"
 dependencies = [
  "near-account-id 1.1.4",
  "near-account-id 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.4"
+version = "3.0.5"
 edition = "2024"
 license = "MIT"
 

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -1,13 +1,12 @@
 ---
 source: crates/contract/tests/abi.rs
-assertion_line: 48
 expression: abi
 ---
 {
   "schema_version": "0.4.0",
   "metadata": {
     "name": "mpc-contract",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "build": {
       "compiler": "rustc 1.86.0",
       "builder": "[CARGO_NEAR_BUILD_VERSION]"


### PR DESCRIPTION
Part of #1513 