### PR TITLE
docs: warn that docker inspect must run on Linux for hash verification

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1167,13 +1167,17 @@ Notice that the suffix of the image tag is the short version of the git hash.
   hash shown in DockerHub. For that you need to install `docker` and `jq`, and
   have the `docker` daemon running.
 
-> **Important:** The `docker inspect` command below must be run on **Linux**. On macOS, Docker Desktop returns the manifest digest instead of the config digest, which produces a different hash value.
-
 ```bash
 $ docker pull nearone/mpc-node:main-828f816
 $ docker inspect nearone/mpc-node:main-828f816 | jq -r .[0].Id
 sha256:0e48003c0ac6ec01e79ce47aa094379e7a8fac428512dfeb18d49d558e100a53
 ```
+
+> **macOS:** `docker inspect` on Docker Desktop may return a different digest.
+> Use this instead:
+> ```bash
+> $ docker manifest inspect nearone/mpc-node:main-828f816 | jq -r '.config.digest'
+> ```
 
 * Download the MPC code from this repository:
 


### PR DESCRIPTION
## Summary
- Adds a warning in the **Image/code inspection** section that `docker inspect` must be run on Linux, not macOS
- On macOS, Docker Desktop returns the manifest digest instead of the config digest, producing a different hash value that can mislead operators verifying image hashes before voting

## Context
Raised originally by  @DSharifi in https://github.com/near/mpc/pull/2621#discussion_r2999667744 — @gilcu3 noted the painful difference between `docker inspect .ID` on Linux vs macOS, and @barakeinav1 suggested adding this to the operator guide.

