### PR TITLE
feat: add metrics for TEE attestation generation attempts

### DIFF
--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -352,3 +352,16 @@ pub static PARTICIPANT_TOTAL_TIMES_SEEN_IN_FAILED_SIGNATURE_COMPUTATION_FOLLOWER
 
 pub const MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL: &str = "total";
 pub const MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL: &str = "succeeded";
+
+pub static MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL: LazyLock<prometheus::IntCounterVec> =
+    LazyLock::new(|| {
+        prometheus::register_int_counter_vec!(
+            "mpc_tee_attestation_attempts_total",
+            "Total number of completed TEE attestation generation attempts",
+            &["outcome"],
+        )
+        .unwrap()
+    });
+
+pub const MPC_TEE_ATTESTATION_OUTCOME_SUCCESS: &str = "success";
+pub const MPC_TEE_ATTESTATION_OUTCOME_FAILURE: &str = "failure";

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -112,13 +112,18 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     )
     .into();
 
-    // TODO(#2723): add metrics for attestation generation success/failure
     let attestation = match tee_authority.generate_attestation(report_data).await {
         Ok(att) => {
+            crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_SUCCESS])
+                .inc();
             tracing::info!("TEE attestation generated successfully");
             Some(att)
         }
         Err(tee_authority::tee_authority::AttestationError::CollateralUpload(e)) => {
+            crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
+                .inc();
             tracing::error!(
                 error = ?e,
                 "TEE attestation failed. Node will continue without attestation and retry periodically",
@@ -126,6 +131,9 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             None
         }
         Err(e) => {
+            crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
+                .inc();
             return Err(anyhow::anyhow!(e).context("TEE attestation failed, cannot continue"));
         }
     };

--- a/crates/node/src/tee/remote_attestation.rs
+++ b/crates/node/src/tee/remote_attestation.rs
@@ -138,6 +138,7 @@ pub async fn validate_and_submit_remote_attestation(
     submit_remote_attestation(tx_sender, attestation, tls_public_key).await
 }
 
+#[tracing::instrument(skip_all)]
 pub async fn periodic_attestation_submission<T: TransactionSender + Clone, I: Tick>(
     tee_authority: TeeAuthority,
     tx_sender: T,
@@ -157,12 +158,23 @@ pub async fn periodic_attestation_submission<T: TransactionSender + Clone, I: Ti
             .generate_attestation(report_data.clone())
             .await
         {
-            Ok(att) => att,
+            Ok(att) => {
+                crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                    .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_SUCCESS])
+                    .inc();
+                att
+            }
             Err(tee_authority::tee_authority::AttestationError::CollateralUpload(e)) => {
+                crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                    .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
+                    .inc();
                 tracing::warn!(error = ?e, "TEE attestation failed, will retry next interval");
                 continue;
             }
             Err(e) => {
+                crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                    .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
+                    .inc();
                 return Err(anyhow::anyhow!(e).context("TEE attestation failed, cannot continue"));
             }
         };
@@ -195,6 +207,7 @@ fn is_node_in_contract_tee_accounts(
 /// This function watches TEE account changes in the contract and resubmits attestations when
 /// the node's TEE attestation is no longer available.
 #[expect(clippy::too_many_arguments)]
+#[tracing::instrument(skip_all)]
 pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
     node_account_id: AccountId,
     tee_authority: TeeAuthority,
@@ -244,8 +257,16 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
                 .generate_attestation(report_data.clone())
                 .await
             {
-                Ok(att) => att,
+                Ok(att) => {
+                    crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                        .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_SUCCESS])
+                        .inc();
+                    att
+                }
                 Err(tee_authority::tee_authority::AttestationError::CollateralUpload(e)) => {
+                    crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                        .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
+                        .inc();
                     tracing::warn!(
                         error = ?e,
                         "TEE attestation failed, periodic attestation task will retry",
@@ -254,6 +275,9 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
                     continue;
                 }
                 Err(e) => {
+                    crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
+                        .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
+                        .inc();
                     return Err(
                         anyhow::anyhow!(e).context("TEE attestation failed, cannot continue")
                     );


### PR DESCRIPTION
## Summary

- Add `mpc_tee_attestation_attempts_total` Prometheus counter with `outcome` label (`success`/`failure`), incremented in all 3 attestation paths (startup, periodic submission, attestation removal monitor)
- Add `#[tracing::instrument(skip_all)]` to `periodic_attestation_submission` and `monitor_attestation_removal` to differentiate identical log messages ([review comment](https://github.com/near/mpc/pull/2711#discussion_r3040879500))

Closes #2723

## Test plan

- [ ] CI passes
- [ ] `/metrics` endpoint shows `mpc_tee_attestation_attempts_total` counter with `outcome` label