### PR TITLE
test: debug Phala attestation tcb_info_issuer_chain parsing failure

### DIFF
--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -90,13 +90,14 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     let attestation = match tee_authority.generate_attestation(report_data).await {
         Ok(att) => {
             tracing::info!("TEE attestation generated successfully");
-            att
+            Some(att)
         }
         Err(e) => {
-            tracing::error!("TEE attestation failed, falling back to Mock: {:#}", e);
-            mpc_attestation::attestation::Attestation::Mock(
-                mpc_attestation::attestation::MockAttestation::Valid,
-            )
+            tracing::error!(
+                "TEE attestation failed: {:#}. Node will continue without attestation.",
+                e
+            );
+            None
         }
     };
 
@@ -113,7 +114,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             root_task_handle.clone(),
             debug_request_sender.clone(),
             node_config.web_ui,
-            static_web_data(&secrets, Some(attestation)),
+            static_web_data(&secrets, attestation),
             protocol_state_receiver,
             migration_state_receiver,
             config.node.clone(),

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -87,7 +87,18 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     )
     .into();
 
-    let attestation = tee_authority.generate_attestation(report_data).await?;
+    let attestation = match tee_authority.generate_attestation(report_data).await {
+        Ok(att) => {
+            tracing::info!("TEE attestation generated successfully");
+            att
+        }
+        Err(e) => {
+            tracing::error!("TEE attestation failed, falling back to Mock: {:#}", e);
+            mpc_attestation::attestation::Attestation::Mock(
+                mpc_attestation::attestation::MockAttestation::Valid,
+            )
+        }
+    };
 
     // Create communication channels and runtime
     let (debug_request_sender, _) = tokio::sync::broadcast::channel(10);

--- a/crates/tee-authority/Cargo.toml
+++ b/crates/tee-authority/Cargo.toml
@@ -17,6 +17,7 @@ http = { workspace = true }
 mpc-attestation = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
 

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -131,6 +131,8 @@ impl TeeAuthority {
         let upload_tdx_quote = async || {
             let form = Form::new().text("hex", tdx_quote.to_string());
 
+            tracing::info!("Uploading TDX quote to {}", quote_upload_url);
+
             let response = reqwest_client
                 .post(quote_upload_url.clone())
                 .multipart(form)
@@ -138,6 +140,7 @@ impl TeeAuthority {
                 .await?;
 
             let status = response.status();
+            tracing::info!("Phala response status: {}", status);
 
             if status != StatusCode::OK {
                 bail!(
@@ -147,7 +150,29 @@ impl TeeAuthority {
                 );
             }
 
-            Ok(response.json::<UploadResponse>().await?)
+            // Debug: dump raw response before parsing
+            let response_text = response.text().await?;
+            tracing::info!("Phala response length: {} bytes", response_text.len());
+            // Dump first 500 and last 500 chars
+            let len = response_text.len();
+            tracing::info!("Phala response start: {}", &response_text[..len.min(500)]);
+            if len > 500 {
+                tracing::info!("Phala response end: {}", &response_text[len.saturating_sub(500)..]);
+            }
+
+            // Try to parse - if it fails, show the error with context
+            let parsed: Result<UploadResponse, _> = serde_json::from_str(&response_text);
+            match parsed {
+                Ok(p) => Ok(p),
+                Err(e) => {
+                    let col = e.column();
+                    let start = col.saturating_sub(100);
+                    let end = len.min(col + 100);
+                    tracing::error!("Failed to parse UploadResponse: {}", e);
+                    tracing::error!("Response around column {} (chars {}..{}): {}", col, start, end, &response_text[start..end]);
+                    bail!("error decoding response body\n\nCaused by:\n    {}", e)
+                }
+            }
         };
 
         let upload_response =


### PR DESCRIPTION
## DO NOT MERGE — debugging only

Temporary debug changes to investigate the `tcb_info_issuer_chain` parsing error when uploading TDX quotes to Phala's attestation service.

### Changes
- Dump raw Phala response before parsing (length, first/last 500 chars)
- Show response context around the error column on parse failure
- Fall back to Mock attestation instead of crashing (so the node stays alive for further debugging)

### Background
All MPC nodes fail Dstack attestation with:
```
Missing or invalid field: tcb_info_issuer_chain at line 1 column 5620
```

See mpc-private#261 for full investigation.

### To test
Build and push the MPC node image from this branch, deploy in a TEE CVM, check logs.