### PR TITLE
chore: move `rustfmt.toml` file to workspace root

### DIFF
--- a/crates/attestation/rustfmt.toml
+++ b/crates/attestation/rustfmt.toml
@@ -1,3 +1,0 @@
-use_small_heuristics = "Default"
-reorder_imports = true
-edition = "2024"

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2024"
+reorder_imports = true


### PR DESCRIPTION
closes #630 