### PR TITLE
ci: allow failed pytest jobs to re-run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,6 @@ jobs:
   mpc-pytests-cache-cleanup:
     name: "MPC pytests: cache cleanup"
     needs: mpc-pytests
-    if: ${{ always() }}
     runs-on: warp-ubuntu-2404-x64-2x
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Closes #2512 

Notice cache will not stay around indefinitely because warpbuild should delete it after a week of not being used