### PR TITLE
test: implement request_during_resharing test

### DIFF
--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -15,7 +15,6 @@ pub const SIGN_REQUEST_PER_SCHEME_PORT_SEED: u16 = 1;
 pub const WEB_ENDPOINTS_PORT_SEED: u16 = 2;
 #[expect(dead_code)]
 pub const KEY_RESHARING_PORT_SEED: u16 = 3;
-#[expect(dead_code)]
 pub const REQUEST_DURING_RESHARING_PORT_SEED: u16 = 4;
 pub const SUBMIT_PARTICIPANT_INFO_PORT_SEED: u16 = 5;
 #[expect(dead_code)]

--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -1,4 +1,5 @@
 mod common;
+mod request_during_resharing;
 mod request_lifecycle;
 mod submit_participant_info;
 mod web_endpoints;

--- a/crates/e2e-tests/tests/request_during_resharing.rs
+++ b/crates/e2e-tests/tests/request_during_resharing.rs
@@ -12,7 +12,7 @@ use rand::SeedableRng;
 #[tokio::test]
 async fn test_request_during_resharing() {
     // given
-    let (mut cluster, running) =
+    let (mut cluster, contract_state) =
         common::setup_cluster(common::REQUEST_DURING_RESHARING_PORT_SEED, |c| {
             c.num_nodes = 4;
             c.initial_participant_indices = vec![0, 1];
@@ -32,15 +32,13 @@ async fn test_request_during_resharing() {
     cluster.kill_nodes(&[3]).expect("failed to kill node 3");
 
     // then
-    // start_resharing already waited for the contract to enter Resharing state.
-
-    let sign_domain = running
+    let sign_domain = contract_state
         .domains
         .domains
         .iter()
         .find(|d| d.scheme == SignatureScheme::Secp256k1 && d.purpose == Some(DomainPurpose::Sign))
         .expect("no Secp256k1 Sign domain");
-    let ckd_domain = running
+    let ckd_domain = contract_state
         .domains
         .domains
         .iter()
@@ -59,20 +57,7 @@ async fn test_request_during_resharing() {
             "sign request {i} failed: {:?}",
             outcome.failure_message()
         );
-    }
 
-    assert!(
-        matches!(
-            cluster
-                .get_contract_state()
-                .await
-                .expect("failed to get state"),
-            ProtocolContractState::Resharing(_)
-        ),
-        "expected Resharing after sign requests"
-    );
-
-    for i in 0..3 {
         tracing::info!(i, "sending CKD request during resharing");
         let outcome = cluster
             .send_ckd_request(ckd_domain.id, common::generate_ckd_app_public_key(&mut rng))

--- a/crates/e2e-tests/tests/request_during_resharing.rs
+++ b/crates/e2e-tests/tests/request_during_resharing.rs
@@ -11,6 +11,7 @@ use rand::SeedableRng;
 /// Requests should still succeed using the old threshold of 2.
 #[tokio::test]
 async fn test_request_during_resharing() {
+    // given
     let (mut cluster, running) =
         common::setup_cluster(common::REQUEST_DURING_RESHARING_PORT_SEED, |c| {
             c.num_nodes = 4;
@@ -20,18 +21,17 @@ async fn test_request_during_resharing() {
         })
         .await;
 
-    // Begin resharing to all 4 nodes with threshold 4 — don't wait for completion.
+    // when
     tracing::info!("beginning resharing to 4 nodes, threshold 4");
     cluster
         .start_resharing(&[0, 1, 2, 3], 4)
         .await
         .expect("start_resharing failed");
 
-    // Kill node 3 so resharing is stuck (needs all 4 for threshold 4).
     tracing::info!("killing node 3 to block resharing");
     cluster.kill_nodes(&[3]).expect("failed to kill node 3");
 
-    // Verify we're stuck in Resharing state.
+    // then
     let state = cluster
         .get_contract_state()
         .await
@@ -41,13 +41,18 @@ async fn test_request_during_resharing() {
         "expected Resharing state, got: {state:?}"
     );
 
-    // Send sign requests — should succeed using old threshold (2).
     let sign_domain = running
         .domains
         .domains
         .iter()
         .find(|d| d.scheme == SignatureScheme::Secp256k1 && d.purpose == Some(DomainPurpose::Sign))
         .expect("no Secp256k1 Sign domain");
+    let ckd_domain = running
+        .domains
+        .domains
+        .iter()
+        .find(|d| d.purpose == Some(DomainPurpose::CKD))
+        .expect("no CKD domain");
 
     let mut rng = rand::rngs::StdRng::seed_from_u64(0);
     for i in 0..3 {
@@ -63,23 +68,16 @@ async fn test_request_during_resharing() {
         );
     }
 
-    // Verify state is still Resharing after sign requests.
-    let state = cluster
-        .get_contract_state()
-        .await
-        .expect("failed to get state");
     assert!(
-        matches!(state, ProtocolContractState::Resharing(_)),
-        "expected Resharing after sign requests, got: {state:?}"
+        matches!(
+            cluster
+                .get_contract_state()
+                .await
+                .expect("failed to get state"),
+            ProtocolContractState::Resharing(_)
+        ),
+        "expected Resharing after sign requests"
     );
-
-    // Send CKD requests — should also succeed with old threshold.
-    let ckd_domain = running
-        .domains
-        .domains
-        .iter()
-        .find(|d| d.purpose == Some(DomainPurpose::CKD))
-        .expect("no CKD domain");
 
     for i in 0..3 {
         tracing::info!(i, "sending CKD request during resharing");
@@ -94,13 +92,14 @@ async fn test_request_during_resharing() {
         );
     }
 
-    // Verify state is still Resharing after CKD requests.
-    let state = cluster
-        .get_contract_state()
-        .await
-        .expect("failed to get state");
     assert!(
-        matches!(state, ProtocolContractState::Resharing(_)),
-        "expected Resharing after CKD requests, got: {state:?}"
+        matches!(
+            cluster
+                .get_contract_state()
+                .await
+                .expect("failed to get state"),
+            ProtocolContractState::Resharing(_)
+        ),
+        "expected Resharing after CKD requests"
     );
 }

--- a/crates/e2e-tests/tests/request_during_resharing.rs
+++ b/crates/e2e-tests/tests/request_during_resharing.rs
@@ -32,14 +32,7 @@ async fn test_request_during_resharing() {
     cluster.kill_nodes(&[3]).expect("failed to kill node 3");
 
     // then
-    let state = cluster
-        .get_contract_state()
-        .await
-        .expect("failed to get state");
-    assert!(
-        matches!(state, ProtocolContractState::Resharing(_)),
-        "expected Resharing state, got: {state:?}"
-    );
+    // start_resharing already waited for the contract to enter Resharing state.
 
     let sign_domain = running
         .domains

--- a/crates/e2e-tests/tests/request_during_resharing.rs
+++ b/crates/e2e-tests/tests/request_during_resharing.rs
@@ -1,6 +1,7 @@
-mod common;
+use crate::common;
 
 use near_mpc_contract_interface::types::{DomainPurpose, ProtocolContractState, SignatureScheme};
+use rand::SeedableRng;
 
 /// Tests that signature and CKD requests are processed using the previous
 /// running state's threshold while resharing is in progress.
@@ -13,7 +14,7 @@ async fn test_request_during_resharing() {
     let (mut cluster, running) =
         common::setup_cluster(common::REQUEST_DURING_RESHARING_PORT_SEED, |c| {
             c.num_nodes = 4;
-            c.initial_participants = 2;
+            c.initial_participant_indices = vec![0, 1];
             c.triples_to_buffer = 2;
             c.presignatures_to_buffer = 2;
         })
@@ -48,10 +49,11 @@ async fn test_request_during_resharing() {
         .find(|d| d.scheme == SignatureScheme::Secp256k1 && d.purpose == Some(DomainPurpose::Sign))
         .expect("no Secp256k1 Sign domain");
 
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
     for i in 0..3 {
         tracing::info!(i, "sending sign request during resharing");
         let outcome = cluster
-            .send_sign_request(sign_domain.id, common::generate_ecdsa_payload())
+            .send_sign_request(sign_domain.id, common::generate_ecdsa_payload(&mut rng))
             .await
             .expect("sign request failed");
         assert!(
@@ -82,7 +84,7 @@ async fn test_request_during_resharing() {
     for i in 0..3 {
         tracing::info!(i, "sending CKD request during resharing");
         let outcome = cluster
-            .send_ckd_request(ckd_domain.id, common::generate_ckd_app_public_key())
+            .send_ckd_request(ckd_domain.id, common::generate_ckd_app_public_key(&mut rng))
             .await
             .expect("ckd request failed");
         assert!(

--- a/crates/e2e-tests/tests/request_during_resharing.rs
+++ b/crates/e2e-tests/tests/request_during_resharing.rs
@@ -1,0 +1,104 @@
+mod common;
+
+use near_mpc_contract_interface::types::{DomainPurpose, ProtocolContractState, SignatureScheme};
+
+/// Tests that signature and CKD requests are processed using the previous
+/// running state's threshold while resharing is in progress.
+///
+/// Setup: 4 nodes, 2 initial participants (threshold 2). Begin resharing to
+/// all 4 with threshold 4, then kill node 3 so resharing can't complete.
+/// Requests should still succeed using the old threshold of 2.
+#[tokio::test]
+async fn test_request_during_resharing() {
+    let (mut cluster, running) =
+        common::setup_cluster(common::REQUEST_DURING_RESHARING_PORT_SEED, |c| {
+            c.num_nodes = 4;
+            c.initial_participants = 2;
+            c.triples_to_buffer = 2;
+            c.presignatures_to_buffer = 2;
+        })
+        .await;
+
+    // Begin resharing to all 4 nodes with threshold 4 — don't wait for completion.
+    tracing::info!("beginning resharing to 4 nodes, threshold 4");
+    cluster
+        .start_resharing(&[0, 1, 2, 3], 4)
+        .await
+        .expect("start_resharing failed");
+
+    // Kill node 3 so resharing is stuck (needs all 4 for threshold 4).
+    tracing::info!("killing node 3 to block resharing");
+    cluster.kill_nodes(&[3]).expect("failed to kill node 3");
+
+    // Verify we're stuck in Resharing state.
+    let state = cluster
+        .get_contract_state()
+        .await
+        .expect("failed to get state");
+    assert!(
+        matches!(state, ProtocolContractState::Resharing(_)),
+        "expected Resharing state, got: {state:?}"
+    );
+
+    // Send sign requests — should succeed using old threshold (2).
+    let sign_domain = running
+        .domains
+        .domains
+        .iter()
+        .find(|d| d.scheme == SignatureScheme::Secp256k1 && d.purpose == Some(DomainPurpose::Sign))
+        .expect("no Secp256k1 Sign domain");
+
+    for i in 0..3 {
+        tracing::info!(i, "sending sign request during resharing");
+        let outcome = cluster
+            .send_sign_request(sign_domain.id, common::generate_ecdsa_payload())
+            .await
+            .expect("sign request failed");
+        assert!(
+            outcome.is_success(),
+            "sign request {i} failed: {:?}",
+            outcome.failure_message()
+        );
+    }
+
+    // Verify state is still Resharing after sign requests.
+    let state = cluster
+        .get_contract_state()
+        .await
+        .expect("failed to get state");
+    assert!(
+        matches!(state, ProtocolContractState::Resharing(_)),
+        "expected Resharing after sign requests, got: {state:?}"
+    );
+
+    // Send CKD requests — should also succeed with old threshold.
+    let ckd_domain = running
+        .domains
+        .domains
+        .iter()
+        .find(|d| d.purpose == Some(DomainPurpose::CKD))
+        .expect("no CKD domain");
+
+    for i in 0..3 {
+        tracing::info!(i, "sending CKD request during resharing");
+        let outcome = cluster
+            .send_ckd_request(ckd_domain.id, common::generate_ckd_app_public_key())
+            .await
+            .expect("ckd request failed");
+        assert!(
+            outcome.is_success(),
+            "ckd request {i} failed: {:?}",
+            outcome.failure_message()
+        );
+    }
+
+    // Verify state is still Resharing after CKD requests.
+    let state = cluster
+        .get_contract_state()
+        .await
+        .expect("failed to get state");
+    assert!(
+        matches!(state, ProtocolContractState::Resharing(_)),
+        "expected Resharing after CKD requests, got: {state:?}"
+    );
+}


### PR DESCRIPTION
Closes: https://github.com/near/mpc/issues/2841
Work towards: https://github.com/near/mpc/issues/2684


Test ported from pytest:
- request_during_resharing: requests succeed with old threshold while resharing stalls