### PR TITLE
fix: Use DTO contract types in the node

### DIFF
--- a/crates/contract/src/primitives/key_state.rs
+++ b/crates/contract/src/primitives/key_state.rs
@@ -47,6 +47,9 @@ impl AttemptId {
     pub fn get(&self) -> u64 {
         self.0
     }
+    pub fn from_raw(val: u64) -> Self {
+        AttemptId(val)
+    }
     pub fn legacy_attempt_id() -> Self {
         AttemptId(0)
     }

--- a/crates/node/src/assets/test_utils.rs
+++ b/crates/node/src/assets/test_utils.rs
@@ -34,7 +34,9 @@ pub fn random_verifying_key() -> VerifyingKey {
 pub fn gen_four_participants() -> (EpochData, ParticipantId) {
     let epoch_id = EpochId::new(rand::thread_rng().next_u64());
     let parameters = ThresholdParameters::new(gen_participants(4), Threshold::new(3)).unwrap();
-    let participants: ParticipantsConfig = convert_participant_infos(parameters, None).unwrap();
+    let dto_params: contract_interface::types::ThresholdParameters =
+        serde_json::from_value(serde_json::to_value(&parameters).unwrap()).unwrap();
+    let participants: ParticipantsConfig = convert_participant_infos(&dto_params, None).unwrap();
     let epoch_data = EpochData {
         epoch_id,
         participants,

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -23,9 +23,9 @@ use crate::{
 };
 use anyhow::{anyhow, Context};
 use clap::{Args, Parser, Subcommand, ValueEnum};
+use contract_interface::types as dtos;
 use hex::FromHex;
 use mpc_attestation::report_data::ReportDataV1;
-use mpc_contract::state::ProtocolContractState;
 use near_account_id::AccountId;
 use near_indexer_primitives::types::Finality;
 use near_time::Clock;
@@ -287,7 +287,7 @@ impl StartCmd {
         let root_task_handle = Arc::new(OnceLock::new());
 
         let (protocol_state_sender, protocol_state_receiver) =
-            watch::channel(ProtocolContractState::NotInitialized);
+            watch::channel(dtos::ProtocolContractState::NotInitialized);
 
         let (migration_state_sender, migration_state_receiver) =
             watch::channel((0, BTreeMap::new()));

--- a/crates/node/src/indexer.rs
+++ b/crates/node/src/indexer.rs
@@ -22,7 +22,6 @@ use contract_interface::types as dtos;
 use handler::ChainBlockUpdate;
 use mpc_contract::{
     primitives::signature::YieldIndex,
-    state::ProtocolContractState,
     tee::{
         proposal::{LauncherDockerComposeHash, MpcDockerImageHash},
         tee_state::NodeId,
@@ -47,6 +46,7 @@ use tokio::sync::{
 use types::ChainSendTransactionRequest;
 
 pub mod configs;
+pub mod dto_conversions;
 pub mod handler;
 pub mod migrations;
 pub mod participants;
@@ -300,7 +300,7 @@ impl IndexerViewClient {
     pub(crate) async fn get_mpc_contract_state(
         &self,
         mpc_contract_id: AccountId,
-    ) -> anyhow::Result<(u64, ProtocolContractState)> {
+    ) -> anyhow::Result<(u64, dtos::ProtocolContractState)> {
         self.get_mpc_state(mpc_contract_id, STATE).await
     }
 

--- a/crates/node/src/indexer/dto_conversions.rs
+++ b/crates/node/src/indexer/dto_conversions.rs
@@ -1,0 +1,74 @@
+//! Conversion functions from contract-interface DTO types to internal contract types.
+//!
+//! These conversions are used at the chain-reading boundary: the node deserializes
+//! chain JSON into DTO types (which have relaxed fields like `purpose: Option<DomainPurpose>`),
+//! then converts them into the stricter internal types used by node logic.
+
+use anyhow::Context;
+use contract_interface::types as dtos;
+use mpc_contract::{
+    crypto_shared::types::PublicKeyExtended,
+    primitives::{
+        domain::{infer_purpose_from_scheme, DomainConfig, DomainId, SignatureScheme},
+        key_state::{AttemptId, EpochId, KeyForDomain, Keyset},
+    },
+};
+
+pub fn convert_epoch_id(dto: &dtos::EpochId) -> EpochId {
+    EpochId::new(dto.0)
+}
+
+pub fn convert_attempt_id(dto: &dtos::AttemptId) -> AttemptId {
+    AttemptId::from_raw(dto.0)
+}
+
+pub fn convert_domain_id(dto: &dtos::DomainId) -> DomainId {
+    DomainId(dto.0)
+}
+
+pub fn convert_signature_scheme(dto: &dtos::SignatureScheme) -> SignatureScheme {
+    match dto {
+        dtos::SignatureScheme::Secp256k1 => SignatureScheme::Secp256k1,
+        dtos::SignatureScheme::Ed25519 => SignatureScheme::Ed25519,
+        dtos::SignatureScheme::Bls12381 => SignatureScheme::Bls12381,
+        dtos::SignatureScheme::V2Secp256k1 => SignatureScheme::V2Secp256k1,
+    }
+}
+
+pub fn convert_domain_config(dto: &dtos::DomainConfig) -> DomainConfig {
+    let scheme = convert_signature_scheme(&dto.scheme);
+    let purpose = dto
+        .purpose
+        .unwrap_or_else(|| infer_purpose_from_scheme(scheme));
+    DomainConfig {
+        id: convert_domain_id(&dto.id),
+        scheme,
+        purpose,
+    }
+}
+
+/// Convert DTO PublicKeyExtended to internal PublicKeyExtended via serde roundtrip.
+/// Both types have compatible JSON representations.
+pub fn convert_public_key_extended(
+    dto: &dtos::PublicKeyExtended,
+) -> anyhow::Result<PublicKeyExtended> {
+    let json = serde_json::to_value(dto).context("failed to serialize DTO PublicKeyExtended")?;
+    serde_json::from_value(json).context("failed to deserialize internal PublicKeyExtended")
+}
+
+pub fn convert_key_for_domain(dto: &dtos::KeyForDomain) -> anyhow::Result<KeyForDomain> {
+    Ok(KeyForDomain {
+        domain_id: convert_domain_id(&dto.domain_id),
+        key: convert_public_key_extended(&dto.key)?,
+        attempt: convert_attempt_id(&dto.attempt),
+    })
+}
+
+pub fn convert_keyset(dto: &dtos::Keyset) -> anyhow::Result<Keyset> {
+    let domains = dto
+        .domains
+        .iter()
+        .map(convert_key_for_domain)
+        .collect::<anyhow::Result<Vec<_>>>()?;
+    Ok(Keyset::new(convert_epoch_id(&dto.epoch_id), domains))
+}

--- a/crates/node/src/indexer/fake.rs
+++ b/crates/node/src/indexer/fake.rs
@@ -461,8 +461,11 @@ impl FakeIndexerCore {
                 loop {
                     {
                         let state = contract.lock().await;
+                        let dto_state: dtos::ProtocolContractState =
+                            serde_json::from_value(serde_json::to_value(&state.state).unwrap())
+                                .expect("internal state must round-trip to DTO");
                         let config = ContractState::from_contract_state(
-                            &state.state,
+                            &dto_state,
                             state.env.block_height,
                             None,
                         )

--- a/crates/node/src/indexer/real.rs
+++ b/crates/node/src/indexer/real.rs
@@ -10,8 +10,8 @@ use crate::indexer::tee::{
     monitor_allowed_docker_images, monitor_allowed_launcher_compose_hashes, monitor_tee_accounts,
 };
 use crate::indexer::tx_sender::{TransactionProcessorHandle, TransactionSender};
+use contract_interface::types as dtos;
 use ed25519_dalek::{SigningKey, VerifyingKey};
-use mpc_contract::state::ProtocolContractState;
 use near_account_id::AccountId;
 use near_indexer::Indexer;
 use std::path::PathBuf;
@@ -53,7 +53,7 @@ pub fn spawn_real_indexer(
     account_secret_key: SigningKey,
     respond_config: RespondConfig,
     indexer_exit_sender: oneshot::Sender<anyhow::Result<()>>,
-    protocol_state_sender: watch::Sender<ProtocolContractState>,
+    protocol_state_sender: watch::Sender<dtos::ProtocolContractState>,
     migration_state_sender: watch::Sender<(u64, ContractMigrationInfo)>,
     tls_public_key: VerifyingKey,
 ) -> IndexerAPI<impl TransactionSender, RealForeignChainPolicyReader> {

--- a/crates/node/src/migration_service/types.rs
+++ b/crates/node/src/migration_service/types.rs
@@ -487,11 +487,20 @@ pub mod tests {
     const BLOCK_HEIGHT: u64 = 6;
     const PORT_OVERRIDE: Option<u16> = None;
     const NUM_DOMAINS: usize = 5;
+    /// Converts an internal ProtocolContractState to a DTO via serde roundtrip.
+    fn to_dto_state(
+        state: &ProtocolContractState,
+    ) -> contract_interface::types::ProtocolContractState {
+        serde_json::from_value(serde_json::to_value(state).unwrap())
+            .expect("internal state must round-trip to DTO")
+    }
+
     pub(crate) fn make_resharing_contract_case(
         onboarding_node_p2p_public_key: VerifyingKey,
     ) -> ContractCase {
+        let internal = ProtocolContractState::Resharing(gen_resharing_state(NUM_DOMAINS).1);
         let contract = ContractState::from_contract_state(
-            &ProtocolContractState::Resharing(gen_resharing_state(NUM_DOMAINS).1),
+            &to_dto_state(&internal),
             BLOCK_HEIGHT,
             PORT_OVERRIDE,
         )
@@ -502,8 +511,9 @@ pub mod tests {
         onboarding_node_p2p_public_key: VerifyingKey,
     ) -> (ContractCase, Keyset) {
         let running_state = gen_running_state(NUM_DOMAINS);
+        let internal = ProtocolContractState::Running(running_state.clone());
         let contract = ContractState::from_contract_state(
-            &ProtocolContractState::Running(running_state.clone()),
+            &to_dto_state(&internal),
             BLOCK_HEIGHT,
             PORT_OVERRIDE,
         )
@@ -517,8 +527,10 @@ pub mod tests {
     pub(crate) fn make_initializing_contract_case(
         onboarding_node_p2p_public_key: VerifyingKey,
     ) -> ContractCase {
+        let internal =
+            ProtocolContractState::Initializing(gen_initializing_state(NUM_DOMAINS, 0).1);
         let contract = ContractState::from_contract_state(
-            &ProtocolContractState::Initializing(gen_initializing_state(NUM_DOMAINS, 0).1),
+            &to_dto_state(&internal),
             BLOCK_HEIGHT,
             PORT_OVERRIDE,
         )

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -1,10 +1,10 @@
 use aes_gcm::{Aes256Gcm, KeyInit};
+use contract_interface::types as dtos;
 use contract_interface::types::{
     BitcoinExtractor, BitcoinRpcRequest, ForeignChainRpcRequest,
     VerifyForeignTransactionRequestArgs,
 };
 use mpc_contract::primitives::key_state::Keyset;
-use mpc_contract::state::ProtocolContractState;
 use rand::rngs::OsRng;
 use std::collections::BTreeMap;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -102,7 +102,7 @@ impl OneNodeTestConfig {
                 let (debug_request_sender, _) = tokio::sync::broadcast::channel(10);
 
                 let (_, dummy_protocol_state_receiver) =
-                    watch::channel(ProtocolContractState::NotInitialized);
+                    watch::channel(dtos::ProtocolContractState::NotInitialized);
                 let (_, dummy_migration_state_receiver) = watch::channel((0, BTreeMap::new()));
                 let web_server = start_web_server(
                     root_task.into(),


### PR DESCRIPTION
Alternative approach for #2188 based on using the contract DTO types in the node directly.

Currently unfiltered Claude draft.