### PR TITLE
ci: enable debug-asserttions on CI test profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -162,6 +162,7 @@ near-time = { git = "https://github.com/near/nearcore", tag = "2.10.2" }
 inherits = "release"
 overflow-checks = true
 debug = true
+debug-assertions = true
 
 [profile.release-contract]
 inherits = "release"


### PR DESCRIPTION
This was an oversight in #1676, and should have been included there.

part of #1677

