### PR TITLE
PoC for test seed proc macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9486,6 +9486,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
+name = "test-macros"
+version = "0.1.0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rand 0.8.5",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "test-macros-tests"
+version = "0.1.0"
+dependencies = [
+ "rand 0.8.5",
+ "test-macros",
+]
+
+[[package]]
 name = "test-migration-contract"
 version = "3.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ members = [
     "crates/node-types",
     "crates/primitives",
     "crates/tee-authority",
+    "crates/test-macros",
+    "crates/test-macros-tests",
     "crates/test-migration-contract",
     "crates/test-parallel-contract",
     "crates/test-utils",
@@ -102,6 +104,9 @@ near-sdk = { version = "5.18.1", features = [
     "unit-testing",
     "unstable",
 ] }
+proc-macro2 = "1"
+quote = "1"
+syn = { version = "2", features = ["full"] }
 near-workspaces = { version = "0.21.0" }
 prometheus = { version = "0.13.4", default-features = false }
 rand = "0.8.5"

--- a/crates/test-macros-tests/Cargo.toml
+++ b/crates/test-macros-tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "test-macros-tests"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+test-macros = { path = "../test-macros" }
+rand = "0.8"

--- a/crates/test-macros-tests/README.md
+++ b/crates/test-macros-tests/README.md
@@ -1,0 +1,10 @@
+Example usage:
+
+```
+TEST_SEED="71,08,70,63,09,6d,77,b5,36,ac,4a,36,6c,31,fe,de,81,5e,a9,02,fa,a6,61,ef,9a,32,b4,b4,9a,5d,6c,7c" \
+cargo test -- --nocapture
+```
+
+```
+TEST_SEED="71,08,70,63,09,6d,77,b5,36,ac,4a,36,6c,31,fe,de,81,5e,a9,02,fa,a6,61,ef,9a,32,b4,b4,9a,5d,6c,7c" cargo nextest run --release -- test_fails_sometimes
+```

--- a/crates/test-macros-tests/tests/with_rng.rs
+++ b/crates/test-macros-tests/tests/with_rng.rs
@@ -1,0 +1,13 @@
+use test_macros::with_rng;
+
+#[with_rng]
+fn test_basic() {
+    let x = rng.gen_range(0..10);
+    assert!(x < 10);
+}
+
+#[with_rng]
+fn test_fails_sometimes() {
+    let x = rng.gen_range(0..2);
+    assert_eq!(x, 1);
+}

--- a/crates/test-macros/Cargo.toml
+++ b/crates/test-macros/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "test-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true
+rand.workspace = true

--- a/crates/test-macros/src/lib.rs
+++ b/crates/test-macros/src/lib.rs
@@ -1,0 +1,67 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{parse_macro_input, ItemFn};
+
+
+
+#[proc_macro_attribute]
+pub fn with_rng(_attr: TokenStream, item: TokenStream) -> TokenStream {
+    let func = parse_macro_input!(item as ItemFn);
+    let fn_name = &func.sig.ident;
+    let fn_block = &func.block;
+
+    // The name of the RNG variable the user gets
+    let rng_ident = syn::Ident::new("rng", fn_name.span());
+
+    // Wrap the original body
+    let wrapped = quote! {
+        #[test]
+        fn #fn_name() {
+            use rand::{RngCore, SeedableRng};
+            use rand::rngs::StdRng;
+            use rand::Rng;
+
+            fn extract_seed_from_env()-> Option<[u8; 32]> {
+                let Ok(val) = std::env::var("TEST_SEED") else {
+                    return None
+                };
+                // Expected format: "71,08,70,..."
+                let bytes: Vec<u8> = val
+                    .split(',')
+                    .map(|s| u8::from_str_radix(s.trim().trim_start_matches("0x"), 16)
+                         .expect("Invalid TEST_SEED byte"))
+                    .collect();
+            
+                assert_eq!(bytes.len(), 32, "TEST_SEED must have 32 bytes");
+                let mut arr = [0u8; 32];
+                arr.copy_from_slice(&bytes);
+                eprintln!("Using explicit TEST_SEED = {:?}", arr);
+                Some(arr)
+            }
+            
+            fn gen_seed() -> [u8; 32] {
+                let mut seed = [0u8; 32];
+                rand::thread_rng().fill_bytes(&mut seed);
+                seed
+            }
+
+            // Generate seed
+            let seed = extract_seed_from_env().unwrap_or(gen_seed());
+
+            // Initialize RNG
+            let mut #rng_ident = StdRng::from_seed(seed);
+
+            // Run the test body with panic capture
+            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                #fn_block
+            }));
+
+            if let Err(e) = result {
+                eprintln!("Test failed with RNG seed: {:02x?}", seed);
+                std::panic::resume_unwind(e);
+            }
+        }
+    };
+
+    wrapped.into()
+}


### PR DESCRIPTION
will clean this PR up in case we want this.
Tldr:
We can add a proc macro over a test to initialize a rng with seed:
```rust
#[with_rng]
fn test_fails_sometimes() {
    let x = rng.gen_range(0..2);
    assert_eq!(x, 1);
}
```

in case it fails, the test outputs the seed and we re-run with the seed:
```bash
kevin@barista:~/near/mpc$ cargo nextest run --release -- test_fails_sometimes
    Finished `release` profile [optimized] target(s) in 0.30s
warning: the following packages contain code that will be rejected by a future version of Rust: wasmparser v0.78.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 2`
────────────
 Nextest run ID 68112f89-b783-45e8-8935-28dcccd9a751 with nextest profile: default
    Starting 1 test across 28 binaries (390 tests skipped)
        FAIL [   0.003s] test-macros-tests::with_rng test_fails_sometimes
──── STDOUT:             test-macros-tests::with_rng test_fails_sometimes

running 1 test
test test_fails_sometimes ... FAILED

failures:

failures:
    test_fails_sometimes

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 1 filtered out; finished in 0.00s

──── STDERR:             test-macros-tests::with_rng test_fails_sometimes

thread 'test_fails_sometimes' panicked at crates/test-macros-tests/tests/with_rng.rs:12:5:
assertion `left == right` failed
  left: 0
 right: 1
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Test failed with RNG seed: [99, b7, c6, 79, 52, 7f, ec, bd, 29, f4, 65, 63, 5a, f7, 4d, 3e, d7, 4f, 50, 4e, 87, 24, 02, 9a, 8a, 4b, 18, 11, 1f, d9, b0, 73]

  Cancelling due to test failure
────────────
     Summary [   0.007s] 1 test run: 0 passed, 1 failed, 390 skipped
        FAIL [   0.003s] test-macros-tests::with_rng test_fails_sometimes
error: test run failed

```
