### PR TITLE
fix: set 0o600 permissions on secret files

### DIFF
--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -362,8 +362,12 @@ fn write_secret_file(path: &Path, data: &[u8]) -> anyhow::Result<()> {
         .with_context(|| format!("failed to create secret file {}", path.display()))?;
     file.write_all(data)
         .with_context(|| format!("failed to write secret file {}", path.display()))?;
-    fs::set_permissions(path, fs::Permissions::from_mode(0o600))
-        .with_context(|| format!("failed to set permissions on secret file {}", path.display()))?;
+    fs::set_permissions(path, fs::Permissions::from_mode(0o600)).with_context(|| {
+        format!(
+            "failed to set permissions on secret file {}",
+            path.display()
+        )
+    })?;
     Ok(())
 }
 


### PR DESCRIPTION
fixes #2548
## Summary
- Add `write_secret_file` helper that writes files with `0o600` (owner-only) permissions
- Apply to `secrets.json` (Ed25519 signing keys) and `backup_encryption_key.hex` (AES-256 backup key)
- Both files were previously written with default umask permissions (typically `0644`, world-readable)

## Test plan
- [x] `cargo test -p mpc-node --all-features test_secret_gen` passes
- [ ] Verify file permissions on a running node: `stat -c '%a' /data/secrets.json` should show `600`



From audit findings [BE-F213](https://github.com/near/mpc-private/blob/main/vulnerability_audit/findings/valid/BE-F213-backup-key-default-permissions.md).