### PR TITLE
fix: cargo-make check-all using wrong profile parameter

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -71,7 +71,7 @@ command = "cargo"
 args = [
   "nextest",
   "run",
-  "--profile=test-release",
+  "--cargo-profile=test-release",
   "--all-features",
   "--all-targets",
   "--locked",


### PR DESCRIPTION
Closes #1827 