### PR TITLE
docs: indexer proposal

### DIFF
--- a/docs/indexer-design.md
+++ b/docs/indexer-design.md
@@ -545,7 +545,7 @@ while let Some(update) = block_stream_receiver.recv().await {
 
 ```
 
-Specific types (c.f. [Appendix](current-block-update) and `indexer/handler.rs` for justification).
+Specific types (c.f. [Appendix](#current-block-update) and `indexer/handler.rs` for justification).
 ```rust
 /// The BlockUpdate returned by the Chain indexer. Similar to the current `BlockUpdate`
 pub struct BlockUpdate {


### PR DESCRIPTION
resolves #1904 

This is an (improved) alternative to https://github.com/near/mpc/pull/1905, putting more importance on the difference between Near Chain indexing and MPC node context: This PR introduces concepts and definitions that should help us reason about this.
While the State viewing and subscription interface remains pretty close to what was proposed in #1905, the `BlockEventSubscriber` and `TransactionSender` interfaces are more mature and generic enough that they will serve us well for backup service, HOT wallet and if we chose to do so, oracle networks and production monitoring systems.