### PR TITLE
chore: rename shadowed variable in verify_event_log_rtmr3

### DIFF
--- a/crates/attestation/src/attestation.rs
+++ b/crates/attestation/src/attestation.rs
@@ -166,9 +166,13 @@ impl DstackAttestation {
                     return Err(VerificationError::EventDecoding(hex::encode(*event.digest)));
                 }
             };
-            let expected_digest =
+            let expected_event_digest =
                 Self::event_digest(event.event_type, &event.event, &payload_bytes);
-            compare_hashes("event_digest", event.digest.as_slice(), &expected_digest)?;
+            compare_hashes(
+                "event_digest",
+                event.digest.as_slice(),
+                &expected_event_digest,
+            )?;
 
             hasher.update(event.digest.as_slice());
 


### PR DESCRIPTION
## Summary
- Rename inner `expected_digest` to `expected_event_digest` in `verify_event_log_rtmr3` to avoid shadowing the function parameter of the same name

- No behavioral change — purely a readability improvement  (shadowing was only in the inner loop)

