### PR TITLE
build: use nixpkgss to install cargo-nextest

### DIFF
--- a/nix/cargo-tools.nix
+++ b/nix/cargo-tools.nix
@@ -3,7 +3,6 @@
   rustPlatform,
   fetchCrate,
   pkgs,
-  stdenv,
 }:
 
 let


### PR DESCRIPTION
closes #2093 