### PR TITLE
chore: add public verifiability support in ckd-example-cli

### DIFF
--- a/crates/ckd-example-cli/README.md
+++ b/crates/ckd-example-cli/README.md
@@ -48,6 +48,24 @@ Your response: {
 The key is: bc73293faedf534d8028d575bcf9cf5455ffe5f468882928305be9d2be2e838d
 ```
 
+### Publicly verifiable variant
+
+By passing the `--publicly-verifiable` flag, the CLI generates an ephemeral key
+pair on both G1 and G2 (`a·G1`, `a·G2`) and uses `AppPublicKeyPV` in the
+request. This allows the contract to verify the CKD response on-chain.
+
+```console
+❯ cargo run -p ckd-example-cli -- --domain-id 2 --signer-account-id frodo.test.near --derivation-path "mykey" --mpc-ckd-public-key bls12381g2:22AgdyBXAQor5kiToW4frjEksuAhyic1S7CWWX7LFBTXFt1MxjcXwuB73yFCQVQfwMjKQoFFtmxPSUg2fCjhNUNVCFPVdtotAFMkPpoDg9s3QWQSZ2gUfvS3Uw1gaESFCfrw --publicly-verifiable
+
+Call the function request_app_private_key with parameters:
+{"request":{"derivation_path":"mykey","app_public_key":{"AppPublicKeyPV":{"pk1":"bls12381g1:...","pk2":"bls12381g2:..."}},"domain_id":2}}
+Please enter a the response in json format (for example {"big_c": "bls12381g1:...","big_y": "bls12381g1:..."}):
+Your response: {"big_c": "bls12381g1:...","big_y": "bls12381g1:..."}
+The key is: ...
+```
+
+### Deterministic output
+
 If the tool is used again, it will generate a different `app_public_key`, but obtain the same key at the end.
 
 ```console

--- a/crates/ckd-example-cli/src/ckd.rs
+++ b/crates/ckd-example-cli/src/ckd.rs
@@ -8,7 +8,8 @@ use sha3::{Digest, Sha3_256};
 use std::io::{self, Write as _};
 
 use near_mpc_contract_interface::types::{
-    AccountId, Bls12381G1PublicKey, Bls12381G2PublicKey, CKDAppPublicKey, CKDRequestArgs, CkdAppId,
+    AccountId, Bls12381G1PublicKey, Bls12381G2PublicKey, CKDAppPublicKey, CKDAppPublicKeyPV,
+    CKDRequestArgs, CkdAppId,
 };
 
 use crate::{cli::Args, types::CKDResponse};
@@ -21,10 +22,19 @@ pub fn run(args: Args) -> Result<()> {
     let account_id = AccountId(args.signer_account_id);
     let app_id = derive_app_id(&account_id, &args.derivation_path);
 
-    let (ephemeral_private_key, ephemeral_public_key) = generate_ephemeral_key(&mut OsRng);
+    let (ephemeral_private_key, app_public_key) = if args.publicly_verifiable {
+        let (scalar, pk1, pk2) = generate_ephemeral_key_pv(&mut OsRng);
+        (
+            scalar,
+            CKDAppPublicKey::AppPublicKeyPV(CKDAppPublicKeyPV { pk1, pk2 }),
+        )
+    } else {
+        let (scalar, pk) = generate_ephemeral_key(&mut OsRng);
+        (scalar, CKDAppPublicKey::AppPublicKey(pk))
+    };
     let ckd_params = CKDRequestArgs {
         derivation_path: args.derivation_path,
-        app_public_key: CKDAppPublicKey::AppPublicKey(ephemeral_public_key),
+        app_public_key,
         domain_id: args.domain_id,
     };
     let function_name = near_mpc_contract_interface::method_names::REQUEST_APP_PRIVATE_KEY;
@@ -72,6 +82,19 @@ fn generate_ephemeral_key(rng: &mut impl CryptoRngCore) -> (Scalar, Bls12381G1Pu
     let x = blstrs::Scalar::random(rng);
     let big_x = blstrs::G1Projective::generator() * x;
     (x, Bls12381G1PublicKey::from(&big_x))
+}
+
+fn generate_ephemeral_key_pv(
+    rng: &mut impl CryptoRngCore,
+) -> (Scalar, Bls12381G1PublicKey, Bls12381G2PublicKey) {
+    let x = blstrs::Scalar::random(rng);
+    let pk1 = blstrs::G1Projective::generator() * x;
+    let pk2 = blstrs::G2Projective::generator() * x;
+    (
+        x,
+        Bls12381G1PublicKey::from(&pk1),
+        Bls12381G2PublicKey::from(&pk2),
+    )
 }
 
 pub fn verify(public_key: &G2Projective, app_id: &[u8], signature: &G1Projective) -> bool {

--- a/crates/ckd-example-cli/src/cli.rs
+++ b/crates/ckd-example-cli/src/cli.rs
@@ -18,4 +18,8 @@ pub struct Args {
     /// The account that will be used to call the MPC contract
     #[arg(long, env)]
     pub signer_account_id: String,
+
+    /// Use the publicly verifiable variant of CKD
+    #[arg(long, env, default_value_t = false)]
+    pub publicly_verifiable: bool,
 }


### PR DESCRIPTION
Closes #2576 

tested on testnet:

```
❯ cargo run -p ckd-example-cli -- --domain-id 2 --signer-account-id gilcu3.testnet --mpc-ckd-public-key bls12381g2:xeYho48G2Sr9oJz4gw9sLGZGspeeKpHZvMDAwWvoNTRnVMFJH96GxX98TT2MRhTtsot1wcGR1Ti2Xh8PCsbYJ2enbLNdJXDvTYSK8aTE3nJ5NZXU7Kt1F6mFtReWs5pR4kj --derivation-path mykey2 --publicly-verifiable
Call the function request_app_private_key with parameters:
{"request":{"app_public_key":{"AppPublicKeyPV":{"pk1":"bls12381g1:7nGwpCVfXQvELkMTVWKedAcjzacKagrDH5iNSz9WxLpdaHDacBiMPdDHXCtntTuZQP","pk2":"bls12381g2:zrQxbJKmeeKPcrN9HUZnbE9KejJbCKZhywN23m7HaPjgKHdogf1Pcq5jJjnquuFxuBHQKpmUQYsYj5GWvUFEXYCxTxqz2BEiBDcuwFyFewfeVTnAcP8SUAt4FWTEtEvkXXj"}},"derivation_path":"mykey2","domain_id":2}}
Please enter a the response in json format (for example {"big_c": "bls12381g1:...","big_y": "bls12381g1:..."}):
Your response: {
  "big_c": "bls12381g1:73tyfkpri5m4ivkBvQ2xopFfH4oE4L7KeWmgFkhPc7sbCMkYSDasKtNm4dEgVeFo42",
  "big_y": "bls12381g1:5pKXUZNV2GHRHg2eJzq3HuUdDTWpsGhAeX9E8b18XabKnVewAVMoznEv3gMdwRAK62"
}
The key is: 32b3fc0ab89080e6600a32b2739075d26419127afaa14335c394006f6e2b860c
```

with:
```
❯ near contract call-function as-transaction v1.signer-prod.testnet request_app_private_key json-args '{"request":{"app_public_key":{"AppPublicKeyPV":{"pk1":"bls12381g1:7nGwpCVfXQvELkMTVWKedAcjzacKagrDH5iNSz9WxLpdaHDacBiMPdDHXCtntTuZQP","pk2":"bls12381g2:zrQxbJKmeeKPcrN9HUZnbE9KejJbCKZhywN23m7HaPjgKHdogf1Pcq5jJjnquuFxuBHQKpmUQYsYj5GWvUFEXYCxTxqz2BEiBDcuwFyFewfeVTnAcP8SUAt4FWTEtEvkXXj"}},"derivation_path":"mykey2","domain_id":2}}' prepaid-gas '100.0 Tgas' attached-deposit '1 yoctoNEAR' sign-as gilcu3.testnet network-config testnet sign-with-keychain send
...
Function execution return value (printed to stdout):
{
  "big_c": "bls12381g1:73tyfkpri5m4ivkBvQ2xopFfH4oE4L7KeWmgFkhPc7sbCMkYSDasKtNm4dEgVeFo42",
  "big_y": "bls12381g1:5pKXUZNV2GHRHg2eJzq3HuUdDTWpsGhAeX9E8b18XabKnVewAVMoznEv3gMdwRAK62"
}
...
```

