### PR TITLE
refactor: Decouple and rename chain gateway traits

### DIFF
--- a/crates/chain-gateway/src/chain_gateway.rs
+++ b/crates/chain-gateway/src/chain_gateway.rs
@@ -3,7 +3,7 @@ use near_account_id::AccountId;
 use crate::errors::{ChainGatewayError, NearClientError, NearViewClientError};
 use crate::near_internals_wrapper::{ClientWrapper, ViewClientWrapper};
 use crate::primitives::{SyncChecker, ViewFunctionQuerySubmitter};
-use crate::state_viewer::{ContractStateSubscriber, ContractViewer, MethodViewer};
+use crate::state_viewer::ViewRaw;
 use crate::types::RawObservedState;
 
 #[derive(Clone)]
@@ -14,9 +14,7 @@ pub struct ChainGateway {
     client: ClientWrapper,
 }
 
-impl ContractViewer for ChainGateway {}
-impl ContractStateSubscriber for ChainGateway {}
-impl MethodViewer for ChainGateway {}
+impl ViewRaw for ChainGateway {}
 
 impl SyncChecker for ChainGateway {
     type Error = NearClientError;

--- a/crates/chain-gateway/src/chain_gateway.rs
+++ b/crates/chain-gateway/src/chain_gateway.rs
@@ -2,7 +2,7 @@ use near_account_id::AccountId;
 
 use crate::errors::{ChainGatewayError, NearClientError, NearViewClientError};
 use crate::near_internals_wrapper::{ClientWrapper, ViewClientWrapper};
-use crate::primitives::{SyncChecker, ViewFunctionQuerySubmitter};
+use crate::primitives::{CheckSync, QueryViewFunction};
 use crate::types::RawObservedState;
 
 #[derive(Clone)]
@@ -13,23 +13,23 @@ pub struct ChainGateway {
     client: ClientWrapper,
 }
 
-impl SyncChecker for ChainGateway {
+impl CheckSync for ChainGateway {
     type Error = NearClientError;
     async fn is_syncing(&self) -> Result<bool, Self::Error> {
         self.client.is_syncing().await
     }
 }
 
-impl ViewFunctionQuerySubmitter for ChainGateway {
+impl QueryViewFunction for ChainGateway {
     type Error = NearViewClientError;
-    async fn view_function_query(
+    async fn query_view_function(
         &self,
         contract_id: &AccountId,
         method_name: &str,
         args: &[u8],
     ) -> Result<RawObservedState, Self::Error> {
         self.view_client
-            .view_function_query(contract_id, method_name, args)
+            .query_view_function(contract_id, method_name, args)
             .await
     }
 }

--- a/crates/chain-gateway/src/chain_gateway.rs
+++ b/crates/chain-gateway/src/chain_gateway.rs
@@ -3,7 +3,6 @@ use near_account_id::AccountId;
 use crate::errors::{ChainGatewayError, NearClientError, NearViewClientError};
 use crate::near_internals_wrapper::{ClientWrapper, ViewClientWrapper};
 use crate::primitives::{SyncChecker, ViewFunctionQuerySubmitter};
-use crate::state_viewer::ViewRaw;
 use crate::types::RawObservedState;
 
 #[derive(Clone)]
@@ -13,8 +12,6 @@ pub struct ChainGateway {
     /// For querying blockchain sync status.
     client: ClientWrapper,
 }
-
-impl ViewRaw for ChainGateway {}
 
 impl SyncChecker for ChainGateway {
     type Error = NearClientError;

--- a/crates/chain-gateway/src/lib.rs
+++ b/crates/chain-gateway/src/lib.rs
@@ -1,7 +1,7 @@
 pub mod chain_gateway;
 pub mod errors;
 mod near_internals_wrapper;
-pub mod primitives;
+pub(crate) mod primitives;
 pub mod state_viewer;
 pub mod types;
 

--- a/crates/chain-gateway/src/mock.rs
+++ b/crates/chain-gateway/src/mock.rs
@@ -1,5 +1,4 @@
 use crate::primitives::{SyncChecker, ViewFunctionQuerySubmitter};
-use crate::state_viewer::ViewRaw;
 use crate::types::RawObservedState;
 use near_account_id::AccountId;
 use std::sync::{Arc, RwLock};
@@ -135,8 +134,6 @@ impl ViewFunctionQuerySubmitter for MockChainState {
         inner.response.clone()
     }
 }
-
-impl ViewRaw for MockChainState {}
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum MockError {

--- a/crates/chain-gateway/src/mock.rs
+++ b/crates/chain-gateway/src/mock.rs
@@ -1,5 +1,5 @@
 use crate::primitives::{SyncChecker, ViewFunctionQuerySubmitter};
-use crate::state_viewer::{ContractStateSubscriber, ContractViewer, MethodViewer};
+use crate::state_viewer::ViewRaw;
 use crate::types::RawObservedState;
 use near_account_id::AccountId;
 use std::sync::{Arc, RwLock};
@@ -136,9 +136,7 @@ impl ViewFunctionQuerySubmitter for MockChainState {
     }
 }
 
-impl ContractViewer for MockChainState {}
-impl MethodViewer for MockChainState {}
-impl ContractStateSubscriber for MockChainState {}
+impl ViewRaw for MockChainState {}
 
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 pub enum MockError {

--- a/crates/chain-gateway/src/mock.rs
+++ b/crates/chain-gateway/src/mock.rs
@@ -1,4 +1,4 @@
-use crate::primitives::{SyncChecker, ViewFunctionQuerySubmitter};
+use crate::primitives::{CheckSync, QueryViewFunction};
 use crate::types::RawObservedState;
 use near_account_id::AccountId;
 use std::sync::{Arc, RwLock};
@@ -39,7 +39,7 @@ impl MockChainState {
         inner.response = value;
     }
 
-    /// Wait for the next view_function_query call (polls submitted.len() every 10ms).
+    /// Wait for the next query_view_function call (polls submitted.len() every 10ms).
     pub async fn await_next_view_call(&self, max_wait_duration: Duration) -> Result<(), MockError> {
         tokio::time::timeout(max_wait_duration, async {
             let baseline = {
@@ -67,7 +67,7 @@ impl MockChainState {
 
 pub struct MockChainStateBuilder {
     sync_response: Result<bool, MockError>,
-    view_function_query_response: Result<RawObservedState, MockError>,
+    query_view_function_response: Result<RawObservedState, MockError>,
 }
 
 impl Default for MockChainStateBuilder {
@@ -80,7 +80,7 @@ impl MockChainStateBuilder {
     pub fn new() -> Self {
         Self {
             sync_response: Err(MockError::NotInitialized),
-            view_function_query_response: Err(MockError::NotInitialized),
+            query_view_function_response: Err(MockError::NotInitialized),
         }
     }
 
@@ -93,7 +93,7 @@ impl MockChainStateBuilder {
         mut self,
         r: Result<RawObservedState, MockError>,
     ) -> Self {
-        self.view_function_query_response = r;
+        self.query_view_function_response = r;
         self
     }
 
@@ -102,7 +102,7 @@ impl MockChainStateBuilder {
             sync_response: Arc::new(RwLock::new(self.sync_response)),
             view_function_query_submitter_state: Arc::new(Mutex::new(
                 MockViewFunctionQuerySubmitterState {
-                    response: self.view_function_query_response,
+                    response: self.query_view_function_response,
                     submitted: Vec::new(),
                 },
             )),
@@ -110,16 +110,16 @@ impl MockChainStateBuilder {
     }
 }
 
-impl SyncChecker for MockChainState {
+impl CheckSync for MockChainState {
     type Error = MockError;
     async fn is_syncing(&self) -> Result<bool, Self::Error> {
         self.sync_response.read().unwrap().clone()
     }
 }
 
-impl ViewFunctionQuerySubmitter for MockChainState {
+impl QueryViewFunction for MockChainState {
     type Error = MockError;
-    async fn view_function_query(
+    async fn query_view_function(
         &self,
         contract_id: &AccountId,
         method_name: &str,

--- a/crates/chain-gateway/src/near_internals_wrapper/client.rs
+++ b/crates/chain-gateway/src/near_internals_wrapper/client.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use near_async::messaging::CanSendAsync as _;
 
-use crate::{errors::NearClientError, primitives::SyncChecker};
+use crate::{errors::NearClientError, primitives::CheckSync};
 
 /// Wrapper around near-internal struct
 #[derive(Clone)]
@@ -20,8 +20,8 @@ impl ClientWrapper {
     }
 }
 
-/// Implement SyncChecker for our near client
-impl SyncChecker for ClientWrapper {
+/// Implement CheckSync for our near client
+impl CheckSync for ClientWrapper {
     type Error = NearClientError;
     async fn is_syncing(&self) -> Result<bool, Self::Error> {
         let status_request = near_client::Status {

--- a/crates/chain-gateway/src/near_internals_wrapper/view_client.rs
+++ b/crates/chain-gateway/src/near_internals_wrapper/view_client.rs
@@ -7,7 +7,7 @@ use crate::{
     errors::{
         NearViewClientError, NearViewClientErrorKind, UnexpectedResponseError, ViewClientQuery,
     },
-    primitives::ViewFunctionQuerySubmitter,
+    primitives::QueryViewFunction,
     types::ObservedState,
 };
 
@@ -30,10 +30,10 @@ impl ViewClientWrapper {
     }
 }
 
-impl ViewFunctionQuerySubmitter for ViewClientWrapper {
+impl QueryViewFunction for ViewClientWrapper {
     type Error = NearViewClientError;
     /// calls view method contract_id::method_name(args) and returns the result
-    async fn view_function_query(
+    async fn query_view_function(
         &self,
         contract_id: &AccountId,
         method_name: &str,

--- a/crates/chain-gateway/src/primitives.rs
+++ b/crates/chain-gateway/src/primitives.rs
@@ -1,6 +1,6 @@
 //! This file contains the primitives we need to interact with the NEAR blockchain:
-//!     - SyncChecker --> checks whether the node is fully synced
-//!     - ViewFunctionQuerySubmitter --> can call view methods on a contract
+//!     - CheckSync --> checks whether the node is fully synced
+//!     - QueryViewFunction --> can call view methods on a contract
 //!     - TODO(#2342): LatestFinalBlockInfoFecher --> fetches height and hash of the latest final block
 //!     - TODO(#2342): SignedTransactionSubmitter --> submits  asigned transaction to the blockchain
 use crate::types::RawObservedState;
@@ -9,7 +9,7 @@ use std::future::Future;
 use std::time::Duration;
 
 /// Low-level trait for checking indexer sync status.
-pub trait SyncChecker: Send + Sync + 'static {
+pub trait CheckSync: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
     /// Returns whether the node is currently syncing.
     fn is_syncing(&self) -> impl Future<Output = Result<bool, Self::Error>> + Send;
@@ -34,9 +34,9 @@ pub trait SyncChecker: Send + Sync + 'static {
     }
 }
 
-pub trait ViewFunctionQuerySubmitter: Send + Sync + 'static {
+pub trait QueryViewFunction: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
-    fn view_function_query(
+    fn query_view_function(
         &self,
         contract_id: &AccountId,
         method_name: &str,

--- a/crates/chain-gateway/src/state_viewer.rs
+++ b/crates/chain-gateway/src/state_viewer.rs
@@ -2,4 +2,4 @@ mod monitoring;
 mod subscription;
 mod traits;
 
-pub use traits::{ContractStateStream, SubscribeMethod, ViewMethod};
+pub use traits::{ContractStateStream, SubscribeToContractMethod, ViewContractMethod};

--- a/crates/chain-gateway/src/state_viewer.rs
+++ b/crates/chain-gateway/src/state_viewer.rs
@@ -2,4 +2,5 @@ mod monitoring;
 mod subscription;
 mod traits;
 
-pub use traits::{ContractStateStream, ContractStateSubscriber, ContractViewer, MethodViewer};
+pub(crate) use traits::ViewRaw;
+pub use traits::{ContractStateStream, SubscribeMethod, ViewMethod};

--- a/crates/chain-gateway/src/state_viewer.rs
+++ b/crates/chain-gateway/src/state_viewer.rs
@@ -2,5 +2,4 @@ mod monitoring;
 mod subscription;
 mod traits;
 
-pub(crate) use traits::ViewRaw;
 pub use traits::{ContractStateStream, SubscribeMethod, ViewMethod};

--- a/crates/chain-gateway/src/state_viewer/monitoring.rs
+++ b/crates/chain-gateway/src/state_viewer/monitoring.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use super::traits::ContractViewer;
+use super::traits::ViewRaw;
 
 pub(crate) struct MonitoringTask {
     _task_handle: JoinHandle<()>,
@@ -29,7 +29,7 @@ pub(crate) async fn make_monitoring_task<V>(
     args: Vec<u8>,
 ) -> MonitoringTask
 where
-    V: ContractViewer,
+    V: ViewRaw,
 {
     let observed_state = viewer.view_raw(&contract_id, method_name, &args).await;
 
@@ -54,7 +54,7 @@ where
 
 pub(crate) const POLL_INTERVAL: Duration = Duration::from_millis(200);
 
-async fn monitor<V: ContractViewer>(
+async fn monitor<V: ViewRaw>(
     viewer: V,
     contract_id: AccountId,
     method_name: String,

--- a/crates/chain-gateway/src/state_viewer/subscription.rs
+++ b/crates/chain-gateway/src/state_viewer/subscription.rs
@@ -1,5 +1,5 @@
 use super::monitoring::{MonitoringTask, make_monitoring_task};
-use super::traits::{ContractStateStream, ContractViewer};
+use super::traits::{ContractStateStream, ViewRaw};
 use crate::errors::ChainGatewayError;
 use crate::types::ObservedState;
 use near_account_id::AccountId;
@@ -53,7 +53,7 @@ impl<Res> ContractMethodSubscription<Res>
 where
     Res: DeserializeOwned,
 {
-    pub(super) async fn new<V: ContractViewer>(
+    pub(super) async fn new<V: ViewRaw>(
         viewer: V,
         contract_id: AccountId,
         method_name: &str,

--- a/crates/chain-gateway/src/state_viewer/traits.rs
+++ b/crates/chain-gateway/src/state_viewer/traits.rs
@@ -73,7 +73,7 @@ impl<T: SyncChecker + ViewFunctionQuerySubmitter> ViewRaw for T {
 ///     assert_eq!(result.observed_at, 1.into());
 /// }
 /// ```
-pub trait ViewMethod: Send + Sync {
+pub trait ViewMethod {
     fn view_method<Arg, Res>(
         &self,
         contract_id: AccountId,
@@ -114,7 +114,7 @@ pub trait ViewMethod: Send + Sync {
 ///     assert_eq!(state.value, "hello");
 /// }
 /// ```
-pub trait SubscribeMethod: Send + Sync {
+pub trait SubscribeMethod {
     /// Subscribes to a contract view method and returns a stream of state updates.
     ///
     /// The returned stream polls the contract every 200 ms.

--- a/crates/chain-gateway/src/state_viewer/traits.rs
+++ b/crates/chain-gateway/src/state_viewer/traits.rs
@@ -2,7 +2,7 @@ use std::future::Future;
 use std::sync::Arc;
 
 use crate::errors::{ChainGatewayError, ChainGatewayOp};
-use crate::primitives::{SyncChecker, ViewFunctionQuerySubmitter};
+use crate::primitives::{CheckSync, QueryViewFunction};
 use crate::types::ObservedState;
 use near_account_id::AccountId;
 use serde::{Serialize, de::DeserializeOwned};
@@ -24,7 +24,7 @@ pub(crate) trait ViewRaw: Send + Sync + 'static {
 
 /// Blanket impl: any type that can check sync and submit view queries gets `ViewRaw`
 /// by waiting for full sync, then delegating to the view function query.
-impl<T: SyncChecker + ViewFunctionQuerySubmitter> ViewRaw for T {
+impl<T: CheckSync + QueryViewFunction> ViewRaw for T {
     async fn view_raw(
         &self,
         contract_id: &AccountId,
@@ -32,7 +32,7 @@ impl<T: SyncChecker + ViewFunctionQuerySubmitter> ViewRaw for T {
         args: &[u8],
     ) -> Result<ObservedState, ChainGatewayError> {
         self.wait_for_full_sync().await;
-        self.view_function_query(contract_id, method_name, args)
+        self.query_view_function(contract_id, method_name, args)
             .await
             .map_err(|err| ChainGatewayError::ViewClient {
                 op: ChainGatewayOp::ViewCall {
@@ -189,7 +189,12 @@ impl<T: ViewRaw + Clone> SubscribeToContractMethod for T {
     where
         R: DeserializeOwned + Send + Clone,
     {
-        ContractMethodSubscription::new(self.clone(), contract, view_contract_method, b"{}".to_vec())
+        ContractMethodSubscription::new(
+            self.clone(),
+            contract,
+            view_contract_method,
+            b"{}".to_vec(),
+        )
     }
 }
 

--- a/crates/chain-gateway/src/state_viewer/traits.rs
+++ b/crates/chain-gateway/src/state_viewer/traits.rs
@@ -9,9 +9,12 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use super::subscription::ContractMethodSubscription;
 
-/// All other viewer traits are derived from this one
-pub trait ContractViewer: SyncChecker + ViewFunctionQuerySubmitter {
-    // waits until self is synced and then queries the view function
+/// Internal trait combining sync-checking and view-function querying.
+/// Waits for the node to be fully synced, then performs a raw (untyped) view call.
+///
+/// This is `pub(crate)` because it is an implementation detail — public consumers
+/// should use [`ViewMethod`] or [`SubscribeMethod`] instead.
+pub(crate) trait ViewRaw: SyncChecker + ViewFunctionQuerySubmitter {
     fn view_raw(
         &self,
         contract_id: &AccountId,
@@ -33,67 +36,14 @@ pub trait ContractViewer: SyncChecker + ViewFunctionQuerySubmitter {
     }
 }
 
-/// Blanket-implemented for all `T: HasContractViewer`.
-///
-/// Provides a subscribe-and-poll interface for observing contract state changes.
-/// Polls the view method every 200 ms and emits change notifications only when
-/// the returned bytes differ.
+/// Performs a one-shot typed view call: serializes `args` as JSON, queries the
+/// contract, and deserializes the response.
 ///
 /// # Example
 ///
 /// ```
-/// use chain_gateway::mock::{MockChainState, Call};
-/// use chain_gateway::state_viewer::{ContractStateStream, ContractStateSubscriber};
-/// use chain_gateway::types::ObservedState;
-///
-/// #[tokio::main]
-/// async fn main() {
-///     let viewer = MockChainState::builder()
-///         .with_syncing_status(Ok(false))
-///         .with_view_function_query_response(Ok(ObservedState {
-///             observed_at: 1.into(),
-///             value: br#""hello""#.to_vec(),
-///         }))
-///         .build();
-///
-///     let mut stream = viewer
-///         .subscribe::<String>("contract.near".parse().unwrap(), "get_greeting")
-///         .await;
-///
-///     let state = stream.latest().unwrap();
-///     assert_eq!(state.value, "hello");
-/// }
-/// ```
-pub trait ContractStateSubscriber: ContractViewer + Clone {
-    /// Subscribes to a contract view method and returns a stream of state updates.
-    ///
-    /// The returned stream polls the contract every 200 ms.
-    ///
-    /// # Type Parameter
-    ///
-    /// `T` is the deserialized return type of the contract method.
-    fn subscribe<T>(
-        &self,
-        contract: AccountId,
-        view_method: &str,
-    ) -> impl Future<Output = impl ContractStateStream<T> + Send> + Send
-    where
-        T: DeserializeOwned + Send + Clone,
-    {
-        ContractMethodSubscription::new(self.clone(), contract, view_method, b"{}".to_vec())
-    }
-}
-
-/// Blanket-implemented for all `T: HasContractViewer`.
-///
-/// Performs a one-shot typed view call: serializes `args` as JSON, calls the
-/// underlying [`ContractViewer::view_raw`], and deserializes the response.
-///
-/// # Example
-///
-/// ```
-/// use chain_gateway::mock::{MockChainState, Call};
-/// use chain_gateway::state_viewer::MethodViewer;
+/// use chain_gateway::mock::MockChainState;
+/// use chain_gateway::state_viewer::ViewMethod;
 /// use chain_gateway::types::{NoArgs, ObservedState};
 ///
 /// #[tokio::main]
@@ -107,7 +57,7 @@ pub trait ContractStateSubscriber: ContractViewer + Clone {
 ///         .build();
 ///
 ///     let result: ObservedState<String> = viewer
-///         .view("contract.near".parse().unwrap(), "get_greeting", &NoArgs {})
+///         .view_method("contract.near".parse().unwrap(), "get_greeting", &NoArgs {})
 ///         .await
 ///         .unwrap();
 ///
@@ -115,8 +65,8 @@ pub trait ContractStateSubscriber: ContractViewer + Clone {
 ///     assert_eq!(result.observed_at, 1.into());
 /// }
 /// ```
-pub trait MethodViewer: ContractViewer {
-    fn view<Arg, Res>(
+pub trait ViewMethod: Send + Sync {
+    fn view_method<Arg, Res>(
         &self,
         contract_id: AccountId,
         method_name: &str,
@@ -124,30 +74,53 @@ pub trait MethodViewer: ContractViewer {
     ) -> impl Future<Output = Result<ObservedState<Res>, ChainGatewayError>> + Send
     where
         Arg: Serialize + Sync,
-        Res: DeserializeOwned + Send + Clone,
-    {
-        async move {
-            let args: Vec<u8> =
-                serde_json::to_vec(args).map_err(|err| ChainGatewayError::Serialization {
-                    op: ChainGatewayOp::ViewCall {
-                        account_id: contract_id.to_string(),
-                        method_name: method_name.to_string(),
-                    },
-                    source: Arc::new(err),
-                })?;
-            let res = self.view_raw(&contract_id, method_name, &args).await?;
-            let value = serde_json::from_slice::<Res>(&res.value).map_err(|err| {
-                ChainGatewayError::Deserialization {
-                    source: Arc::new(err),
-                }
-            })?;
+        Res: DeserializeOwned + Send + Clone;
+}
 
-            Ok(ObservedState {
-                observed_at: res.observed_at,
-                value,
-            })
-        }
-    }
+/// Provides a subscribe-and-poll interface for observing contract state changes.
+/// Polls the view method every 200 ms and emits change notifications only when
+/// the returned bytes differ.
+///
+/// # Example
+///
+/// ```
+/// use chain_gateway::mock::MockChainState;
+/// use chain_gateway::state_viewer::{ContractStateStream, SubscribeMethod};
+/// use chain_gateway::types::ObservedState;
+///
+/// #[tokio::main]
+/// async fn main() {
+///     let viewer = MockChainState::builder()
+///         .with_syncing_status(Ok(false))
+///         .with_view_function_query_response(Ok(ObservedState {
+///             observed_at: 1.into(),
+///             value: br#""hello""#.to_vec(),
+///         }))
+///         .build();
+///
+///     let mut stream = viewer
+///         .subscribe_method::<String>("contract.near".parse().unwrap(), "get_greeting")
+///         .await;
+///
+///     let state = stream.latest().unwrap();
+///     assert_eq!(state.value, "hello");
+/// }
+/// ```
+pub trait SubscribeMethod: Send + Sync {
+    /// Subscribes to a contract view method and returns a stream of state updates.
+    ///
+    /// The returned stream polls the contract every 200 ms.
+    ///
+    /// # Type Parameter
+    ///
+    /// `T` is the deserialized return type of the contract method.
+    fn subscribe_method<T>(
+        &self,
+        contract: AccountId,
+        view_method: &str,
+    ) -> impl Future<Output = impl ContractStateStream<T> + Send> + Send
+    where
+        T: DeserializeOwned + Send + Clone;
 }
 
 /// A watch-like stream of contract state changes.
@@ -164,12 +137,60 @@ pub trait ContractStateStream<Res> {
     fn changed(&mut self) -> impl Future<Output = Result<(), ChainGatewayError>> + Send;
 }
 
+/// Implement `ViewMethod` for any type that implements `ViewRaw`.
+impl<T: ViewRaw> ViewMethod for T {
+    async fn view_method<Arg, Res>(
+        &self,
+        contract_id: AccountId,
+        method_name: &str,
+        args: &Arg,
+    ) -> Result<ObservedState<Res>, ChainGatewayError>
+    where
+        Arg: Serialize + Sync,
+        Res: DeserializeOwned + Send + Clone,
+    {
+        let args: Vec<u8> =
+            serde_json::to_vec(args).map_err(|err| ChainGatewayError::Serialization {
+                op: ChainGatewayOp::ViewCall {
+                    account_id: contract_id.to_string(),
+                    method_name: method_name.to_string(),
+                },
+                source: Arc::new(err),
+            })?;
+        let res = self.view_raw(&contract_id, method_name, &args).await?;
+        let value = serde_json::from_slice::<Res>(&res.value).map_err(|err| {
+            ChainGatewayError::Deserialization {
+                source: Arc::new(err),
+            }
+        })?;
+
+        Ok(ObservedState {
+            observed_at: res.observed_at,
+            value,
+        })
+    }
+}
+
+/// Implement `SubscribeMethod` for any cloneable type that implements `ViewRaw`.
+impl<T: ViewRaw + Clone> SubscribeMethod for T {
+    fn subscribe_method<R>(
+        &self,
+        contract: AccountId,
+        view_method: &str,
+    ) -> impl Future<Output = impl ContractStateStream<R> + Send> + Send
+    where
+        R: DeserializeOwned + Send + Clone,
+    {
+        ContractMethodSubscription::new(self.clone(), contract, view_method, b"{}".to_vec())
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ContractViewer;
+    use super::ViewRaw;
     use crate::errors::{ChainGatewayError, ChainGatewayOp};
     use crate::mock::{Call, MockChainState, MockError};
-    use crate::state_viewer::{ContractStateStream, ContractStateSubscriber, MethodViewer};
+    use crate::state_viewer::{ContractStateStream, SubscribeMethod, ViewMethod};
     use crate::types::{NoArgs, RawObservedState};
     use near_account_id::AccountId;
     use rand::distributions::{Alphanumeric, DistString};
@@ -296,10 +317,10 @@ mod tests {
         handle.await.unwrap().unwrap();
     }
 
-    // --- view (MethodViewer) tests ---
+    // --- view_method (ViewMethod) tests ---
 
     #[tokio::test]
-    async fn test_view_deserializes_response() {
+    async fn test_view_method_deserializes_response() {
         let mut rng = StdRng::seed_from_u64(5);
         let block_height: u64 = rng.gen_range(1..1_000_000);
         let value = Alphanumeric.sample_string(&mut rng, 12);
@@ -314,7 +335,7 @@ mod tests {
             .build();
 
         let result = viewer
-            .view::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
+            .view_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
             .await
             .unwrap();
 
@@ -323,14 +344,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_view_propagates_view_error() {
+    async fn test_view_method_propagates_view_error() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
             .with_view_function_query_response(Err(MockError::RpcError))
             .build();
 
         let err = viewer
-            .view::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
+            .view_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
             .await
             .unwrap_err();
 
@@ -338,7 +359,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_view_returns_deserialization_error_on_bad_bytes() {
+    async fn test_view_method_returns_deserialization_error_on_bad_bytes() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
             .with_view_function_query_response(Ok(RawObservedState {
@@ -348,17 +369,17 @@ mod tests {
             .build();
 
         let err = viewer
-            .view::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
+            .view_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
             .await
             .unwrap_err();
 
         assert!(matches!(err, ChainGatewayError::Deserialization { .. }));
     }
 
-    // --- subscribe (ContractStateSubscriber) tests ---
+    // --- subscribe_method (SubscribeMethod) tests ---
 
     #[tokio::test(start_paused = true)]
-    async fn test_subscribe_latest_returns_initial_value() {
+    async fn test_subscribe_method_latest_returns_initial_value() {
         let mut rng = StdRng::seed_from_u64(8);
         let block_height: u64 = rng.gen_range(1..1_000_000);
         let value = Alphanumeric.sample_string(&mut rng, 12);
@@ -373,7 +394,7 @@ mod tests {
             .build();
 
         let mut sub = viewer
-            .subscribe::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_method::<String>("a.testnet".parse().unwrap(), "m")
             .await;
 
         let state = sub.latest().unwrap();
@@ -382,7 +403,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_subscribe_latest_returns_deserialization_error() {
+    async fn test_subscribe_method_latest_returns_deserialization_error() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
             .with_view_function_query_response(Ok(RawObservedState {
@@ -392,7 +413,7 @@ mod tests {
             .build();
 
         let mut sub = viewer
-            .subscribe::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_method::<String>("a.testnet".parse().unwrap(), "m")
             .await;
 
         assert!(matches!(
@@ -402,7 +423,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_subscribe_changed_fires_on_value_change() {
+    async fn test_subscribe_method_changed_fires_on_value_change() {
         let mut rng = StdRng::seed_from_u64(10);
         let initial = Alphanumeric.sample_string(&mut rng, 10);
         let updated = Alphanumeric.sample_string(&mut rng, 10);
@@ -416,7 +437,7 @@ mod tests {
             .build();
 
         let mut sub = viewer
-            .subscribe::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_method::<String>("a.testnet".parse().unwrap(), "m")
             .await;
         assert_eq!(sub.latest().unwrap().value, initial);
 

--- a/crates/chain-gateway/src/state_viewer/traits.rs
+++ b/crates/chain-gateway/src/state_viewer/traits.rs
@@ -12,7 +12,7 @@ use super::subscription::ContractMethodSubscription;
 /// Internal trait for performing raw (untyped) view calls.
 ///
 /// This is `pub(crate)` because it is an implementation detail — public consumers
-/// should use [`ViewMethod`] or [`SubscribeMethod`] instead.
+/// should use [`ViewContractMethod`] or [`SubscribeToContractMethod`] instead.
 pub(crate) trait ViewRaw: Send + Sync + 'static {
     fn view_raw(
         &self,
@@ -51,7 +51,7 @@ impl<T: SyncChecker + ViewFunctionQuerySubmitter> ViewRaw for T {
 ///
 /// ```
 /// use chain_gateway::mock::MockChainState;
-/// use chain_gateway::state_viewer::ViewMethod;
+/// use chain_gateway::state_viewer::ViewContractMethod;
 /// use chain_gateway::types::{NoArgs, ObservedState};
 ///
 /// #[tokio::main]
@@ -65,7 +65,7 @@ impl<T: SyncChecker + ViewFunctionQuerySubmitter> ViewRaw for T {
 ///         .build();
 ///
 ///     let result: ObservedState<String> = viewer
-///         .view_method("contract.near".parse().unwrap(), "get_greeting", &NoArgs {})
+///         .view_contract_method("contract.near".parse().unwrap(), "get_greeting", &NoArgs {})
 ///         .await
 ///         .unwrap();
 ///
@@ -73,8 +73,8 @@ impl<T: SyncChecker + ViewFunctionQuerySubmitter> ViewRaw for T {
 ///     assert_eq!(result.observed_at, 1.into());
 /// }
 /// ```
-pub trait ViewMethod {
-    fn view_method<Arg, Res>(
+pub trait ViewContractMethod {
+    fn view_contract_method<Arg, Res>(
         &self,
         contract_id: AccountId,
         method_name: &str,
@@ -93,7 +93,7 @@ pub trait ViewMethod {
 ///
 /// ```
 /// use chain_gateway::mock::MockChainState;
-/// use chain_gateway::state_viewer::{ContractStateStream, SubscribeMethod};
+/// use chain_gateway::state_viewer::{ContractStateStream, SubscribeToContractMethod};
 /// use chain_gateway::types::ObservedState;
 ///
 /// #[tokio::main]
@@ -107,14 +107,14 @@ pub trait ViewMethod {
 ///         .build();
 ///
 ///     let mut stream = viewer
-///         .subscribe_method::<String>("contract.near".parse().unwrap(), "get_greeting")
+///         .subscribe_to_contract_method::<String>("contract.near".parse().unwrap(), "get_greeting")
 ///         .await;
 ///
 ///     let state = stream.latest().unwrap();
 ///     assert_eq!(state.value, "hello");
 /// }
 /// ```
-pub trait SubscribeMethod {
+pub trait SubscribeToContractMethod {
     /// Subscribes to a contract view method and returns a stream of state updates.
     ///
     /// The returned stream polls the contract every 200 ms.
@@ -122,10 +122,10 @@ pub trait SubscribeMethod {
     /// # Type Parameter
     ///
     /// `T` is the deserialized return type of the contract method.
-    fn subscribe_method<T>(
+    fn subscribe_to_contract_method<T>(
         &self,
         contract: AccountId,
-        view_method: &str,
+        view_contract_method: &str,
     ) -> impl Future<Output = impl ContractStateStream<T> + Send> + Send
     where
         T: DeserializeOwned + Send + Clone;
@@ -145,9 +145,9 @@ pub trait ContractStateStream<Res> {
     fn changed(&mut self) -> impl Future<Output = Result<(), ChainGatewayError>> + Send;
 }
 
-/// Implement `ViewMethod` for any type that implements `ViewRaw`.
-impl<T: ViewRaw> ViewMethod for T {
-    async fn view_method<Arg, Res>(
+/// Implement `ViewContractMethod` for any type that implements `ViewRaw`.
+impl<T: ViewRaw> ViewContractMethod for T {
+    async fn view_contract_method<Arg, Res>(
         &self,
         contract_id: AccountId,
         method_name: &str,
@@ -179,17 +179,17 @@ impl<T: ViewRaw> ViewMethod for T {
     }
 }
 
-/// Implement `SubscribeMethod` for any cloneable type that implements `ViewRaw`.
-impl<T: ViewRaw + Clone> SubscribeMethod for T {
-    fn subscribe_method<R>(
+/// Implement `SubscribeToContractMethod` for any cloneable type that implements `ViewRaw`.
+impl<T: ViewRaw + Clone> SubscribeToContractMethod for T {
+    fn subscribe_to_contract_method<R>(
         &self,
         contract: AccountId,
-        view_method: &str,
+        view_contract_method: &str,
     ) -> impl Future<Output = impl ContractStateStream<R> + Send> + Send
     where
         R: DeserializeOwned + Send + Clone,
     {
-        ContractMethodSubscription::new(self.clone(), contract, view_method, b"{}".to_vec())
+        ContractMethodSubscription::new(self.clone(), contract, view_contract_method, b"{}".to_vec())
     }
 }
 
@@ -198,7 +198,7 @@ mod tests {
     use super::ViewRaw;
     use crate::errors::{ChainGatewayError, ChainGatewayOp};
     use crate::mock::{Call, MockChainState, MockError};
-    use crate::state_viewer::{ContractStateStream, SubscribeMethod, ViewMethod};
+    use crate::state_viewer::{ContractStateStream, SubscribeToContractMethod, ViewContractMethod};
     use crate::types::{NoArgs, RawObservedState};
     use near_account_id::AccountId;
     use rand::distributions::{Alphanumeric, DistString};
@@ -325,10 +325,10 @@ mod tests {
         handle.await.unwrap().unwrap();
     }
 
-    // --- view_method (ViewMethod) tests ---
+    // --- view_contract_method (ViewContractMethod) tests ---
 
     #[tokio::test]
-    async fn test_view_method_deserializes_response() {
+    async fn test_view_contract_method_deserializes_response() {
         let mut rng = StdRng::seed_from_u64(5);
         let block_height: u64 = rng.gen_range(1..1_000_000);
         let value = Alphanumeric.sample_string(&mut rng, 12);
@@ -343,7 +343,7 @@ mod tests {
             .build();
 
         let result = viewer
-            .view_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
+            .view_contract_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
             .await
             .unwrap();
 
@@ -352,14 +352,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_view_method_propagates_view_error() {
+    async fn test_view_contract_method_propagates_view_error() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
             .with_view_function_query_response(Err(MockError::RpcError))
             .build();
 
         let err = viewer
-            .view_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
+            .view_contract_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
             .await
             .unwrap_err();
 
@@ -367,7 +367,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_view_method_returns_deserialization_error_on_bad_bytes() {
+    async fn test_view_contract_method_returns_deserialization_error_on_bad_bytes() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
             .with_view_function_query_response(Ok(RawObservedState {
@@ -377,17 +377,17 @@ mod tests {
             .build();
 
         let err = viewer
-            .view_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
+            .view_contract_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
             .await
             .unwrap_err();
 
         assert!(matches!(err, ChainGatewayError::Deserialization { .. }));
     }
 
-    // --- subscribe_method (SubscribeMethod) tests ---
+    // --- subscribe_to_contract_method (SubscribeToContractMethod) tests ---
 
     #[tokio::test(start_paused = true)]
-    async fn test_subscribe_method_latest_returns_initial_value() {
+    async fn test_subscribe_to_contract_method_latest_returns_initial_value() {
         let mut rng = StdRng::seed_from_u64(8);
         let block_height: u64 = rng.gen_range(1..1_000_000);
         let value = Alphanumeric.sample_string(&mut rng, 12);
@@ -402,7 +402,7 @@ mod tests {
             .build();
 
         let mut sub = viewer
-            .subscribe_method::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_to_contract_method::<String>("a.testnet".parse().unwrap(), "m")
             .await;
 
         let state = sub.latest().unwrap();
@@ -411,7 +411,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_subscribe_method_latest_returns_deserialization_error() {
+    async fn test_subscribe_to_contract_method_latest_returns_deserialization_error() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
             .with_view_function_query_response(Ok(RawObservedState {
@@ -421,7 +421,7 @@ mod tests {
             .build();
 
         let mut sub = viewer
-            .subscribe_method::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_to_contract_method::<String>("a.testnet".parse().unwrap(), "m")
             .await;
 
         assert!(matches!(
@@ -431,7 +431,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_subscribe_method_changed_fires_on_value_change() {
+    async fn test_subscribe_to_contract_method_changed_fires_on_value_change() {
         let mut rng = StdRng::seed_from_u64(10);
         let initial = Alphanumeric.sample_string(&mut rng, 10);
         let updated = Alphanumeric.sample_string(&mut rng, 10);
@@ -445,7 +445,7 @@ mod tests {
             .build();
 
         let mut sub = viewer
-            .subscribe_method::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_to_contract_method::<String>("a.testnet".parse().unwrap(), "m")
             .await;
         assert_eq!(sub.latest().unwrap().value, initial);
 

--- a/crates/chain-gateway/src/state_viewer/traits.rs
+++ b/crates/chain-gateway/src/state_viewer/traits.rs
@@ -9,30 +9,38 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use super::subscription::ContractMethodSubscription;
 
-/// Internal trait combining sync-checking and view-function querying.
-/// Waits for the node to be fully synced, then performs a raw (untyped) view call.
+/// Internal trait for performing raw (untyped) view calls.
 ///
 /// This is `pub(crate)` because it is an implementation detail — public consumers
 /// should use [`ViewMethod`] or [`SubscribeMethod`] instead.
-pub(crate) trait ViewRaw: SyncChecker + ViewFunctionQuerySubmitter {
+pub(crate) trait ViewRaw: Send + Sync + 'static {
     fn view_raw(
         &self,
         contract_id: &AccountId,
         method_name: &str,
         args: &[u8],
-    ) -> impl Future<Output = Result<ObservedState, ChainGatewayError>> + Send {
-        async move {
-            self.wait_for_full_sync().await;
-            self.view_function_query(contract_id, method_name, args)
-                .await
-                .map_err(|err| ChainGatewayError::ViewClient {
-                    op: ChainGatewayOp::ViewCall {
-                        account_id: contract_id.to_string(),
-                        method_name: method_name.to_string(),
-                    },
-                    source: Arc::new(err),
-                })
-        }
+    ) -> impl Future<Output = Result<ObservedState, ChainGatewayError>> + Send;
+}
+
+/// Blanket impl: any type that can check sync and submit view queries gets `ViewRaw`
+/// by waiting for full sync, then delegating to the view function query.
+impl<T: SyncChecker + ViewFunctionQuerySubmitter> ViewRaw for T {
+    async fn view_raw(
+        &self,
+        contract_id: &AccountId,
+        method_name: &str,
+        args: &[u8],
+    ) -> Result<ObservedState, ChainGatewayError> {
+        self.wait_for_full_sync().await;
+        self.view_function_query(contract_id, method_name, args)
+            .await
+            .map_err(|err| ChainGatewayError::ViewClient {
+                op: ChainGatewayOp::ViewCall {
+                    account_id: contract_id.to_string(),
+                    method_name: method_name.to_string(),
+                },
+                source: Arc::new(err),
+            })
     }
 }
 

--- a/crates/chain-gateway/tests/state_viewer_integration.rs
+++ b/crates/chain-gateway/tests/state_viewer_integration.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use base64::Engine;
 use chain_gateway::errors::ChainGatewayError;
 use chain_gateway::state_viewer::ContractStateStream;
-use chain_gateway::state_viewer::{ContractStateSubscriber, MethodViewer};
+use chain_gateway::state_viewer::{SubscribeMethod, ViewMethod};
 use chain_gateway::types::NoArgs;
 use chain_gateway::types::ObservedState;
 use near_indexer::near_primitives::hash::hash;
@@ -19,7 +19,7 @@ async fn test_view_contract_state() {
     let (gw, _dir) = setup_chain_gateway().await;
 
     let value: ObservedState<String> = gw
-        .view(
+        .view_method(
             TEST_CONTRACT_ACCOUNT.parse().unwrap(),
             TEST_METHOD,
             &NoArgs {},
@@ -36,7 +36,7 @@ async fn test_view_nonexistent_method_returns_error() {
     let (gw, _dir) = setup_chain_gateway().await;
 
     let result = gw
-        .view::<NoArgs, String>(
+        .view_method::<NoArgs, String>(
             TEST_CONTRACT_ACCOUNT.parse().unwrap(),
             "nonexistent",
             &NoArgs {},
@@ -54,7 +54,7 @@ async fn test_subscription_receives_initial_value() {
     let (gw, _dir) = setup_chain_gateway().await;
 
     let mut sub = gw
-        .subscribe::<String>(TEST_CONTRACT_ACCOUNT.parse().unwrap(), TEST_METHOD)
+        .subscribe_method::<String>(TEST_CONTRACT_ACCOUNT.parse().unwrap(), TEST_METHOD)
         .await;
 
     let res = sub.latest().expect("subscription latest should succeed");

--- a/crates/chain-gateway/tests/state_viewer_integration.rs
+++ b/crates/chain-gateway/tests/state_viewer_integration.rs
@@ -2,7 +2,7 @@ use assert_matches::assert_matches;
 use base64::Engine;
 use chain_gateway::errors::ChainGatewayError;
 use chain_gateway::state_viewer::ContractStateStream;
-use chain_gateway::state_viewer::{SubscribeMethod, ViewMethod};
+use chain_gateway::state_viewer::{SubscribeToContractMethod, ViewContractMethod};
 use chain_gateway::types::NoArgs;
 use chain_gateway::types::ObservedState;
 use near_indexer::near_primitives::hash::hash;
@@ -19,7 +19,7 @@ async fn test_view_contract_state() {
     let (gw, _dir) = setup_chain_gateway().await;
 
     let value: ObservedState<String> = gw
-        .view_method(
+        .view_contract_method(
             TEST_CONTRACT_ACCOUNT.parse().unwrap(),
             TEST_METHOD,
             &NoArgs {},
@@ -36,7 +36,7 @@ async fn test_view_nonexistent_method_returns_error() {
     let (gw, _dir) = setup_chain_gateway().await;
 
     let result = gw
-        .view_method::<NoArgs, String>(
+        .view_contract_method::<NoArgs, String>(
             TEST_CONTRACT_ACCOUNT.parse().unwrap(),
             "nonexistent",
             &NoArgs {},
@@ -54,7 +54,7 @@ async fn test_subscription_receives_initial_value() {
     let (gw, _dir) = setup_chain_gateway().await;
 
     let mut sub = gw
-        .subscribe_method::<String>(TEST_CONTRACT_ACCOUNT.parse().unwrap(), TEST_METHOD)
+        .subscribe_to_contract_method::<String>(TEST_CONTRACT_ACCOUNT.parse().unwrap(), TEST_METHOD)
         .await;
 
     let res = sub.latest().expect("subscription latest should succeed");

--- a/docs/chain-gateway-design.md
+++ b/docs/chain-gateway-design.md
@@ -463,14 +463,14 @@ The public traits (`ViewContractMethod`, `SubscribeToContractMethod`) have no su
 
 ```rust
 // Internal trait with no supertraits. Blanket-implemented for any type
-// that implements SyncChecker + ViewFunctionQuerySubmitter.
+// that implements CheckSync + QueryViewFunction.
 pub(crate) trait ViewRaw { ... }
 
 // Internal: queries the actual state via the NEAR view client actor.
-pub(crate) trait ViewFunctionQuerySubmitter: Send + Sync + 'static { ... }
+pub(crate) trait QueryViewFunction: Send + Sync + 'static { ... }
 
 // Internal: checks whether the node is still syncing with the blockchain.
-pub(crate) trait SyncChecker: Send + Sync + 'static { ... }
+pub(crate) trait CheckSync: Send + Sync + 'static { ... }
 ```
 
 Blanket impls provide `ViewContractMethod` for all `T: ViewRaw` and

--- a/docs/chain-gateway-design.md
+++ b/docs/chain-gateway-design.md
@@ -422,19 +422,18 @@ The Chain Gateway provides three functionalities:
 
 The Chain Gateway offers a trait-based API for viewing and subscribing to contract state.
 
-It offers the following API:
+It offers the following public API:
 ```rust
-
 /// One-shot typed view call with JSON serialization/deserialization.
-pub trait MethodViewer: ContractViewer {
-    async fn view<Arg: Serialize + Sync, Res: DeserializeOwned + Send + Clone>(
+pub trait ViewMethod: Send + Sync {
+    async fn view_method<Arg: Serialize + Sync, Res: DeserializeOwned + Send + Clone>(
         &self, contract_id: AccountId, method_name: &str, args: &Arg,
     ) -> Result<ObservedState<Res>, ChainGatewayError>;
 }
 
 /// Polls every 200ms; emits change only when returned bytes differ.
-pub trait ContractStateSubscriber: ContractViewer + Clone {
-    async fn subscribe<T: DeserializeOwned + Send + Clone>(
+pub trait SubscribeMethod: Send + Sync {
+    async fn subscribe_method<T: DeserializeOwned + Send + Clone>(
         &self, contract: AccountId, view_method: &str,
     ) -> impl ContractStateStream<T> + Send;
 }
@@ -458,34 +457,24 @@ pub struct NoArgs {}
 pub struct BlockHeight(u64);
 ```
 
-Note that the above traits derive from `ContractViewer`, which in turn derives from two low-level traits.
+The public traits (`ViewMethod`, `SubscribeMethod`) have no supertraits — they describe
+pure capabilities. Internally, `ChainGateway` implements them via a `pub(crate)` trait
+hierarchy that handles sync-waiting and raw RPC plumbing:
 
 ```rust
-/// Waits for sync then delegates to ViewFunctionQuerySubmitter.
-/// Supertraits provide the raw RPC plumbing.
-pub trait ContractViewer: SyncChecker + ViewFunctionQuerySubmitter {
-    async fn view_raw(
-        &self,
-        contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
-    ) -> Result<ObservedState, ChainGatewayError>;
-}
+// Internal: waits for sync then delegates to ViewFunctionQuerySubmitter.
+pub(crate) trait ViewRaw: SyncChecker + ViewFunctionQuerySubmitter { ... }
 
-// queries the actual state
-pub trait ViewFunctionQuerySubmitter: Send + Sync + 'static {
-    async fn view_function_query(
-        &self,
-        contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
-    ) -> Result<RawObservedState, Error>;
-}
-// returns true if the node is still syncing with the blockchain
-pub trait SyncChecker: Send + Sync + 'static {
-    /// Returns whether the node is currently syncing.
-    async fn is_syncing(&self) -> Result<bool, Error>;
+// Internal: queries the actual state via the NEAR view client actor.
+pub(crate) trait ViewFunctionQuerySubmitter: Send + Sync + 'static { ... }
+
+// Internal: checks whether the node is still syncing with the blockchain.
+pub(crate) trait SyncChecker: Send + Sync + 'static { ... }
 ```
+
+Blanket impls provide `ViewMethod` for all `T: ViewRaw` and `SubscribeMethod`
+for all `T: ViewRaw + Clone`, so implementors only need to provide the low-level
+primitives.
 
 
 ##### Block Event Subscriber

--- a/docs/chain-gateway-design.md
+++ b/docs/chain-gateway-design.md
@@ -425,15 +425,15 @@ The Chain Gateway offers a trait-based API for viewing and subscribing to contra
 It offers the following public API:
 ```rust
 /// One-shot typed view call with JSON serialization/deserialization.
-pub trait ViewMethod: Send + Sync {
-    async fn view_method<Arg: Serialize + Sync, Res: DeserializeOwned + Send + Clone>(
+pub trait ViewContractMethod {
+    async fn view_contract_method<Arg: Serialize + Sync, Res: DeserializeOwned + Send + Clone>(
         &self, contract_id: AccountId, method_name: &str, args: &Arg,
     ) -> Result<ObservedState<Res>, ChainGatewayError>;
 }
 
 /// Polls every 200ms; emits change only when returned bytes differ.
-pub trait SubscribeMethod: Send + Sync {
-    async fn subscribe_method<T: DeserializeOwned + Send + Clone>(
+pub trait SubscribeToContractMethod {
+    async fn subscribe_to_contract_method<T: DeserializeOwned + Send + Clone>(
         &self, contract: AccountId, view_method: &str,
     ) -> impl ContractStateStream<T> + Send;
 }
@@ -457,13 +457,14 @@ pub struct NoArgs {}
 pub struct BlockHeight(u64);
 ```
 
-The public traits (`ViewMethod`, `SubscribeMethod`) have no supertraits — they describe
-pure capabilities. Internally, `ChainGateway` implements them via a `pub(crate)` trait
-hierarchy that handles sync-waiting and raw RPC plumbing:
+The public traits (`ViewContractMethod`, `SubscribeToContractMethod`) have no supertraits
+— they describe pure capabilities. Internally, `ChainGateway` implements them via a
+`pub(crate)` trait hierarchy that handles sync-waiting and raw RPC plumbing:
 
 ```rust
-// Internal: waits for sync then delegates to ViewFunctionQuerySubmitter.
-pub(crate) trait ViewRaw: SyncChecker + ViewFunctionQuerySubmitter { ... }
+// Internal trait with no supertraits. Blanket-implemented for any type
+// that implements SyncChecker + ViewFunctionQuerySubmitter.
+pub(crate) trait ViewRaw { ... }
 
 // Internal: queries the actual state via the NEAR view client actor.
 pub(crate) trait ViewFunctionQuerySubmitter: Send + Sync + 'static { ... }
@@ -472,9 +473,9 @@ pub(crate) trait ViewFunctionQuerySubmitter: Send + Sync + 'static { ... }
 pub(crate) trait SyncChecker: Send + Sync + 'static { ... }
 ```
 
-Blanket impls provide `ViewMethod` for all `T: ViewRaw` and `SubscribeMethod`
-for all `T: ViewRaw + Clone`, so implementors only need to provide the low-level
-primitives.
+Blanket impls provide `ViewContractMethod` for all `T: ViewRaw` and
+`SubscribeToContractMethod` for all `T: ViewRaw + Clone`, so implementors only
+need to provide the low-level primitives.
 
 
 ##### Block Event Subscriber


### PR DESCRIPTION
PR suggestion for #2344 

This shows how we could decouple the traits by not relying on a hierarchy of supertraits, but instead let each trait be independently defined and provide blanket implementations to reuse the lower level trait implementations for higher level traits.

Additionally I also incorporated my naming suggestions of making (most of) these trait names verbs instead of nouns with "er" suffixes.