### PR TITLE
feat: embed abi in contract

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -31,7 +31,6 @@ container_build_command = [
     "--profile=release-contract",
     "--features",
     "abi",
-    "--no-embed-abi",
 ]
 
 [package.metadata.cargo-shear]


### PR DESCRIPTION
Closes #1562 

Example [MPC contract](https://testnet.nearblocks.io/address/gilcu3-contract.testnet?tab=contract) with embedded abi deployed in testnet

Contract size change: before -> 1.2M, after -> 1.2M, so it seems compression worked pretty well.

Note: I am not removing the abi feature from the contract because IIRC it would break clippy/tests somehow