### PR TITLE
docs: Post-discussion updates for foreign chain transaction design doc

### DIFF
--- a/docs/foreign_chain_transactions.md
+++ b/docs/foreign_chain_transactions.md
@@ -69,16 +69,13 @@ respond_verify_foreign_tx({ request, response }) // Respond method for signers
 ```rust
 // Contract DTOs
 pub struct VerifyForeignTxRequestArgs {
-    pub chain: ForeignChain,
-    pub tx_id: ForeignTransactionId, // TxID is the payload we're signing
+    pub request: ForeignChainRpcRequest,
     pub path: String, // Key derivation path
     pub domain_id: DomainId,
 }
 
 pub struct VerifyForeignTxRequest {
-    // Constructed from the args
-    pub chain: ForeignChainRpcRequest,
-    pub tx_id: ForeignTransactionId,
+    pub request: ForeignChainRpcRequest,
     pub tweak: Tweak,
     pub domain_id: DomainId,
 }
@@ -95,12 +92,12 @@ pub enum ForeignChainRpcRequest {
 }
 
 pub struct SolanaRpcRequest {
-    pub tx_id: SolanaTxId,
+    pub tx_id: SolanaTxId, // This is the payload we're signing
     pub finality: Finality, // Optimistic or Final
 }
 
 pub struct BitcoinRpcRequest {
-    pub tx_id: BitcoinTxId,
+    pub tx_id: BitcoinTxId, // This is the payload we're signing
     pub confirmations: usize, // required confirmations before considering final
 }
 


### PR DESCRIPTION
Closes #1924 

This PR incorporates review feedback and conclusions from various discussions into the design doc keeping it up-to-date with the latest design ideas.

Note: We have a pretty big design change ahead of us as we found that just verifying transaction existence isn't sufficient for the bridge use case. I added a note about this, I'll follow up with a design proposal to handle this and we have a meeting on Monday to discuss it.