### PR TITLE
ci: fix flaky claude review permissions

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -48,7 +48,8 @@ REVIEW STYLE:
 - Sign off with: ✅ (approved) or ⚠️ (issues found)
 
 Consult the repository's [CLAUDE.md], [CONTRIBUTING.md], and [AGENTS.md] for project-specific conventions.
-Use `gh pr comment` to post your review.
+Don't try to use `gh pr review` you don't have permissions for that and it will fail. 
+Please always use `gh pr comment` to post your review instead.
 
 [CLAUDE.md]: ../../CLAUDE.md
 [CONTRIBUTING.md]: ../../CONTRIBUTING.md

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
       issues: read
       id-token: write
 


### PR DESCRIPTION
Closes #2166 

Observe these two runs:
- [failed] https://github.com/near/mpc/actions/runs/22172056322
- [succeeded] https://github.com/near/mpc/actions/runs/22172056322

The only difference is that in the failed one claude gave up after failing to submit a review with `gh pr review`. So this is a prompt engineering issue, welcome to the LLM world!
