### PR TITLE
ci: ignore `RUSTSEC-2026-0001` in `cargo-deny` check

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -31,6 +31,10 @@ ignore = [
   # - `ruint` is a transitive dependency through `alloy`.
   # - The affected function is unused in alloy (ref: recmo/uint#550, alloy-rs/alloy#3416).
   "RUSTSEC-2025-0137",
+  # - `rkyv` has potential UB in Arc/Rc impls on OOM (ref: rkyv/rkyv#644).
+  # - `rkyv` is a transitive dependency through `nearcore`.
+  # - We cannot update it directly; waiting for nearcore to bump their dependency.
+  "RUSTSEC-2026-0001",
 ]
 
 [bans]


### PR DESCRIPTION
This issue has a similar rationale to https://github.com/near/mpc/issues/1714.

See also:
- the related comment here for more context:
   https://github.com/near/mpc/blob/7f0a2b287fd57620d425c258255c4c1a26fcaaf5/deny.toml#L34-L37
- https://rustsec.org/advisories/RUSTSEC-2026-0001.html
- https://github.com/rkyv/rkyv/issues/644