### PR TITLE
chore: bump to nearcore 2.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1318,7 +1318,7 @@ dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "regex",
@@ -1799,7 +1799,7 @@ dependencies = [
  "near-account-id 2.6.0",
  "near-async",
  "near-client",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-indexer",
  "near-indexer-primitives",
  "near-o11y",
@@ -5742,15 +5742,15 @@ dependencies = [
  "near-account-id 2.6.0",
  "near-async",
  "near-client",
- "near-config-utils 2.11.0-rc.3",
- "near-crypto 2.11.0-rc.3",
+ "near-config-utils 2.11.0",
+ "near-crypto 2.11.0",
  "near-indexer",
  "near-indexer-primitives",
  "near-mpc-bounded-collections",
  "near-mpc-contract-interface",
  "near-o11y",
  "near-sdk",
- "near-time 2.11.0-rc.3",
+ "near-time 2.11.0",
  "node-types",
  "num_enum",
  "pprof",
@@ -5958,14 +5958,14 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "crossbeam-channel",
  "futures",
  "near-async-derive",
  "near-o11y",
- "near-time 2.11.0-rc.3",
+ "near-time 2.11.0",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
@@ -5977,8 +5977,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5987,8 +5987,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "lru 0.16.3",
  "parking_lot 0.12.5",
@@ -5996,8 +5996,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6010,19 +6010,19 @@ dependencies = [
  "lru 0.16.3",
  "near-async",
  "near-cache",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
+ "near-parameters 2.11.0",
  "near-pool",
- "near-primitives 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
+ "near-primitives 2.11.0",
+ "near-schema-checker-lib 2.11.0",
  "near-store",
- "near-vm-runner 2.11.0-rc.3",
+ "near-vm-runner 2.11.0",
  "node-runtime",
  "num-rational",
  "parking_lot 0.12.5",
@@ -6091,19 +6091,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.1.1",
- "near-config-utils 2.11.0-rc.3",
- "near-crypto 2.11.0-rc.3",
+ "near-config-utils 2.11.0",
+ "near-crypto 2.11.0",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
- "near-time 2.11.0-rc.3",
+ "near-parameters 2.11.0",
+ "near-primitives 2.11.0",
+ "near-time 2.11.0",
  "num-rational",
  "parking_lot 0.12.5",
  "serde",
@@ -6116,33 +6116,33 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
- "near-crypto 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
- "near-time 2.11.0-rc.3",
+ "near-crypto 2.11.0",
+ "near-primitives 2.11.0",
+ "near-time 2.11.0",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.3",
  "near-async",
  "near-chain",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-chunks-primitives",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-epoch-manager",
  "near-network",
  "near-o11y",
  "near-pool",
- "near-primitives 2.11.0-rc.3",
+ "near-primitives 2.11.0",
  "near-store",
  "parking_lot 0.12.5",
  "rand 0.8.5",
@@ -6154,17 +6154,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.11.0-rc.3",
+ "near-primitives 2.11.0",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6175,22 +6175,22 @@ dependencies = [
  "near-async",
  "near-cache",
  "near-chain",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
+ "near-parameters 2.11.0",
  "near-pool",
- "near-primitives 2.11.0-rc.3",
+ "near-primitives 2.11.0",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.11.0-rc.3",
+ "near-vm-runner 2.11.0",
  "node-runtime",
  "num-rational",
  "parking_lot 0.12.5",
@@ -6215,14 +6215,14 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
- "near-time 2.11.0-rc.3",
+ "near-crypto 2.11.0",
+ "near-primitives 2.11.0",
+ "near-time 2.11.0",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.18",
@@ -6255,8 +6255,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -6318,8 +6318,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "blake2",
  "borsh",
@@ -6329,9 +6329,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id 2.6.0",
- "near-config-utils 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
- "near-stdx 2.11.0-rc.3",
+ "near-config-utils 2.11.0",
+ "near-schema-checker-lib 2.11.0",
+ "near-stdx 2.11.0",
  "primitive-types 0.10.1",
  "rand 0.8.5",
  "secp256k1 0.27.0",
@@ -6343,8 +6343,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto-ed25519-batch"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "curve25519-dalek",
  "ed25519-dalek",
@@ -6355,14 +6355,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-o11y",
- "near-primitives 2.11.0-rc.3",
- "near-time 2.11.0-rc.3",
+ "near-primitives 2.11.0",
+ "near-time 2.11.0",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -6370,18 +6370,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
  "near-cache",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-chain-primitives",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-o11y",
- "near-primitives 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
+ "near-primitives 2.11.0",
+ "near-schema-checker-lib 2.11.0",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational",
@@ -6396,12 +6396,12 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "futures",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "object_store",
  "percent-encoding",
  "reqwest 0.12.28",
@@ -6431,10 +6431,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
- "near-primitives-core 2.11.0-rc.3",
+ "near-primitives-core 2.11.0",
 ]
 
 [[package]]
@@ -6450,22 +6450,22 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "futures",
  "near-async",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.11.0-rc.3",
+ "near-config-utils 2.11.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-indexer-primitives",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
+ "near-parameters 2.11.0",
+ "near-primitives 2.11.0",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -6477,30 +6477,30 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
- "near-primitives 2.11.0-rc.3",
+ "near-primitives 2.11.0",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "axum",
  "bs58 0.4.0",
  "easy-ext",
  "near-async",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-client",
  "near-client-primitives",
  "near-jsonrpc-client-internal",
- "near-jsonrpc-primitives 2.11.0-rc.3",
+ "near-jsonrpc-primitives 2.11.0",
  "near-network",
  "near-o11y",
- "near-primitives 2.11.0-rc.3",
+ "near-primitives 2.11.0",
  "serde",
  "serde_json",
  "tokio",
@@ -6548,12 +6548,12 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "futures",
- "near-jsonrpc-primitives 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
+ "near-jsonrpc-primitives 2.11.0",
+ "near-primitives 2.11.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -6597,16 +6597,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "arbitrary",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-client-primitives",
- "near-crypto 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
- "near-time 2.11.0-rc.3",
+ "near-crypto 2.11.0",
+ "near-primitives 2.11.0",
+ "near-schema-checker-lib 2.11.0",
+ "near-time 2.11.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6658,12 +6658,12 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "near-account-id 2.6.0",
- "near-chain-configs 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
+ "near-primitives 2.11.0",
  "serde_json",
 ]
 
@@ -6751,8 +6751,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6767,12 +6767,12 @@ dependencies = [
  "lru 0.16.3",
  "named-lock",
  "near-async",
- "near-chain-configs 2.11.0-rc.3",
- "near-crypto 2.11.0-rc.3",
- "near-fmt 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
+ "near-crypto 2.11.0",
+ "near-fmt 2.11.0",
  "near-o11y",
- "near-primitives 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
+ "near-primitives 2.11.0",
+ "near-schema-checker-lib 2.11.0",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.5",
@@ -6793,13 +6793,13 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 2.11.0-rc.3",
- "near-primitives-core 2.11.0-rc.3",
+ "near-crypto 2.11.0",
+ "near-primitives-core 2.11.0",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -6855,14 +6855,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id 2.6.0",
- "near-primitives-core 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
+ "near-primitives-core 2.11.0",
+ "near-schema-checker-lib 2.11.0",
  "num-rational",
  "serde",
  "serde_repr",
@@ -6873,13 +6873,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "borsh",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-o11y",
- "near-primitives 2.11.0-rc.3",
+ "near-primitives 2.11.0",
  "rand 0.8.5",
 ]
 
@@ -6969,8 +6969,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -6985,13 +6985,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto 2.11.0-rc.3",
- "near-fmt 2.11.0-rc.3",
- "near-parameters 2.11.0-rc.3",
- "near-primitives-core 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
- "near-stdx 2.11.0-rc.3",
- "near-time 2.11.0-rc.3",
+ "near-crypto 2.11.0",
+ "near-fmt 2.11.0",
+ "near-parameters 2.11.0",
+ "near-primitives-core 2.11.0",
+ "near-schema-checker-lib 2.11.0",
+ "near-stdx 2.11.0",
+ "near-time 2.11.0",
  "num-rational",
  "ordered-float 4.6.0",
  "primitive-types 0.10.1",
@@ -7057,8 +7057,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -7068,7 +7068,7 @@ dependencies = [
  "enum-map",
  "near-account-id 2.6.0",
  "near-gas",
- "near-schema-checker-lib 2.11.0-rc.3",
+ "near-schema-checker-lib 2.11.0",
  "near-token",
  "num-rational",
  "serde",
@@ -7080,8 +7080,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "axum",
  "derive_more 2.1.1",
@@ -7090,14 +7090,14 @@ dependencies = [
  "insta",
  "near-account-id 2.6.0",
  "near-async",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
+ "near-parameters 2.11.0",
+ "near-primitives 2.11.0",
  "node-runtime",
  "serde",
  "serde_json",
@@ -7143,8 +7143,8 @@ checksum = "041c3f48dac0f8986d2cce36ca9ee4fc34967a6a8537750c117c26f58b6bd098"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -7168,11 +7168,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
- "near-schema-checker-core 2.11.0-rc.3",
- "near-schema-checker-macro 2.11.0-rc.3",
+ "near-schema-checker-core 2.11.0",
+ "near-schema-checker-macro 2.11.0",
 ]
 
 [[package]]
@@ -7189,8 +7189,8 @@ checksum = "e2a9928bf41d38efba9e4a3afc10842fd28505b9f2e4ca36f0cf8c58246d96d2"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 
 [[package]]
 name = "near-sdk"
@@ -7251,13 +7251,13 @@ checksum = "dba5c1d9236e8e08f9a9ea6519a7b75f6bad1fe21dfb326e71a7f361170055ca"
 
 [[package]]
 name = "near-stdx"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 
 [[package]]
 name = "near-store"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -7274,19 +7274,18 @@ dependencies = [
  "itoa",
  "lru 0.16.3",
  "near-async",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-chain-primitives",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-external-storage",
- "near-fmt 2.11.0-rc.3",
+ "near-fmt 2.11.0",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
- "near-stdx 2.11.0-rc.3",
- "near-time 2.11.0-rc.3",
- "near-vm-runner 2.11.0-rc.3",
- "near-wallet-contract",
+ "near-parameters 2.11.0",
+ "near-primitives 2.11.0",
+ "near-schema-checker-lib 2.11.0",
+ "near-stdx 2.11.0",
+ "near-time 2.11.0",
+ "near-vm-runner 2.11.0",
  "num_cpus",
  "parking_lot 0.12.5",
  "rand 0.8.5",
@@ -7313,8 +7312,8 @@ checksum = "f4ea77bb86969ff09c83faa517b2209c4876928381ed31e29c06cae2de0a216b"
 
 [[package]]
 name = "near-telemetry"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "futures",
  "near-async",
@@ -7348,8 +7347,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -7370,8 +7369,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.0",
@@ -7386,8 +7385,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -7405,8 +7404,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.0",
@@ -7457,8 +7456,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "blst",
@@ -7470,12 +7469,12 @@ dependencies = [
  "finite-wasm 0.6.0",
  "lru 0.16.3",
  "memoffset 0.8.0",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
- "near-primitives-core 2.11.0-rc.3",
- "near-schema-checker-lib 2.11.0-rc.3",
- "near-stdx 2.11.0-rc.3",
+ "near-parameters 2.11.0",
+ "near-primitives-core 2.11.0",
+ "near-schema-checker-lib 2.11.0",
+ "near-stdx 2.11.0",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -7505,8 +7504,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "indexmap 2.13.0",
  "num-traits",
@@ -7516,8 +7515,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "backtrace",
  "cc",
@@ -7537,12 +7536,12 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.11.0-rc.3",
- "near-vm-runner 2.11.0-rc.3",
+ "near-primitives-core 2.11.0",
+ "near-vm-runner 2.11.0",
 ]
 
 [[package]]
@@ -7609,8 +7608,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7623,28 +7622,28 @@ dependencies = [
  "itertools 0.14.0",
  "near-async",
  "near-chain",
- "near-chain-configs 2.11.0-rc.3",
+ "near-chain-configs 2.11.0",
  "near-chain-primitives",
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.11.0-rc.3",
- "near-crypto 2.11.0-rc.3",
+ "near-config-utils 2.11.0",
+ "near-crypto 2.11.0",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-jsonrpc",
- "near-jsonrpc-primitives 2.11.0-rc.3",
+ "near-jsonrpc-primitives 2.11.0",
  "near-mainnet-res",
  "near-network",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
+ "near-parameters 2.11.0",
  "near-pool",
- "near-primitives 2.11.0-rc.3",
+ "near-primitives 2.11.0",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.11.0-rc.3",
+ "near-vm-runner 2.11.0",
  "node-runtime",
  "num-rational",
  "parking_lot 0.12.5",
@@ -7677,8 +7676,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.11.0-rc.3"
-source = "git+https://github.com/near/nearcore?tag=2.11.0-rc.3#e14d0211789f7112f4af68110979a5bec36b5933"
+version = "2.11.0"
+source = "git+https://github.com/near/nearcore?tag=2.11.0#72dbd0f789a427bed7e7552070b1828794f122b9"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
@@ -7687,14 +7686,14 @@ dependencies = [
  "dashmap",
  "ed25519-dalek",
  "itertools 0.14.0",
- "near-crypto 2.11.0-rc.3",
+ "near-crypto 2.11.0",
  "near-crypto-ed25519-batch",
  "near-o11y",
- "near-parameters 2.11.0-rc.3",
- "near-primitives 2.11.0-rc.3",
- "near-primitives-core 2.11.0-rc.3",
+ "near-parameters 2.11.0",
+ "near-primitives 2.11.0",
+ "near-primitives-core 2.11.0",
  "near-store",
- "near-vm-runner 2.11.0-rc.3",
+ "near-vm-runner 2.11.0",
  "near-wallet-contract",
  "num-integer",
  "parking_lot 0.12.5",
@@ -8742,7 +8741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8755,7 +8754,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,16 +222,16 @@ zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zstd = "0.13.3"
 
 # NEAR CORE DEPENDENCIES:
-near-async = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-store = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
-nearcore = { git = "https://github.com/near/nearcore", tag = "2.11.0-rc.3" }
+near-async = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-store = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+nearcore = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
 
 ## Outdated dependencies we cannot upgrade ##
 # Version 0.8.3 requires rustc 1.88

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -20,7 +20,7 @@ use crate::mpc_node::{MpcNode, MpcNodeSetup, MpcNodeSetupArgs, NodePorts};
 use crate::near_sandbox::NearSandbox;
 use crate::port_allocator::E2ePortAllocator;
 
-const DEFAULT_SANDBOX_VERSION: &str = "2.11.0-rc.3";
+const DEFAULT_SANDBOX_VERSION: &str = "2.11.0";
 const SANDBOX_ROOT_ACCOUNT: &str = "sandbox";
 const SANDBOX_ROOT_SECRET_KEY: &str = near_sandbox::config::DEFAULT_GENESIS_ACCOUNT_PRIVATE_KEY;
 const POLL_INTERVAL: Duration = Duration::from_millis(200);


### PR DESCRIPTION
Automated bump from 2.11.0-rc.3 to 2.11.0.