### PR TITLE
ci(cargo-deny): remove unnecessary skip for `prost`

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -32,7 +32,6 @@ ignore = [
 
 [bans]
 multiple-versions = "deny"
-skip = [{ name = "prost-types" }]
 skip-tree = [
   { name = "axum" },
   { name = "near-jsonrpc-client" },


### PR DESCRIPTION
closes #2029
