### PR TITLE
chore: bump prometheus to `0.14.0`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5319,7 +5319,7 @@ dependencies = [
  "node-types",
  "num_enum",
  "pprof",
- "prometheus",
+ "prometheus 0.14.0",
  "rand 0.8.5",
  "regex",
  "rocksdb",
@@ -6233,7 +6233,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "parking_lot 0.12.5",
- "prometheus",
+ "prometheus 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6928,7 +6928,7 @@ dependencies = [
  "num-rational",
  "parking_lot 0.12.5",
  "prefix-sum-vec",
- "prometheus",
+ "prometheus 0.13.4",
  "rand 0.8.5",
  "rayon",
  "ripemd",
@@ -8092,6 +8092,20 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.5",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if 1.0.4",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.5",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,7 +115,7 @@ near-workspaces = { version = "0.22.1" }
 num_enum = { version = "0.7", features = ["complex-expressions"] }
 pprof = { version = "0.15.0", features = ["cpp", "flamegraph"], default-features = false }
 proc-macro2 = "1.0"
-prometheus = { version = "0.13.4", default-features = false }
+prometheus = { version = "0.14.0", default-features = false }
 quote = "1.0"
 rand = "0.8.5"
 rand_chacha = "0.3"


### PR DESCRIPTION
closes #1909