### PR TITLE
refactor: remove HashSpec trait and define_hash! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5787,7 +5787,6 @@ dependencies = [
  "derive-where",
  "derive_more 2.1.1",
  "hex",
- "paste",
  "rand 0.8.5",
  "schemars 0.8.22",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -163,7 +163,6 @@ near-sdk = { version = "5.24.1", features = [
 near-workspaces = { version = "0.22.1" }
 num_enum = { version = "0.7.6", features = ["complex-expressions"] }
 pairing = { version = "0.23.0" }
-paste = "1.0"
 pprof = { version = "0.15.0", features = [
     "cpp",
     "flamegraph",

--- a/crates/contract/src/tee/measurements.rs
+++ b/crates/contract/src/tee/measurements.rs
@@ -5,26 +5,25 @@ use std::collections::BTreeMap;
 
 use crate::primitives::{key_state::AuthenticatedParticipantId, participants::Participants};
 
-mpc_primitives::define_hash!(
-    /// SHA-384 digest of the MRTD (Module Run-Time Data) TDX measurement.
-    MrtdHash, 48
-);
-mpc_primitives::define_hash!(
-    /// SHA-384 digest of the RTMR0 TDX measurement.
-    Rtmr0Hash, 48
-);
-mpc_primitives::define_hash!(
-    /// SHA-384 digest of the RTMR1 TDX measurement.
-    Rtmr1Hash, 48
-);
-mpc_primitives::define_hash!(
-    /// SHA-384 digest of the RTMR2 TDX measurement.
-    Rtmr2Hash, 48
-);
-mpc_primitives::define_hash!(
-    /// SHA-384 digest of the key provider event.
-    KeyProviderEventDigest, 48
-);
+pub struct MrtdHashMarker;
+/// SHA-384 digest of the MRTD (Module Run-Time Data) TDX measurement.
+pub type MrtdHash = mpc_primitives::hash::Hash<MrtdHashMarker, 48>;
+
+pub struct Rtmr0HashMarker;
+/// SHA-384 digest of the RTMR0 TDX measurement.
+pub type Rtmr0Hash = mpc_primitives::hash::Hash<Rtmr0HashMarker, 48>;
+
+pub struct Rtmr1HashMarker;
+/// SHA-384 digest of the RTMR1 TDX measurement.
+pub type Rtmr1Hash = mpc_primitives::hash::Hash<Rtmr1HashMarker, 48>;
+
+pub struct Rtmr2HashMarker;
+/// SHA-384 digest of the RTMR2 TDX measurement.
+pub type Rtmr2Hash = mpc_primitives::hash::Hash<Rtmr2HashMarker, 48>;
+
+pub struct KeyProviderEventDigestMarker;
+/// SHA-384 digest of the key provider event.
+pub type KeyProviderEventDigest = mpc_primitives::hash::Hash<KeyProviderEventDigestMarker, 48>;
 
 /// Tracks votes for adding or removing OS measurements.
 /// Each participant can have at most one active vote at a time.

--- a/crates/foreign-chain-inspector/src/abstract_chain.rs
+++ b/crates/foreign-chain-inspector/src/abstract_chain.rs
@@ -2,5 +2,8 @@ pub use ethereum_types;
 
 pub mod inspector;
 
-mpc_primitives::define_hash!(AbstractBlockHash, 32);
-mpc_primitives::define_hash!(AbstractTransactionHash, 32);
+pub struct AbstractBlockHashMarker;
+pub type AbstractBlockHash = mpc_primitives::hash::Hash<AbstractBlockHashMarker, 32>;
+
+pub struct AbstractTransactionHashMarker;
+pub type AbstractTransactionHash = mpc_primitives::hash::Hash<AbstractTransactionHashMarker, 32>;

--- a/crates/foreign-chain-inspector/src/bitcoin.rs
+++ b/crates/foreign-chain-inspector/src/bitcoin.rs
@@ -1,7 +1,10 @@
 pub mod inspector;
 
-mpc_primitives::define_hash!(BitcoinBlockHash, 32);
-mpc_primitives::define_hash!(BitcoinTransactionHash, 32);
+pub struct BitcoinBlockHashMarker;
+pub type BitcoinBlockHash = mpc_primitives::hash::Hash<BitcoinBlockHashMarker, 32>;
+
+pub struct BitcoinTransactionHashMarker;
+pub type BitcoinTransactionHash = mpc_primitives::hash::Hash<BitcoinTransactionHashMarker, 32>;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum BitcoinExtractedValue {

--- a/crates/foreign-chain-inspector/src/starknet.rs
+++ b/crates/foreign-chain-inspector/src/starknet.rs
@@ -2,8 +2,11 @@ use near_mpc_contract_interface::types::StarknetLog;
 
 pub mod inspector;
 
-mpc_primitives::define_hash!(StarknetBlockHash, 32);
-mpc_primitives::define_hash!(StarknetTransactionHash, 32);
+pub struct StarknetBlockHashMarker;
+pub type StarknetBlockHash = mpc_primitives::hash::Hash<StarknetBlockHashMarker, 32>;
+
+pub struct StarknetTransactionHashMarker;
+pub type StarknetTransactionHash = mpc_primitives::hash::Hash<StarknetTransactionHashMarker, 32>;
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum StarknetExtractedValue {

--- a/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
@@ -3,8 +3,13 @@ use crate::to_rpc_params_impl;
 use jsonrpsee::core::traits::ToRpcParams;
 use serde::{Deserialize, Serialize};
 
-mpc_primitives::define_hash!(TransportBitcoinBlockHash, 32);
-mpc_primitives::define_hash!(TransportBitcoinTransactionHash, 32);
+pub struct TransportBitcoinBlockHashMarker;
+pub type TransportBitcoinBlockHash =
+    mpc_primitives::hash::Hash<TransportBitcoinBlockHashMarker, 32>;
+
+pub struct TransportBitcoinTransactionHashMarker;
+pub type TransportBitcoinTransactionHash =
+    mpc_primitives::hash::Hash<TransportBitcoinTransactionHashMarker, 32>;
 
 /// Partial RPC response for `getrawtransaction`. See link below for full spec;
 /// <https://developer.bitcoin.org/reference/rpc/getrawtransaction.html#result-if-verbose-is-set-to-true>

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -15,7 +15,6 @@ borsh = { workspace = true }
 derive-where = { workspace = true }
 derive_more = { workspace = true }
 hex = { workspace = true }
-paste = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 thiserror = { workspace = true }

--- a/crates/primitives/src/hash.rs
+++ b/crates/primitives/src/hash.rs
@@ -13,18 +13,27 @@ pub enum HashParseError {
     InvalidLength { expected: usize, got: usize },
 }
 
-/// Marker trait binding a hash type name to its display name.
-pub trait HashSpec {
-    const NAME: &'static str;
+/// Extracts a clean type name from a marker struct, stripping the module path and `Marker` suffix.
+/// E.g. `my_crate::DockerImageHashMarker` → `"DockerImageHash"`.
+fn marker_name<S: 'static>() -> &'static str {
+    let full = core::any::type_name::<S>();
+    let short = match full.rsplit_once("::") {
+        Some((_, s)) => s,
+        None => full,
+    };
+    match short.strip_suffix("Marker") {
+        Some(s) => s,
+        None => short,
+    }
 }
 
-/// A fixed-size hash digest parameterized by a [`HashSpec`] marker and byte length `N`.
+/// A fixed-size hash digest parameterized by a marker type and byte length `N`.
 #[serde_with::serde_as]
 #[derive(derive_where::DeriveWhere, derive_more::Deref, derive_more::AsRef, derive_more::Into)]
 #[derive_where(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[derive_where(Serialize, Deserialize)]
 #[serde(transparent)]
-pub struct HashDigest<S: HashSpec, const N: usize> {
+pub struct Hash<S: 'static, const N: usize> {
     #[deref]
     #[as_ref]
     #[into]
@@ -36,19 +45,19 @@ pub struct HashDigest<S: HashSpec, const N: usize> {
     _marker: PhantomData<S>,
 }
 
-impl<S: HashSpec, const N: usize> core::fmt::Debug for HashDigest<S, N> {
+impl<S: 'static, const N: usize> core::fmt::Debug for Hash<S, N> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{}({})", S::NAME, hex::encode(self.bytes))
+        write!(f, "{}({})", marker_name::<S>(), hex::encode(self.bytes))
     }
 }
 
-impl<S: HashSpec, const N: usize> borsh::BorshSerialize for HashDigest<S, N> {
+impl<S: 'static, const N: usize> borsh::BorshSerialize for Hash<S, N> {
     fn serialize<W: borsh::io::Write>(&self, writer: &mut W) -> borsh::io::Result<()> {
         self.bytes.serialize(writer)
     }
 }
 
-impl<S: HashSpec, const N: usize> borsh::BorshDeserialize for HashDigest<S, N> {
+impl<S: 'static, const N: usize> borsh::BorshDeserialize for Hash<S, N> {
     fn deserialize_reader<R: borsh::io::Read>(reader: &mut R) -> borsh::io::Result<Self> {
         let bytes = <[u8; N]>::deserialize_reader(reader)?;
         Ok(Self::new(bytes))
@@ -56,9 +65,9 @@ impl<S: HashSpec, const N: usize> borsh::BorshDeserialize for HashDigest<S, N> {
 }
 
 #[cfg(all(feature = "abi", not(target_arch = "wasm32")))]
-impl<S: HashSpec, const N: usize> borsh::BorshSchema for HashDigest<S, N> {
+impl<S: 'static, const N: usize> borsh::BorshSchema for Hash<S, N> {
     fn declaration() -> borsh::schema::Declaration {
-        S::NAME.to_string()
+        marker_name::<S>().to_string()
     }
 
     fn add_definitions_recursively(
@@ -81,9 +90,9 @@ impl<S: HashSpec, const N: usize> borsh::BorshSchema for HashDigest<S, N> {
 }
 
 #[cfg(all(feature = "abi", not(target_arch = "wasm32")))]
-impl<S: HashSpec, const N: usize> schemars::JsonSchema for HashDigest<S, N> {
+impl<S: 'static, const N: usize> schemars::JsonSchema for Hash<S, N> {
     fn schema_name() -> String {
-        S::NAME.to_string()
+        marker_name::<S>().to_string()
     }
 
     fn json_schema(_generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
@@ -102,13 +111,13 @@ impl<S: HashSpec, const N: usize> schemars::JsonSchema for HashDigest<S, N> {
     }
 }
 
-impl<S: HashSpec, const N: usize> From<[u8; N]> for HashDigest<S, N> {
+impl<S: 'static, const N: usize> From<[u8; N]> for Hash<S, N> {
     fn from(bytes: [u8; N]) -> Self {
         Self::new(bytes)
     }
 }
 
-impl<S: HashSpec, const N: usize> HashDigest<S, N> {
+impl<S: 'static, const N: usize> Hash<S, N> {
     /// Converts the hash to a hexadecimal string representation.
     pub fn as_hex(&self) -> String {
         hex::encode(self.as_ref())
@@ -122,7 +131,7 @@ impl<S: HashSpec, const N: usize> HashDigest<S, N> {
     }
 }
 
-impl<S: HashSpec, const N: usize> FromStr for HashDigest<S, N> {
+impl<S: 'static, const N: usize> FromStr for Hash<S, N> {
     type Err = HashParseError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
@@ -138,49 +147,25 @@ impl<S: HashSpec, const N: usize> FromStr for HashDigest<S, N> {
     }
 }
 
-/// Defines a new hash type as `HashDigest<{Name}Spec, N>`.
-#[macro_export]
-macro_rules! define_hash {
-    ($(#[$meta:meta])* $name:ident, $n:literal) => {
-        $crate::_macro_deps::paste::paste! {
-            #[doc(hidden)]
-            pub struct [<$name Spec>];
-
-            impl $crate::hash::HashSpec for [<$name Spec>] {
-                const NAME: &'static str = stringify!($name);
-            }
-
-            $(#[$meta])*
-            pub type $name = $crate::hash::HashDigest<[<$name Spec>], $n>;
-        }
-    };
-}
-
-define_hash!(
-    /// Hash of a Docker image running in the TEE environment. Used as a proposal for a new TEE
-    /// code hash to add to the whitelist, together with the TEE quote (which includes the RTMR3
-    /// measurement and more).
-    DockerImageHash,
-    32
-);
+pub struct DockerImageHashMarker;
+/// Hash of a Docker image running in the TEE environment. Used as a proposal for a new TEE
+/// code hash to add to the whitelist, together with the TEE quote (which includes the RTMR3
+/// measurement and more).
+pub type DockerImageHash = Hash<DockerImageHashMarker, 32>;
 
 /// Hash of the MPC node's Docker image.
 pub type NodeImageHash = DockerImageHash;
 
-define_hash!(
-    /// Hash of the launcher's Docker Compose file used to run the MPC node in the TEE environment.
-    /// It is computed from the launcher's Docker Compose template populated with the launcher image
-    /// hash and the MPC node's Docker image hash.
-    LauncherDockerComposeHash,
-    32
-);
+pub struct LauncherDockerComposeHashMarker;
+/// Hash of the launcher's Docker Compose file used to run the MPC node in the TEE environment.
+/// It is computed from the launcher's Docker Compose template populated with the launcher image
+/// hash and the MPC node's Docker image hash.
+pub type LauncherDockerComposeHash = Hash<LauncherDockerComposeHashMarker, 32>;
 
-define_hash!(
-    /// Hash of the launcher Docker image itself. Voted on by participants to allow
-    /// launcher upgrades without contract redeployment.
-    LauncherImageHash,
-    32
-);
+pub struct LauncherImageHashMarker;
+/// Hash of the launcher Docker image itself. Voted on by participants to allow
+/// launcher upgrades without contract redeployment.
+pub type LauncherImageHash = Hash<LauncherImageHashMarker, 32>;
 
 #[cfg(test)]
 mod tests {
@@ -191,8 +176,11 @@ mod tests {
     use borsh::BorshDeserialize;
     use rand::{RngCore, SeedableRng, rngs::StdRng};
 
-    define_hash!(TestHash, 32);
-    define_hash!(TestHash48, 48);
+    struct TestHashMarker;
+    type TestHash = Hash<TestHashMarker, 32>;
+
+    struct TestHash48Marker;
+    type TestHash48 = Hash<TestHash48Marker, 48>;
 
     #[test]
     fn test_from_bytes_array() {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -4,9 +4,3 @@
 extern crate alloc;
 
 pub mod hash;
-
-/// Re-exports used by the [`define_hash!`] macro. Not part of the public API.
-#[doc(hidden)]
-pub mod _macro_deps {
-    pub use ::paste;
-}


### PR DESCRIPTION
## Summary
- Remove `HashSpec` trait and `define_hash!` macro — hash types are now defined with plain marker structs + type aliases
- Remove `paste` dependency (no longer needed)
- Remove `_macro_deps` module
- Rename `HashDigest` → `Hash` for brevity
- Type names for Debug/BorshSchema/JsonSchema derived from marker struct name via `core::any::type_name`

Defining a new hash type is now just:
```rust
pub struct MrtdHashMarker;
pub type MrtdHash = mpc_primitives::hash::Hash<MrtdHashMarker, 48>;
```

## Test plan
- [ ] All existing tests pass (`cargo nextest run -p mpc-primitives`)
- [ ] ABI snapshot may need updating (`cargo insta review`)
- [ ] `cargo make check-all-fast` passes (except pre-existing tee-launcher issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)