### PR TITLE
fix: fix derivation_path params in ckd-example-cli

### DIFF
--- a/crates/ckd-example-cli/README.md
+++ b/crates/ckd-example-cli/README.md
@@ -39,7 +39,7 @@ of the MPC contract.
 ❯ cargo run -p ckd-example-cli -- --domain-id 2 --signer-account-id frodo.test.near --derivation-path "mykey" --mpc-ckd-public-key bls12381g2:22AgdyBXAQor5kiToW4frjEksuAhyic1S7CWWX7LFBTXFt1MxjcXwuB73yFCQVQfwMjKQoFFtmxPSUg2fCjhNUNVCFPVdtotAFMkPpoDg9s3QWQSZ2gUfvS3Uw1gaESFCfrw
 
 Call the function request_app_private_key with parameters:
-{"request":{"derivation-path": "mykey", "app_public_key":"bls12381g1:64PJdGWrTzm5HY7wkXxWWPdaa6rtadsRuz4DxpZKK6nAVFE8xDPrQBLNbApfWM45ar","domain_id":2}}
+{"request":{"derivation_path": "mykey", "app_public_key":"bls12381g1:64PJdGWrTzm5HY7wkXxWWPdaa6rtadsRuz4DxpZKK6nAVFE8xDPrQBLNbApfWM45ar","domain_id":2}}
 Please enter a the response in json format (for example {"big_c": "bls12381g1:...","big_y": "bls12381g1:..."}):
 Your response: {
   "big_c": "bls12381g1:5qzsECuw1B4oCG78dUwJQ49o5egkNBfPvGfcJLKbznEeL7fpEv4hZYyu9VRt64ucRz",
@@ -54,7 +54,7 @@ If the tool is used again, it will generate a different `app_public_key`, but ob
 ❯ cargo run -p ckd-example-cli -- --domain-id 2 --signer-account-id frodo.test.near --derivation-path "mykey" --mpc-ckd-public-key bls12381g2:22AgdyBXAQor5kiToW4frjEksuAhyic1S7CWWX7LFBTXFt1MxjcXwuB73yFCQVQfwMjKQoFFtmxPSUg2fCjhNUNVCFPVdtotAFMkPpoDg9s3QWQSZ2gUfvS3Uw1gaESFCfrw
 
 Call the function request_app_private_key with parameters:
-{"request":{"derivation-path": "mykey", "app_public_key":"bls12381g1:5ieM9Vog2JyWnTsHjh2eEMMZzHae8BcGXmdtrgjqkjBDWSSGY2ndv7dRQhGEiZ9BvB","domain_id":2}}
+{"request":{"derivation_path": "mykey", "app_public_key":"bls12381g1:5ieM9Vog2JyWnTsHjh2eEMMZzHae8BcGXmdtrgjqkjBDWSSGY2ndv7dRQhGEiZ9BvB","domain_id":2}}
 Please enter a the response in json format (for example {"big_c": "bls12381g1:...","big_y": "bls12381g1:..."}):
 Your response: {
   "big_c": "bls12381g1:6AZZQCerkTtGxV7J3AQuzSdghn2uUim41m88hL4NHdxn7GT8GjdBzZ2fGe6WbVkZGS",

--- a/crates/ckd-example-cli/src/types.rs
+++ b/crates/ckd-example-cli/src/types.rs
@@ -10,7 +10,7 @@ pub struct CKDResponse {
 
 #[derive(Clone, Debug, Serialize, Deserialize, derive_more::Constructor)]
 pub struct CKDArgs {
-    pub path: String,
+    pub derivation_path: String,
     pub app_public_key: Bls12381G1PublicKey,
     pub domain_id: DomainId,
 }


### PR DESCRIPTION
Follow-up to #1627 