### PR TITLE
ci: fix phala test filter

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,2 @@
 [profile.ci-other]
-default-filter = 'not package(mpc-node) and not package(mpc-contract) and not package(contract-history) and not test(=test_upload_quote_for_collateral_with_phala_endpoint)'
+default-filter = 'not package(mpc-node) and not package(mpc-contract) and not package(contract-history) and not test(=tee_authority::tests::test_upload_quote_for_collateral_with_phala_endpoint)'


### PR DESCRIPTION
Closes #2532 

Can be verified that it works now by running

```
cargo nextest list --all-features --locked --profile=ci-other | grep -i "phala"
```