### PR TITLE
feat: add support for setting rust backtrace through config file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5591,6 +5591,7 @@ dependencies = [
  "rocksdb",
  "rstest",
  "rustls",
+ "rusty-fork",
  "serde",
  "serde_json",
  "serde_with",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,6 +170,7 @@ reqwest = { version = "0.12.28", features = ["multipart", "json"] }
 rmp-serde = "1.3.1"
 rstest = { version = "0.26.1" }
 rustls = { version = "0.23.37", default-features = false, features = ["std"] }
+rusty-fork = "0.3.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.19"
 serde_json = "1.0"

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -101,6 +101,7 @@ mockall = { workspace = true }
 mpc-contract = { workspace = true, features = ["test-utils"] }
 near-sdk = { workspace = true }
 rstest = { workspace = true }
+rusty-fork = { workspace = true }
 serial_test = { workspace = true }
 test-log = { workspace = true }
 threshold-signatures = { workspace = true, features = ["test-utils"] }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -144,6 +144,7 @@ impl StartCmd {
             log: LogConfig {
                 format: log_format,
                 filter: std::env::var("RUST_LOG").ok(),
+                rust_backtrace: None,
             },
         }
     }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -38,6 +38,10 @@ pub struct LogConfig {
     /// Examples: `"info"`, `"mpc_node=debug,info"`, `"mpc_node::indexer=trace,warn"`
     /// Falls back to the `RUST_LOG` env var when not set.
     pub filter: Option<String>,
+
+    /// Configures the rust backtrace environment variable, to allow for configurable
+    /// backtrace reports in case of panics
+    pub rust_backtrace: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, ValueEnum, Serialize, Deserialize)]

--- a/crates/node/src/tracing.rs
+++ b/crates/node/src/tracing.rs
@@ -1,13 +1,24 @@
+use crate::config::start::{LogConfig, LogFormat};
 use tracing_subscriber::EnvFilter;
 
-use crate::config::start::{LogConfig, LogFormat};
+const RUST_BACKTRACE: &str = "RUST_BACKTRACE";
 
 pub fn init_logging(log_config: &LogConfig) {
+    if let Some(rust_backtrace) = &log_config.rust_backtrace {
+        set_rust_backtrace(rust_backtrace.clone());
+    }
+
     let filter = env_filter(log_config.filter.as_deref());
 
     match log_config.format {
         LogFormat::Json => init_json_logging(filter),
         LogFormat::Plain => init_plain_logging(filter),
+    }
+}
+
+fn set_rust_backtrace(rust_backtrace_value: String) {
+    unsafe {
+        std::env::set_var(RUST_BACKTRACE, rust_backtrace_value);
     }
 }
 
@@ -31,4 +42,29 @@ fn init_json_logging(filter: EnvFilter) {
         .with_env_filter(filter)
         .try_init()
         .ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rusty_fork::rusty_fork_test;
+
+    // Tests run in forked subprocesses to avoid mutating the env of other tests
+    rusty_fork_test! {
+        #[test]
+        fn init_logging_sets_rust_backtrace_when_configured() {
+            let foo_backtrace = "FOO_BACKTRACE".to_string();
+
+            let config = LogConfig {
+                format: LogFormat::Plain,
+                filter: None,
+                rust_backtrace: Some(foo_backtrace.clone()),
+            };
+            init_logging(&config);
+
+            let backtrace_value = std::env::var(RUST_BACKTRACE).expect("init_logging set backtrace value");
+
+            assert_eq!(backtrace_value, foo_backtrace);
+        }
+    }
 }


### PR DESCRIPTION
closes #2502

I skipped doing this in the launcher, since we then can avoid increasing attack surface on the launcher where malicious strings can be injected