### PR TITLE
ci: try all nearcore branches to have a better chance of getting the binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,7 +179,7 @@ jobs:
           downloaded=false
           for branch_name in $branches; do
             url="https://s3.us-west-1.amazonaws.com/build.nearprotocol.com/nearcore/${os_and_arch}/${branch_name}/${commit_hash}/neard"
-            status_code=$(curl -s -o target/release/neard -w "%{http_code}" "${url}")
+            status_code=$(curl -s -f -o target/release/neard -w "%{http_code}" "${url}" || true)
             if [ "$status_code" -eq 200 ]; then
               echo "Downloaded neard from branch: ${branch_name}"
               downloaded=true


### PR DESCRIPTION
Closes #2387 

This will probably not be needed after we migrate from pytests, but until then, I would love to have 6 minutes less in CI

This is how it looks now:

<img width="2594" height="325" alt="image" src="https://github.com/user-attachments/assets/6051f06f-d879-4ff7-8bed-d864f6c1b5aa" />
