### PR TITLE
ci: move reproducible build of contract as separate task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -292,19 +292,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:
           persist-credentials: false
-
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@f13886b937689c021905a6b90929199931d60db1 # v2.8.1
-        with:
-          save-if: ${{ github.ref == 'refs/heads/main' }}
-          cache-provider: "warpbuild"
-
-      - name: Clear cache for fresh rebuild
-        if: github.event_name == 'schedule'
-        run: |
-          cargo clean
-          rm -rf ~/.cargo
-
+          
       - name: Install build dependencies
         run: |
           sudo apt-get update


### PR DESCRIPTION
closes #2519 

Building the contract is a bottleneck requirement to start the pytests. This PR moves the reproducible build of the contract as a separate job, and uses normal cargo build + wasm-opt for building for the pytests.

The building of the contract for pytests:

Before: ~1m 36s
After: ~19s (with a cold cache)