### PR TITLE
refactor: notify instead of polling in mock

### DIFF
--- a/crates/chain-gateway/src/mock.rs
+++ b/crates/chain-gateway/src/mock.rs
@@ -2,14 +2,14 @@ use crate::primitives::{IsSyncing, QueryViewFunction};
 use crate::types::ObservedState;
 use near_account_id::AccountId;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 use thiserror::Error;
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, Notify};
 
 #[derive(Clone)]
 pub struct MockChainState {
     sync_response: Arc<RwLock<Result<bool, MockError>>>,
     query_view_function_submitter_state: Arc<Mutex<MockQueryViewFunctionState>>,
+    view_call_notify: Arc<Notify>,
 }
 
 pub struct MockQueryViewFunctionState {
@@ -39,23 +39,9 @@ impl MockChainState {
         inner.response = value;
     }
 
-    /// Wait for the next query_view_function call (polls submitted.len() every 10ms).
-    pub async fn await_next_view_call(&self, max_wait_duration: Duration) -> Result<(), MockError> {
-        tokio::time::timeout(max_wait_duration, async {
-            let baseline = {
-                let inner = self.query_view_function_submitter_state.lock().await;
-                inner.submitted.len()
-            };
-            loop {
-                let inner = self.query_view_function_submitter_state.lock().await;
-                if inner.submitted.len() > baseline {
-                    return;
-                }
-                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
-            }
-        })
-        .await
-        .map_err(|_| MockError::Timeout)
+    /// Wait for the next query_view_function call.
+    pub async fn await_next_view_call(&self) {
+        self.view_call_notify.notified().await;
     }
 
     /// Returns a snapshot of all recorded view function calls.
@@ -104,6 +90,7 @@ impl MockChainStateBuilder {
                 response: self.query_view_function_response,
                 submitted: Vec::new(),
             })),
+            view_call_notify: Arc::new(Notify::new()),
         }
     }
 }
@@ -129,7 +116,10 @@ impl QueryViewFunction for MockChainState {
             method_name: method_name.to_string(),
             args: args.to_vec(),
         });
-        inner.response.clone()
+        let response = inner.response.clone();
+        drop(inner);
+        self.view_call_notify.notify_waiters();
+        response
     }
 }
 

--- a/crates/chain-gateway/src/state_viewer/monitoring.rs
+++ b/crates/chain-gateway/src/state_viewer/monitoring.rs
@@ -119,7 +119,7 @@ mod tests {
     use crate::{
         errors::{ChainGatewayError, ChainGatewayOp},
         mock::{Call, MockChainState, MockError},
-        state_viewer::monitoring::{POLL_INTERVAL, modify, monitor},
+        state_viewer::monitoring::{modify, monitor},
         types::ObservedState,
     };
     use rstest::rstest;
@@ -197,10 +197,7 @@ mod tests {
 
         let call = expected_call();
         let (viewer, _receiver, _cancel) = setup(call.clone(), init_mock);
-        viewer
-            .await_next_view_call(POLL_INTERVAL * 2)
-            .await
-            .unwrap();
+        viewer.await_next_view_call().await;
         let calls = viewer.view_calls().await;
         assert!(calls.iter().all(|c| c == &call));
         assert!(!calls.is_empty());
@@ -235,10 +232,7 @@ mod tests {
         // when: view response changes
         let next_mock_response = mock_spec(next_spec.clone());
         viewer.set_view_response(next_mock_response).await;
-        viewer
-            .await_next_view_call(POLL_INTERVAL * 2)
-            .await
-            .unwrap();
+        viewer.await_next_view_call().await;
 
         // Then:
         // we expect the receiver to be notified in case of change
@@ -333,10 +327,7 @@ mod tests {
         viewer.set_view_response(next_mock).await;
 
         // Wait for the background monitor loop to actually call view again
-        viewer
-            .await_next_view_call(POLL_INTERVAL * 2)
-            .await
-            .unwrap();
+        viewer.await_next_view_call().await;
 
         // Now check whether the watch receiver reports a change
         assert_eq!(
@@ -373,10 +364,7 @@ mod tests {
 
         let call = expected_call();
         let (viewer, _task) = setup_task(call.clone(), init_mock).await;
-        viewer
-            .await_next_view_call(POLL_INTERVAL * 2)
-            .await
-            .unwrap();
+        viewer.await_next_view_call().await;
         let calls = viewer.view_calls().await;
         assert!(calls.iter().all(|c| c == &call));
         assert!(!calls.is_empty());


### PR DESCRIPTION
Suggestion for #2344 to simplify the `MockChainState` by using a notify channel instead of having a polling loop to know when a view call has happened.