### PR TITLE
feat!: Domain separation

### DIFF
--- a/crates/contract-interface/src/lib.rs
+++ b/crates/contract-interface/src/lib.rs
@@ -19,10 +19,10 @@ pub mod types {
     };
     pub use state::{
         AddDomainsVotes, AttemptId, AuthenticatedAccountId, AuthenticatedParticipantId,
-        DomainConfig, DomainRegistry, EpochId, InitializingContractState, KeyEvent, KeyEventId,
-        KeyEventInstance, KeyForDomain, Keyset, ProtocolContractState, PublicKeyExtended,
-        ResharingContractState, RunningContractState, SignatureScheme, Threshold,
-        ThresholdParameters, ThresholdParametersVotes,
+        DomainConfig, DomainPurpose, DomainRegistry, EpochId, InitializingContractState, KeyEvent,
+        KeyEventId, KeyEventInstance, KeyForDomain, Keyset, ProtocolContractState,
+        PublicKeyExtended, ResharingContractState, RunningContractState, SignatureScheme,
+        Threshold, ThresholdParameters, ThresholdParametersVotes,
     };
     pub use updates::{ProposedUpdates, UpdateHash};
 

--- a/crates/contract-interface/src/types/state.rs
+++ b/crates/contract-interface/src/types/state.rs
@@ -160,6 +160,31 @@ pub enum SignatureScheme {
     V2Secp256k1,
 }
 
+/// The intended purpose of a domain.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema)
+)]
+pub enum DomainPurpose {
+    Sign,
+    ForeignTx,
+    CKD,
+}
+
 /// Configuration for a signature domain.
 #[derive(
     Clone, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
@@ -291,7 +316,8 @@ pub struct ThresholdParametersVotes {
     derive(schemars::JsonSchema)
 )]
 pub struct AddDomainsVotes {
-    pub proposal_by_account: BTreeMap<AuthenticatedParticipantId, Vec<DomainConfig>>,
+    pub proposal_by_account:
+        BTreeMap<AuthenticatedParticipantId, Vec<(DomainConfig, DomainPurpose)>>,
 }
 
 // =============================================================================

--- a/crates/contract-interface/src/types/state.rs
+++ b/crates/contract-interface/src/types/state.rs
@@ -177,7 +177,7 @@ pub enum SignatureScheme {
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
-    derive(schemars::JsonSchema)
+    derive(schemars::JsonSchema, borsh::BorshSchema)
 )]
 pub enum DomainPurpose {
     Sign,

--- a/crates/contract/src/dto_mapping.rs
+++ b/crates/contract/src/dto_mapping.rs
@@ -30,7 +30,9 @@ use crate::{
     derive_foreign_tx_tweak,
     errors::{ConversionError, Error},
     primitives::{
-        domain::{AddDomainsVotes, DomainConfig, DomainId, DomainRegistry, SignatureScheme},
+        domain::{
+            AddDomainsVotes, DomainConfig, DomainId, DomainPurpose, DomainRegistry, SignatureScheme,
+        },
         key_state::{
             AttemptId, AuthenticatedAccountId, AuthenticatedParticipantId, EpochId, KeyEventId,
             KeyForDomain, Keyset,
@@ -634,6 +636,26 @@ impl IntoInterfaceType<dtos::SignatureScheme> for SignatureScheme {
     }
 }
 
+impl IntoInterfaceType<dtos::DomainPurpose> for DomainPurpose {
+    fn into_dto_type(self) -> dtos::DomainPurpose {
+        match self {
+            DomainPurpose::Sign => dtos::DomainPurpose::Sign,
+            DomainPurpose::ForeignTx => dtos::DomainPurpose::ForeignTx,
+            DomainPurpose::CKD => dtos::DomainPurpose::CKD,
+        }
+    }
+}
+
+impl IntoContractType<DomainPurpose> for dtos::DomainPurpose {
+    fn into_contract_type(self) -> DomainPurpose {
+        match self {
+            dtos::DomainPurpose::Sign => DomainPurpose::Sign,
+            dtos::DomainPurpose::ForeignTx => DomainPurpose::ForeignTx,
+            dtos::DomainPurpose::CKD => DomainPurpose::CKD,
+        }
+    }
+}
+
 impl IntoInterfaceType<dtos::DomainConfig> for &DomainConfig {
     fn into_dto_type(self) -> dtos::DomainConfig {
         dtos::DomainConfig {
@@ -763,7 +785,10 @@ impl IntoInterfaceType<dtos::AddDomainsVotes> for &AddDomainsVotes {
                 .map(|(participant, domains)| {
                     (
                         participant.into_dto_type(),
-                        domains.iter().map(|d| d.into_dto_type()).collect(),
+                        domains
+                            .iter()
+                            .map(|(d, p)| (d.into_dto_type(), p.into_dto_type()))
+                            .collect(),
                     )
                 })
                 .collect(),

--- a/crates/contract/src/dto_mapping.rs
+++ b/crates/contract/src/dto_mapping.rs
@@ -30,9 +30,7 @@ use crate::{
     derive_foreign_tx_tweak,
     errors::{ConversionError, Error},
     primitives::{
-        domain::{
-            AddDomainsVotes, DomainConfig, DomainId, DomainPurpose, DomainRegistry, SignatureScheme,
-        },
+        domain::{AddDomainsVotes, DomainConfig, DomainId, DomainRegistry, SignatureScheme},
         key_state::{
             AttemptId, AuthenticatedAccountId, AuthenticatedParticipantId, EpochId, KeyEventId,
             KeyForDomain, Keyset,
@@ -636,26 +634,6 @@ impl IntoInterfaceType<dtos::SignatureScheme> for SignatureScheme {
     }
 }
 
-impl IntoInterfaceType<dtos::DomainPurpose> for DomainPurpose {
-    fn into_dto_type(self) -> dtos::DomainPurpose {
-        match self {
-            DomainPurpose::Sign => dtos::DomainPurpose::Sign,
-            DomainPurpose::ForeignTx => dtos::DomainPurpose::ForeignTx,
-            DomainPurpose::CKD => dtos::DomainPurpose::CKD,
-        }
-    }
-}
-
-impl IntoContractType<DomainPurpose> for dtos::DomainPurpose {
-    fn into_contract_type(self) -> DomainPurpose {
-        match self {
-            dtos::DomainPurpose::Sign => DomainPurpose::Sign,
-            dtos::DomainPurpose::ForeignTx => DomainPurpose::ForeignTx,
-            dtos::DomainPurpose::CKD => DomainPurpose::CKD,
-        }
-    }
-}
-
 impl IntoInterfaceType<dtos::DomainConfig> for &DomainConfig {
     fn into_dto_type(self) -> dtos::DomainConfig {
         dtos::DomainConfig {
@@ -787,7 +765,7 @@ impl IntoInterfaceType<dtos::AddDomainsVotes> for &AddDomainsVotes {
                         participant.into_dto_type(),
                         domains
                             .iter()
-                            .map(|(d, p)| (d.into_dto_type(), p.into_dto_type()))
+                            .map(|(d, p)| (d.into_dto_type(), *p))
                             .collect(),
                     )
                 })

--- a/crates/contract/src/errors.rs
+++ b/crates/contract/src/errors.rs
@@ -124,6 +124,8 @@ pub enum InvalidParameters {
     InvalidTlsPublicKey,
     #[error("Caller is not the signer account.")]
     CallerNotSigner,
+    #[error("Domain purpose mismatch for domain {domain_id}.")]
+    DomainPurposeMismatch { domain_id: DomainId },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -161,17 +161,6 @@ impl ForeignChainPolicyVotes {
 }
 
 impl MpcContract {
-    fn effective_domain_purpose(
-        &self,
-        domain_id: DomainId,
-        scheme: SignatureScheme,
-    ) -> DomainPurpose {
-        self.domain_purposes
-            .get(&domain_id)
-            .copied()
-            .unwrap_or_else(|| DomainPurpose::infer_from_scheme(scheme))
-    }
-
     pub(crate) fn public_key_extended(
         &self,
         domain_id: DomainId,
@@ -221,6 +210,17 @@ impl MpcContract {
             }
         }
         Ok(())
+    }
+
+    fn effective_domain_purpose(
+        &self,
+        domain_id: DomainId,
+        scheme: SignatureScheme,
+    ) -> DomainPurpose {
+        self.domain_purposes
+            .get(&domain_id)
+            .copied()
+            .unwrap_or_else(|| DomainPurpose::infer_from_scheme(scheme))
     }
 }
 

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1019,9 +1019,9 @@ impl MpcContract {
             domains,
         );
 
-        if let Some((new_state, purposes)) = self.protocol_state.vote_add_domains(domains)? {
-            self.protocol_state = new_state;
-            for (domain_id, purpose) in purposes {
+        if let Some(outcome) = self.protocol_state.vote_add_domains(domains)? {
+            self.protocol_state = ProtocolContractState::Initializing(outcome.new_state);
+            for (domain_id, purpose) in outcome.purposes {
                 self.domain_purposes.insert(domain_id, purpose);
             }
         }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -212,15 +212,11 @@ impl MpcContract {
         Ok(())
     }
 
-    fn effective_domain_purpose(
-        &self,
-        domain_id: DomainId,
-        scheme: SignatureScheme,
-    ) -> DomainPurpose {
+    fn effective_domain_purpose(&self, domain_config: &DomainConfig) -> DomainPurpose {
         self.domain_purposes
-            .get(&domain_id)
+            .get(&domain_config.id)
             .copied()
-            .unwrap_or_else(|| DomainPurpose::infer_from_scheme(scheme))
+            .unwrap_or_else(|| DomainPurpose::infer_from_scheme(domain_config.scheme))
     }
 }
 
@@ -254,7 +250,7 @@ impl MpcContract {
             );
         };
 
-        let purpose = self.effective_domain_purpose(domain_config.id, domain_config.scheme);
+        let purpose = self.effective_domain_purpose(&domain_config);
         if purpose != DomainPurpose::Sign {
             env::panic_str(
                 &InvalidParameters::DomainPurposeMismatch {
@@ -443,7 +439,7 @@ impl MpcContract {
                 .to_string(),
             );
         };
-        let purpose = self.effective_domain_purpose(domain_config.id, domain_config.scheme);
+        let purpose = self.effective_domain_purpose(&domain_config);
         if purpose != DomainPurpose::CKD {
             env::panic_str(
                 &InvalidParameters::DomainPurposeMismatch {
@@ -564,7 +560,7 @@ impl MpcContract {
             );
         };
 
-        let purpose = self.effective_domain_purpose(domain_config.id, domain_config.scheme);
+        let purpose = self.effective_domain_purpose(&domain_config);
         if purpose != DomainPurpose::ForeignTx {
             env::panic_str(
                 &InvalidParameters::DomainPurposeMismatch {

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1705,7 +1705,7 @@ impl MpcContract {
     pub fn get_domain_purposes(&self) -> BTreeMap<dtos::DomainId, dtos::DomainPurpose> {
         self.domain_purposes
             .iter()
-            .map(|(id, purpose)| (id.into_dto_type(), purpose.into_dto_type()))
+            .map(|(id, purpose)| (id.into_dto_type(), *purpose))
             .collect()
     }
 

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -212,7 +212,7 @@ impl MpcContract {
         Ok(())
     }
 
-    fn effective_domain_purpose(&self, domain_config: &DomainConfig) -> DomainPurpose {
+    fn domain_purpose(&self, domain_config: &DomainConfig) -> DomainPurpose {
         self.domain_purposes
             .get(&domain_config.id)
             .copied()
@@ -250,7 +250,7 @@ impl MpcContract {
             );
         };
 
-        let purpose = self.effective_domain_purpose(&domain_config);
+        let purpose = self.domain_purpose(&domain_config);
         if purpose != DomainPurpose::Sign {
             env::panic_str(
                 &InvalidParameters::DomainPurposeMismatch {
@@ -439,7 +439,7 @@ impl MpcContract {
                 .to_string(),
             );
         };
-        let purpose = self.effective_domain_purpose(&domain_config);
+        let purpose = self.domain_purpose(&domain_config);
         if purpose != DomainPurpose::CKD {
             env::panic_str(
                 &InvalidParameters::DomainPurposeMismatch {
@@ -560,7 +560,7 @@ impl MpcContract {
             );
         };
 
-        let purpose = self.effective_domain_purpose(&domain_config);
+        let purpose = self.domain_purpose(&domain_config);
         if purpose != DomainPurpose::ForeignTx {
             env::panic_str(
                 &InvalidParameters::DomainPurposeMismatch {

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -69,7 +69,9 @@ use near_sdk::{
 };
 use node_migrations::{BackupServiceInfo, DestinationNodeInfo, NodeMigrations};
 use primitives::{
-    domain::{DomainConfig, DomainId, DomainPurpose, DomainRegistry, SignatureScheme},
+    domain::{
+        DomainConfig, DomainId, DomainPurpose, DomainRegistry, InferFromScheme, SignatureScheme,
+    },
     key_state::{AuthenticatedAccountId, AuthenticatedParticipantId, EpochId, KeyEventId, Keyset},
     signature::{SignRequest, SignRequestArgs, SignatureRequest, YieldIndex},
     thresholds::{Threshold, ThresholdParameters},

--- a/crates/contract/src/primitives/domain.rs
+++ b/crates/contract/src/primitives/domain.rs
@@ -50,7 +50,6 @@ impl Default for SignatureScheme {
 }
 
 pub trait InferFromScheme {
-    /// Infer purpose from scheme for legacy domains not in the purpose map.
     fn infer_from_scheme(scheme: SignatureScheme) -> Self;
 }
 

--- a/crates/contract/src/primitives/test_utils.rs
+++ b/crates/contract/src/primitives/test_utils.rs
@@ -1,4 +1,4 @@
-use super::domain::{DomainConfig, DomainId, DomainRegistry, SignatureScheme};
+use super::domain::{DomainConfig, DomainId, DomainPurpose, DomainRegistry, SignatureScheme};
 use crate::{
     crypto_shared::types::{serializable::SerializableEdwardsPoint, PublicKeyExtended},
     primitives::{
@@ -42,6 +42,20 @@ pub fn gen_domains_to_add(registry: &DomainRegistry, num_domains: usize) -> Vec<
         });
     }
     new_domains
+}
+
+/// Generates a valid list of (DomainConfig, DomainPurpose) to add to the given registry.
+pub fn gen_domains_to_add_with_purposes(
+    registry: &DomainRegistry,
+    num_domains: usize,
+) -> Vec<(DomainConfig, DomainPurpose)> {
+    gen_domains_to_add(registry, num_domains)
+        .into_iter()
+        .map(|d| {
+            let purpose = DomainPurpose::infer_from_scheme(d.scheme);
+            (d, purpose)
+        })
+        .collect()
 }
 fn gen_random_edwards_point() -> (SerializableEdwardsPoint, CompressedEdwardsY) {
     let rng = rand::thread_rng();

--- a/crates/contract/src/primitives/test_utils.rs
+++ b/crates/contract/src/primitives/test_utils.rs
@@ -1,4 +1,6 @@
-use super::domain::{DomainConfig, DomainId, DomainPurpose, DomainRegistry, SignatureScheme};
+use super::domain::{
+    DomainConfig, DomainId, DomainPurpose, DomainRegistry, InferFromScheme, SignatureScheme,
+};
 use crate::{
     crypto_shared::types::{serializable::SerializableEdwardsPoint, PublicKeyExtended},
     primitives::{

--- a/crates/contract/src/state.rs
+++ b/crates/contract/src/state.rs
@@ -8,7 +8,7 @@ pub mod test_utils;
 use crate::crypto_shared::types::PublicKeyExtended;
 use crate::errors::{DomainError, Error, InvalidState};
 use crate::primitives::{
-    domain::{DomainConfig, DomainId, DomainRegistry, SignatureScheme},
+    domain::{DomainConfig, DomainId, DomainPurpose, DomainRegistry, SignatureScheme},
     key_state::{AuthenticatedParticipantId, EpochId, KeyEventId},
     participants::Participants,
     thresholds::{Threshold, ThresholdParameters},
@@ -138,15 +138,20 @@ impl ProtocolContractState {
         .map(|x| x.map(ProtocolContractState::Resharing))
     }
 
+    #[allow(clippy::type_complexity)]
     pub fn vote_add_domains(
         &mut self,
-        domains: Vec<DomainConfig>,
-    ) -> Result<Option<ProtocolContractState>, Error> {
+        domains: Vec<(DomainConfig, DomainPurpose)>,
+    ) -> Result<Option<(ProtocolContractState, Vec<(DomainId, DomainPurpose)>)>, Error> {
         match self {
             ProtocolContractState::Running(state) => state.vote_add_domains(domains),
             _ => Err(InvalidState::ProtocolStateNotRunning.into()),
         }
-        .map(|x| x.map(ProtocolContractState::Initializing))
+        .map(|x| {
+            x.map(|(init_state, purposes)| {
+                (ProtocolContractState::Initializing(init_state), purposes)
+            })
+        })
     }
 
     pub fn vote_abort_key_event_instance(&mut self, key_event_id: KeyEventId) -> Result<(), Error> {

--- a/crates/contract/src/state.rs
+++ b/crates/contract/src/state.rs
@@ -138,20 +138,14 @@ impl ProtocolContractState {
         .map(|x| x.map(ProtocolContractState::Resharing))
     }
 
-    #[allow(clippy::type_complexity)]
     pub fn vote_add_domains(
         &mut self,
         domains: Vec<(DomainConfig, DomainPurpose)>,
-    ) -> Result<Option<(ProtocolContractState, Vec<(DomainId, DomainPurpose)>)>, Error> {
+    ) -> Result<Option<running::AddDomainsOutcome>, Error> {
         match self {
             ProtocolContractState::Running(state) => state.vote_add_domains(domains),
             _ => Err(InvalidState::ProtocolStateNotRunning.into()),
         }
-        .map(|x| {
-            x.map(|(init_state, purposes)| {
-                (ProtocolContractState::Initializing(init_state), purposes)
-            })
-        })
     }
 
     pub fn vote_abort_key_event_instance(&mut self, key_event_id: KeyEventId) -> Result<(), Error> {

--- a/crates/contract/src/state/running.rs
+++ b/crates/contract/src/state/running.rs
@@ -160,10 +160,11 @@ impl RunningContractState {
         let participant = AuthenticatedParticipantId::new(self.parameters.participants())?;
         let n_votes = self.add_domains_votes.vote(domains.clone(), &participant);
         if self.parameters.participants().len() as u64 == n_votes {
-            let domain_configs: Vec<DomainConfig> =
-                domains.iter().map(|(d, _)| d.clone()).collect();
-            let purposes: Vec<(DomainId, DomainPurpose)> =
-                domains.iter().map(|(d, p)| (d.id, *p)).collect();
+            let (domain_configs, purposes): (Vec<DomainConfig>, Vec<(DomainId, DomainPurpose)>) =
+                domains
+                    .iter()
+                    .map(|(domain, purpose)| (domain.clone(), (domain.id, *purpose)))
+                    .unzip();
             let new_domains = self.domains.add_domains(domain_configs.clone())?;
             Ok(Some(AddDomainsOutcome {
                 new_state: InitializingContractState {

--- a/crates/contract/src/state/test_utils.rs
+++ b/crates/contract/src/state/test_utils.rs
@@ -116,7 +116,7 @@ pub fn gen_initializing_state(
         initializing_state = running
             .vote_add_domains(domains_to_add.clone())
             .unwrap()
-            .map(|(state, _purposes)| state);
+            .map(|outcome| outcome.new_state);
     }
     let initializing_state = initializing_state
         .expect("Enough votes to add domains should transition into initializing");

--- a/crates/contract/src/state/test_utils.rs
+++ b/crates/contract/src/state/test_utils.rs
@@ -1,6 +1,8 @@
 use super::resharing::ResharingContractState;
 use super::InitializingContractState;
-use crate::primitives::test_utils::{bogus_ed25519_public_key_extended, gen_domains_to_add};
+use crate::primitives::test_utils::{
+    bogus_ed25519_public_key_extended, gen_domains_to_add_with_purposes,
+};
 use crate::primitives::{key_state::AttemptId, test_utils::gen_domain_registry};
 use crate::state::key_event::tests::Environment;
 use crate::state::running::RunningContractState;
@@ -104,13 +106,17 @@ pub fn gen_initializing_state(
 ) -> (Environment, InitializingContractState) {
     let mut env = Environment::new(None, None, None);
     let mut running = gen_running_state(num_generated);
-    let domains_to_add = gen_domains_to_add(&running.domains, num_domains - num_generated);
+    let domains_to_add =
+        gen_domains_to_add_with_purposes(&running.domains, num_domains - num_generated);
 
     let mut initializing_state = None;
     for (account, _, _) in running.parameters.participants().participants().clone() {
         env.set_signer(&account);
         assert!(initializing_state.is_none());
-        initializing_state = running.vote_add_domains(domains_to_add.clone()).unwrap();
+        initializing_state = running
+            .vote_add_domains(domains_to_add.clone())
+            .unwrap()
+            .map(|(state, _purposes)| state);
     }
     let initializing_state = initializing_state
         .expect("Enough votes to add domains should transition into initializing");

--- a/crates/contract/src/v3_4_1_state.rs
+++ b/crates/contract/src/v3_4_1_state.rs
@@ -228,7 +228,7 @@ mod tests {
 
         // Then
         // Current-state decode fails on legacy `Vec<DomainConfig>` vote payloads.
-        assert!(crate::state::ProtocolContractState::try_from_slice(&serialized).is_err());
+        let _ = crate::state::ProtocolContractState::try_from_slice(&serialized).unwrap_err();
 
         let migrated_vote = migrated_running
             .add_domains_votes

--- a/crates/contract/src/v3_4_1_state.rs
+++ b/crates/contract/src/v3_4_1_state.rs
@@ -7,7 +7,7 @@
 //! However, this approach (a) requires manual effort from a developer and (b) increases the binary size.
 //! A better approach: only copy the structures that have changed and import the rest from the existing codebase.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashSet};
 
 use borsh::{BorshDeserialize, BorshSerialize};
 use contract_interface::types as dtos;
@@ -17,13 +17,108 @@ use crate::{
     node_migrations::NodeMigrations,
     primitives::{
         ckd::CKDRequest,
+        domain::{DomainConfig, DomainPurpose, DomainRegistry},
+        key_state::{
+            AuthenticatedAccountId, AuthenticatedParticipantId, EpochId, KeyForDomain, Keyset,
+        },
         signature::{SignatureRequest, YieldIndex},
+        thresholds::ThresholdParameters,
+        votes::ThresholdParametersVotes,
     },
-    state::ProtocolContractState,
+    state::{initializing::InitializingContractState, key_event::KeyEvent},
     tee::tee_state::TeeState,
     update::ProposedUpdates,
     Config, ForeignChainPolicyVotes, StaleData, StorageKey,
 };
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+struct AddDomainsVotes {
+    proposal_by_account: BTreeMap<AuthenticatedParticipantId, Vec<DomainConfig>>,
+}
+
+impl From<AddDomainsVotes> for crate::primitives::domain::AddDomainsVotes {
+    fn from(value: AddDomainsVotes) -> Self {
+        let proposal_by_account = value
+            .proposal_by_account
+            .into_iter()
+            .map(|(participant, proposed_domains)| {
+                let proposal = proposed_domains
+                    .into_iter()
+                    .map(|domain| {
+                        let scheme = domain.scheme;
+                        (domain, DomainPurpose::infer_from_scheme(scheme))
+                    })
+                    .collect();
+                (participant, proposal)
+            })
+            .collect();
+
+        Self {
+            proposal_by_account,
+        }
+    }
+}
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+struct RunningContractState {
+    domains: DomainRegistry,
+    keyset: Keyset,
+    parameters: ThresholdParameters,
+    parameters_votes: ThresholdParametersVotes,
+    add_domains_votes: AddDomainsVotes,
+    previously_cancelled_resharing_epoch_id: Option<EpochId>,
+}
+
+impl From<RunningContractState> for crate::state::running::RunningContractState {
+    fn from(value: RunningContractState) -> Self {
+        Self {
+            domains: value.domains,
+            keyset: value.keyset,
+            parameters: value.parameters,
+            parameters_votes: value.parameters_votes,
+            add_domains_votes: value.add_domains_votes.into(),
+            previously_cancelled_resharing_epoch_id: value.previously_cancelled_resharing_epoch_id,
+        }
+    }
+}
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+struct ResharingContractState {
+    previous_running_state: RunningContractState,
+    reshared_keys: Vec<KeyForDomain>,
+    resharing_key: KeyEvent,
+    cancellation_requests: HashSet<AuthenticatedAccountId>,
+}
+
+impl From<ResharingContractState> for crate::state::resharing::ResharingContractState {
+    fn from(value: ResharingContractState) -> Self {
+        Self {
+            previous_running_state: value.previous_running_state.into(),
+            reshared_keys: value.reshared_keys,
+            resharing_key: value.resharing_key,
+            cancellation_requests: value.cancellation_requests,
+        }
+    }
+}
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+enum ProtocolContractState {
+    NotInitialized,
+    Initializing(InitializingContractState),
+    Running(RunningContractState),
+    Resharing(ResharingContractState),
+}
+
+impl From<ProtocolContractState> for crate::state::ProtocolContractState {
+    fn from(value: ProtocolContractState) -> Self {
+        match value {
+            ProtocolContractState::NotInitialized => Self::NotInitialized,
+            ProtocolContractState::Initializing(state) => Self::Initializing(state),
+            ProtocolContractState::Running(state) => Self::Running(state.into()),
+            ProtocolContractState::Resharing(state) => Self::Resharing(state.into()),
+        }
+    }
+}
 
 /// The contract state layout of the current production contract.
 /// This does not have `pending_verify_foreign_tx_requests` or `domain_purposes`.
@@ -44,9 +139,9 @@ pub struct MpcContract {
 
 impl From<MpcContract> for crate::MpcContract {
     fn from(value: MpcContract) -> Self {
-        let protocol_state = value.protocol_state;
+        let protocol_state: crate::state::ProtocolContractState = value.protocol_state.into();
 
-        let crate::ProtocolContractState::Running(_running_state) = &protocol_state else {
+        let crate::state::ProtocolContractState::Running(_running_state) = &protocol_state else {
             env::panic_str("Contract must be in running state when migrating.");
         };
 
@@ -67,5 +162,79 @@ impl From<MpcContract> for crate::MpcContract {
             stale_data: crate::StaleData {},
             domain_purposes: BTreeMap::new(),
         }
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use borsh::{to_vec, BorshDeserialize};
+    use near_sdk::{test_utils::VMContextBuilder, testing_env};
+
+    use super::{AddDomainsVotes, ProtocolContractState, RunningContractState};
+    use crate::primitives::{
+        domain::DomainPurpose, key_state::AuthenticatedParticipantId,
+        test_utils::gen_domains_to_add,
+    };
+    use crate::state::test_utils::gen_running_state;
+
+    #[test]
+    fn legacy_running_state__should_decode_and_preserve_domain_votes_during_migration() {
+        // Given
+        let running = gen_running_state(2);
+        let first_participant_account = running.parameters.participants().participants()[0]
+            .0
+            .clone();
+
+        let mut context = VMContextBuilder::new();
+        context.signer_account_id(first_participant_account);
+        testing_env!(context.build());
+
+        let participant =
+            AuthenticatedParticipantId::new(running.parameters.participants()).unwrap();
+        let proposed_domains = gen_domains_to_add(&running.domains, 2);
+        let expected_domains_with_purpose = proposed_domains
+            .iter()
+            .map(|domain| {
+                (
+                    domain.clone(),
+                    DomainPurpose::infer_from_scheme(domain.scheme),
+                )
+            })
+            .collect::<Vec<_>>();
+
+        let legacy_protocol_state = ProtocolContractState::Running(RunningContractState {
+            domains: running.domains.clone(),
+            keyset: running.keyset.clone(),
+            parameters: running.parameters.clone(),
+            parameters_votes: running.parameters_votes.clone(),
+            add_domains_votes: AddDomainsVotes {
+                proposal_by_account: BTreeMap::from([(participant, proposed_domains)]),
+            },
+            previously_cancelled_resharing_epoch_id: running
+                .previously_cancelled_resharing_epoch_id,
+        });
+
+        // When
+        let serialized = to_vec(&legacy_protocol_state).unwrap();
+        let decoded_legacy = ProtocolContractState::try_from_slice(&serialized).unwrap();
+        let crate::state::ProtocolContractState::Running(migrated_running) = decoded_legacy.into()
+        else {
+            panic!("expected running state");
+        };
+
+        // Then
+        // Current-state decode fails on legacy `Vec<DomainConfig>` vote payloads.
+        assert!(crate::state::ProtocolContractState::try_from_slice(&serialized).is_err());
+
+        let migrated_vote = migrated_running
+            .add_domains_votes
+            .proposal_by_account
+            .values()
+            .next()
+            .unwrap();
+        assert_eq!(migrated_vote, &expected_domains_with_purpose);
     }
 }

--- a/crates/contract/src/v3_4_1_state.rs
+++ b/crates/contract/src/v3_4_1_state.rs
@@ -17,7 +17,7 @@ use crate::{
     node_migrations::NodeMigrations,
     primitives::{
         ckd::CKDRequest,
-        domain::{DomainConfig, DomainPurpose, DomainRegistry},
+        domain::{DomainConfig, DomainPurpose, DomainRegistry, InferFromScheme},
         key_state::{
             AuthenticatedAccountId, AuthenticatedParticipantId, EpochId, KeyForDomain, Keyset,
         },
@@ -175,7 +175,8 @@ mod tests {
 
     use super::{AddDomainsVotes, ProtocolContractState, RunningContractState};
     use crate::primitives::{
-        domain::DomainPurpose, key_state::AuthenticatedParticipantId,
+        domain::{DomainPurpose, InferFromScheme},
+        key_state::AuthenticatedParticipantId,
         test_utils::gen_domains_to_add,
     };
     use crate::state::test_utils::gen_running_state;

--- a/crates/contract/src/v3_4_1_state.rs
+++ b/crates/contract/src/v3_4_1_state.rs
@@ -7,6 +7,8 @@
 //! However, this approach (a) requires manual effort from a developer and (b) increases the binary size.
 //! A better approach: only copy the structures that have changed and import the rest from the existing codebase.
 
+use std::collections::BTreeMap;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use contract_interface::types as dtos;
 use near_sdk::{env, store::LookupMap};
@@ -23,6 +25,8 @@ use crate::{
     Config, ForeignChainPolicyVotes, StaleData, StorageKey,
 };
 
+/// The contract state layout of the current production contract.
+/// This does not have `pending_verify_foreign_tx_requests` or `domain_purposes`.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct MpcContract {
     protocol_state: ProtocolContractState,
@@ -61,6 +65,7 @@ impl From<MpcContract> for crate::MpcContract {
             accept_requests: value.accept_requests,
             node_migrations: value.node_migrations,
             stale_data: crate::StaleData {},
+            domain_purposes: BTreeMap::new(),
         }
     }
 }

--- a/crates/contract/tests/inprocess/attestation_submission.rs
+++ b/crates/contract/tests/inprocess/attestation_submission.rs
@@ -2,7 +2,7 @@ use contract_interface::types::{Attestation, InitConfig, MockAttestation, Protoc
 use mpc_contract::{
     crypto_shared::types::PublicKeyExtended,
     primitives::{
-        domain::{DomainConfig, DomainId, SignatureScheme},
+        domain::{DomainConfig, DomainId, DomainPurpose, SignatureScheme},
         key_state::{AttemptId, EpochId, KeyForDomain, Keyset},
         participants::{ParticipantId, ParticipantInfo},
         test_utils::{bogus_ed25519_near_public_key, gen_participants},
@@ -117,9 +117,15 @@ impl TestSetupBuilder {
         testing_env!(context);
 
         let init_config = self.init_config;
-        let contract =
-            MpcContract::init_running(domains, 1, keyset, parameters.clone(), init_config.clone())
-                .unwrap();
+        let contract = MpcContract::init_running(
+            domains,
+            1,
+            keyset,
+            parameters.clone(),
+            init_config.clone(),
+            None,
+        )
+        .unwrap();
 
         let mut setup = TestSetup {
             contract,
@@ -147,10 +153,13 @@ impl TestSetupBuilder {
 
                     setup
                         .contract
-                        .vote_add_domains(vec![DomainConfig {
-                            id: DomainId(1),
-                            scheme: SignatureScheme::Ed25519,
-                        }])
+                        .vote_add_domains(vec![(
+                            DomainConfig {
+                                id: DomainId(1),
+                                scheme: SignatureScheme::Ed25519,
+                            },
+                            DomainPurpose::Sign,
+                        )])
                         .unwrap();
                 }
 

--- a/crates/contract/tests/sandbox/utils/consts.rs
+++ b/crates/contract/tests/sandbox/utils/consts.rs
@@ -39,7 +39,7 @@ pub const GAS_FOR_VOTE_BEFORE_THRESHOLD: Gas = Gas::from_tgas(5);
 /// Maximum gas expected for the threshold vote that triggers the contract update.
 /// This vote is more expensive because it deploys the new contract code and executes
 /// the migration function.
-pub const MAX_GAS_FOR_THRESHOLD_VOTE: Gas = Gas::from_tgas(166);
+pub const MAX_GAS_FOR_THRESHOLD_VOTE: Gas = Gas::from_tgas(170);
 
 /* --- Deposit constants --- */
 /// This is the current deposit required for a contract deploy. This is subject to change but make
@@ -47,6 +47,6 @@ pub const MAX_GAS_FOR_THRESHOLD_VOTE: Gas = Gas::from_tgas(166);
 /// not be getting that big.
 ///
 /// TODO(#771): Reduce this to the minimal value possible after #770 is resolved
-pub const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(14000);
+pub const CURRENT_CONTRACT_DEPLOY_DEPOSIT: NearToken = NearToken::from_millinear(15000);
 
 pub const DEFAULT_MAX_TIMEOUT_TX_INCLUDED: Duration = Duration::from_secs(3);

--- a/crates/contract/tests/sandbox/utils/initializing_utils.rs
+++ b/crates/contract/tests/sandbox/utils/initializing_utils.rs
@@ -1,6 +1,6 @@
 use contract_interface::method_names;
 use contract_interface::types::{self as dtos};
-use dtos::KeyEventId;
+use dtos::{DomainPurpose, KeyEventId};
 use mpc_contract::primitives::domain::DomainConfig;
 use near_workspaces::{Account, Contract};
 use serde_json::json;
@@ -12,6 +12,26 @@ use super::{
 };
 
 pub async fn vote_add_domains(
+    contract: &Contract,
+    accounts: &[Account],
+    domains: &[(DomainConfig, DomainPurpose)],
+) -> anyhow::Result<()> {
+    let args = json!({
+        "domains": domains,
+    });
+    execute_async_transactions(
+        accounts,
+        contract,
+        "vote_add_domains",
+        &args,
+        GAS_FOR_VOTE_NEW_DOMAIN,
+    )
+    .await
+}
+
+/// Legacy version of `vote_add_domains` for old contracts that don't have
+/// `DomainPurpose` in the `vote_add_domains` API.
+pub async fn vote_add_domains_legacy(
     contract: &Contract,
     accounts: &[Account],
     domains: &[DomainConfig],

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -208,7 +208,7 @@ expression: abi
           "type_schema": {
             "type": "object",
             "additionalProperties": {
-              "$ref": "#/definitions/DomainPurpose2"
+              "$ref": "#/definitions/DomainPurpose"
             }
           }
         }
@@ -1377,7 +1377,7 @@ expression: abi
                       "$ref": "#/definitions/DomainConfig2"
                     },
                     {
-                      "$ref": "#/definitions/DomainPurpose2"
+                      "$ref": "#/definitions/DomainPurpose"
                     }
                   ],
                   "maxItems": 2,
@@ -1763,15 +1763,6 @@ expression: abi
           "minimum": 0.0
         },
         "DomainPurpose": {
-          "description": "The intended purpose of a domain, used to enforce that `sign()`, `verify_foreign_transaction()`, and `request_app_private_key()` are each called only on domains created for that purpose.",
-          "type": "string",
-          "enum": [
-            "Sign",
-            "ForeignTx",
-            "CKD"
-          ]
-        },
-        "DomainPurpose2": {
           "description": "The intended purpose of a domain.",
           "type": "string",
           "enum": [

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/contract/tests/abi.rs
+assertion_line: 49
 expression: abi
 ---
 {
@@ -196,6 +197,19 @@ expression: abi
                 "type": "null"
               }
             ]
+          }
+        }
+      },
+      {
+        "name": "get_domain_purposes",
+        "kind": "view",
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "object",
+            "additionalProperties": {
+              "$ref": "#/definitions/DomainPurpose2"
+            }
           }
         }
       },
@@ -398,6 +412,18 @@ expression: abi
                     "type": "null"
                   }
                 ]
+              }
+            },
+            {
+              "name": "domain_purposes",
+              "type_schema": {
+                "type": [
+                  "object",
+                  "null"
+                ],
+                "additionalProperties": {
+                  "$ref": "#/definitions/DomainPurpose"
+                }
               }
             }
           ]
@@ -1105,7 +1131,7 @@ expression: abi
       },
       {
         "name": "vote_add_domains",
-        "doc": " Propose adding a new set of domains for the MPC network.\n If a threshold number of votes are reached on the exact same proposal, this will transition\n the contract into the Initializing state to generate keys for the new domains.\n\n The specified list of domains must have increasing and contiguous IDs, and the first ID\n must be the same as the `next_domain_id` returned by state().",
+        "doc": " Propose adding a new set of domains for the MPC network.\n If a threshold number of votes are reached on the exact same proposal, this will transition\n the contract into the Initializing state to generate keys for the new domains.\n\n The specified list of domains must have increasing and contiguous IDs, and the first ID\n must be the same as the `next_domain_id` returned by state().\n Each domain must be accompanied by a `DomainPurpose` that determines which endpoints\n can use the domain.",
         "kind": "call",
         "params": {
           "serialization_type": "json",
@@ -1115,7 +1141,17 @@ expression: abi
               "type_schema": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/DomainConfig"
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/DomainConfig"
+                    },
+                    {
+                      "$ref": "#/definitions/DomainPurpose"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
                 }
               }
             }
@@ -1335,7 +1371,17 @@ expression: abi
               "additionalProperties": {
                 "type": "array",
                 "items": {
-                  "$ref": "#/definitions/DomainConfig2"
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/DomainConfig2"
+                    },
+                    {
+                      "$ref": "#/definitions/DomainPurpose2"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
                 }
               }
             }
@@ -1715,6 +1761,24 @@ expression: abi
           "type": "integer",
           "format": "uint64",
           "minimum": 0.0
+        },
+        "DomainPurpose": {
+          "description": "The intended purpose of a domain, used to enforce that `sign()`, `verify_foreign_transaction()`, and `request_app_private_key()` are each called only on domains created for that purpose.",
+          "type": "string",
+          "enum": [
+            "Sign",
+            "ForeignTx",
+            "CKD"
+          ]
+        },
+        "DomainPurpose2": {
+          "description": "The intended purpose of a domain.",
+          "type": "string",
+          "enum": [
+            "Sign",
+            "ForeignTx",
+            "CKD"
+          ]
         },
         "DomainRegistry": {
           "description": "Registry of all signature domains.",

--- a/docs/localnet/args/add_domain.json
+++ b/docs/localnet/args/add_domain.json
@@ -1,16 +1,8 @@
 {
   "domains": [
-    {
-      "id": 0,
-      "scheme": "Secp256k1"
-    },
-    {
-      "id": 1,
-      "scheme": "Ed25519"
-    },
-    {
-      "id": 2,
-      "scheme": "Bls12381"
-    }
+    [{"id": 0, "scheme": "Secp256k1"}, "Sign"],
+    [{"id": 1, "scheme": "Ed25519"}, "Sign"],
+    [{"id": 2, "scheme": "Bls12381"}, "CKD"],
+    [{"id": 3, "scheme": "Secp256k1"}, "ForeignTx"]
   ]
 }

--- a/docs/localnet/args/verify_foreign_tx_abstract.json
+++ b/docs/localnet/args/verify_foreign_tx_abstract.json
@@ -15,7 +15,7 @@
             }
         },
         "derivation_path": "some_example_path",
-        "domain_id": 0,
+        "domain_id": 3,
         "payload_version": 1
     }
 }

--- a/docs/localnet/args/verify_foreign_tx_bitcoin.json
+++ b/docs/localnet/args/verify_foreign_tx_bitcoin.json
@@ -10,7 +10,7 @@
             }
         },
         "derivation_path": "some_example_path",
-        "domain_id": 0,
+        "domain_id": 3,
         "payload_version": 1
     }
 }

--- a/docs/localnet/localnet.md
+++ b/docs/localnet/localnet.md
@@ -387,7 +387,8 @@ Now the contract should be initialized and both nodes are running.
 To verify that the network is working let's request a singature from it.
 To do this, we first need to add a domain.
 
-Let's have Frodo and Sam both vote to add secp256k1, ed25519 and bls12381 domains.
+Let's have Frodo and Sam both vote to add secp256k1, ed25519, bls12381, and a ForeignTx (secp256k1) domain.
+The ForeignTx domain is used for foreign chain transaction verification.
 
 ```shell
 near contract call-function as-transaction mpc-contract.test.near vote_add_domains file-args docs/localnet/args/add_domain.json prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' sign-as frodo.test.near network-config mpc-localnet sign-with-keychain send
@@ -455,6 +456,9 @@ Tadaaa! Now you should have a fully functioning MPC network running on your
 machine ready to produce signatures.
 
 ### Foreign transaction validation request
+
+This uses the ForeignTx domain (domain_id 3) which was created for this purpose.
+
 ```shell
 near contract call-function as-transaction mpc-contract.test.near verify_foreign_transaction file-args docs/localnet/args/verify_foreign_tx.json prepaid-gas '300.0 Tgas' attached-deposit '100 yoctoNEAR' sign-as frodo.test.near network-config mpc-localnet sign-with-keychain send
 ```

--- a/pytest/common_lib/shared/mpc_cluster.py
+++ b/pytest/common_lib/shared/mpc_cluster.py
@@ -14,7 +14,6 @@ from common_lib.constants import TGAS
 from common_lib.contract_state import (
     ContractState,
     ProtocolState,
-    SignatureScheme,
     RunningProtocolState,
 )
 from common_lib.contracts import ContractMethod

--- a/pytest/tests/test_foreign_transaction_validation.py
+++ b/pytest/tests/test_foreign_transaction_validation.py
@@ -547,10 +547,11 @@ def test_verify_foreign_transaction_starknet(
     """
     cluster, _mpc_nodes = foreign_tx_validation_cluster
 
-    # Find the Secp256k1 domain
-    contract_state = cluster.contract_state()
-    domains = contract_state.get_running_domains()
-    secp_domain = next(d for d in domains if d.scheme == "Secp256k1")
+    # Find the ForeignTx domain via the domain_purposes view
+    domain_purposes = cluster.view_contract_function("get_domain_purposes")
+    foreign_tx_domain_id = next(
+        int(did) for did, purpose in domain_purposes.items() if purpose == "ForeignTx"
+    )
 
     # Build the verify_foreign_transaction args
     args = {
@@ -563,7 +564,7 @@ def test_verify_foreign_transaction_starknet(
                 }
             },
             "derivation_path": "test",
-            "domain_id": secp_domain.id,
+            "domain_id": foreign_tx_domain_id,
             "payload_version": 1,
         }
     }


### PR DESCRIPTION
closes #2076 

This PR introduces domain purposes as a `BTreeMap<DomainId, DomainPurpose>` in the contract. See the change in [docs/foreign_chain_transactions.md](https://github.com/near/mpc/pull/2135/changes#diff-efe2abd54085303e9cae3132932ce2342119a05b449233938c85d08720936236) for a high-level overview of the design change.