### PR TITLE
perf(bench): make snap-then-simulate benchmarks faster

### DIFF
--- a/crates/threshold-signatures/benches/advanced_dkg.rs
+++ b/crates/threshold-signatures/benches/advanced_dkg.rs
@@ -12,6 +12,7 @@ use threshold_signatures::{
     frost_ed25519::Ed25519Sha512,
     frost_secp256k1::Secp256K1Sha256,
     keygen,
+    participants::Participant,
     protocol::Protocol,
     test_utils::{
         run_protocol_and_take_snapshots, run_simulated_protocol, MockCryptoRng, Simulator,
@@ -36,7 +37,9 @@ where
 {
     let num = participants_num();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
+
+    let setup = setup_dkg_snapshot::<C>(threshold());
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("dkg");
     group.sample_size(*SAMPLE_SIZE);
@@ -44,17 +47,13 @@ where
         format!("dkg_{name}_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_dkg::<C>(threshold());
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_dkg::<C>(&setup, threshold()),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 fn bench_dkg_secp256k1(c: &mut Criterion) {
@@ -75,10 +74,15 @@ criterion_group!(
 );
 criterion_main!(benches);
 
-/// Used to simulate DKG keygen for benchmarking
-fn prepare_simulated_dkg<C: Ciphersuite>(
-    threshold: ReconstructionLowerBound,
-) -> PreparedSimulatedDkg<C>
+struct DkgSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    rng_for_protocol: MockCryptoRng,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup: runs the full N-party protocol to capture snapshots
+fn setup_dkg_snapshot<C: Ciphersuite>(threshold: ReconstructionLowerBound) -> DkgSetup
 where
     Element<C>: Send,
     Scalar<C>: Send,
@@ -94,17 +98,38 @@ where
         .choose(&mut rng)
         .expect("participant list is not empty");
 
-    let real_protocol = keygen::<C>(&participants, real_participant, threshold, rng)
-        .map(|p| Box::new(p) as Box<dyn Protocol<Output = KeygenOutput<C>>>)
-        .expect("Keygen should succeed");
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
+    DkgSetup {
+        participants,
+        real_participant,
+        rng_for_protocol: rng,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh protocol and clones the cached simulator
+fn prepare_simulated_dkg<C: Ciphersuite>(
+    setup: &DkgSetup,
+    threshold: ReconstructionLowerBound,
+) -> PreparedSimulatedDkg<C>
+where
+    Element<C>: Send,
+    Scalar<C>: Send,
+{
+    let real_protocol = keygen::<C>(
+        &setup.participants,
+        setup.real_participant,
+        threshold,
+        setup.rng_for_protocol.clone(),
+    )
+    .map(|p| Box::new(p) as Box<dyn Protocol<Output = KeygenOutput<C>>>)
+    .expect("Keygen should succeed");
 
     PreparedSimulatedDkg {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }

--- a/crates/threshold-signatures/benches/advanced_eddsa_frost_sign_v1.rs
+++ b/crates/threshold-signatures/benches/advanced_eddsa_frost_sign_v1.rs
@@ -9,7 +9,7 @@ use crate::bench_utils::{
     RECONSTRUCTION_LOWER_BOUND, SAMPLE_SIZE,
 };
 use threshold_signatures::{
-    frost::eddsa::{sign::sign_v1, SignatureOption},
+    frost::eddsa::{sign::sign_v1, KeygenOutput, SignatureOption},
     participants::Participant,
     protocol::Protocol,
     test_utils::{
@@ -24,7 +24,9 @@ type PreparedSimulatedSig = PreparedOutputs<SignatureOption>;
 fn bench_sign(c: &mut Criterion) {
     let num = RECONSTRUCTION_LOWER_BOUND.value();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
+
+    let setup = setup_sign_snapshot(*RECONSTRUCTION_LOWER_BOUND);
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("sign");
     group.sample_size(*SAMPLE_SIZE);
@@ -32,25 +34,29 @@ fn bench_sign(c: &mut Criterion) {
         format!("frost_ed25519_sign_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_sign(*RECONSTRUCTION_LOWER_BOUND);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_sign(&setup, *RECONSTRUCTION_LOWER_BOUND),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 criterion_group!(benches, bench_sign);
 criterion_main!(benches);
 
-/// Used to simulate robust ecdsa signatures for benchmarking
-fn prepare_simulated_sign(threshold: ReconstructionLowerBound) -> PreparedSimulatedSig {
+struct SignSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    keygen_out: KeygenOutput,
+    message: Vec<u8>,
+    rng_for_protocol: MockCryptoRng,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup: runs the full N-party protocol to capture snapshots
+fn setup_sign_snapshot(threshold: ReconstructionLowerBound) -> SignSetup {
     let mut rng = MockCryptoRng::seed_from_u64(41);
     let preps = ed25519_prepare_sign_v1(threshold, &mut rng);
     let (_, protocol_snapshot) = run_protocol_and_take_snapshots(preps.protocols)
@@ -64,25 +70,40 @@ fn prepare_simulated_sign(threshold: ReconstructionLowerBound) -> PreparedSimula
 
     // choose the real_participant being the coordinator
     let (real_participant, keygen_out) = preps.key_packages[preps.index].clone();
-    let real_protocol = sign_v1(
-        &participants,
-        threshold,
-        real_participant,
+
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    SignSetup {
+        participants,
         real_participant,
         keygen_out,
-        preps.message,
-        rng,
+        message: preps.message,
+        rng_for_protocol: rng,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh sign protocol and clones the cached simulator
+fn prepare_simulated_sign(
+    setup: &SignSetup,
+    threshold: ReconstructionLowerBound,
+) -> PreparedSimulatedSig {
+    let real_protocol = sign_v1(
+        &setup.participants,
+        threshold,
+        setup.real_participant,
+        setup.real_participant,
+        setup.keygen_out.clone(),
+        setup.message.clone(),
+        setup.rng_for_protocol.clone(),
     )
     .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = SignatureOption>>)
     .expect("Signing should succeed");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
-
     PreparedSimulatedSig {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }

--- a/crates/threshold-signatures/benches/advanced_eddsa_frost_sign_v2.rs
+++ b/crates/threshold-signatures/benches/advanced_eddsa_frost_sign_v2.rs
@@ -10,7 +10,9 @@ use crate::bench_utils::{
     MAX_MALICIOUS, RECONSTRUCTION_LOWER_BOUND, SAMPLE_SIZE,
 };
 use threshold_signatures::{
-    frost::eddsa::{presign, sign::sign_v2, PresignArguments, PresignOutput, SignatureOption},
+    frost::eddsa::{
+        presign, sign::sign_v2, KeygenOutput, PresignArguments, PresignOutput, SignatureOption,
+    },
     participants::Participant,
     protocol::Protocol,
     test_utils::{
@@ -27,7 +29,9 @@ type PreparedSimulatedSig = PreparedOutputs<SignatureOption>;
 fn bench_presign(c: &mut Criterion) {
     let num = RECONSTRUCTION_LOWER_BOUND.value();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
+
+    let setup = setup_presign_snapshot(num);
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("presign");
     group.sample_size(*SAMPLE_SIZE);
@@ -35,25 +39,22 @@ fn bench_presign(c: &mut Criterion) {
         format!("frost_ed25519_presign_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulate_presign(num);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulate_presign(&setup),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 /// Benches the signing protocol
 fn bench_sign(c: &mut Criterion) {
     let num = RECONSTRUCTION_LOWER_BOUND.value();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
+
+    let setup = setup_sign_snapshot(*RECONSTRUCTION_LOWER_BOUND);
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("sign");
     group.sample_size(*SAMPLE_SIZE);
@@ -61,25 +62,28 @@ fn bench_sign(c: &mut Criterion) {
         format!("frost_ed25519_sign_v2_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_sign(*RECONSTRUCTION_LOWER_BOUND);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_sign(&setup, *RECONSTRUCTION_LOWER_BOUND),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 criterion_group!(benches, bench_presign, bench_sign);
 criterion_main!(benches);
 
-/// Used to simulate Frost Ed25519 presignatures for benchmarking
-fn prepare_simulate_presign(num_participants: usize) -> PreparedPresig {
+struct PresignSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    keygen_out: KeygenOutput,
+    real_participant_rng: MockCryptoRng,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup for presign: runs the full N-party protocol to capture snapshots
+fn setup_presign_snapshot(num_participants: usize) -> PresignSetup {
     // Running presign a first time with snapshots
     let mut rng = MockCryptoRng::seed_from_u64(42);
     let preps = ed25519_prepare_presign(num_participants, &mut rng);
@@ -102,31 +106,50 @@ fn prepare_simulate_presign(num_participants: usize) -> PreparedPresig {
         }
     }
 
-    let real_protocol = presign(
-        &preps.participants,
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    PresignSetup {
+        participants: preps.participants,
         real_participant,
+        keygen_out,
+        real_participant_rng,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh presign protocol and clones the cached simulator
+fn prepare_simulate_presign(setup: &PresignSetup) -> PreparedPresig {
+    let real_protocol = presign(
+        &setup.participants,
+        setup.real_participant,
         &PresignArguments {
-            keygen_out,
+            keygen_out: setup.keygen_out.clone(),
             threshold: *RECONSTRUCTION_LOWER_BOUND,
         },
-        real_participant_rng, // provide the exact same randomness
+        setup.real_participant_rng.clone(), // provide the exact same randomness
     )
     .map(|presig| Box::new(presig) as Box<dyn Protocol<Output = PresignOutput>>)
     .expect("Presignature should succeed");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
-
     PreparedPresig {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }
 
-/// Used to simulate Frost Ed25519 signatures for benchmarking
-fn prepare_simulated_sign(threshold: ReconstructionLowerBound) -> PreparedSimulatedSig {
+struct SignSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    keygen_out: KeygenOutput,
+    presig: PresignOutput,
+    message: Vec<u8>,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup for sign: runs the full N-party protocol to capture snapshots
+fn setup_sign_snapshot(threshold: ReconstructionLowerBound) -> SignSetup {
     let mut rng = MockCryptoRng::seed_from_u64(41);
     let preps = ed25519_prepare_presign(threshold.value(), &mut rng);
     let result = run_protocol(preps.protocols).expect("Prepare sign should not fail");
@@ -142,25 +165,40 @@ fn prepare_simulated_sign(threshold: ReconstructionLowerBound) -> PreparedSimula
 
     // choose the real_participant being the coordinator
     let (real_participant, keygen_out) = preps.key_packages[preps.index].clone();
-    let real_protocol = sign_v2(
-        &participants,
-        threshold,
-        real_participant,
+
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    SignSetup {
+        participants,
         real_participant,
         keygen_out,
-        preps.presig,
-        preps.message,
+        presig: preps.presig,
+        message: preps.message,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh sign protocol and clones the cached simulator
+fn prepare_simulated_sign(
+    setup: &SignSetup,
+    threshold: ReconstructionLowerBound,
+) -> PreparedSimulatedSig {
+    let real_protocol = sign_v2(
+        &setup.participants,
+        threshold,
+        setup.real_participant,
+        setup.real_participant,
+        setup.keygen_out.clone(),
+        setup.presig.clone(),
+        setup.message.clone(),
     )
     .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = SignatureOption>>)
     .expect("Presignature should succeed");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
-
     PreparedSimulatedSig {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }

--- a/crates/threshold-signatures/benches/advanced_ot_based_ecdsa.rs
+++ b/crates/threshold-signatures/benches/advanced_ot_based_ecdsa.rs
@@ -19,9 +19,9 @@ use threshold_signatures::{
             presign::presign,
             sign::sign,
             triples::{generate_triple_many, TriplePub, TripleShare},
-            PresignArguments, PresignOutput,
+            PresignArguments, PresignOutput, RerandomizedPresignOutput,
         },
-        SignatureOption,
+        KeygenOutput, SignatureOption,
     },
     participants::Participant,
     protocol::Protocol,
@@ -31,6 +31,9 @@ use threshold_signatures::{
     },
     ReconstructionLowerBound,
 };
+
+use k256::AffinePoint;
+use threshold_signatures::ecdsa::Scalar;
 
 type PreparedSimulatedTriples = PreparedOutputs<Vec<(TripleShare, TriplePub)>>;
 type PreparedSimulatedPresig = PreparedOutputs<PresignOutput>;
@@ -44,7 +47,9 @@ fn participants_num() -> usize {
 fn bench_triples(c: &mut Criterion) {
     let num = participants_num();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
+
+    let setup = setup_triples_snapshot(num);
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("triples");
     group.sample_size(*SAMPLE_SIZE);
@@ -52,30 +57,27 @@ fn bench_triples(c: &mut Criterion) {
         format!("ot_ecdsa_triples_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_triples(num);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_triples(&setup),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 /// Benches the presigning protocol
 fn bench_presign(c: &mut Criterion) {
     let num = participants_num();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
 
     let mut rng = MockCryptoRng::seed_from_u64(42);
     let preps = ot_ecdsa_prepare_triples(num, *RECONSTRUCTION_LOWER_BOUND, &mut rng);
     let two_triples =
         run_protocol(preps.protocols).expect("Running triple preparations should succeed");
+
+    let setup = setup_presign_snapshot(&two_triples);
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("presign");
     group.sample_size(*SAMPLE_SIZE);
@@ -83,25 +85,19 @@ fn bench_presign(c: &mut Criterion) {
         format!("ot_ecdsa_presign_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_presign(&two_triples);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_presign(&setup),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 /// Benches the signing protocol
 fn bench_sign(c: &mut Criterion) {
     let num = participants_num();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
     let mut rng = MockCryptoRng::seed_from_u64(42);
     let preps = ot_ecdsa_prepare_triples(num, *RECONSTRUCTION_LOWER_BOUND, &mut rng);
     let two_triples =
@@ -111,31 +107,36 @@ fn bench_sign(c: &mut Criterion) {
     let result = run_protocol(preps.protocols).expect("Running presign preparation should succeed");
     let pk = preps.key_packages[0].1.public_key;
 
+    let setup = setup_sign_snapshot(&result, *RECONSTRUCTION_LOWER_BOUND, pk);
+    let size = setup.cached_simulator.get_view_size();
+
     let mut group = c.benchmark_group("sign");
     group.sample_size(*SAMPLE_SIZE);
     group.bench_function(
         format!("ot_ecdsa_sign_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_sign(&result, *RECONSTRUCTION_LOWER_BOUND, pk);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_sign(&setup, *RECONSTRUCTION_LOWER_BOUND),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 criterion_group!(benches, bench_triples, bench_presign, bench_sign);
 criterion_main!(benches);
 
-/// Used to simulate ot based ecdsa triples for benchmarking
-fn prepare_simulated_triples(participant_num: usize) -> PreparedSimulatedTriples {
+struct TriplesSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    real_participant_rng: MockCryptoRng,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup for triples: runs the full N-party protocol to capture snapshots
+fn setup_triples_snapshot(participant_num: usize) -> TriplesSetup {
     let mut rng = MockCryptoRng::seed_from_u64(42);
 
     let preps = ot_ecdsa_prepare_triples(participant_num, *RECONSTRUCTION_LOWER_BOUND, &mut rng);
@@ -158,29 +159,50 @@ fn prepare_simulated_triples(participant_num: usize) -> PreparedSimulatedTriples
     }
     let real_participant_rng = MockCryptoRng::seed_from_u64(rng_copy.next_u64());
 
-    let real_protocol = generate_triple_many::<2>(
-        &preps.participants,
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    TriplesSetup {
+        participants: preps.participants,
         real_participant,
-        *RECONSTRUCTION_LOWER_BOUND,
         real_participant_rng,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh triples protocol and clones the cached simulator
+fn prepare_simulated_triples(setup: &TriplesSetup) -> PreparedSimulatedTriples {
+    let real_protocol = generate_triple_many::<2>(
+        &setup.participants,
+        setup.real_participant,
+        *RECONSTRUCTION_LOWER_BOUND,
+        setup.real_participant_rng.clone(),
     )
     .map(|prot| Box::new(prot) as Box<dyn Protocol<Output = Vec<(TripleShare, TriplePub)>>>)
     .expect("The rerun of the triple generation should not but raising error");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
     PreparedSimulatedTriples {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }
 
-/// Used to simulate ot based ecdsa presignatures for benchmarking
-fn prepare_simulated_presign(
+struct PresignSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    keygen_out: KeygenOutput,
+    share0: TripleShare,
+    pub0: TriplePub,
+    share1: TripleShare,
+    pub1: TriplePub,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup for presign: runs the full N-party protocol to capture snapshots
+fn setup_presign_snapshot(
     two_triples: &[(Participant, Vec<(TripleShare, TriplePub)>)],
-) -> PreparedSimulatedPresig {
+) -> PresignSetup {
     let mut rng = MockCryptoRng::seed_from_u64(40);
     let preps = ot_ecdsa_prepare_presign(two_triples, *RECONSTRUCTION_LOWER_BOUND, &mut rng);
     let (_, protocol_snapshot) = run_protocol_and_take_snapshots(preps.protocols)
@@ -195,36 +217,58 @@ fn prepare_simulated_presign(
     let (share0, pub0) = shares[0].clone();
     let (share1, pub1) = shares[1].clone();
 
-    let real_protocol = presign(
-        &preps.participants,
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    PresignSetup {
+        participants: preps.participants,
         real_participant,
+        keygen_out,
+        share0,
+        pub0,
+        share1,
+        pub1,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh presign protocol and clones the cached simulator
+fn prepare_simulated_presign(setup: &PresignSetup) -> PreparedSimulatedPresig {
+    let real_protocol = presign(
+        &setup.participants,
+        setup.real_participant,
         PresignArguments {
-            triple0: (share0, pub0),
-            triple1: (share1, pub1),
-            keygen_out,
+            triple0: (setup.share0.clone(), setup.pub0.clone()),
+            triple1: (setup.share1.clone(), setup.pub1.clone()),
+            keygen_out: setup.keygen_out.clone(),
             threshold: *RECONSTRUCTION_LOWER_BOUND,
         },
     )
     .map(|presig| Box::new(presig) as Box<dyn Protocol<Output = PresignOutput>>)
     .expect("Presigning should succeed");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
-
     PreparedSimulatedPresig {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }
 
-/// Used to simulate ot based ecdsa signatures for benchmarking
-pub fn prepare_simulated_sign(
+struct SignSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    derived_pk: AffinePoint,
+    presig: RerandomizedPresignOutput,
+    msg_hash: Scalar,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup for sign: runs the full N-party protocol to capture snapshots
+fn setup_sign_snapshot(
     result: &[(Participant, PresignOutput)],
     threshold: ReconstructionLowerBound,
     pk: VerifyingKey,
-) -> PreparedSimulatedSig {
+) -> SignSetup {
     let mut rng = MockCryptoRng::seed_from_u64(40);
     let preps = ot_ecdsa_prepare_sign(result, threshold, pk, &mut rng);
     let (_, protocol_snapshot) = run_protocol_and_take_snapshots(preps.protocols)
@@ -236,24 +280,41 @@ pub fn prepare_simulated_sign(
     // collect all participants
     let participants: Vec<Participant> =
         result.iter().map(|(participant, _)| *participant).collect();
+
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    SignSetup {
+        participants,
+        real_participant,
+        derived_pk: preps.derived_pk,
+        presig: preps.presig,
+        msg_hash: preps.msg_hash,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh sign protocol and clones the cached simulator
+fn prepare_simulated_sign(
+    setup: &SignSetup,
+    threshold: ReconstructionLowerBound,
+) -> PreparedSimulatedSig {
     let real_protocol = sign(
-        &participants,
-        real_participant,
+        &setup.participants,
+        setup.real_participant,
         threshold,
-        real_participant,
-        preps.derived_pk,
-        preps.presig,
-        preps.msg_hash,
+        setup.real_participant,
+        setup.derived_pk,
+        setup.presig.clone(),
+        setup.msg_hash,
     )
     .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = SignatureOption>>)
     .expect("Simulated signing should succeed");
 
     // now preparing the being the coordinator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
     PreparedSimulatedSig {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }

--- a/crates/threshold-signatures/benches/advanced_robust_ecdsa.rs
+++ b/crates/threshold-signatures/benches/advanced_robust_ecdsa.rs
@@ -12,8 +12,11 @@ use crate::bench_utils::{
 };
 use threshold_signatures::{
     ecdsa::{
-        robust_ecdsa::{presign::presign, sign::sign, PresignArguments, PresignOutput},
-        SignatureOption,
+        robust_ecdsa::{
+            presign::presign, sign::sign, PresignArguments, PresignOutput,
+            RerandomizedPresignOutput,
+        },
+        KeygenOutput, SignatureOption,
     },
     participants::Participant,
     protocol::Protocol,
@@ -22,6 +25,9 @@ use threshold_signatures::{
         Simulator,
     },
 };
+
+use k256::AffinePoint;
+use threshold_signatures::ecdsa::Scalar;
 
 type PreparedPresig = PreparedOutputs<PresignOutput>;
 type PreparedSimulatedSig = PreparedOutputs<SignatureOption>;
@@ -34,7 +40,9 @@ fn participants_num() -> usize {
 fn bench_presign(c: &mut Criterion) {
     let num = participants_num();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
+
+    let setup = setup_presign_snapshot(num);
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("presign");
     group.sample_size(*SAMPLE_SIZE);
@@ -42,30 +50,27 @@ fn bench_presign(c: &mut Criterion) {
         format!("robust_ecdsa_presign_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulate_presign(num);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulate_presign(&setup),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 /// Benches the signing protocol
 fn bench_sign(c: &mut Criterion) {
     let num = participants_num();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
 
     let mut rng = MockCryptoRng::seed_from_u64(42);
     let preps = robust_ecdsa_prepare_presign(num, &mut rng);
     let result = run_protocol(preps.protocols).expect("Prepare sign should not fail");
     let pk = preps.key_packages[0].1.public_key;
+
+    let setup = setup_sign_snapshot(&result, max_malicious, pk);
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("sign");
     group.sample_size(*SAMPLE_SIZE);
@@ -73,25 +78,28 @@ fn bench_sign(c: &mut Criterion) {
         format!("robust_ecdsa_sign_advanced_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_sign(&result, max_malicious, pk);
-                    // collecting data sizes
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_sign(&setup, max_malicious),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 criterion_group!(benches, bench_presign, bench_sign);
 criterion_main!(benches);
 
-/// Used to simulate robust ecdsa presignatures for benchmarking
-fn prepare_simulate_presign(num_participants: usize) -> PreparedPresig {
+struct PresignSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    keygen_out: KeygenOutput,
+    real_participant_rng: MockCryptoRng,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup for presign: runs the full N-party protocol to capture snapshots
+fn setup_presign_snapshot(num_participants: usize) -> PresignSetup {
     // Running presign a first time with snapshots
     let mut rng = MockCryptoRng::seed_from_u64(42);
     let preps = robust_ecdsa_prepare_presign(num_participants, &mut rng);
@@ -116,35 +124,54 @@ fn prepare_simulate_presign(num_participants: usize) -> PreparedPresig {
     }
     let real_participant_rng = MockCryptoRng::seed_from_u64(rng_copy.next_u64());
 
-    let real_protocol = presign(
-        &preps.participants,
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    PresignSetup {
+        participants: preps.participants,
         real_participant,
+        keygen_out,
+        real_participant_rng,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh presign protocol and clones the cached simulator
+fn prepare_simulate_presign(setup: &PresignSetup) -> PreparedPresig {
+    let real_protocol = presign(
+        &setup.participants,
+        setup.real_participant,
         PresignArguments {
-            keygen_out,
+            keygen_out: setup.keygen_out.clone(),
             max_malicious: (*MAX_MALICIOUS).into(),
         },
-        real_participant_rng, // provide the exact same randomness
+        setup.real_participant_rng.clone(), // provide the exact same randomness
     )
     .map(|presig| Box::new(presig) as Box<dyn Protocol<Output = PresignOutput>>)
     .expect("Presignature should succeed");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
-
     PreparedPresig {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }
 
-/// Used to simulate robust ecdsa signatures for benchmarking
-fn prepare_simulated_sign(
+struct SignSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    derived_pk: AffinePoint,
+    presig: RerandomizedPresignOutput,
+    msg_hash: Scalar,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup for sign: runs the full N-party protocol to capture snapshots
+fn setup_sign_snapshot(
     result: &[(Participant, PresignOutput)],
     max_malicious: usize,
     pk: VerifyingKey,
-) -> PreparedSimulatedSig {
+) -> SignSetup {
     let mut rng = MockCryptoRng::seed_from_u64(41);
     let preps = robust_ecdsa_prepare_sign(result, max_malicious.into(), pk, &mut rng);
     let (_, protocol_snapshot) = run_protocol_and_take_snapshots(preps.protocols)
@@ -155,25 +182,37 @@ fn prepare_simulated_sign(
         result.iter().map(|(participant, _)| *participant).collect();
     // choose the real_participant being the coordinator
     let (real_participant, _) = result[preps.index];
+
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    SignSetup {
+        participants,
+        real_participant,
+        derived_pk: preps.derived_pk,
+        presig: preps.presig,
+        msg_hash: preps.msg_hash,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh sign protocol and clones the cached simulator
+fn prepare_simulated_sign(setup: &SignSetup, max_malicious: usize) -> PreparedSimulatedSig {
     let real_protocol = sign(
-        &participants,
-        real_participant,
+        &setup.participants,
+        setup.real_participant,
         max_malicious,
-        real_participant,
-        preps.derived_pk,
-        preps.presig,
-        preps.msg_hash,
+        setup.real_participant,
+        setup.derived_pk,
+        setup.presig.clone(),
+        setup.msg_hash,
     )
     .map(|sig| Box::new(sig) as Box<dyn Protocol<Output = SignatureOption>>)
     .expect("Presignature should succeed");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
-
     PreparedSimulatedSig {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }

--- a/crates/threshold-signatures/benches/ckd.rs
+++ b/crates/threshold-signatures/benches/ckd.rs
@@ -8,7 +8,9 @@ use crate::bench_utils::{
     analyze_received_sizes, prepare_ckd, PreparedOutputs, MAX_MALICIOUS, SAMPLE_SIZE,
 };
 use threshold_signatures::{
-    confidential_key_derivation::{protocol::ckd, CKDOutputOption},
+    confidential_key_derivation::{
+        protocol::ckd as ckd_protocol, AppId, CKDOutputOption, ElementG1, KeygenOutput,
+    },
     participants::Participant,
     protocol::Protocol,
     test_utils::{
@@ -27,7 +29,9 @@ fn threshold() -> ReconstructionLowerBound {
 fn bench_ckd(c: &mut Criterion) {
     let num = threshold().value();
     let max_malicious = *MAX_MALICIOUS;
-    let mut sizes = Vec::with_capacity(*SAMPLE_SIZE);
+
+    let setup = setup_ckd_snapshot(threshold());
+    let size = setup.cached_simulator.get_view_size();
 
     let mut group = c.benchmark_group("ckd");
     group.sample_size(*SAMPLE_SIZE);
@@ -35,23 +39,30 @@ fn bench_ckd(c: &mut Criterion) {
         format!("ckd_MAX_MALICIOUS_{max_malicious}_PARTICIPANTS_{num}"),
         |b| {
             b.iter_batched(
-                || {
-                    let preps = prepare_simulated_ckd(threshold());
-                    sizes.push(preps.simulator.get_view_size());
-                    preps
-                },
+                || prepare_simulated_ckd(&setup),
                 |preps| run_simulated_protocol(preps.participant, preps.protocol, preps.simulator),
                 criterion::BatchSize::SmallInput,
             );
         },
     );
-    analyze_received_sizes(&sizes, true);
+    analyze_received_sizes(&[size], true);
 }
 
 criterion_group!(benches, bench_ckd);
 criterion_main!(benches);
 
-fn prepare_simulated_ckd(threshold: ReconstructionLowerBound) -> PreparedSimulatedCkd {
+struct CkdSetup {
+    participants: Vec<Participant>,
+    real_participant: Participant,
+    keygen_out: KeygenOutput,
+    app_id: AppId,
+    app_pk: ElementG1,
+    rng_for_protocol: MockCryptoRng,
+    cached_simulator: Simulator,
+}
+
+/// Expensive one-time setup: runs the full N-party protocol to capture snapshots
+fn setup_ckd_snapshot(threshold: ReconstructionLowerBound) -> CkdSetup {
     let mut rng = MockCryptoRng::seed_from_u64(41);
     let preps = prepare_ckd(threshold, &mut rng);
     let (_, protocol_snapshot) = run_protocol_and_take_snapshots(preps.protocols)
@@ -65,25 +76,38 @@ fn prepare_simulated_ckd(threshold: ReconstructionLowerBound) -> PreparedSimulat
 
     // choose the real_participant being the coordinator
     let (real_participant, keygen_out) = preps.key_packages[preps.index].clone();
-    let real_protocol = ckd(
-        &participants,
-        real_participant,
+
+    let cached_simulator = Simulator::new(real_participant, &protocol_snapshot)
+        .expect("Simulator should not be empty");
+
+    CkdSetup {
+        participants,
         real_participant,
         keygen_out,
-        preps.app_id,
-        preps.app_pk,
-        rng,
+        app_id: preps.app_id,
+        app_pk: preps.app_pk,
+        rng_for_protocol: rng,
+        cached_simulator,
+    }
+}
+
+/// Cheap per-sample setup: creates fresh ckd protocol and clones the cached simulator
+fn prepare_simulated_ckd(setup: &CkdSetup) -> PreparedSimulatedCkd {
+    let real_protocol = ckd_protocol(
+        &setup.participants,
+        setup.real_participant,
+        setup.real_participant,
+        setup.keygen_out.clone(),
+        setup.app_id.clone(),
+        setup.app_pk,
+        setup.rng_for_protocol.clone(),
     )
     .map(|ckd| Box::new(ckd) as Box<dyn Protocol<Output = CKDOutputOption>>)
     .expect("Ckd should succeed");
 
-    // now preparing the simulator
-    let simulated_protocol =
-        Simulator::new(real_participant, protocol_snapshot).expect("Simulator should not be empty");
-
     PreparedSimulatedCkd {
-        participant: real_participant,
+        participant: setup.real_participant,
         protocol: real_protocol,
-        simulator: simulated_protocol,
+        simulator: setup.cached_simulator.clone(),
     }
 }

--- a/crates/threshold-signatures/src/test_utils/participant_simulation.rs
+++ b/crates/threshold-signatures/src/test_utils/participant_simulation.rs
@@ -2,6 +2,7 @@ use crate::participants::Participant;
 use crate::protocol::MessageData;
 use crate::test_utils::snapshot::ProtocolSnapshot;
 
+#[derive(Clone)]
 pub struct Simulator {
     /// the `real_participant` we are simulating for
     real_participant: Participant,
@@ -10,7 +11,7 @@ pub struct Simulator {
 }
 
 impl Simulator {
-    pub fn new(real_participant: Participant, protocol_snap: ProtocolSnapshot) -> Option<Self> {
+    pub fn new(real_participant: Participant, protocol_snap: &ProtocolSnapshot) -> Option<Self> {
         if protocol_snap.number_of_participants() <= 1 {
             return None;
         }

--- a/crates/threshold-signatures/src/test_utils/snapshot.rs
+++ b/crates/threshold-signatures/src/test_utils/snapshot.rs
@@ -97,7 +97,7 @@ impl ProtocolSnapshot {
 
     /// Returns a vector of all received messages by a specific participant
     pub fn get_received_messages(
-        self,
+        &self,
         participant: &Participant,
     ) -> Option<Vec<(Participant, MessageData)>> {
         self.snapshots


### PR DESCRIPTION
Closes #2774 
takes 12 minutes on my machine:
```
❯ MAX_MALICIOUS=40 cargo bench -p threshold-signatures --bench advanced_dkg
    Finished `bench` profile [optimized] target(s) in 0.16s
     Running benches/advanced_dkg.rs (target/release/deps/advanced_dkg-433c4cf2c869f36c)
dkg/dkg_secp256k1_MAX_MALICIOUS_40_PARTICIPANTS_41
                        time:   [2.5496 ms 2.5653 ms 2.5822 ms]
Found 3 outliers among 15 measurements (20.00%)
  3 (20.00%) low mild

dkg/dkg_ed25519_MAX_MALICIOUS_40_PARTICIPANTS_41
                        time:   [2.8598 ms 2.9045 ms 2.9366 ms]
Found 2 outliers among 15 measurements (13.33%)
  2 (13.33%) low mild

dkg/dkg_bls12381_MAX_MALICIOUS_40_PARTICIPANTS_41
                        time:   [2.8873 ms 2.9659 ms 3.0107 ms]
```