### PR TITLE
ci(fix): set `DOCKER_API_VERSION` for skopeo on Ubuntu 24.04 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,6 +82,8 @@ jobs:
 
       - name: Build launcher docker image and verify its hash
         shell: bash
+        env:
+          DOCKER_API_VERSION: "1.40"
         run: |
           ./scripts/build-and-verify-launcher-docker-image.sh
 


### PR DESCRIPTION
Fast claude code fix:

- Fix docker-launcher-build-and-verify CI job failing after runner upgrade to Ubuntu 24.04 (#2146)
- The skopeo package from Ubuntu 24.04 apt defaults to Docker API version 1.22, but the Docker daemon requires minimum 1.24, causing skopeo copy docker-daemon:... to fail
- Set DOCKER_API_VERSION=1.40 for the verification step to resolve the API version mismatch


Example failure:
https://github.com/near/mpc/actions/runs/22135706889/job/63986726748?pr=2144