### PR TITLE
chore: have per chain specific builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6248,8 +6248,10 @@ dependencies = [
 name = "near-mpc-sdk"
 version = "3.5.1"
 dependencies = [
+ "assert_matches",
  "bounded-collections",
  "contract-interface",
+ "derive_more 2.1.1",
 ]
 
 [[package]]

--- a/crates/near-mpc-sdk/Cargo.toml
+++ b/crates/near-mpc-sdk/Cargo.toml
@@ -7,8 +7,10 @@ license.workspace = true
 [dependencies]
 bounded-collections = { workspace = true }
 contract-interface = { workspace = true }
+derive_more = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/near-mpc-sdk/src/foreign_chain.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain.rs
@@ -1,0 +1,103 @@
+use crate::sign::NotSet;
+pub use contract_interface::method_names::VERIFY_FOREIGN_TRANSACTION as VERIFY_FOREIGN_TRANSACTION_METHOD_NAME;
+
+pub mod bitcoin;
+
+// response types
+pub use contract_interface::types::{Hash256, SignatureResponse, VerifyForeignTransactionResponse};
+
+// raw request arg type
+pub use contract_interface::types::{
+    BlockConfirmations, DomainId, ExtractedValue, ForeignChain, ForeignChainPolicy,
+    ForeignChainRpcRequest, ForeignTxSignPayload, ForeignTxSignPayloadV1,
+    VerifyForeignTransactionRequestArgs,
+};
+
+#[allow(dead_code, reason = "TODO(#2130): Implement verification")]
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+pub struct ForeignChainSignatureVerifier {
+    expected_extracted_values: Vec<ExtractedValue>,
+    request: ForeignChainRpcRequest,
+}
+
+pub const DEFAULT_PAYLOAD_VERSION: u8 = 1;
+
+pub trait RequestFinishedBuilding: Into<(ForeignChainRpcRequest, Vec<ExtractedValue>)> {}
+
+#[derive(Debug, Clone)]
+pub struct ForeignChainRequestBuilder<Request, DerivationPath, DomainId> {
+    request: Request,
+    derivation_path: DerivationPath,
+    domain_id: DomainId,
+    payload_version: u8,
+}
+
+impl Default for ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
+    pub fn new() -> Self {
+        Self {
+            request: NotSet,
+            derivation_path: NotSet,
+            domain_id: NotSet,
+            payload_version: DEFAULT_PAYLOAD_VERSION,
+        }
+    }
+}
+
+impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, NotSet, NotSet> {
+    pub fn with_derivation_path(
+        self,
+        derivation_path: String,
+    ) -> ForeignChainRequestBuilder<Request, String, NotSet> {
+        ForeignChainRequestBuilder {
+            request: self.request,
+            derivation_path,
+            domain_id: NotSet,
+            payload_version: self.payload_version,
+        }
+    }
+}
+
+impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, String, NotSet> {
+    pub fn with_domain_id(
+        self,
+        domain_id: impl Into<DomainId>,
+    ) -> ForeignChainRequestBuilder<Request, String, DomainId> {
+        ForeignChainRequestBuilder {
+            request: self.request,
+            derivation_path: self.derivation_path,
+            domain_id: domain_id.into(),
+            payload_version: self.payload_version,
+        }
+    }
+}
+
+impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, String, DomainId> {
+    pub fn build(
+        self,
+    ) -> (
+        ForeignChainSignatureVerifier,
+        VerifyForeignTransactionRequestArgs,
+    ) {
+        let (request, expected_values) = self.request.into();
+
+        let verifier = ForeignChainSignatureVerifier {
+            expected_extracted_values: expected_values,
+            request: request.clone(),
+        };
+
+        let request_args = VerifyForeignTransactionRequestArgs {
+            request,
+            derivation_path: self.derivation_path,
+            domain_id: self.domain_id,
+            payload_version: self.payload_version,
+        };
+
+        (verifier, request_args)
+    }
+}

--- a/crates/near-mpc-sdk/src/foreign_chain.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain.rs
@@ -24,7 +24,10 @@ pub const DEFAULT_PAYLOAD_VERSION: u8 = 1;
 
 /// Marker trait for chain-specific request types that have all required fields set
 /// and can be converted into the contract's RPC request format with expected extracted values.
-pub trait RequestFinishedBuilding: Into<(ForeignChainRpcRequest, Vec<ExtractedValue>)> {}
+pub trait BuildableForeignChainRequest:
+    Into<(ForeignChainRpcRequest, Vec<ExtractedValue>)>
+{
+}
 
 #[derive(Debug, Clone)]
 pub struct ForeignChainRequestBuilder<Request, DerivationPath, DomainId> {
@@ -51,7 +54,7 @@ impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
     }
 }
 
-impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, NotSet, NotSet> {
+impl<Request: BuildableForeignChainRequest> ForeignChainRequestBuilder<Request, NotSet, NotSet> {
     pub fn with_derivation_path(
         self,
         derivation_path: String,
@@ -65,7 +68,7 @@ impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, NotSe
     }
 }
 
-impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, String, NotSet> {
+impl<Request: BuildableForeignChainRequest> ForeignChainRequestBuilder<Request, String, NotSet> {
     pub fn with_domain_id(
         self,
         domain_id: impl Into<DomainId>,
@@ -79,7 +82,7 @@ impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, Strin
     }
 }
 
-impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, String, DomainId> {
+impl<Request: BuildableForeignChainRequest> ForeignChainRequestBuilder<Request, String, DomainId> {
     pub fn build(
         self,
     ) -> (

--- a/crates/near-mpc-sdk/src/foreign_chain.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain.rs
@@ -22,6 +22,8 @@ pub struct ForeignChainSignatureVerifier {
 
 pub const DEFAULT_PAYLOAD_VERSION: u8 = 1;
 
+/// Marker trait for chain-specific request types that have all required fields set
+/// and can be converted into the contract's RPC request format with expected extracted values.
 pub trait RequestFinishedBuilding: Into<(ForeignChainRpcRequest, Vec<ExtractedValue>)> {}
 
 #[derive(Debug, Clone)]
@@ -57,7 +59,7 @@ impl<Request: RequestFinishedBuilding> ForeignChainRequestBuilder<Request, NotSe
         ForeignChainRequestBuilder {
             request: self.request,
             derivation_path,
-            domain_id: NotSet,
+            domain_id: self.domain_id,
             payload_version: self.payload_version,
         }
     }

--- a/crates/near-mpc-sdk/src/foreign_chain.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain.rs
@@ -27,24 +27,6 @@ pub struct ForeignChainRequestBuilder<Request, DerivationPath, DomainId> {
     request: Request,
     derivation_path: DerivationPath,
     domain_id: DomainId,
-    payload_version: u8,
-}
-
-impl Default for ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
-    pub fn new() -> Self {
-        Self {
-            request: NotSet,
-            derivation_path: NotSet,
-            domain_id: NotSet,
-            payload_version: DEFAULT_PAYLOAD_VERSION,
-        }
-    }
 }
 
 impl<Request: Into<ForeignChainRpcRequestWithExpectations>>
@@ -58,7 +40,6 @@ impl<Request: Into<ForeignChainRpcRequestWithExpectations>>
             request: self.request,
             derivation_path,
             domain_id: self.domain_id,
-            payload_version: self.payload_version,
         }
     }
 }
@@ -74,7 +55,6 @@ impl<Request: Into<ForeignChainRpcRequestWithExpectations>>
             request: self.request,
             derivation_path: self.derivation_path,
             domain_id: domain_id.into(),
-            payload_version: self.payload_version,
         }
     }
 }
@@ -102,7 +82,7 @@ impl<Request: Into<ForeignChainRpcRequestWithExpectations>>
             request,
             derivation_path: self.derivation_path,
             domain_id: self.domain_id,
-            payload_version: self.payload_version,
+            payload_version: DEFAULT_PAYLOAD_VERSION,
         };
 
         (verifier, request_args)

--- a/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
@@ -51,6 +51,21 @@ impl From<BuildableBitcoinRequest> for ForeignChainRpcRequestWithExpectations {
 }
 
 impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
+    pub fn new_bitcoin()
+    -> ForeignChainRequestBuilder<BitcoinRequest<NotSet, NotSet>, NotSet, NotSet> {
+        ForeignChainRequestBuilder {
+            request: BitcoinRequest {
+                tx_id: NotSet,
+                confirmations: NotSet,
+                expected_block_hash: None,
+            },
+            derivation_path: NotSet,
+            domain_id: NotSet,
+        }
+    }
+}
+
+impl ForeignChainRequestBuilder<BitcoinRequest<NotSet, NotSet>, NotSet, NotSet> {
     pub fn with_tx_id(
         self,
         tx_id: impl Into<BitcoinTxId>,
@@ -63,7 +78,6 @@ impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
             },
             derivation_path: self.derivation_path,
             domain_id: self.domain_id,
-            payload_version: self.payload_version,
         }
     }
 }
@@ -81,7 +95,6 @@ impl ForeignChainRequestBuilder<BitcoinRequest<BitcoinTxId, NotSet>, NotSet, Not
             },
             derivation_path: self.derivation_path,
             domain_id: self.domain_id,
-            payload_version: self.payload_version,
         }
     }
 }
@@ -96,7 +109,6 @@ impl ForeignChainRequestBuilder<BuildableBitcoinRequest, NotSet, NotSet> {
             },
             derivation_path: self.derivation_path,
             domain_id: self.domain_id,
-            payload_version: self.payload_version,
         }
     }
 }
@@ -115,7 +127,7 @@ mod test {
         let tx_id = BitcoinTxId::from([123; 32]);
 
         // when
-        let builder = ForeignChainRequestBuilder::new().with_tx_id(tx_id.clone());
+        let builder = ForeignChainRequestBuilder::new_bitcoin().with_tx_id(tx_id.clone());
 
         // then
         assert_eq!(builder.request.tx_id, tx_id);
@@ -127,7 +139,7 @@ mod test {
         let tx_id = BitcoinTxId::from([123; 32]);
 
         // when
-        let builder = ForeignChainRequestBuilder::new()
+        let builder = ForeignChainRequestBuilder::new_bitcoin()
             .with_tx_id(tx_id)
             .with_block_confirmations(10);
 
@@ -142,7 +154,7 @@ mod test {
         let expected_hash = [9; 32];
 
         // when
-        let builder = ForeignChainRequestBuilder::new()
+        let builder = ForeignChainRequestBuilder::new_bitcoin()
             .with_tx_id(tx_id)
             .with_block_confirmations(10)
             .with_expected_block_hash(expected_hash);
@@ -163,7 +175,7 @@ mod test {
         let expected_hash = [9; 32];
 
         // when
-        let (_verifier, request_args) = ForeignChainRequestBuilder::new()
+        let (_verifier, request_args) = ForeignChainRequestBuilder::new_bitcoin()
             .with_tx_id(tx_id.clone())
             .with_block_confirmations(10)
             .with_expected_block_hash(expected_hash)
@@ -193,7 +205,7 @@ mod test {
         let expected_hash = [9; 32];
 
         // when
-        let (verifier, _request_args) = ForeignChainRequestBuilder::new()
+        let (verifier, _request_args) = ForeignChainRequestBuilder::new_bitcoin()
             .with_tx_id(tx_id.clone())
             .with_block_confirmations(10)
             .with_expected_block_hash(expected_hash)
@@ -219,7 +231,7 @@ mod test {
     #[test]
     fn verifier_request_matches_request_args() {
         // given
-        let (verifier, request_args) = ForeignChainRequestBuilder::new()
+        let (verifier, request_args) = ForeignChainRequestBuilder::new_bitcoin()
             .with_tx_id(BitcoinTxId::from([123; 32]))
             .with_block_confirmations(10)
             .with_derivation_path("path".to_string())

--- a/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
@@ -78,9 +78,9 @@ impl ForeignChainRequestBuilder<BitcoinRequest<BitcoinTxId, NotSet>, NotSet, Not
     ) -> ForeignChainRequestBuilder<BuiltBitcoinRequest, NotSet, NotSet> {
         ForeignChainRequestBuilder {
             request: BitcoinRequest {
-                tx_id: self.request.tx_id,
                 confirmations: confirmations.into(),
-                expected_block_hash: None,
+                tx_id: self.request.tx_id,
+                expected_block_hash: self.request.expected_block_hash,
             },
             derivation_path: self.derivation_path,
             domain_id: self.domain_id,
@@ -113,17 +113,60 @@ mod test {
     use super::*;
 
     #[test]
-    fn builder_builds_as_expected() {
+    fn with_tx_id_sets_expected_value() {
+        // given
+        let tx_id = BitcoinTxId::from([123; 32]);
+
+        // when
+        let builder = ForeignChainRequestBuilder::new().with_tx_id(tx_id.clone());
+
+        // then
+        assert_eq!(builder.request.tx_id, tx_id);
+    }
+
+    #[test]
+    fn with_block_confirmations_sets_expected_value() {
+        // given
+        let tx_id = BitcoinTxId::from([123; 32]);
+
+        // when
+        let builder = ForeignChainRequestBuilder::new()
+            .with_tx_id(tx_id)
+            .with_block_confirmations(10);
+
+        // then
+        assert_eq!(builder.request.confirmations, BlockConfirmations::from(10));
+    }
+
+    #[test]
+    fn with_expected_block_hash_sets_expected_value() {
+        // given
+        let tx_id = BitcoinTxId::from([123; 32]);
+        let expected_hash = [9; 32];
+
+        // when
+        let builder = ForeignChainRequestBuilder::new()
+            .with_tx_id(tx_id)
+            .with_block_confirmations(10)
+            .with_expected_block_hash(expected_hash);
+
+        // then
+        assert_eq!(
+            builder.request.expected_block_hash.as_deref(),
+            Some(&expected_hash)
+        );
+    }
+
+    #[test]
+    fn build_produces_correct_request_args() {
         // given
         let path = "test_path".to_string();
         let domain_id = DomainId::from(2);
         let tx_id = BitcoinTxId::from([123; 32]);
-        let confirmations = 10;
-
         let expected_hash = [9; 32];
 
         // when
-        let (verifier, built_sign_request_args) = ForeignChainRequestBuilder::new()
+        let (_verifier, request_args) = ForeignChainRequestBuilder::new()
             .with_tx_id(tx_id.clone())
             .with_block_confirmations(10)
             .with_expected_block_hash(expected_hash)
@@ -132,32 +175,62 @@ mod test {
             .build();
 
         // then
-        let block_hash_extractor = BitcoinExtractor::BlockHash;
-        let example_extracted_value = BitcoinExtractedValue::BlockHash(expected_hash.into());
-
-        let expected_rpc_request = ForeignChainRpcRequest::Bitcoin({
-            BitcoinRpcRequest {
+        let expected = VerifyForeignTransactionRequestArgs {
+            request: ForeignChainRpcRequest::Bitcoin(BitcoinRpcRequest {
                 tx_id,
-                confirmations: BlockConfirmations::from(confirmations),
-                extractors: vec![block_hash_extractor],
-            }
-        });
-
-        let expected_request = VerifyForeignTransactionRequestArgs {
-            request: expected_rpc_request,
+                confirmations: BlockConfirmations::from(10),
+                extractors: vec![BitcoinExtractor::BlockHash],
+            }),
             derivation_path: path,
             domain_id,
             payload_version: DEFAULT_PAYLOAD_VERSION,
         };
 
+        assert_eq!(request_args, expected);
+    }
+
+    #[test]
+    fn build_produces_correct_verifier() {
+        // given
+        let tx_id = BitcoinTxId::from([123; 32]);
+        let expected_hash = [9; 32];
+
+        // when
+        let (verifier, _request_args) = ForeignChainRequestBuilder::new()
+            .with_tx_id(tx_id.clone())
+            .with_block_confirmations(10)
+            .with_expected_block_hash(expected_hash)
+            .with_derivation_path("path".to_string())
+            .with_domain_id(DomainId::from(1))
+            .build();
+
+        // then
         let expected_verifier = ForeignChainSignatureVerifier {
             expected_extracted_values: vec![ExtractedValue::BitcoinExtractedValue(
-                example_extracted_value,
+                BitcoinExtractedValue::BlockHash(expected_hash.into()),
             )],
-            request: expected_request.request.clone(),
+            request: ForeignChainRpcRequest::Bitcoin(BitcoinRpcRequest {
+                tx_id,
+                confirmations: BlockConfirmations::from(10),
+                extractors: vec![BitcoinExtractor::BlockHash],
+            }),
         };
 
-        assert_eq!(built_sign_request_args, expected_request);
         assert_eq!(verifier, expected_verifier);
+    }
+
+    #[test]
+    fn verifier_request_matches_request_args() {
+        // given
+        let (verifier, request_args) = ForeignChainRequestBuilder::new()
+            .with_tx_id(BitcoinTxId::from([123; 32]))
+            .with_block_confirmations(10)
+            .with_derivation_path("path".to_string())
+            .with_domain_id(DomainId::from(1))
+            // when
+            .build();
+
+        // then
+        assert_eq!(verifier.request, request_args.request);
     }
 }

--- a/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    foreign_chain::{ForeignChainRequestBuilder, RequestFinishedBuilding},
+    foreign_chain::{BuildableForeignChainRequest, ForeignChainRequestBuilder},
     sign::NotSet,
 };
 
@@ -13,7 +13,7 @@ pub use contract_interface::types::{
 
 /// Type alias with concrete types for when [`BitcoinRequest`] is ready to be built
 /// as part of the [`ForeignChainRequestBuilder`] builder.
-type BuiltBitcoinRequest = BitcoinRequest<BitcoinTxId, BlockConfirmations>;
+type BuildableBitcoinRequest = BitcoinRequest<BitcoinTxId, BlockConfirmations>;
 
 #[derive(Debug, Clone, derive_more::From, derive_more::Deref)]
 pub struct BitcoinBlockHash([u8; 32]);
@@ -28,10 +28,10 @@ pub struct BitcoinRequest<TxId, Confirmations> {
 }
 
 // This means the request can be built
-impl RequestFinishedBuilding for BuiltBitcoinRequest {}
+impl BuildableForeignChainRequest for BuildableBitcoinRequest {}
 
-impl From<BuiltBitcoinRequest> for (ForeignChainRpcRequest, Vec<ExtractedValue>) {
-    fn from(built_request: BuiltBitcoinRequest) -> Self {
+impl From<BuildableBitcoinRequest> for (ForeignChainRpcRequest, Vec<ExtractedValue>) {
+    fn from(built_request: BuildableBitcoinRequest) -> Self {
         let mut extractors = vec![];
         let mut expected_values = vec![];
 
@@ -75,7 +75,7 @@ impl ForeignChainRequestBuilder<BitcoinRequest<BitcoinTxId, NotSet>, NotSet, Not
     pub fn with_block_confirmations(
         self,
         confirmations: impl Into<BlockConfirmations>,
-    ) -> ForeignChainRequestBuilder<BuiltBitcoinRequest, NotSet, NotSet> {
+    ) -> ForeignChainRequestBuilder<BuildableBitcoinRequest, NotSet, NotSet> {
         ForeignChainRequestBuilder {
             request: BitcoinRequest {
                 confirmations: confirmations.into(),
@@ -89,7 +89,7 @@ impl ForeignChainRequestBuilder<BitcoinRequest<BitcoinTxId, NotSet>, NotSet, Not
     }
 }
 
-impl ForeignChainRequestBuilder<BuiltBitcoinRequest, NotSet, NotSet> {
+impl ForeignChainRequestBuilder<BuildableBitcoinRequest, NotSet, NotSet> {
     pub fn with_expected_block_hash(self, block_hash: impl Into<BitcoinBlockHash>) -> Self {
         ForeignChainRequestBuilder {
             request: BitcoinRequest {

--- a/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
@@ -64,8 +64,8 @@ impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
                 confirmations: NotSet,
                 expected_block_hash: None,
             },
-            derivation_path: NotSet,
-            domain_id: NotSet,
+            derivation_path: self.derivation_path,
+            domain_id: self.domain_id,
             payload_version: self.payload_version,
         }
     }
@@ -82,8 +82,8 @@ impl ForeignChainRequestBuilder<BitcoinRequest<BitcoinTxId, NotSet>, NotSet, Not
                 confirmations: confirmations.into(),
                 expected_block_hash: None,
             },
-            derivation_path: NotSet,
-            domain_id: NotSet,
+            derivation_path: self.derivation_path,
+            domain_id: self.domain_id,
             payload_version: self.payload_version,
         }
     }
@@ -97,8 +97,8 @@ impl ForeignChainRequestBuilder<BuiltBitcoinRequest, NotSet, NotSet> {
                 confirmations: self.request.confirmations,
                 expected_block_hash: Some(block_hash.into()),
             },
-            derivation_path: NotSet,
-            domain_id: NotSet,
+            derivation_path: self.derivation_path,
+            domain_id: self.domain_id,
             payload_version: self.payload_version,
         }
     }

--- a/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
@@ -4,12 +4,15 @@ use crate::{
 };
 
 use contract_interface::types::{ExtractedValue, Hash256};
+
 // API types
 pub use contract_interface::types::{
     BitcoinExtractedValue, BitcoinExtractor, BitcoinRpcRequest, BitcoinTxId, BlockConfirmations,
     ForeignChainRpcRequest,
 };
 
+/// Type alias with concrete types for when [`BitcoinRequest`] is ready to be built
+/// as part of the [`ForeignChainRequestBuilder`] builder.
 type BuiltBitcoinRequest = BitcoinRequest<BitcoinTxId, BlockConfirmations>;
 
 #[derive(Debug, Clone, derive_more::From, derive_more::Deref)]
@@ -23,6 +26,9 @@ pub struct BitcoinRequest<TxId, Confirmations> {
     // Extractors
     expected_block_hash: Option<BitcoinBlockHash>,
 }
+
+// This means the request can be built
+impl RequestFinishedBuilding for BuiltBitcoinRequest {}
 
 impl From<BuiltBitcoinRequest> for (ForeignChainRpcRequest, Vec<ExtractedValue>) {
     fn from(built_request: BuiltBitcoinRequest) -> Self {
@@ -46,9 +52,6 @@ impl From<BuiltBitcoinRequest> for (ForeignChainRpcRequest, Vec<ExtractedValue>)
         )
     }
 }
-
-// This means the request can be built
-impl RequestFinishedBuilding for BuiltBitcoinRequest {}
 
 impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
     pub fn with_tx_id(

--- a/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
@@ -1,0 +1,160 @@
+use crate::{
+    foreign_chain::{ForeignChainRequestBuilder, RequestFinishedBuilding},
+    sign::NotSet,
+};
+
+use contract_interface::types::{ExtractedValue, Hash256};
+// API types
+pub use contract_interface::types::{
+    BitcoinExtractedValue, BitcoinExtractor, BitcoinRpcRequest, BitcoinTxId, BlockConfirmations,
+    ForeignChainRpcRequest,
+};
+
+type BuiltBitcoinRequest = BitcoinRequest<BitcoinTxId, BlockConfirmations>;
+
+#[derive(Debug, Clone, derive_more::From, derive_more::Deref)]
+pub struct BitcoinBlockHash([u8; 32]);
+
+#[derive(Debug, Clone)]
+pub struct BitcoinRequest<TxId, Confirmations> {
+    tx_id: TxId,
+    confirmations: Confirmations,
+
+    // Extractors
+    expected_block_hash: Option<BitcoinBlockHash>,
+}
+
+impl From<BuiltBitcoinRequest> for (ForeignChainRpcRequest, Vec<ExtractedValue>) {
+    fn from(built_request: BuiltBitcoinRequest) -> Self {
+        let mut extractors = vec![];
+        let mut expected_values = vec![];
+
+        if let Some(expected_block_hash) = built_request.expected_block_hash {
+            extractors.push(BitcoinExtractor::BlockHash);
+            expected_values.push(ExtractedValue::BitcoinExtractedValue(
+                BitcoinExtractedValue::BlockHash(Hash256::from(*expected_block_hash)),
+            ));
+        }
+
+        (
+            ForeignChainRpcRequest::Bitcoin(BitcoinRpcRequest {
+                tx_id: built_request.tx_id,
+                confirmations: built_request.confirmations,
+                extractors,
+            }),
+            expected_values,
+        )
+    }
+}
+
+// This means the request can be built
+impl RequestFinishedBuilding for BuiltBitcoinRequest {}
+
+impl ForeignChainRequestBuilder<NotSet, NotSet, NotSet> {
+    pub fn with_tx_id(
+        self,
+        tx_id: impl Into<BitcoinTxId>,
+    ) -> ForeignChainRequestBuilder<BitcoinRequest<BitcoinTxId, NotSet>, NotSet, NotSet> {
+        ForeignChainRequestBuilder {
+            request: BitcoinRequest {
+                tx_id: tx_id.into(),
+                confirmations: NotSet,
+                expected_block_hash: None,
+            },
+            derivation_path: NotSet,
+            domain_id: NotSet,
+            payload_version: self.payload_version,
+        }
+    }
+}
+
+impl ForeignChainRequestBuilder<BitcoinRequest<BitcoinTxId, NotSet>, NotSet, NotSet> {
+    pub fn with_block_confirmations(
+        self,
+        confirmations: impl Into<BlockConfirmations>,
+    ) -> ForeignChainRequestBuilder<BuiltBitcoinRequest, NotSet, NotSet> {
+        ForeignChainRequestBuilder {
+            request: BitcoinRequest {
+                tx_id: self.request.tx_id,
+                confirmations: confirmations.into(),
+                expected_block_hash: None,
+            },
+            derivation_path: NotSet,
+            domain_id: NotSet,
+            payload_version: self.payload_version,
+        }
+    }
+}
+
+impl ForeignChainRequestBuilder<BuiltBitcoinRequest, NotSet, NotSet> {
+    pub fn with_expected_block_hash(self, block_hash: impl Into<BitcoinBlockHash>) -> Self {
+        ForeignChainRequestBuilder {
+            request: BitcoinRequest {
+                tx_id: self.request.tx_id,
+                confirmations: self.request.confirmations,
+                expected_block_hash: Some(block_hash.into()),
+            },
+            derivation_path: NotSet,
+            domain_id: NotSet,
+            payload_version: self.payload_version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use contract_interface::types::{DomainId, VerifyForeignTransactionRequestArgs};
+
+    use crate::foreign_chain::{DEFAULT_PAYLOAD_VERSION, ForeignChainSignatureVerifier};
+
+    use super::*;
+
+    #[test]
+    fn builder_builds_as_expected() {
+        // given
+        let path = "test_path".to_string();
+        let domain_id = DomainId::from(2);
+        let tx_id = BitcoinTxId::from([123; 32]);
+        let confirmations = 10;
+
+        let expected_hash = [9; 32];
+
+        // when
+        let (verifier, built_sign_request_args) = ForeignChainRequestBuilder::new()
+            .with_tx_id(tx_id.clone())
+            .with_block_confirmations(10)
+            .with_expected_block_hash(expected_hash)
+            .with_derivation_path(path.clone())
+            .with_domain_id(domain_id)
+            .build();
+
+        // then
+        let block_hash_extractor = BitcoinExtractor::BlockHash;
+        let example_extracted_value = BitcoinExtractedValue::BlockHash(expected_hash.into());
+
+        let expected_rpc_request = ForeignChainRpcRequest::Bitcoin({
+            BitcoinRpcRequest {
+                tx_id,
+                confirmations: BlockConfirmations::from(confirmations),
+                extractors: vec![block_hash_extractor],
+            }
+        });
+
+        let expected_request = VerifyForeignTransactionRequestArgs {
+            request: expected_rpc_request,
+            derivation_path: path,
+            domain_id,
+            payload_version: DEFAULT_PAYLOAD_VERSION,
+        };
+
+        let expected_verifier = ForeignChainSignatureVerifier {
+            expected_extracted_values: vec![ExtractedValue::BitcoinExtractedValue(
+                example_extracted_value,
+            )],
+            request: expected_request.request.clone(),
+        };
+
+        assert_eq!(built_sign_request_args, expected_request);
+        assert_eq!(verifier, expected_verifier);
+    }
+}

--- a/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/bitcoin.rs
@@ -1,5 +1,5 @@
 use crate::{
-    foreign_chain::{BuildableForeignChainRequest, ForeignChainRequestBuilder},
+    foreign_chain::{ForeignChainRequestBuilder, ForeignChainRpcRequestWithExpectations},
     sign::NotSet,
 };
 
@@ -27,10 +27,7 @@ pub struct BitcoinRequest<TxId, Confirmations> {
     expected_block_hash: Option<BitcoinBlockHash>,
 }
 
-// This means the request can be built
-impl BuildableForeignChainRequest for BuildableBitcoinRequest {}
-
-impl From<BuildableBitcoinRequest> for (ForeignChainRpcRequest, Vec<ExtractedValue>) {
+impl From<BuildableBitcoinRequest> for ForeignChainRpcRequestWithExpectations {
     fn from(built_request: BuildableBitcoinRequest) -> Self {
         let mut extractors = vec![];
         let mut expected_values = vec![];
@@ -42,14 +39,14 @@ impl From<BuildableBitcoinRequest> for (ForeignChainRpcRequest, Vec<ExtractedVal
             ));
         }
 
-        (
-            ForeignChainRpcRequest::Bitcoin(BitcoinRpcRequest {
+        ForeignChainRpcRequestWithExpectations {
+            request: ForeignChainRpcRequest::Bitcoin(BitcoinRpcRequest {
                 tx_id: built_request.tx_id,
                 confirmations: built_request.confirmations,
                 extractors,
             }),
             expected_values,
-        )
+        }
     }
 }
 

--- a/crates/near-mpc-sdk/src/lib.rs
+++ b/crates/near-mpc-sdk/src/lib.rs
@@ -1,4 +1,5 @@
 pub use bounded_collections;
 pub use contract_interface;
 
+pub mod foreign_chain;
 pub mod sign;

--- a/crates/near-mpc-sdk/src/sign.rs
+++ b/crates/near-mpc-sdk/src/sign.rs
@@ -1,8 +1,7 @@
 pub use contract_interface::method_names::SIGN as SIGN_METHOD_NAME;
-use contract_interface::types::DomainId;
 // response types
 pub use contract_interface::types::{
-    Ed25519Signature, K256AffinePoint, K256Scalar, K256Signature,
+    DomainId, Ed25519Signature, K256AffinePoint, K256Scalar, K256Signature,
     SignatureResponse as SignatureRequestResponse,
 };
 

--- a/crates/near-mpc-sdk/tests/bitcoin.rs
+++ b/crates/near-mpc-sdk/tests/bitcoin.rs
@@ -12,7 +12,7 @@ fn no_extractor_added() {
     let tx_id = BitcoinTxId::from([123; 32]);
 
     // when
-    let (_verifier, built_sign_request_args) = ForeignChainRequestBuilder::new()
+    let (_verifier, built_sign_request_args) = ForeignChainRequestBuilder::new_bitcoin()
         .with_tx_id(tx_id)
         .with_block_confirmations(10)
         .with_derivation_path(path)

--- a/crates/near-mpc-sdk/tests/bitcoin.rs
+++ b/crates/near-mpc-sdk/tests/bitcoin.rs
@@ -1,0 +1,28 @@
+use assert_matches::assert_matches;
+use near_mpc_sdk::foreign_chain::{
+    DomainId, ForeignChainRequestBuilder,
+    bitcoin::{BitcoinTxId, ForeignChainRpcRequest},
+};
+
+#[test]
+fn no_extractor_added() {
+    // given
+    let path = "test_path".to_string();
+    let domain_id = DomainId::from(2);
+    let tx_id = BitcoinTxId::from([123; 32]);
+
+    // when
+    let (_verifier, built_sign_request_args) = ForeignChainRequestBuilder::new()
+        .with_tx_id(tx_id)
+        .with_block_confirmations(10)
+        .with_derivation_path(path)
+        .with_domain_id(domain_id)
+        .build();
+
+    // then
+    let no_extractors = vec![];
+
+    assert_matches!(built_sign_request_args.request, ForeignChainRpcRequest::Bitcoin(bitcoin_rpc_request) => {
+        assert_eq!(bitcoin_rpc_request.extractors, no_extractors);
+    });
+}


### PR DESCRIPTION
follow up to #2215 

This PR:
- removes `fn new()` in favor of per chain specific constructors `new_bitcoin`, `new_abstract`, etc.
- removes `payload_version` field as it always is a hard coded constant