### PR TITLE
fix: hot loop bug in running state when no keyshares are found

### DIFF
--- a/crates/node/src/coordinator.rs
+++ b/crates/node/src/coordinator.rs
@@ -602,10 +602,7 @@ where
             tracing::info!("Waiting on resharing handle.");
             resharing_handle.await?;
         }
-
-        running_handle.await??;
-
-        Ok(MpcJobResult::Done)
+        running_handle.await?
     }
 
     /// Entry point to handle the Resharing state of the contract.


### PR DESCRIPTION
Closes #1834 

The bug being solved is basically that the function `run_mpc` was always returning `Ok(MpcJobResult::Done)` instead of the result stored in `running_handle.await?` as was expected by the function logic. In the special case of `running_handle.await? == Ok(MpcJobResult::HaltUntilInterrupted)` this was causing the node enter in a hot loop under certain conditions, such as the one described in the issue