### PR TITLE
chore: Bump crate versions to 3.0.6 and update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,36 @@ All notable changes to this project will be documented in this file.
 
 This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
-## [3.0.5] - 2025-11-21
+## [3.0.6] - 2025-11-25
+
+### 🚀 Features
+
+- [#1533](https://github.com/near/mpc/pull/1533)(@gilcu3): Fix rust-cache in CI (#1533)
+
+- [#1537](https://github.com/near/mpc/pull/1537)(@kevindeforth): Allow participants to withdraw their update vote (#1537)
+
+- [#1542](https://github.com/near/mpc/pull/1542)(@gilcu3): Initial ckd example app (#1542)
+
+
+### 🐛 Bug Fixes
+
+- [#1521](https://github.com/near/mpc/pull/1521)(@gilcu3): Both test could be fixed by bumping gas appropiately (#1521)
+
+- [#1530](https://github.com/near/mpc/pull/1530)(@gilcu3): Enable pytest optimizations removed in #1511  (#1530)
+
+- [#1531](https://github.com/near/mpc/pull/1531)(@gilcu3): Use reproducible build in existing test (#1531)
+
+- [#1539](https://github.com/near/mpc/pull/1539)(@gilcu3): Use correct nearcore commit in submodule (#1539)
+
+- [#1547](https://github.com/near/mpc/pull/1547)(@gilcu3): Patch nearcore version 210 (#1547)
+
+
+### 📚 Documentation
+
+- [#1467](https://github.com/near/mpc/pull/1467)(@pbeza): Design TEE-enabled backup service (#1467)
+
+
+## [3.0.5] - 2025-11-23
 
 ### 🚀 Features
 
@@ -26,6 +55,8 @@ This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conv
 
 - [#1509](https://github.com/near/mpc/pull/1509)(@andrei-near): Nightly build MPC workflow (#1509)
 
+- [#1525](https://github.com/near/mpc/pull/1525)(@netrome): Use patched near core supporting reproducible builds (#1525)
+
 
 ### 🧪 Testing
 
@@ -39,6 +70,8 @@ This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conv
 - [#1503](https://github.com/near/mpc/pull/1503)(@DSharifi): Update mainnet to use 3_0_2 release for backwards compatibilit… (#1503)
 
 - [#1511](https://github.com/near/mpc/pull/1511)(@DSharifi): Bump nearcore dependency to `2.10.0-rc.3` (#1511)
+
+- [#1523](https://github.com/near/mpc/pull/1523)(@netrome): Bump crate versions to 3.0.5 and update changelog (#1523)
 
 
 ## [3.0.4] - 2025-11-18

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -886,7 +886,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "borsh",
  "dcap-qvl",
@@ -1116,7 +1116,7 @@ dependencies = [
 
 [[package]]
 name = "backup-cli"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -1629,7 +1629,7 @@ dependencies = [
 
 [[package]]
 name = "ckd-example-cli"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "blstrs",
@@ -1803,7 +1803,7 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "contract-interface"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "borsh",
  "bs58 0.5.1",
@@ -1817,7 +1817,7 @@ dependencies = [
 
 [[package]]
 name = "contract_history"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "bs58 0.5.1",
  "clap",
@@ -4652,7 +4652,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mpc-contract"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-devnet"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "borsh",
@@ -4727,7 +4727,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "borsh",
  "derive_more 2.0.1",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-tls"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -6592,7 +6592,7 @@ dependencies = [
 
 [[package]]
 name = "node-types"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "attestation",
@@ -9419,7 +9419,7 @@ checksum = "df7f62577c25e07834649fc3b39fafdc597c0a3527dc1c60129201ccfcbaa50c"
 
 [[package]]
 name = "tee_authority"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "anyhow",
  "attestation",
@@ -9467,7 +9467,7 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-migration-contract"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "borsh",
  "near-sdk",
@@ -9475,7 +9475,7 @@ dependencies = [
 
 [[package]]
 name = "test-parallel-contract"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "blstrs",
  "borsh",
@@ -9490,7 +9490,7 @@ dependencies = [
 
 [[package]]
 name = "test_utils"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "attestation",
  "contract-interface",
@@ -10206,7 +10206,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utilities"
-version = "3.0.5"
+version = "3.0.6"
 dependencies = [
  "near-account-id 1.1.4",
  "near-account-id 2.0.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.0.5"
+version = "3.0.6"
 edition = "2024"
 license = "MIT"
 

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -6,7 +6,7 @@ expression: abi
   "schema_version": "0.4.0",
   "metadata": {
     "name": "mpc-contract",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "build": {
       "compiler": "rustc 1.86.0",
       "builder": "[CARGO_NEAR_BUILD_VERSION]"


### PR DESCRIPTION
part of #1548 