### PR TITLE
build: make sure nix includes all needed tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,18 @@ Add the following to your project settings in `.vscode/settings.json`:
 }
 ```
 
+### Verifying the Nix shell is complete
+
+Because `nix develop` inherits the system `$PATH`, missing packages can go unnoticed
+if the host already has them installed. To verify the shell provides everything needed,
+run the checks in a clean environment that hides system binaries:
+
+```shell
+nix develop --ignore-environment --command bash -c 'cargo make check-all-fast'
+```
+
+This should be done after modifying `flake.nix` or adding new tool dependencies.
+
 ## How it works
 
 There are two main parts of the binary: NEAR indexer and MPC signing:

--- a/flake.nix
+++ b/flake.nix
@@ -150,6 +150,7 @@
             git
             binaryen
             jq
+            perl
           ];
 
           buildLibs =


### PR DESCRIPTION
Closes #2194 

- The advertised command in the doc does not check absolutely all tools are in, but does cover the majority of it. Therefore, I don't think we should be more verbose about that.