### PR TITLE
build: bump cargo resolver version to version `3`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-resolver = "2"
+resolver = "3"
 exclude = ["libs/nearcore"]
 members = [
     "crates/attestation",


### PR DESCRIPTION
closes #2047