### PR TITLE
ci: fix rust-tee launcher failing with OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
 
   rust-launcher-nontee-check:
     name: "MPC Rust Launcher non-tee check"
-    runs-on: warp-ubuntu-2404-x64-4x
+    runs-on: warp-ubuntu-2404-x64-2x
     timeout-minutes: 60
     permissions:
       contents: read

--- a/deployment/cvm-deployment/user-config.toml
+++ b/deployment/cvm-deployment/user-config.toml
@@ -1,5 +1,7 @@
 # Minimal config for non-TEE CI check.
 # Only needs enough for the launcher to start and pull the MPC node image.
+# Uses mainnet chain_id with embedded genesis to avoid downloading the large
+# testnet genesis file, which requires ~20 GiB of RAM.
 
 [launcher_config]
 image_tags = ["main-9515e18"]
@@ -20,12 +22,13 @@ format = "plain"
 filter = "info"
 
 [mpc_node_config.near_init]
-chain_id = "testnet"
+chain_id = "mainnet"
 boot_nodes = "ed25519:ERguu7jQuYk8pxNsRC6FdezvNsegBPva1GRGqjmtD7i2@10.10.10.10:24567"
-download_genesis = true
+download_genesis = false
+download_config = "rpc"
 
 [mpc_node_config.secrets]
-secret_store_key_hex = "BD399143F5B3126098B0EAA023A0E730BD399143F5B3126098B0EAA023A0E730"
+secret_store_key_hex = "BD399143F5B3126098B0EAA023A0E730"
 backup_encryption_key_hex = "0000000000000000000000000000000000000000000000000000000000000000"
 
 [mpc_node_config.node]
@@ -40,7 +43,7 @@ cores = 4
 validate_genesis = false
 sync_mode = "Latest"
 concurrency = 1
-mpc_contract_id = "v1.signer_test"
+mpc_contract_id = "v1.signer"
 finality = "optimistic"
 
 [mpc_node_config.node.triple]

--- a/scripts/check-mpc-node-docker-starts.sh
+++ b/scripts/check-mpc-node-docker-starts.sh
@@ -83,11 +83,6 @@ echo "Container started: $CONTAINER_ID"
 
 # Check if container is actually running
 WAIT_SECS=60
-if $USE_RUST_LAUNCHER; then
-  # TODO(#2661): Rust launcher path OOMs during testnet genesis download on CI runners.
-  # Reduced to 15s so the check completes before OOM. Investigate root cause.
-  WAIT_SECS=15
-fi
 sleep $WAIT_SECS
 if [ -z "$(docker ps --filter "id=$CONTAINER_ID" --format "{{.ID}}")" ]; then
   docker logs --tail 100 "$CONTAINER_ID" 2>&1


### PR DESCRIPTION
Closes #2661 

EDIT:

The OOM was due to testnet requiring genesis download and processing, which requires ~20 GiB of RAM. Switched to mainnet to avoid the issue.