### PR TITLE
build: set Cargo linker for aarch64-darwin to resolve -lSystem

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -113,6 +113,10 @@
 
             AR = "${stdenv.cc.bintools}/bin/ar";
             RANLIB = "${stdenv.cc.bintools}/bin/ranlib";
+
+            # Cargo resolves its linker separately from CC — force it to use the
+            # SDK-aware wrapper so -lSystem (and other SDK libs) are found.
+            CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER = "${stdenv.cc}/bin/cc";
           };
 
           dockerTools = with pkgs; [


### PR DESCRIPTION
## Summary

- Set `CARGO_TARGET_AARCH64_APPLE_DARWIN_LINKER` to `stdenv.cc`'s SDK-aware wrapper in the Nix flake so Cargo's linker can find `-lSystem` and other macOS SDK libraries
- Fixes build failure on aarch64-darwin where `librocksdb-sys` and `zstd-sys` build scripts fail with `ld: library not found for -lSystem`

Closes #2183

## Test plan

- [x] Run `nix develop` then `cargo build` on aarch64-darwin — should no longer fail with `-lSystem` not found
- [x] Verify `cargo build` still works on Linux (no env var is set on non-Darwin)

🤖 Generated with [Claude Code](https://claude.com/claude-code)