### PR TITLE
build(nix): include `apple-sdk_14` package to build `neard` on MacOs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -158,6 +158,9 @@
             ++ lib.optionals stdenv.isLinux [
               udev
               dbus
+            ]
+            ++ lib.optionals stdenv.isDarwin [
+              apple-sdk_14
             ];
 
           hardening = [


### PR DESCRIPTION
closes #1807