### PR TITLE
chore: bump MAX_GAS_FOR_THRESHOLD_VOTE from 178 to 180

### DIFF
--- a/crates/contract/tests/sandbox/utils/consts.rs
+++ b/crates/contract/tests/sandbox/utils/consts.rs
@@ -39,7 +39,7 @@ pub const GAS_FOR_VOTE_BEFORE_THRESHOLD: Gas = Gas::from_tgas(5);
 /// Maximum gas expected for the threshold vote that triggers the contract update.
 /// This vote is more expensive because it deploys the new contract code and executes
 /// the migration function.
-pub const MAX_GAS_FOR_THRESHOLD_VOTE: Gas = Gas::from_tgas(178);
+pub const MAX_GAS_FOR_THRESHOLD_VOTE: Gas = Gas::from_tgas(180);
 
 /* --- Deposit constants --- */
 /// This is the current deposit required for a contract deploy. This is subject to change but make


### PR DESCRIPTION
Addresses comment: https://github.com/near/mpc/pull/2446#issuecomment-4116949904

This constant seems to be set too conservatively, bumping it up as tests are failing.