### PR TITLE
chore: bump tar to fix RUSTSEC-2026-0067/0068

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10626,9 +10626,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",


### PR DESCRIPTION
## Summary
- Bumps `tar` crate 0.4.44 -> 0.4.45 to fix two security advisories (symlink chmod + PAX size header)
- Lock-file only change

