### PR TITLE
ci: automatic draft release creation on tag push

### DIFF
--- a/.github/workflows/docker_launcher_release.yml
+++ b/.github/workflows/docker_launcher_release.yml
@@ -1,7 +1,7 @@
 name: Release Launcher Docker Image
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: retag-launcher-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -15,6 +15,19 @@ on:
         description: "Release tag for the image (e.g., '3.0.4')"
         required: true
         type: string
+  workflow_call:
+    inputs:
+      source-tag:
+        required: true
+        type: string
+      release-tag:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 jobs:
   retag-launcher-image:
@@ -37,17 +50,17 @@ jobs:
 
       - name: Verify source image exists
         env:
-          SOURCE_TAG: ${{ github.event.inputs.source-tag }}
+          SOURCE_TAG: ${{ inputs.source-tag }}
         run: |
           if ! skopeo inspect docker://nearone/mpc-launcher:$SOURCE_TAG > /dev/null 2>&1; then
-            echo "❌ Source image nearone/mpc-launcher:$SOURCE_TAG does not exist"
+            echo "Source image nearone/mpc-launcher:$SOURCE_TAG does not exist"
             exit 1
           fi
 
       - name: Retag image
         env:
-          SOURCE_TAG: ${{ github.event.inputs.source-tag }}
-          RELEASE_TAG: ${{ github.event.inputs.release-tag }}
+          SOURCE_TAG: ${{ inputs.source-tag }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
         run: |
           skopeo copy \
             docker://nearone/mpc-launcher:$SOURCE_TAG \

--- a/.github/workflows/docker_node_release.yml
+++ b/.github/workflows/docker_node_release.yml
@@ -1,7 +1,7 @@
 name: Release Node Docker Image
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event.inputs.repository }}
+  group: retag-node-${{ inputs.repository }}-${{ github.ref }}
   cancel-in-progress: true
 
 on:
@@ -20,6 +20,22 @@ on:
         required: false
         type: string
         default: mpc-node-gcp
+  workflow_call:
+    inputs:
+      source-tag:
+        required: true
+        type: string
+      release-tag:
+        required: true
+        type: string
+      repository:
+        required: true
+        type: string
+    secrets:
+      DOCKERHUB_USERNAME:
+        required: true
+      DOCKERHUB_TOKEN:
+        required: true
 
 jobs:
   retag-node-image:
@@ -42,19 +58,19 @@ jobs:
 
       - name: Verify source image exists
         env:
-          SOURCE_TAG: ${{ github.event.inputs.source-tag }}
-          REPOSITORY: ${{ github.event.inputs.repository }}
+          SOURCE_TAG: ${{ inputs.source-tag }}
+          REPOSITORY: ${{ inputs.repository }}
         run: |
           if ! skopeo inspect docker://nearone/$REPOSITORY:$SOURCE_TAG > /dev/null 2>&1; then
-            echo "❌ Source image nearone/$REPOSITORY:$SOURCE_TAG does not exist"
+            echo "Source image nearone/$REPOSITORY:$SOURCE_TAG does not exist"
             exit 1
           fi
 
       - name: Retag image
         env:
-          SOURCE_TAG: ${{ github.event.inputs.source-tag }}
-          REPOSITORY: ${{ github.event.inputs.repository }}
-          RELEASE_TAG: ${{ github.event.inputs.release-tag }}
+          SOURCE_TAG: ${{ inputs.source-tag }}
+          REPOSITORY: ${{ inputs.repository }}
+          RELEASE_TAG: ${{ inputs.release-tag }}
         run: |
           skopeo copy \
             docker://nearone/$REPOSITORY:$SOURCE_TAG \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,275 @@
+name: Release
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    tags:
+      - '*.*.*'
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions: {}
+
+jobs:
+  release-info:
+    name: "Extract release info"
+    if: >-
+      github.event_name == 'push'
+      || (github.event.pull_request.merged == true
+          && startsWith(github.event.pull_request.head.ref, 'release/v'))
+    runs-on: warp-ubuntu-2404-x64-2x
+    permissions:
+      contents: write
+
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+      short-sha: ${{ steps.version.outputs.short-sha }}
+
+    steps:
+      - name: Extract version
+        id: version
+        env:
+          EVENT: ${{ github.event_name }}
+          TAG_REF: ${{ github.ref }}
+          TAG_SHA: ${{ github.sha }}
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+          PR_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          if [[ "$EVENT" == "push" ]]; then
+            VERSION="${TAG_REF#refs/tags/v}"
+            SHA="$TAG_SHA"
+          else
+            VERSION="${BRANCH#release/v}"
+            SHA="$PR_SHA"
+          fi
+          if [[ ! "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Invalid semver: $VERSION"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "short-sha=${SHA::7}" >> "$GITHUB_OUTPUT"
+
+      - name: Create tag
+        if: github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+          SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          gh api "repos/$GITHUB_REPOSITORY/git/refs" \
+            --method POST \
+            -f ref="refs/tags/$TAG" \
+            -f sha="$SHA"
+
+  retag-launcher:
+    name: "Retag mpc-launcher"
+    needs: release-info
+    uses: ./.github/workflows/docker_launcher_release.yml
+    with:
+      source-tag: "main-${{ needs.release-info.outputs.short-sha }}"
+      release-tag: ${{ needs.release-info.outputs.version }}
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  retag-node:
+    name: "Retag mpc-node"
+    needs: release-info
+    uses: ./.github/workflows/docker_node_release.yml
+    with:
+      source-tag: "main-${{ needs.release-info.outputs.short-sha }}"
+      release-tag: ${{ needs.release-info.outputs.version }}
+      repository: mpc-node
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  retag-node-gcp:
+    name: "Retag mpc-node-gcp"
+    needs: release-info
+    uses: ./.github/workflows/docker_node_release.yml
+    with:
+      source-tag: "main-${{ needs.release-info.outputs.short-sha }}"
+      release-tag: ${{ needs.release-info.outputs.version }}
+      repository: mpc-node-gcp
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+
+  collect-digests:
+    name: "Collect Docker image digests"
+    needs: [release-info, retag-launcher, retag-node, retag-node-gcp]
+    runs-on: warp-ubuntu-2404-x64-2x
+
+    outputs:
+      mpc_node_manifest_digest: ${{ steps.digests.outputs.mpc_node_manifest_digest }}
+      mpc_node_image_id: ${{ steps.digests.outputs.mpc_node_image_id }}
+      mpc_node_gcp_manifest_digest: ${{ steps.digests.outputs.mpc_node_gcp_manifest_digest }}
+      mpc_node_gcp_image_id: ${{ steps.digests.outputs.mpc_node_gcp_image_id }}
+      mpc_launcher_manifest_digest: ${{ steps.digests.outputs.mpc_launcher_manifest_digest }}
+      mpc_launcher_image_id: ${{ steps.digests.outputs.mpc_launcher_image_id }}
+
+    steps:
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
+      - name: Get image digests
+        id: digests
+        env:
+          RELEASE_TAG: ${{ needs.release-info.outputs.version }}
+        run: |
+          set -euo pipefail
+          for REPO in mpc-launcher mpc-node-gcp mpc-node; do
+            SAFE_NAME="${REPO//-/_}"
+            MANIFEST_DIGEST=$(skopeo inspect docker://nearone/$REPO:$RELEASE_TAG | jq -r '.Digest')
+            IMAGE_ID=$(skopeo inspect --raw --override-os linux --override-arch amd64 docker://nearone/$REPO:$RELEASE_TAG | jq -r '.config.digest')
+            if [[ -z "$MANIFEST_DIGEST" || -z "$IMAGE_ID" ]]; then
+              echo "::error::Failed to get digests for nearone/$REPO:$RELEASE_TAG"
+              exit 1
+            fi
+            echo "${SAFE_NAME}_manifest_digest=$MANIFEST_DIGEST" >> "$GITHUB_OUTPUT"
+            echo "${SAFE_NAME}_image_id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
+          done
+
+  build-contract:
+    name: "Build contract"
+    needs: release-info
+    runs-on: warp-ubuntu-2404-x64-16x
+    permissions:
+      contents: read
+
+    outputs:
+      contract-hash: ${{ steps.contract-hash.outputs.sha256 }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ needs.release-info.outputs.tag }}
+          persist-credentials: false
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y liblzma-dev libudev-dev
+
+      - name: Install cargo-binstall
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
+        with:
+          tool: cargo-binstall
+
+      - name: Install cargo-near
+        run: |
+          cargo binstall --force --no-confirm --locked cargo-near@0.19.1 --pkg-url="{ repo }/releases/download/{ name }-v{ version }/{ name }-{ target }.{ archive-format }"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build contract
+        run: |
+          cargo near build reproducible-wasm \
+            --manifest-path crates/contract/Cargo.toml
+
+      - name: Compute contract hash
+        id: contract-hash
+        run: |
+          CONTRACT_HASH=$(sha256sum target/near/mpc_contract/mpc_contract.wasm | awk '{print $1}')
+          echo "sha256=$CONTRACT_HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Package contract artifacts
+        env:
+          VERSION: ${{ needs.release-info.outputs.version }}
+        run: |
+          cd target/near/mpc_contract/
+          mv mpc_contract.wasm "mpc-contract-v${VERSION}.wasm"
+          tar -czf "mpc-contract-v${VERSION}.tar.gz" "mpc-contract-v${VERSION}.wasm"
+
+      - name: Upload contract artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: mpc-contract
+          path: target/near/mpc_contract/mpc-contract-v${{ needs.release-info.outputs.version }}.tar.gz
+
+  create-release:
+    name: "Create draft GitHub release"
+    needs: [release-info, collect-digests, build-contract]
+    runs-on: warp-ubuntu-2404-x64-2x
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          ref: ${{ needs.release-info.outputs.tag }}
+          persist-credentials: false
+
+      - name: Extract changelog
+        env:
+          VERSION: ${{ needs.release-info.outputs.version }}
+        run: |
+          awk "/^## \\[${VERSION}\\]/{found=1; next} /^## \\[/{if(found) exit} found" CHANGELOG.md > release-notes-raw.md
+          if [ ! -s release-notes-raw.md ]; then
+            echo "::error::No changelog found for version ${VERSION} in CHANGELOG.md"
+            exit 1
+          fi
+
+      - name: Download contract artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: mpc-contract
+
+      - name: Compose release body
+        env:
+          VERSION: ${{ needs.release-info.outputs.version }}
+          NODE_MANIFEST: ${{ needs.collect-digests.outputs.mpc_node_manifest_digest }}
+          NODE_IMAGE_ID: ${{ needs.collect-digests.outputs.mpc_node_image_id }}
+          NODE_GCP_MANIFEST: ${{ needs.collect-digests.outputs.mpc_node_gcp_manifest_digest }}
+          NODE_GCP_IMAGE_ID: ${{ needs.collect-digests.outputs.mpc_node_gcp_image_id }}
+          LAUNCHER_MANIFEST: ${{ needs.collect-digests.outputs.mpc_launcher_manifest_digest }}
+          LAUNCHER_IMAGE_ID: ${{ needs.collect-digests.outputs.mpc_launcher_image_id }}
+          CONTRACT_HASH: ${{ needs.build-contract.outputs.contract-hash }}
+        run: |
+          cp release-notes-raw.md release-notes.md
+          cat >> release-notes.md <<EOF
+
+          ## Docker images
+
+          - [nearone/mpc-node:${VERSION}](https://hub.docker.com/layers/nearone/mpc-node/${VERSION}/)
+              Manifest digest: \`${NODE_MANIFEST}\`
+              Image ID: \`${NODE_IMAGE_ID}\`
+
+          - [nearone/mpc-node-gcp:${VERSION}](https://hub.docker.com/layers/nearone/mpc-node-gcp/${VERSION}/)
+              Manifest digest: \`${NODE_GCP_MANIFEST}\`
+              Image ID: \`${NODE_GCP_IMAGE_ID}\`
+
+          - [nearone/mpc-launcher:${VERSION}](https://hub.docker.com/layers/nearone/mpc-launcher/${VERSION}/)
+              Manifest digest: \`${LAUNCHER_MANIFEST}\`
+              Image ID: \`${LAUNCHER_IMAGE_ID}\`
+
+          ## MPC contract
+
+          - digest: \`sha256:${CONTRACT_HASH}\`
+          EOF
+
+      - name: Create draft release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release-info.outputs.tag }}
+          VERSION: ${{ needs.release-info.outputs.version }}
+        run: |
+          gh release create "$TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "MPC ${VERSION}" \
+            --notes-file release-notes.md \
+            --draft \
+            "mpc-contract-v${VERSION}.tar.gz"


### PR DESCRIPTION
Closes #1971, supersedes #2203  

This was tested in https://github.com/near/mpc-release-test
with release in https://github.com/near/mpc-release-test/releases/tag/untagged-c32331a90dc143d4acc8