### PR TITLE
fix: Don't log raw mpc protocol messages

### DIFF
--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -1387,4 +1387,3 @@ mod fault_handling_tests {
         }
     }
 }
-


### PR DESCRIPTION
closes #2307 