### PR TITLE
docs: fix test-utils assets README and single-node guide

### DIFF
--- a/crates/test-utils/assets/README.md
+++ b/crates/test-utils/assets/README.md
@@ -14,18 +14,18 @@ curl http://<MPC_NODE_IP>:<MPC_NODE_PORT>/public_data -o public_data.json
 
 
 See [single-node-readme.md](../../../localnet/tee/scripts/single-node-readme.md)
-for automation script that will launch a TEE MPC node, collect the attestation, and save the public data into /tmp/%user/public_data.json
+for an automation script that will launch a TEE MPC node, collect the attestation, and save the public data to a temp directory (path printed by the script).
 
 
 ## Steps
 
-1. Change into the `crates/test_utils/assets` directory:
+1. Change into the `crates/test-utils/assets` directory:
 
    ```shell
-   cd crates/test_utils/assets
+   cd crates/test-utils/assets
    ```
 
-2. Copy the `public_data.json` file into this directory.  
+2. Copy the `public_data.json` file into this directory.
    Keeping the original file allows future developers to trace the test vectors back to their source.
 
 3. Run the asset extraction script:
@@ -47,4 +47,16 @@ This will regenerate the following files:
 
 All files will be written into the specified output directory.
 
-In addition, look for the `VALID_ATTESTATION_TIMESTAMP` constant in `crates/test-utils/src/attestation.rs` and update it to a Unix timestamp that is after the date when the measurements were taken. This ensures that the tests will consider the measurements valid.
+4. Update `VALID_ATTESTATION_TIMESTAMP` in `crates/test-utils/src/attestation.rs` to a Unix timestamp after the date when the measurements were taken. This ensures that the tests will consider the measurements valid.
+
+5. Update `crates/attestation/assets/tcb_info.json` — copy the newly generated `tcb_info.json` there as well, since unit tests in the `attestation` crate use it.
+
+6. Update the compiled-in measurements in `crates/mpc-attestation/assets/`:
+   - `tcb_info_dev.json` — replace with the `tcb_info.json` from a **dev** image attestation
+   - `tcb_info.json` — replace with the `tcb_info.json` from a **release** (non-dev) image attestation
+
+   These are compiled into the contract and node binary via the `include_measurements!` macro.
+   You need attestation data from **both** release and dev images — run the single-node script
+   twice with `OS_IMAGE=dstack-<version>` and `OS_IMAGE=dstack-dev-<version>`.
+
+7. Update the hardcoded launcher image hash in the contract test helper `setup_approved_launcher_hash` in `crates/contract/src/lib.rs` to match the launcher hash in the new attestation data.

--- a/localnet/tee/scripts/single-node-readme.md
+++ b/localnet/tee/scripts/single-node-readme.md
@@ -18,17 +18,19 @@ See [UPDATING_LAUNCHER.md](../../../tee_launcher/UPDATING_LAUNCHER.md)
 
 ### Required
 ```bash
-# dstack base path (the folder containing vmm or vmm-data folder)
-export BASE_PATH=/path/to/dstack
+# dstack base path — the folder containing the `vmm/src/vmm-cli.py` script.
+# If you cloned meta-dstack, this is the `dstack` subdirectory inside it
+# (e.g. /path/to/meta-dstack/dstack), NOT the meta-dstack root.
+export BASE_PATH=/path/to/meta-dstack/dstack
 # external machine IP (you can use:
 #   ip -4 -o addr show scope global | awk '{print $4}' | cut -d/ -f1   | grep -Ev '^(10\.|192\.168\.|172\.(1[6-9]|2[0-9]|3[0-1])\.)'
 export MACHINE_IP=<host-ip-reachable-from-CVM>
-# the mpc docker image tag. 
+# the mpc docker image tag.
 # 1. make sure it is available on docker hub.
-# 2. make sure that DEFAULT_IMAGE_DIGEST=sha256:<hash> in mpc/tee_launcher/launcher_docker_compose.yaml corresponds to that tag, by calling 
-#   `docker pull nearone/mpc-node:$MPC_IMAGE_TAGS` and then 
+# 2. make sure that DEFAULT_IMAGE_DIGEST=sha256:<hash> in mpc/tee_launcher/launcher_docker_compose.yaml corresponds to that tag, by calling
+#   `docker pull nearone/mpc-node:$MPC_IMAGE_TAGS` and then
 #   `docker inspect --format='{{.Id}}' nearone/mpc-node:$MPC_IMAGE_TAGS`
-export MPC_IMAGE_TAGS=3.3.0
+export MPC_IMAGE_TAGS=3.7.0
 ```
 
 ### dstack port
@@ -38,6 +40,12 @@ export VMM_RPC=http://127.0.0.1:<port>
 ```
 
 ### Optional
+
+Guest OS image (defaults to `dstack-dev-<version>`). To use the production (release) image:
+```bash
+export OS_IMAGE=dstack-0.5.7
+```
+
 If you want to use specific NEAR accounts name instead of defaults:
 ```bash
 export NODE_ACCOUNT=frodo.test.near


### PR DESCRIPTION
## Summary
- Fix path typo in README (`test_utils` → `test-utils`)
- Fix stale output path description  
- Add missing steps for updating all measurement files (attestation/assets, mpc-attestation/assets, contract test launcher hash)
- Note that both release and dev attestation data are needed
- Fix `BASE_PATH` description — must point to the `dstack` subdir containing `vmm/src/vmm-cli.py`, not the meta-dstack root
- Update example `MPC_IMAGE_TAGS` from `3.3.0` to `3.7.0`
- Document `OS_IMAGE` env var for choosing release vs dev image

## Test plan
- [ ] Documentation-only change, no code affected