### PR TITLE
fix: Set default crypto provider to avoid rustls panic

### DIFF
--- a/crates/node/src/main.rs
+++ b/crates/node/src/main.rs
@@ -2,6 +2,14 @@ use clap::Parser;
 use mpc_node::cli;
 
 fn main() -> anyhow::Result<()> {
+    // Install the default rustls crypto provider before any TLS usage.
+    // Required because rustls is configured with default-features=false,
+    // and indirect consumers like hyper-rustls (via reqwest) call
+    // ClientConfig::builder() without an explicit provider.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .map_err(|_| anyhow::anyhow!("Failed to install default rustls CryptoProvider"))?;
+
     // Handle version flags before parsing CLI
     let args: Vec<String> = std::env::args().collect();
     if args.len() > 1 && (args[1] == "--version" || args[1] == "-V") {


### PR DESCRIPTION
closes #2717 

Based on 3.8.0 to make patch-releasing easy.