### PR TITLE
chore: add exceptions to dependabot that are known to fail because of devnet

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -43,3 +43,8 @@ updates:
       - dependency-name: "rand_core"
       # Cannot be upgraded until we get MSVR 1.88
       - dependency-name: "time"
+      # TODO(#657): These are pinned to older versions in the devnet crate and cannot be upgraded
+      - dependency-name: "near-crypto"
+      - dependency-name: "near-jsonrpc-client"
+      - dependency-name: "near-jsonrpc-primitives"
+      - dependency-name: "near-primitives"


### PR DESCRIPTION
Closes #2116 

- I wanted to add the exceptions to the devnet crate only, but it seems dependabot does not support such thing