### PR TITLE
chore: create mpc-node release v3.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,222 @@ All notable changes to this project will be documented in this file.
 
 This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## [3.8.0] - 2026-04-02
+
+### 🚀 Features
+
+- [#2464](https://github.com/near/mpc/pull/2464)(@kevindeforth): Chain gateway transaction sender (#2464)
+
+- [#2483](https://github.com/near/mpc/pull/2483)(@gilcu3): Added ckd public verification support in the contract (#2483)
+
+- [#2500](https://github.com/near/mpc/pull/2500)(@DSharifi): *(node)* Allow configuration of logging through configuration file (#2500)
+
+- [#2495](https://github.com/near/mpc/pull/2495)(@gilcu3): Integrate CKD public verifiability in the node (#2495)
+
+- [#2447](https://github.com/near/mpc/pull/2447)(@barakeinav1): Add voting mechanism for expected OS measurements (#2447)
+
+- [#2505](https://github.com/near/mpc/pull/2505)(@pbeza): Add `tee-context` crate (#2505)
+
+- [#2448](https://github.com/near/mpc/pull/2448)(@barakeinav1): Check OS measurements during attestation re-verification (#2448)
+
+- [#2527](https://github.com/near/mpc/pull/2527)(@anodar): Add e2e-tests crate skeleton with port allocator (#2527)
+
+- [#2601](https://github.com/near/mpc/pull/2601)(@anodar): Support hostnames in backup-cli (#2601)
+
+- [#2621](https://github.com/near/mpc/pull/2621)(@barakeinav1): Add Rust tee-launcher crate (#2621)
+
+- [#2667](https://github.com/near/mpc/pull/2667)(@DSharifi): Implement BorshSchema for NonEmptyBTreeMap (#2667)
+
+- [#2625](https://github.com/near/mpc/pull/2625)(@kevindeforth): Chain-gateway block event subscriber (#2625)
+
+
+### 🐛 Bug Fixes
+
+- [#2431](https://github.com/near/mpc/pull/2431)(@anodar): Downgrade "peer closed connection without TLS close_notify" errors to debug (#2431)
+
+- [#2348](https://github.com/near/mpc/pull/2348)(@SimonRastikian): Threshold signatures sensitive types print custom debug message (#2348)
+
+- [#2567](https://github.com/near/mpc/pull/2567)(@gilcu3): Cleanup stale votes after resharing (#2567)
+
+- [#2574](https://github.com/near/mpc/pull/2574)(@gilcu3): Remove rename scheme from DomainConfig (#2574)
+
+- [#2549](https://github.com/near/mpc/pull/2549)(@barakeinav1): Set 0o600 permissions on secret files (#2549)
+
+- [#2579](https://github.com/near/mpc/pull/2579)(@gilcu3): Use CKDOutput type both for sender and receiver (#2579)
+
+- [#2585](https://github.com/near/mpc/pull/2585)(@gilcu3): Add more informative error messages for participant sets (#2585)
+
+- [#2417](https://github.com/near/mpc/pull/2417)(@SimonRastikian): Improving security by adding zeroization to the secret cryptography material (#2417)
+
+- [#2646](https://github.com/near/mpc/pull/2646)(@gilcu3): Ensure asset id origins are validated before use (#2646)
+
+- [#2636](https://github.com/near/mpc/pull/2636)(@Copilot): Update stale localnet config template (#2636)
+
+- [#2678](https://github.com/near/mpc/pull/2678)(@netrome): Log index lookup finds logs with matching .log_index fields (#2678)
+
+
+### 💼 Other
+
+- [#2640](https://github.com/near/mpc/pull/2640)(@barakeinav1): Add CI and build support for Rust launcher (#2640)
+
+- [#2665](https://github.com/near/mpc/pull/2665)(@gilcu3): Make rust launcher docker build reproducible (#2665)
+
+- [#2668](https://github.com/near/mpc/pull/2668)(@gilcu3): Use debian trixie for rust launcher image (#2668)
+
+
+### 🚜 Refactor
+
+- [#2494](https://github.com/near/mpc/pull/2494)(@anodar): Deduplicate dependencies in check-all target (#2494)
+
+- [#2535](https://github.com/near/mpc/pull/2535)(@pbeza): *(tee-context)* Address post-merge review feedback from #2505 (#2535)
+
+- [#2540](https://github.com/near/mpc/pull/2540)(@pbeza): Rename `MpcDockerImageHash` to `NodeImageHash` (#2540)
+
+- [#2396](https://github.com/near/mpc/pull/2396)(@SimonRastikian): Changing SignatureScheme into Curve (#2396)
+
+- [#2553](https://github.com/near/mpc/pull/2553)(@kevindeforth): Simplify `TeeContext` by removing `SubmitTransaction` indirection (#2553)
+
+- [#2564](https://github.com/near/mpc/pull/2564)(@pbeza): Generalize `Hash32<T>` to `Hash<T, N>` and replace `Sha384Digest` (#2564)
+
+- [#2584](https://github.com/near/mpc/pull/2584)(@pbeza): Replace `assert!(matches!(...))` with `assert_matches!` and enforce in CI (#2584)
+
+- [#2489](https://github.com/near/mpc/pull/2489)(@kevindeforth): Start chain-gateway in dedicated multi-threaded tokio runtime + transaction sender integration test (#2489)
+
+- [#2633](https://github.com/near/mpc/pull/2633)(@gilcu3): Split main.rs in tee-launcher crate (#2633)
+
+- [#2645](https://github.com/near/mpc/pull/2645)(@DSharifi): Use tokio `TaskInterval` type (#2645)
+
+- [#2619](https://github.com/near/mpc/pull/2619)(@pbeza): Unify duplicate hash newtype macros into a single generic `HashDigest<S, N>` type in `primitives` (#2619)
+
+- [#2664](https://github.com/near/mpc/pull/2664)(@anodar): Extract StartConfig from mpc-node into a lightweight config crate (#2664)
+
+- [#2409](https://github.com/near/mpc/pull/2409)(@SimonRastikian): Renaming Ed25519 to Edwards25519 (#2409)
+
+- [#2634](https://github.com/near/mpc/pull/2634)(@SimonRastikian): Improve crypto code without banners (#2634)
+
+- [#2681](https://github.com/near/mpc/pull/2681)(@barakeinav1): Remove unused HostEntry struct from tee-launcher (#2681)
+
+
+### 📚 Documentation
+
+- [#2472](https://github.com/near/mpc/pull/2472)(@DSharifi): Update releases.md to reflect current release process (#2472)
+
+- [#2484](https://github.com/near/mpc/pull/2484)(@barakeinav1): Add vote_add_launcher_hash to deployment scripts and guides (#2484)
+
+- [#2269](https://github.com/near/mpc/pull/2269)(@barakeinav1): AES transport key provisioning design (#2269)
+
+- [#2488](https://github.com/near/mpc/pull/2488)(@barakeinav1): Add OS measurement voting to TEE setup flows (#2488)
+
+- [#2427](https://github.com/near/mpc/pull/2427)(@barakeinav1): Update migration guide after testnet migration. (#2427)
+
+- [#2446](https://github.com/near/mpc/pull/2446)(@anodar): Add design doc for Rust E2E test infrastructure (pytest deprecation) (#2446)
+
+- [#2577](https://github.com/near/mpc/pull/2577)(@gilcu3): Update after public verifiability CKD (#2577)
+
+- [#2522](https://github.com/near/mpc/pull/2522)(@SimonRastikian): Designing domain separation (#2522)
+
+- [#2642](https://github.com/near/mpc/pull/2642)(@barakeinav1): Warn that docker inspect must run on Linux for hash verification (#2642)
+
+
+### ⚡ Performance
+
+- [#2644](https://github.com/near/mpc/pull/2644)(@kevindeforth): *(mpc-node)* Do not send duplicate values between threads (#2644)
+
+- [#2623](https://github.com/near/mpc/pull/2623)(@SimonRastikian): DKG benchmarks implementations (#2623)
+
+
+### 🧪 Testing
+
+- [#2503](https://github.com/near/mpc/pull/2503)(@gilcu3): Add pytest for ckd public verifiability (#2503)
+
+- [#2528](https://github.com/near/mpc/pull/2528)(@anodar): Implement mpc node manager (#2528)
+
+- [#2545](https://github.com/near/mpc/pull/2545)(@barakeinav1): Extract launcher image hash from test assets and improve attestation docs (#2545)
+
+- [#2589](https://github.com/near/mpc/pull/2589)(@anodar): Implement MPC cluster orchestration for Rust E2E tests (#2589)
+
+- [#2590](https://github.com/near/mpc/pull/2590)(@anodar): Implement NearSandbox, NearBlockchain and request lifecycle test (#2590)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- [#2473](https://github.com/near/mpc/pull/2473)(@DSharifi): Use `.cliffignore` file for ignoring commits with `git-cliff` (#2473)
+
+- [#2475](https://github.com/near/mpc/pull/2475)(@gilcu3): Move vscode extension recommendations to doc (#2475)
+
+- [#2457](https://github.com/near/mpc/pull/2457)(@DSharifi): Create interface crate for types shared between rust launcher and node (#2457)
+
+- [#2477](https://github.com/near/mpc/pull/2477)(@gilcu3): Move CKDRequestArgs to the contract interface (#2477)
+
+- [#2481](https://github.com/near/mpc/pull/2481)(@gilcu3): Cleanup migration after 3.7.0 release (#2481)
+
+- [#2499](https://github.com/near/mpc/pull/2499)(@DSharifi): Move TEE config into launcher-interface and enforce image hash file (#2499)
+
+- [#2504](https://github.com/near/mpc/pull/2504)(@DSharifi): Parallelize pytests in separate runners to speed up CI (#2504)
+
+- [#2509](https://github.com/near/mpc/pull/2509)(@gilcu3): Prevent unbounded growth of rust cache (#2509)
+
+- [#2513](https://github.com/near/mpc/pull/2513)(@gilcu3): Allow failed pytest jobs to re-run (#2513)
+
+- [#2510](https://github.com/near/mpc/pull/2510)(@gilcu3): Optimize runners used for pytests (#2510)
+
+- [#2518](https://github.com/near/mpc/pull/2518)(@DSharifi): Move reproducible build of contract as separate task (#2518)
+
+- [#2525](https://github.com/near/mpc/pull/2525)(@gilcu3): Update to nearcore 2.11.0-rc.3 (#2525)
+
+- [#2530](https://github.com/near/mpc/pull/2530)(@gilcu3): Parallelize cargo test (#2530)
+
+- [#2531](https://github.com/near/mpc/pull/2531)(@gilcu3): Rust tests should not use same cache key (#2531)
+
+- [#2534](https://github.com/near/mpc/pull/2534)(@gilcu3): Fix phala test filter (#2534)
+
+- [#2537](https://github.com/near/mpc/pull/2537)(@anodar): Add comment on Code Style regarding checked operations in tests and allow local claude md (#2537)
+
+- [#2550](https://github.com/near/mpc/pull/2550)(@barakeinav1): Bump rustls-webpki to fix RUSTSEC-2026-0049 (#2550)
+
+- [#2556](https://github.com/near/mpc/pull/2556)(@barakeinav1): Bump tar to fix RUSTSEC-2026-0067/0068 (#2556)
+
+- [#2557](https://github.com/near/mpc/pull/2557)(@gilcu3): Bump reqwest to 0.13 (#2557)
+
+- [#2552](https://github.com/near/mpc/pull/2552)(@barakeinav1): Update dstack OS image 0.5.4 to 0.5.7 (#2552)
+
+- [#2566](https://github.com/near/mpc/pull/2566)(@gilcu3): Cache cleanup should not delete cargo binary (#2566)
+
+- [#2559](https://github.com/near/mpc/pull/2559)(@dependabot[bot]): Bump quinn-proto from 0.11.13 to 0.11.14 (#2559)
+
+- [#2568](https://github.com/near/mpc/pull/2568)(@dependabot[bot]): Bump the rust-minor-and-patch group with 4 updates (#2568)
+
+- [#2569](https://github.com/near/mpc/pull/2569)(@dependabot[bot]): Bump gcloud-sdk from 0.28.5 to 0.29.0 (#2569)
+
+- [#2578](https://github.com/near/mpc/pull/2578)(@anodar): Bump MAX_GAS_FOR_THRESHOLD_VOTE from 178 to 180 (#2578)
+
+- [#2573](https://github.com/near/mpc/pull/2573)(@barakeinav1): Update dstack OS image to 0.5.8 and gramine key provider (#2573)
+
+- [#2437](https://github.com/near/mpc/pull/2437)(@gilcu3): Force usage of constructor for PermanentKeyshareData (#2437)
+
+- [#2593](https://github.com/near/mpc/pull/2593)(@gilcu3): Make sure docs explain why we have deposits, handle deposits in a single function (#2593)
+
+- [#2586](https://github.com/near/mpc/pull/2586)(@barakeinav1): Usability improvements for testing scripts (#2586)
+
+- [#2620](https://github.com/near/mpc/pull/2620)(@dependabot[bot]): Bump requests from 2.32.4 to 2.33.0 in /tee_launcher in the pip group across 1 directory (#2620)
+
+- [#2653](https://github.com/near/mpc/pull/2653)(@dependabot[bot]): Bump the rust-minor-and-patch group with 2 updates (#2653)
+
+- [#2563](https://github.com/near/mpc/pull/2563)(@barakeinav1): Add localnet TEE scripts for Rust launcher (#2563)
+
+- [#2658](https://github.com/near/mpc/pull/2658)(@barakeinav1): Add Rust launcher configs, docs, and templates (#2658)
+
+- [#2669](https://github.com/near/mpc/pull/2669)(@gilcu3): Use BTreeMap for permanent keyshare data (#2669)
+
+- [#2591](https://github.com/near/mpc/pull/2591)(@gilcu3): Bump to nearcore 2.11 (#2591)
+
+- [#2689](https://github.com/near/mpc/pull/2689)(@gilcu3): Fix e2e tests, cache being overwritten (#2689)
+
+- [#2674](https://github.com/near/mpc/pull/2674)(@gilcu3): Automatic draft release creation on tag push (#2674)
+
+- [#2691](https://github.com/near/mpc/pull/2691)(@gilcu3): Fix and simplify release automation (#2691)
+
+
 ## [3.7.0] - 2026-03-17
 
 ### 🚀 Features
@@ -100,6 +316,8 @@ This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conv
 - [#2468](https://github.com/near/mpc/pull/2468)(@DSharifi): Bump nearcore to 2.11.0-rc.2 (#2468)
 
 - [#2465](https://github.com/near/mpc/pull/2465)(@dependabot[bot]): Bump the rust-minor-and-patch group with 3 updates (#2465)
+
+- [#2466](https://github.com/near/mpc/pull/2466)(@DSharifi): Update changelog and bump workspace crates to 3.7.0 (#2466)
 
 
 ## [3.6.0] - 2026-03-05

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-cli"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "backup-cli"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1733,7 +1733,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chain-gateway"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",
@@ -1765,7 +1765,7 @@ dependencies = [
 
 [[package]]
 name = "chain-gateway-test-contract"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "borsh",
  "derive_more 2.1.1",
@@ -1826,7 +1826,7 @@ dependencies = [
 
 [[package]]
 name = "ckd-example-cli"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "blstrs",
@@ -2027,7 +2027,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "contract-history"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "bs58 0.5.1",
  "clap",
@@ -2989,7 +2989,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "bs58 0.5.1",
@@ -3537,7 +3537,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-chain-inspector"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "derive_more 2.1.1",
@@ -3557,7 +3557,7 @@ dependencies = [
 
 [[package]]
 name = "foreign-chain-rpc-interfaces"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "derive_more 2.1.1",
  "ethereum-types",
@@ -4660,7 +4660,7 @@ dependencies = [
 
 [[package]]
 name = "include-measurements"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -5095,7 +5095,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-interface"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "derive_more 2.1.1",
@@ -5537,7 +5537,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mpc-attestation"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "attestation",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5606,7 +5606,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-devnet"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5637,7 +5637,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node-config"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -5757,7 +5757,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-tls"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -7646,7 +7646,7 @@ dependencies = [
 
 [[package]]
 name = "node-types"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "mpc-attestation",
  "near-mpc-crypto-types",
@@ -10895,7 +10895,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tee-authority"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -10915,7 +10915,7 @@ dependencies = [
 
 [[package]]
 name = "tee-context"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "chain-gateway",
@@ -10932,7 +10932,7 @@ dependencies = [
 
 [[package]]
 name = "tee-launcher"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "backon",
@@ -11005,7 +11005,7 @@ dependencies = [
 
 [[package]]
 name = "test-migration-contract"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "borsh",
  "near-sdk",
@@ -11013,7 +11013,7 @@ dependencies = [
 
 [[package]]
 name = "test-parallel-contract"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "assert_matches",
  "blstrs",
@@ -11029,7 +11029,7 @@ dependencies = [
 
 [[package]]
 name = "test-port-allocator"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "named-lock",
  "rand 0.8.5",
@@ -11037,7 +11037,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "hex",
  "mpc-attestation",
@@ -11887,7 +11887,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utilities"
-version = "3.7.0"
+version = "3.8.0"
 dependencies = [
  "near-account-id 1.1.4",
  "near-account-id 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.7.0"
+version = "3.8.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/near/mpc"

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -6,7 +6,7 @@ expression: abi
   "schema_version": "0.4.0",
   "metadata": {
     "name": "mpc-contract",
-    "version": "3.7.0",
+    "version": "3.8.0",
     "build": {
       "compiler": "rustc 1.86.0",
       "builder": "[CARGO_NEAR_BUILD_VERSION]"

--- a/third-party-licenses/licenses.html
+++ b/third-party-licenses/licenses.html
@@ -44,13 +44,13 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (645)</li>
-            <li><a href="#MIT">MIT License</a> (200)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (669)</li>
+            <li><a href="#MIT">MIT License</a> (209)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
-            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (9)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (7)</li>
-            <li><a href="#ISC">ISC License</a> (5)</li>
-            <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (4)</li>
+            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (10)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
+            <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (7)</li>
+            <li><a href="#ISC">ISC License</a> (7)</li>
             <li><a href="#Zlib">zlib License</a> (4)</li>
             <li><a href="#BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</a> (3)</li>
             <li><a href="#CDLA-Permissive-2.0">Community Data License Agreement Permissive 2.0</a> (3)</li>
@@ -483,7 +483,7 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.5.6</a></li>
+                    <li><a href=" https://github.com/jhpratt/deranged ">deranged 0.4.0</a></li>
                 </ul>
                 <pre class="license-text">
                                  Apache License
@@ -903,16 +903,16 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/ModProg/derive-where ">derive-where 1.6.0</a></li>
+                    <li><a href=" https://github.com/ModProg/derive-where ">derive-where 1.6.1</a></li>
                     <li><a href=" https://github.com/tormol/encode_unicode ">encode_unicode 1.0.0</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
                     <li><a href=" https://github.com/enarx/flagset ">flagset 0.4.7</a></li>
-                    <li><a href=" https://github.com/lo48576/iri-string ">iri-string 0.7.10</a></li>
+                    <li><a href=" https://github.com/lo48576/iri-string ">iri-string 0.7.12</a></li>
                     <li><a href=" https://github.com/rust-rocksdb/rust-rocksdb ">librocksdb-sys 0.11.0+8.1.1</a></li>
                     <li><a href=" https://github.com/rust-rocksdb/rust-rocksdb ">rocksdb 0.21.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/serdect ">serdect 0.2.0</a></li>
                     <li><a href=" https://github.com/nvzqz/static-assertions-rs ">static_assertions 1.1.0</a></li>
-                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.10.0</a></li>
+                    <li><a href=" https://github.com/Lokathor/tinyvec ">tinyvec 1.11.0</a></li>
                     <li><a href=" https://github.com/hsivonen/utf8_iter ">utf8_iter 1.0.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">zeroize 1.8.2</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils/tree/master/zeroize/derive ">zeroize_derive 1.4.3</a></li>
@@ -1346,7 +1346,7 @@
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-native 0.123.6</a></li>
                     <li><a href=" https://github.com/bytecodealliance/regalloc2 ">regalloc2 0.12.2</a></li>
                     <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.12.16</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.4</a></li>
+                    <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.5</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder ">wasm-encoder 0.27.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.105.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.78.2</a></li>
@@ -2050,8 +2050,8 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/borsh-rs ">borsh-derive 1.6.0</a></li>
-                    <li><a href=" https://github.com/near/borsh-rs ">borsh 1.6.0</a></li>
+                    <li><a href=" https://github.com/near/borsh-rs ">borsh-derive 1.6.1</a></li>
+                    <li><a href=" https://github.com/near/borsh-rs ">borsh 1.6.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2469,7 +2469,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.13</a></li>
+                    <li><a href=" https://github.com/moka-rs/moka ">moka 0.12.15</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -2659,7 +2659,7 @@ Software.
       same &quot;printed page&quot; as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2020 - 2025 Tatsuya Kawano
+   Copyright 2020 - 2026 Tatsuya Kawano
 
    Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
    you may not use this file except in compliance with the License.
@@ -3305,7 +3305,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.39</a></li>
+                    <li><a href=" https://github.com/google/zerocopy ">zerocopy 0.8.48</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3933,60 +3933,60 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-async-derive 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-async 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-cache 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chain-primitives 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chunks-primitives 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-client-primitives 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-dyn-configs 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-external-storage 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-fmt 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-indexer-primitives 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-o11y 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-parameters 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-pool 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-stdx 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-store 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-time 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">node-runtime 0.0.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-async-derive 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-async 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-cache 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chain-primitives 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chunks-primitives 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-client-primitives 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-crypto 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-dyn-configs 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-external-storage 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-fmt 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-indexer-primitives 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-o11y 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-parameters 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-pool 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-stdx 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-store 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-time 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">node-runtime 2.11.0</a></li>
                     <li><a href=" https://github.com/near/near-account-id ">near-account-id 1.1.4</a></li>
-                    <li><a href=" https://github.com/near/near-account-id ">near-account-id 2.5.0</a></li>
+                    <li><a href=" https://github.com/near/near-account-id ">near-account-id 2.6.0</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-chain-configs 0.28.0</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-config-utils 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-crypto 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-crypto 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-fmt 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-fmt 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-fmt 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 0.28.0</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-parameters 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-parameters 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-parameters 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-primitives-core 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-primitives 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-stdx 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-stdx 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-stdx 0.34.7</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-time 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-time 0.34.6</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 0.34.6</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-time 0.34.7</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 0.34.7</a></li>
                     <li><a href=" https://github.com/juhaku/utoipa ">utoipa-gen 5.4.0</a></li>
                     <li><a href=" https://github.com/juhaku/utoipa ">utoipa-swagger-ui 9.0.2</a></li>
                     <li><a href=" https://github.com/juhaku/utoipa ">utoipa 5.4.0</a></li>
@@ -4197,7 +4197,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/abdolence/gcloud-sdk-rs ">gcloud-sdk 0.28.5</a></li>
+                    <li><a href=" https://github.com/abdolence/gcloud-sdk-rs ">gcloud-sdk 0.29.0</a></li>
                     <li><a href=" https://github.com/nolanv-be/http-client-unix-domain-socket ">http-client-unix-domain-socket 0.1.2</a></li>
                     <li><a href=" https://github.com/tmccombs/json-comments-rs ">json_comments 0.2.2</a></li>
                     <li><a href=" https://github.com/lucab/memfd-rs ">memfd 0.6.5</a></li>
@@ -4208,6 +4208,8 @@ Software.
                     <li><a href=" https://github.com/open-telemetry/opentelemetry-rust/tree/main/opentelemetry-sdk ">opentelemetry_sdk 0.30.0</a></li>
                     <li><a href=" https://github.com/paritytech/parity-scale-codec ">parity-scale-codec 3.7.5</a></li>
                     <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.5.3</a></li>
+                    <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier 0.6.2</a></li>
+                    <li><a href=" https://github.com/algesten/ureq ">ureq 3.3.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -4835,7 +4837,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.11.0</a></li>
+                    <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -5253,6 +5255,7 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/idubrov/json-patch ">json-patch 4.1.0</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -5462,18 +5465,18 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 0.6.21</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 0.2.7</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstream 1.0.0</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-parse 1.0.0</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-query 1.1.5</a></li>
                     <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle-wincon 3.0.11</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.13</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">anstyle 1.0.14</a></li>
                     <li><a href=" https://github.com/bytesize-rs/bytesize/ ">bytesize 1.3.3</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.5.60</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.5.60</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.5.55</a></li>
-                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.0.0</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap 4.6.0</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_builder 4.6.0</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_derive 4.6.0</a></li>
+                    <li><a href=" https://github.com/clap-rs/clap ">clap_lex 1.1.0</a></li>
                     <li><a href=" https://github.com/jamesmunns/cobs.rs ">cobs 0.3.0</a></li>
-                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.4</a></li>
+                    <li><a href=" https://github.com/rust-cli/anstyle.git ">colorchoice 1.0.5</a></li>
                     <li><a href=" https://github.com/srijs/rust-crc32fast ">crc32fast 1.5.0</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder 0.20.2</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder_core 0.20.2</a></li>
@@ -5486,19 +5489,19 @@ Software.
                     <li><a href=" https://github.com/KokaKiwi/rust-hex ">hex 0.4.3</a></li>
                     <li><a href=" https://github.com/chronotope/humantime ">humantime 2.3.0</a></li>
                     <li><a href=" https://github.com/polyfill-rs/is_terminal_polyfill ">is_terminal_polyfill 1.70.2</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-jni-sys ">jni-sys 0.3.0</a></li>
-                    <li><a href=" https://github.com/sfackler/rust-native-tls ">native-tls 0.2.14</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.3.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys 0.4.1</a></li>
+                    <li><a href=" https://github.com/rust-native-tls/rust-native-tls ">native-tls 0.2.18</a></li>
                     <li><a href=" https://github.com/polyfill-rs/once_cell_polyfill ">once_cell_polyfill 1.70.2</a></li>
                     <li><a href=" https://crates.io/crates/openssl-macros ">openssl-macros 0.1.1</a></li>
-                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.75</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl 0.10.76</a></li>
                     <li><a href=" https://github.com/hickory-dns/resolv-conf ">resolv-conf 0.7.6</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 1.0.4</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml 1.0.6+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 0.7.5+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.0.0+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.23.10+spec-1.0.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.0.9+spec-1.1.0</a></li>
-                    <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.0.6+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">serde_spanned 1.1.1</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml 1.1.1+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_datetime 1.1.1+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_edit 0.25.9+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_parser 1.1.1+spec-1.1.0</a></li>
+                    <li><a href=" https://github.com/toml-rs/toml ">toml_writer 1.1.1+spec-1.1.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -5702,6 +5705,215 @@ Software.
    See the License for the specific language governing permissions and
    limitations under the License.
 
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/chanced/jsonptr ">jsonptr 0.7.1</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+    &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+    and distribution as defined by Sections 1 through 9 of this document.
+
+    &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+    the copyright owner that is granting the License.
+
+    &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+    other entities that control, are controlled by, or are under common
+    control with that entity. For the purposes of this definition,
+    &quot;control&quot; means (i) the power, direct or indirect, to cause the
+    direction or management of such entity, whether by contract or
+    otherwise, or (ii) ownership of fifty percent (50%) or more of the
+    outstanding shares, or (iii) beneficial ownership of such entity.
+
+    &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+    exercising permissions granted by this License.
+
+    &quot;Source&quot; form shall mean the preferred form for making modifications,
+    including but not limited to software source code, documentation
+    source, and configuration files.
+
+    &quot;Object&quot; form shall mean any form resulting from mechanical
+    transformation or translation of a Source form, including but
+    not limited to compiled object code, generated documentation,
+    and conversions to other media types.
+
+    &quot;Work&quot; shall mean the work of authorship, whether in Source or
+    Object form, made available under the License, as indicated by a
+    copyright notice that is included in or attached to the work
+    (an example is provided in the Appendix below).
+
+    &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+    form, that is based on (or derived from) the Work and for which the
+    editorial revisions, annotations, elaborations, or other modifications
+    represent, as a whole, an original work of authorship. For the purposes
+    of this License, Derivative Works shall not include works that remain
+    separable from, or merely link (or bind by name) to the interfaces of,
+    the Work and Derivative Works thereof.
+
+    &quot;Contribution&quot; shall mean any work of authorship, including
+    the original version of the Work and any modifications or additions
+    to that Work or Derivative Works thereof, that is intentionally
+    submitted to Licensor for inclusion in the Work by the copyright owner
+    or by an individual or Legal Entity authorized to submit on behalf of
+    the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+    means any form of electronic, verbal, or written communication sent
+    to the Licensor or its representatives, including but not limited to
+    communication on electronic mailing lists, source code control systems,
+    and issue tracking systems that are managed by, or on behalf of, the
+    Licensor for the purpose of discussing and improving the Work, but
+    excluding communication that is conspicuously marked or otherwise
+    designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+    &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+    on behalf of whom a Contribution has been received by Licensor and
+    subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+    (a) You must give any other recipients of the Work or
+    Derivative Works a copy of this License; and
+
+    (b) You must cause any modified files to carry prominent notices
+    stating that You changed the files; and
+
+    (c) You must retain, in the Source form of any Derivative Works
+    that You distribute, all copyright, patent, trademark, and
+    attribution notices from the Source form of the Work,
+    excluding those notices that do not pertain to any part of
+    the Derivative Works; and
+
+    (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+    distribution, then any Derivative Works that You distribute must
+    include a readable copy of the attribution notices contained
+    within such NOTICE file, excluding those notices that do not
+    pertain to any part of the Derivative Works, in at least one
+    of the following places: within a NOTICE text file distributed
+    as part of the Derivative Works; within the Source form or
+    documentation, if provided along with the Derivative Works; or,
+    within a display generated by the Derivative Works, if and
+    wherever such third-party notices normally appear. The contents
+    of the NOTICE file are for informational purposes only and
+    do not modify the License. You may add Your own attribution
+    notices within Derivative Works that You distribute, alongside
+    or as an addendum to the NOTICE text from the Work, provided
+    that such additional attribution notices cannot be construed
+    as modifying the License.
+
+    You may add Your own copyright statement to Your modifications and
+    may provide additional or different license terms and conditions
+    for use, reproduction, or distribution of Your modifications, or
+    for any such Derivative Works as a whole, provided Your use,
+    reproduction, and distribution of the Work otherwise complies with
+    the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+Copyright 2024 Chance Dinkins
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 </pre>
             </li>
             <li class="license">
@@ -6556,6 +6768,7 @@ limitations under the License.</pre>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.11.27</a></li>
                     <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.12.28</a></li>
+                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.13.2</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -8860,7 +9073,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.5.10</a></li>
-                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.9</a></li>
+                    <li><a href=" https://github.com/RazrFalcon/memmap2-rs ">memmap2 0.9.10</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9073,7 +9286,7 @@ limitations under the License.
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.7.8</a></li>
                     <li><a href=" https://github.com/tkaitchuck/ahash ">ahash 0.8.12</a></li>
                     <li><a href=" https://github.com/rust-fuzz/arbitrary/ ">arbitrary 1.4.2</a></li>
-                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.8.1</a></li>
+                    <li><a href=" https://github.com/vorner/arc-swap ">arc-swap 1.9.0</a></li>
                     <li><a href=" https://github.com/bluss/arrayvec ">arrayvec 0.7.6</a></li>
                     <li><a href=" https://github.com/rusticata/asn1-rs.git ">asn1-rs-derive 0.5.1</a></li>
                     <li><a href=" https://github.com/rusticata/asn1-rs.git ">asn1-rs-derive 0.6.0</a></li>
@@ -9087,11 +9300,11 @@ limitations under the License.
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.21.7</a></li>
                     <li><a href=" https://github.com/marshallpierce/rust-base64 ">base64 0.22.1</a></li>
                     <li><a href=" https://github.com/bitflags/bitflags ">bitflags 1.3.2</a></li>
-                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.10.0</a></li>
+                    <li><a href=" https://github.com/bitflags/bitflags ">bitflags 2.11.0</a></li>
                     <li><a href=" https://github.com/zkcrypto/bls12_381 ">bls12_381 0.8.0</a></li>
                     <li><a href=" https://github.com/mycorrhiza/bs58-rs ">bs58 0.4.0</a></li>
                     <li><a href=" https://github.com/Nullus157/bs58-rs ">bs58 0.5.1</a></li>
-                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.19.1</a></li>
+                    <li><a href=" https://github.com/fitzgen/bumpalo ">bumpalo 3.20.2</a></li>
                     <li><a href=" https://github.com/alexcrichton/bzip2-rs ">bzip2-sys 0.1.13+1.0.8</a></li>
                     <li><a href=" https://github.com/alexcrichton/cfg-if ">cfg-if 0.1.10</a></li>
                     <li><a href=" https://github.com/rust-lang/cfg-if ">cfg-if 1.0.4</a></li>
@@ -9117,10 +9330,12 @@ limitations under the License.
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
                     <li><a href=" https://github.com/lambda-fairy/rust-errno ">errno 0.3.14</a></li>
                     <li><a href=" https://github.com/smol-rs/fastrand ">fastrand 2.3.0</a></li>
+                    <li><a href=" https://github.com/alexcrichton/filetime ">filetime 0.2.27</a></li>
                     <li><a href=" https://github.com/gimli-rs/findshlibs ">findshlibs 0.10.2</a></li>
                     <li><a href=" https://github.com/rust-lang/flate2-rs ">flate2 1.1.9</a></li>
                     <li><a href=" https://github.com/servo/rust-fnv ">fnv 1.0.7</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">form_urlencoded 1.2.2</a></li>
+                    <li><a href=" https://github.com/al8n/fs4-rs ">fs4 0.13.1</a></li>
                     <li><a href=" https://github.com/smol-rs/futures-lite ">futures-lite 2.6.1</a></li>
                     <li><a href=" https://github.com/gimli-rs/gimli ">gimli 0.32.3</a></li>
                     <li><a href=" https://github.com/zkcrypto/group ">group 0.13.0</a></li>
@@ -9142,17 +9357,17 @@ limitations under the License.
                     <li><a href=" https://github.com/hsivonen/idna_adapter ">idna_adapter 1.2.1</a></li>
                     <li><a href=" https://github.com/bluss/indexmap ">indexmap 1.9.3</a></li>
                     <li><a href=" https://github.com/indexmap-rs/indexmap ">indexmap 2.13.0</a></li>
-                    <li><a href=" https://github.com/mitsuhiko/insta ">insta 1.46.3</a></li>
-                    <li><a href=" https://github.com/liranringel/ipconfig ">ipconfig 0.3.2</a></li>
+                    <li><a href=" https://github.com/mitsuhiko/insta ">insta 1.47.2</a></li>
+                    <li><a href=" https://github.com/liranringel/ipconfig ">ipconfig 0.3.4</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.10.5</a></li>
                     <li><a href=" https://github.com/rust-itertools/itertools ">itertools 0.14.0</a></li>
                     <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.21.1</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/js-sys ">js-sys 0.3.94</a></li>
                     <li><a href=" https://github.com/zkcrypto/jubjub ">jubjub 0.10.0</a></li>
                     <li><a href=" https://github.com/rust-lang-nursery/lazy-static.rs ">lazy_static 1.5.0</a></li>
                     <li><a href=" https://github.com/gimli-rs/leb128 ">leb128 0.2.5</a></li>
                     <li><a href=" https://github.com/bluk/leb128fmt ">leb128fmt 0.1.0</a></li>
-                    <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.23</a></li>
+                    <li><a href=" https://github.com/rust-lang/libz-sys ">libz-sys 1.1.25</a></li>
                     <li><a href=" https://github.com/sunfishcode/linux-raw-sys ">linux-raw-sys 0.12.1</a></li>
                     <li><a href=" https://github.com/Amanieu/parking_lot ">lock_api 0.4.14</a></li>
                     <li><a href=" https://github.com/rust-lang/log ">log 0.4.29</a></li>
@@ -9167,8 +9382,7 @@ limitations under the License.
                     <li><a href=" https://github.com/gimli-rs/object ">object 0.37.3</a></li>
                     <li><a href=" https://github.com/rusticata/oid-registry.git ">oid-registry 0.7.1</a></li>
                     <li><a href=" https://github.com/rusticata/oid-registry.git ">oid-registry 0.8.1</a></li>
-                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.3</a></li>
-                    <li><a href=" https://github.com/alexcrichton/openssl-probe ">openssl-probe 0.1.6</a></li>
+                    <li><a href=" https://github.com/matklad/once_cell ">once_cell 1.21.4</a></li>
                     <li><a href=" https://github.com/rustls/openssl-probe ">openssl-probe 0.2.1</a></li>
                     <li><a href=" https://github.com/zkcrypto/pairing ">pairing 0.23.0</a></li>
                     <li><a href=" https://github.com/smol-rs/parking ">parking 2.2.1</a></li>
@@ -9181,6 +9395,7 @@ limitations under the License.
                     <li><a href=" https://github.com/pest-parser/pest ">pest_derive 2.8.6</a></li>
                     <li><a href=" https://github.com/pest-parser/pest ">pest_generator 2.8.6</a></li>
                     <li><a href=" https://github.com/pest-parser/pest ">pest_meta 2.8.6</a></li>
+                    <li><a href=" https://github.com/randomites/plain ">plain 0.2.3</a></li>
                     <li><a href=" https://github.com/jamesmunns/postcard ">postcard 1.1.3</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive 0.13.5</a></li>
                     <li><a href=" https://github.com/tokio-rs/prost ">prost-derive 0.14.3</a></li>
@@ -9191,7 +9406,7 @@ limitations under the License.
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon-core 1.13.0</a></li>
                     <li><a href=" https://github.com/rayon-rs/rayon ">rayon 1.11.0</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex-automata 0.4.14</a></li>
-                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.9</a></li>
+                    <li><a href=" https://github.com/rust-lang/regex ">regex-syntax 0.8.10</a></li>
                     <li><a href=" https://github.com/rust-lang/regex ">regex 1.12.3</a></li>
                     <li><a href=" https://github.com/briansmith/ring ">ring 0.17.14</a></li>
                     <li><a href=" https://github.com/rust-lang/rustc-demangle ">rustc-demangle 0.1.27</a></li>
@@ -9203,40 +9418,41 @@ limitations under the License.
                     <li><a href=" https://github.com/rustls/pemfile ">rustls-pemfile 2.2.0</a></li>
                     <li><a href=" https://github.com/rustls/rustls ">rustls 0.23.37</a></li>
                     <li><a href=" https://github.com/bluss/scopeguard ">scopeguard 1.2.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.15.0</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 2.11.1</a></li>
-                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.5.1</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
                     <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.17.0</a></li>
                     <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.17.0</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
                     <li><a href=" https://github.com/mitsuhiko/similar ">similar 2.7.0</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
                     <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.2</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
                     <li><a href=" https://github.com/Stebalien/str_stack ">str_stack 0.1.0</a></li>
                     <li><a href=" https://github.com/webrtc-rs/webrtc/tree/master/stun ">stun 0.7.0</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.6.0</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.7.0</a></li>
-                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.26.0</a></li>
+                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.45</a></li>
+                    <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.27.0</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.9</a></li>
                     <li><a href=" https://github.com/rust-threadpool/rust-threadpool ">threadpool 1.8.1</a></li>
                     <li><a href=" https://github.com/tikv/jemallocator ">tikv-jemalloc-sys 0.5.4+5.3.0-patched</a></li>
                     <li><a href=" https://github.com/BurntSushi/ucd-generate ">ucd-trie 0.1.7</a></li>
                     <li><a href=" https://github.com/seanmonstar/unicase ">unicase 2.9.0</a></li>
+                    <li><a href=" https://github.com/unicode-rs/unicode-normalization ">unicode-normalization 0.1.25</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-segmentation ">unicode-segmentation 1.12.0</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-width ">unicode-width 0.2.2</a></li>
                     <li><a href=" https://github.com/unicode-rs/unicode-xid ">unicode-xid 0.2.6</a></li>
                     <li><a href=" https://github.com/servo/rust-url ">url 2.5.8</a></li>
-                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.20.0</a></li>
+                    <li><a href=" https://github.com/uuid-rs/uuid ">uuid 1.23.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi ">wasi 0.11.1+wasi-snapshot-preview1</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.58</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.108</a></li>
-                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.85</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/futures ">wasm-bindgen-futures 0.4.67</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro-support ">wasm-bindgen-macro-support 0.2.117</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/macro ">wasm-bindgen-macro 0.2.117</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/shared ">wasm-bindgen-shared 0.2.117</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen ">wasm-bindgen 0.2.117</a></li>
+                    <li><a href=" https://github.com/wasm-bindgen/wasm-bindgen/tree/master/crates/web-sys ">web-sys 0.3.94</a></li>
                     <li><a href=" https://github.com/webrtc-rs/webrtc/tree/master/util ">webrtc-util 0.10.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.46.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wit-bindgen ">wit-bindgen 0.51.0</a></li>
@@ -10086,18 +10302,22 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/RustCrypto/formats ">base64ct 1.8.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.9.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.4.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/const-oid ">const-oid 0.9.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">cpufeatures 0.2.17</a></li>
                     <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.5.5</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
+                    <li><a href=" https://github.com/RustCrypto/traits ">crypto-mac 0.9.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/block-modes ">ctr 0.9.2</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der/derive ">der_derive 0.7.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
+                    <li><a href=" https://github.com/RustCrypto/traits ">digest 0.9.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits/tree/master/elliptic-curve ">elliptic-curve 0.13.8</a></li>
                     <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.5.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.12.1</a></li>
+                    <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.9.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/k256 ">k256 0.13.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.6</a></li>
@@ -10109,6 +10329,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/RustCrypto/hashes ">ripemd 0.1.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/sec1 ">sec1 0.7.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.10.9</a></li>
+                    <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.9.9</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha3 0.10.8</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits/tree/master/signature ">signature 2.2.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/spki ">spki 0.7.3</a></li>
@@ -10730,7 +10951,7 @@ APPENDIX: How to apply the Apache License to your work.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.2.17</a></li>
                     <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.3.4</a></li>
-                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.1</a></li>
+                    <li><a href=" https://github.com/rust-random/getrandom ">getrandom 0.4.2</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.3.1</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_xorshift 0.3.0</a></li>
                 </ul>
@@ -10942,7 +11163,7 @@ limitations under the License.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/oyvindln/adler2 ">adler2 2.0.1</a></li>
-                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.4.0</a></li>
+                    <li><a href=" https://github.com/bkchr/proc-macro-crate ">proc-macro-crate 3.5.0</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -11847,27 +12068,27 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">nearcore 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chunks 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-client 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-epoch-manager 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-indexer 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-client-internal 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-mainnet-res 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-network 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-rosetta-rpc 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-telemetry 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-engine 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-types 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-vm 0.0.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-wallet-contract 0.0.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">nearcore 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chunks 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-client 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-epoch-manager 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-indexer 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-client-internal 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-mainnet-res 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-network 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-rosetta-rpc 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-telemetry 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-engine 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-types 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-vm 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-wallet-contract 2.11.0</a></li>
                     <li><a href=" https://github.com/ZcashFoundation/reddsa ">reddsa 0.5.1</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-consensus-any 1.0.42</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-consensus 1.0.42</a></li>
-                    <li><a href=" https://github.com/alloy-rs/core ">alloy-core 1.5.6</a></li>
+                    <li><a href=" https://github.com/alloy-rs/core ">alloy-core 1.5.7</a></li>
                     <li><a href=" https://github.com/alloy-rs/eips ">alloy-eip2124 0.2.0</a></li>
                     <li><a href=" https://github.com/alloy-rs/eips ">alloy-eip2930 0.2.1</a></li>
                     <li><a href=" https://github.com/alloy-rs/eips ">alloy-eip7702 0.6.1</a></li>
@@ -11875,7 +12096,7 @@ limitations under the License.
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-json-rpc 1.0.42</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-network-primitives 1.0.42</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-network 1.0.42</a></li>
-                    <li><a href=" https://github.com/alloy-rs/core ">alloy-primitives 1.5.6</a></li>
+                    <li><a href=" https://github.com/alloy-rs/core ">alloy-primitives 1.5.7</a></li>
                     <li><a href=" https://github.com/alloy-rs/rlp ">alloy-rlp-derive 0.3.13</a></li>
                     <li><a href=" https://github.com/alloy-rs/rlp ">alloy-rlp 0.3.13</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-rpc-types-any 1.0.42</a></li>
@@ -11883,32 +12104,35 @@ limitations under the License.
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-serde 1.0.42</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-signer-local 1.0.42</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-signer 1.0.42</a></li>
-                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-macro-expander 1.5.6</a></li>
-                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-macro-input 1.5.6</a></li>
-                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-macro 1.5.6</a></li>
-                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-types 1.5.6</a></li>
-                    <li><a href=" https://github.com/alloy-rs/trie ">alloy-trie 0.9.4</a></li>
+                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-macro-expander 1.5.7</a></li>
+                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-macro-input 1.5.7</a></li>
+                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-macro 1.5.7</a></li>
+                    <li><a href=" https://github.com/alloy-rs/core ">alloy-sol-types 1.5.7</a></li>
+                    <li><a href=" https://github.com/alloy-rs/trie ">alloy-trie 0.9.5</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-tx-macros 1.0.42</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy 1.0.42</a></li>
                     <li><a href=" https://github.com/nical/android_system_properties ">android_system_properties 0.1.5</a></li>
                     <li><a href=" https://github.com/dtolnay/anyhow ">anyhow 1.0.102</a></li>
                     <li><a href=" https://github.com/rusticata/asn1-rs.git ">asn1-rs-impl 0.2.0</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.39</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">async-compression 0.4.41</a></li>
                     <li><a href=" https://github.com/dtolnay/async-trait ">async-trait 0.1.89</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
                     <li><a href=" https://github.com/supranational/blst ">blst 0.3.16</a></li>
                     <li><a href=" https://github.com/filecoin-project/blstrs ">blstrs 0.7.1</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon-macros 3.8.2</a></li>
-                    <li><a href=" https://github.com/elastio/bon ">bon 3.8.2</a></li>
+                    <li><a href=" https://github.com/elastio/bon ">bon-macros 3.9.1</a></li>
+                    <li><a href=" https://github.com/elastio/bon ">bon 3.9.1</a></li>
                     <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
-                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.36</a></li>
+                    <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.37</a></li>
                     <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
-                    <li><a href=" https://github.com/danipopes/const-hex ">const-hex 1.17.0</a></li>
+                    <li><a href=" https://github.com/danipopes/const-hex ">const-hex 1.18.1</a></li>
                     <li><a href=" https://github.com/cesarb/constant_time_eq ">constant_time_eq 0.4.2</a></li>
                     <li><a href=" https://crates.io/crates/cranelift-assembler-x64 ">cranelift-assembler-x64 0.123.6</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-bitset 0.123.6</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.3.7</a></li>
+                    <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
                     <li><a href=" https://github.com/soc/dirs-rs ">dirs 4.0.0</a></li>
-                    <li><a href=" https://github.com/dtolnay/dissimilar ">dissimilar 1.0.10</a></li>
+                    <li><a href=" https://github.com/soc/dirs-rs ">dirs 6.0.0</a></li>
+                    <li><a href=" https://github.com/dtolnay/dissimilar ">dissimilar 1.0.11</a></li>
                     <li><a href=" https://github.com/slint-ui/document-features ">document-features 0.2.12</a></li>
                     <li><a href=" https://gitlab.com/kornelski/dunce ">dunce 1.0.5</a></li>
                     <li><a href=" https://github.com/dtolnay/dyn-clone ">dyn-clone 1.0.20</a></li>
@@ -11930,25 +12154,29 @@ limitations under the License.
                     <li><a href=" https://crates.io/crates/impl-rlp ">impl-rlp 0.4.0</a></li>
                     <li><a href=" https://crates.io/crates/impl-serde ">impl-serde 0.5.0</a></li>
                     <li><a href=" https://github.com/bkchr/impl-trait-for-tuples ">impl-trait-for-tuples 0.2.3</a></li>
-                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.17</a></li>
-                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.183</a></li>
+                    <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.184</a></li>
                     <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                     <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.4.3</a></li>
                     <li><a href=" https://github.com/dtolnay/macro-string ">macro-string 0.1.4</a></li>
                     <li><a href=" https://github.com/stainless-steel/md5 ">md5 0.7.0</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
                     <li><a href=" https://github.com/near/near-jsonrpc-client-rs ">near-jsonrpc-client 0.15.1</a></li>
-                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk-macros 5.24.1</a></li>
-                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk 5.24.1</a></li>
-                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sys 0.2.7</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.5</a></li>
-                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.5</a></li>
+                    <li><a href=" https://github.com/r-near/near-kit-rs ">near-kit-macros 0.7.0</a></li>
+                    <li><a href=" https://github.com/r-near/near-kit-rs ">near-kit 0.7.0</a></li>
+                    <li><a href=" https://github.com/near/near-sandbox-rs ">near-sandbox 0.3.8</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk-macros 5.25.0</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk 5.25.0</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sys 0.2.8</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.6</a></li>
+                    <li><a href=" https://github.com/illicitonion/num_enum ">num_enum_derive 0.7.6</a></li>
                     <li><a href=" https://github.com/alloy-rs/nybbles ">nybbles 0.4.7</a></li>
                     <li><a href=" https://github.com/paritytech/parity-scale-codec ">parity-scale-codec-derive 3.7.5</a></li>
                     <li><a href=" https://github.com/dtolnay/paste ">paste 1.0.15</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.10</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.16</a></li>
-                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.10</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project-internal 1.1.11</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project-lite ">pin-project-lite 0.2.17</a></li>
+                    <li><a href=" https://github.com/taiki-e/pin-project ">pin-project 1.1.11</a></li>
                     <li><a href=" https://github.com/taiki-e/portable-atomic ">portable-atomic 1.13.1</a></li>
                     <li><a href=" https://crates.io/crates/prefix-sum-vec ">prefix-sum-vec 0.1.2</a></li>
                     <li><a href=" https://github.com/dtolnay/prettyplease ">prettyplease 0.2.37</a></li>
@@ -11957,15 +12185,16 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime/tree/main/pulley ">pulley-interpreter 36.0.6</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime/tree/main/pulley/macros ">pulley-macros 36.0.6</a></li>
-                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.44</a></li>
+                    <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
+                    <li><a href=" https://github.com/r-efi/r-efi ">r-efi 6.0.0</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand 0.8.5</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand 0.9.2</a></li>
                     <li><a href=" https://github.com/rust-random/rand ">rand_chacha 0.9.0</a></li>
                     <li><a href=" https://github.com/rust-random/rngs ">rand_hc 0.3.2</a></li>
                     <li><a href=" https://github.com/rustls/rcgen ">rcgen 0.13.2</a></li>
                     <li><a href=" https://github.com/paritytech/parity-common ">rlp 0.6.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.1</a></li>
+                    <li><a href=" https://github.com/rust-lang/rustc-hash ">rustc-hash 2.1.2</a></li>
                     <li><a href=" https://github.com/rustls/rustls-platform-verifier ">rustls-platform-verifier-android 0.1.1</a></li>
                     <li><a href=" https://github.com/dtolnay/rustversion ">rustversion 1.0.22</a></li>
                     <li><a href=" https://github.com/dtolnay/ryu ">ryu 1.0.23</a></li>
@@ -11985,7 +12214,7 @@ limitations under the License.
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
                     <li><a href=" https://github.com/dtolnay/serde-yaml ">serde_yaml 0.9.34+deprecated</a></li>
                     <li><a href=" https://github.com/rusticstuff/simdutf8 ">simdutf8 0.1.5</a></li>
-                    <li><a href=" https://github.com/alloy-rs/core ">syn-solidity 1.5.6</a></li>
+                    <li><a href=" https://github.com/alloy-rs/core ">syn-solidity 1.5.7</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 2.0.117</a></li>
                     <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 0.1.2</a></li>
                     <li><a href=" https://github.com/Actyx/sync_wrapper ">sync_wrapper 1.0.2</a></li>
@@ -11996,17 +12225,20 @@ limitations under the License.
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror-impl 2.0.18</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 1.0.69</a></li>
                     <li><a href=" https://github.com/dtolnay/thiserror ">thiserror 2.0.18</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time-core 0.1.7</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.25</a></li>
-                    <li><a href=" https://github.com/time-rs/time ">time 0.3.45</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time-core 0.1.4</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time-macros 0.2.22</a></li>
+                    <li><a href=" https://github.com/time-rs/time ">time 0.3.41</a></li>
                     <li><a href=" https://github.com/paritytech/parity-common ">uint 0.10.0</a></li>
                     <li><a href=" https://github.com/paritytech/parity-common ">uint 0.9.5</a></li>
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.23</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
+                    <li><a href=" https://github.com/algesten/ureq-proto ">ureq-proto 0.6.0</a></li>
+                    <li><a href=" https://github.com/algesten/utf8-zero ">utf8-zero 0.8.1</a></li>
                     <li><a href=" https://github.com/alacritty/vte ">utf8parse 0.2.2</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip2 1.0.1+wasi-0.2.4</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasi-rs ">wasip3 0.4.0+wasi-0.3.0-rc-2026-01-06</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasm-encoder ">wasm-encoder 0.236.1</a></li>
                     <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.4.2</a></li>
+                    <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.5.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.228.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.236.1</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter ">wasmprinter 0.236.1</a></li>
@@ -12313,7 +12545,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.43</a></li>
+                    <li><a href=" https://github.com/chronotope/chrono ">chrono 0.4.44</a></li>
                 </ul>
                 <pre class="license-text">Rust-chrono is dual-licensed under The MIT License [1] and
 Apache 2.0 License [2]. Copyright (c) 2014--2026, Kang Seonghoon and
@@ -12595,9 +12827,9 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-2-Clause">BSD 2-Clause &quot;Simplified&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/KizzyCode/asn1_der-rust ">asn1_der 0.7.6</a></li>
+                    <li><a href=" https://github.com/KizzyCode/asn1_der-rust ">asn1_der 0.7.7</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2023, Keziah Biermann
+                <pre class="license-text">Copyright (c) 2026, Keziah Biermann
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -12715,7 +12947,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto-ed25519-batch 0.0.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-crypto-ed25519-batch 2.11.0</a></li>
                     <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek ">ed25519-dalek 2.2.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017-2019 isis agora lovecruft. All rights reserved.
@@ -12787,6 +13019,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
                     <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/curve25519-dalek ">curve25519-dalek 4.1.3</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) &lt;year&gt; &lt;owner&gt;. 
@@ -12840,6 +13073,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="CC0-1.0">Creative Commons Zero v1.0 Universal</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-bitcoin/rust-bitcoin ">bitcoin_hashes 0.14.1</a></li>
                     <li><a href=" https://github.com/thomcc/rust-more-asserts ">more-asserts 0.2.2</a></li>
                     <li><a href=" https://crates.io/crates/tiny-keccak ">tiny-keccak 2.0.2</a></li>
                 </ul>
@@ -12970,6 +13204,8 @@ express Statement of Purpose.
                 <h3 id="CC0-1.0">Creative Commons Zero v1.0 Universal</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/rust-bitcoin/rust-bip39/ ">bip39 2.2.2</a></li>
+                    <li><a href=" https://github.com/rust-bitcoin/hex-conservative ">hex-conservative 0.2.2</a></li>
                     <li><a href=" https://github.com/rust-bitcoin/rust-secp256k1/ ">secp256k1-sys 0.8.2</a></li>
                     <li><a href=" https://github.com/rust-bitcoin/rust-secp256k1/ ">secp256k1 0.27.0</a></li>
                 </ul>
@@ -13628,7 +13864,7 @@ CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/kvinwang/dcap-qvl-webpki ">dcap-qvl-webpki 0.103.4+dcap.1</a></li>
-                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.9</a></li>
+                    <li><a href=" https://github.com/rustls/webpki ">rustls-webpki 0.103.10</a></li>
                 </ul>
                 <pre class="license-text">Except as otherwise noted, this project is licensed under the following
 (ISC-style) terms:
@@ -13649,6 +13885,23 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
 The files under third-party/chromium are licensed as described in
 third-party/chromium/LICENSE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="ISC">ISC License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-rs 1.16.2</a></li>
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                </ul>
+                <pre class="license-text">ISC License:
+
+Copyright (c) 2004-2010 by Internet Systems Consortium, Inc. (&quot;ISC&quot;)
+Copyright (c) 1995-2003 by Internet Software Consortium
+
+Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot; AND ISC DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL ISC BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -13754,7 +14007,7 @@ pub use logger::*;
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl-sys 0.9.111</a></li>
+                    <li><a href=" https://github.com/rust-openssl/rust-openssl ">openssl-sys 0.9.112</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Alex Crichton
 
@@ -13787,7 +14040,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.1.1</a></li>
+                    <li><a href=" https://github.com/tokio-rs/mio ">mio 1.2.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014 Carl Lerche and other MIO contributors
 
@@ -13869,9 +14122,9 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.8.1</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.9.0</a></li>
                 </ul>
-                <pre class="license-text">Copyright (c) 2014-2025 Sean McArthur
+                <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the &quot;Software&quot;), to deal
@@ -13956,7 +14209,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.28</a></li>
+                    <li><a href=" https://github.com/steffengy/schannel-rs ">schannel 0.1.29</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2015 steffengy
 
@@ -14341,7 +14594,7 @@ OR OTHER DEALINGS IN THE SOFTWARE.
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-log 0.2.0</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing-opentelemetry ">tracing-opentelemetry 0.31.0</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing-serde 0.2.0</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.22</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tracing ">tracing-subscriber 0.3.23</a></li>
                     <li><a href=" https://github.com/tokio-rs/tracing ">tracing 0.1.44</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2019 Tokio Contributors
@@ -14658,7 +14911,7 @@ THE SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/tonic ">tonic 0.13.1</a></li>
-                    <li><a href=" https://github.com/hyperium/tonic ">tonic 0.14.3</a></li>
+                    <li><a href=" https://github.com/hyperium/tonic ">tonic 0.14.5</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2025 Lucio Franco
 
@@ -15185,7 +15438,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.52</a></li>
+                    <li><a href=" https://github.com/kornelski/rust-rgb ">rgb 0.8.53</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15275,7 +15528,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio-macros 2.6.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15334,7 +15587,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler-singlepass 0.0.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler-singlepass 2.11.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15601,7 +15854,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.12</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/libredox.git ">libredox 0.1.15</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15746,32 +15999,39 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/attestation ">attestation 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/attestation-cli ">attestation-cli 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/backup-cli ">backup-cli 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/chain-gateway ">chain-gateway 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/ckd-example-cli ">ckd-example-cli 3.7.0</a></li>
-                    <li><a href=" https://github.com/near/mpc ">mpc-contract 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/contract-history ">contract-history 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-devnet ">mpc-devnet 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/foreign-chain-inspector ">foreign-chain-inspector 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/foreign-chain-rpc-interfaces ">foreign-chain-rpc-interfaces 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/include-measurements ">include-measurements 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-attestation ">mpc-attestation 3.7.0</a></li>
+                    <li><a href=" https://crates.io/crates/attestation ">attestation 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/attestation-cli ">attestation-cli 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/backup-cli ">backup-cli 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/chain-gateway ">chain-gateway 3.8.0</a></li>
+                    <li><a href=" https://github.com/near/mpc ">chain-gateway-test-contract 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/ckd-example-cli ">ckd-example-cli 3.8.0</a></li>
+                    <li><a href=" https://github.com/near/mpc ">mpc-contract 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/contract-history ">contract-history 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-devnet ">mpc-devnet 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/e2e-tests ">e2e-tests 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/foreign-chain-inspector ">foreign-chain-inspector 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/foreign-chain-rpc-interfaces ">foreign-chain-rpc-interfaces 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/include-measurements ">include-measurements 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/launcher-interface ">launcher-interface 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-attestation ">mpc-attestation 3.8.0</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-bounded-collections 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-contract-interface 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-crypto-types 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-sdk 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-signature-verifier 0.0.1</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-node ">mpc-node 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/node-types ">node-types 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-primitives ">mpc-primitives 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/tee-authority ">tee-authority 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-migration-contract ">test-migration-contract 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-parallel-contract ">test-parallel-contract 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-utils ">test-utils 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-tls ">mpc-tls 3.7.0</a></li>
-                    <li><a href=" https://crates.io/crates/utilities ">utilities 3.7.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-node ">mpc-node 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-node-config ">mpc-node-config 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/node-types ">node-types 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-primitives ">mpc-primitives 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-authority ">tee-authority 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-context ">tee-context 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-launcher ">tee-launcher 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-migration-contract ">test-migration-contract 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-parallel-contract ">test-parallel-contract 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-port-allocator ">test-port-allocator 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-utils ">test-utils 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-tls ">mpc-tls 3.8.0</a></li>
+                    <li><a href=" https://crates.io/crates/utilities ">utilities 3.8.0</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">aws-creds 0.30.0</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">aws-region 0.25.5</a></li>
                     <li><a href=" https://github.com/oconnor663/blake2_simd ">blake2b_simd 1.0.4</a></li>
@@ -15784,9 +16044,10 @@ SOFTWARE.
                     <li><a href=" https://github.com/recmo/uint ">ruint-macro 1.2.1</a></li>
                     <li><a href=" https://github.com/recmo/uint ">ruint 1.17.2</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">rust-s3 0.32.3</a></li>
-                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-common 12.17.2</a></li>
-                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-demangle 12.17.2</a></li>
-                    <li><a href=" https://github.com/hyperium/tonic ">tonic-prost 0.14.3</a></li>
+                    <li><a href=" https://github.com/dj8yfo/slipped10 ">slipped10 0.4.6</a></li>
+                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-common 12.17.3</a></li>
+                    <li><a href=" https://github.com/getsentry/symbolic ">symbolic-demangle 12.17.3</a></li>
+                    <li><a href=" https://github.com/hyperium/tonic ">tonic-prost 0.14.5</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15814,7 +16075,7 @@ USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-stream 0.1.18</a></li>
                     <li><a href=" https://github.com/tokio-rs/tokio ">tokio-util 0.7.18</a></li>
-                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.49.0</a></li>
+                    <li><a href=" https://github.com/tokio-rs/tokio ">tokio 1.50.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15843,7 +16104,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.8</a></li>
+                    <li><a href=" https://github.com/mcountryman/simd-adler32 ">simd-adler32 0.3.9</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -15964,7 +16225,7 @@ DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 0.7.14</a></li>
+                    <li><a href=" https://github.com/winnow-rs/winnow ">winnow 1.0.1</a></li>
                 </ul>
                 <pre class="license-text">Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -16307,6 +16568,36 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/aws/aws-lc-rs ">aws-lc-sys 0.39.1</a></li>
+                </ul>
+                <pre class="license-text">The MIT License (MIT)
+
+Copyright (c) 2015-2020 the fiat-crypto authors (see
+https://github.com/mit-plv/fiat-crypto/blob/master/AUTHORS).
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the &quot;Software&quot;), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MIT">MIT License</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 1.0.0</a></li>
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 2.1.1</a></li>
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more 0.99.20</a></li>
@@ -16399,8 +16690,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/console-rs/console ">console 0.15.11</a></li>
-                    <li><a href=" https://github.com/console-rs/console ">console 0.16.2</a></li>
+                    <li><a href=" https://github.com/console-rs/console ">console 0.16.3</a></li>
                     <li><a href=" https://github.com/console-rs/indicatif ">indicatif 0.18.4</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
@@ -16432,6 +16722,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://gitlab.redox-os.org/redox-os/users ">redox_users 0.4.6</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/users ">redox_users 0.5.2</a></li>
                 </ul>
                 <pre class="license-text">The MIT License (MIT)
 
@@ -17847,6 +18138,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/CensoredUsername/dynasm-rs ">dynasm 2.0.0</a></li>
                     <li><a href=" https://github.com/CensoredUsername/dynasm-rs ">dynasmrt 2.0.0</a></li>
+                    <li><a href=" https://github.com/soc/option-ext.git ">option-ext 0.2.0</a></li>
                     <li><a href=" https://github.com/rustwasm/wee_alloc ">wee_alloc 0.4.5</a></li>
                 </ul>
                 <pre class="license-text">Mozilla Public License Version 2.0
@@ -18228,7 +18520,7 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
                 <h3 id="Unicode-3.0">Unicode License v3</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.23</a></li>
+                    <li><a href=" https://github.com/dtolnay/unicode-ident ">unicode-ident 1.0.24</a></li>
                 </ul>
                 <pre class="license-text">UNICODE LICENSE V3
 


### PR DESCRIPTION
## Summary
- Bump workspace version from 3.7.0 to 3.8.0
- Update changelog via git-cliff
- Update contract ABI snapshot
- Regenerate third-party licenses

See [RELEASES.md](https://github.com/near/mpc/blob/main/RELEASES.md) for reference.

## Test plan
- [x] CI passes
- [x] Review changelog entries
- [x] Verify version bump in `Cargo.toml`