### PR TITLE
docs: Draft Proposal: Separating Oracle and MPC Networks

### DIFF
--- a/docs/foreign_chain_transactions.md
+++ b/docs/foreign_chain_transactions.md
@@ -1,0 +1,59 @@
+```mermaid
+---
+title: Attestation-Gated Signing Architecture - System Context
+---
+flowchart TD
+
+    subgraph OffChain["Off Chain"]
+        RPC["**RPC Providers / Light Clients**"]
+        FC["**Foreign Chain**"]
+        RPC -->|"4. read state"| FC
+    end
+
+    %% Oracle layer
+    subgraph OracleLayer["Oracle Network"]
+        OC["**Oracle Contract**
+            _Attest foreign chain state.
+             Handles requirements for Oracle Nodes._"]
+        
+        ON["**Oracle Nodes**
+             _Running in TEEs.
+             May or may not be MPC nodes_"]
+        
+        ON -->|"5. submit attestation"| OC
+    end
+    
+    ON -->|"3. query"| RPC
+
+    GC["**Gating Contract**
+      _sign_if_attested()_"]
+
+
+    %% MPC layer
+    subgraph MpcLayer["Mpc Network"]
+        MN["**MPC Nodes**"]
+        MC["**MPC Signer Contract**
+          _Threshold signing._"]
+        MN -->|"7. produce signature"| MC
+        
+    end
+
+    %% External
+    DEV["**Developer / Bridge Service**"]
+
+    %% Flows
+    GC -->|"2. verify attestation"| OC
+    GC -->|"6. request signing"| MC
+
+    DEV -->|"1. sign_if_attested()"| GC
+    MC -->|"7. return signature"| GC
+    %% Shapes
+    DEV@{ shape: manual-input}
+    OC@{ shape: db}
+    GC@{ shape: db}
+    MC@{ shape: db}
+    ON@{ shape: proc}
+    MN@{ shape: proc}
+    RPC@{ shape: proc}
+    FC@{ shape: cylinder}
+```


### PR DESCRIPTION
A proposal for #1918 on how to keep oracle and MPC network separate. Alternative to #1920 and #1917

A key concern with  the previously discussed designs is that the MPC network is homogeneous by definition, while oracle networks are inherently heterogeneous.
Oracle functionality varies significantly across chains and may evolve independently over time. Attempting to handle both responsibilities within a single binary is likely to introduce complexity and operational risk. We would like the MPC network to remain functional, even if some oracle functionality is broken due to unforeseen events.
Separating the functionalities into different binaries and contracts _will_ give us those guarantees.

Proposal:
MPC nodes may still participate in oracle verification, but oracle and MPC functionality should be implemented as separate binaries with independent governance and release cycles.
This separation allows the oracle and MPC networks to evolve independently, paying tribute to their inherently different natures.

Benefits:
- **Clear separation of concerns:**
 We keep the core responsibility of the MPC network (signing signatures) separate from oracle functionality. Changes or failures in RPC providers or chain-specific verification logic would not require urgent MPC releases and would instead be confined to the oracle layer. This ensures signing functionality will not be unnecessarily blocked due to issues in the oracle layer.
- While the initial oracle implementation may rely on RPC queries, the architecture should not constrain future improvements. In particular, it should allow for the adoption of light clients running inside TEEs to verify foreign-chain transactions directly.
- Different chains require different trust models. For some chains, a single authenticated RPC response may be sufficient, while others may require cross-checking multiple providers or clients. A dedicated oracle network enables these strategies to be defined and evolved independently on a per-chain basis.


