### PR TITLE
ci: exclude .direnv from lychee link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -9,4 +9,4 @@ offline = true
 # Check anchor/fragment links (e.g., #section-name)
 include_fragments = true
 
-exclude_path = ["libs/nearcore", "target", ".git"]
+exclude_path = ["libs/nearcore", "target", ".git", ".direnv"]


### PR DESCRIPTION
## Summary
- Add `.direnv` to `exclude_path` in `lychee.toml` to prevent the link checker from scanning vendored Nix flake inputs, which produced false errors

Closes #2175

## Test plan
- [x] Verify `cargo make check-markdown-links` no longer reports errors from `.direnv/flake-inputs/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)