### PR TITLE
fix: update deps dcap-qvl and oneshot to avoid known vulnerabilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6985,9 +6985,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "oneshot"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+checksum = "3ce66197e99546da6c6d991285f605192e794ceae69686c17163844a7bf8fcc2"
 
 [[package]]
 name = "opaque-debug"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ curve25519-dalek = { version = "4.1.3", features = [
     "group",
     "serde",
 ], default-features = false }
-dcap-qvl = { version = "0.3.2", default-features = false, features = ["contract", "borsh", "std"] }
+dcap-qvl = { version = "0.3.10", default-features = false, features = ["contract", "borsh", "std"] }
 derive_more = { version = "2.0.1", features = [
     "from",
     "deref",


### PR DESCRIPTION
Closes #1853 