### PR TITLE
build: switch MPC node image push to skopeo with --preserve-digests

### DIFF
--- a/.github/workflows/docker_build_node.yml
+++ b/.github/workflows/docker_build_node.yml
@@ -38,6 +38,11 @@ jobs:
           echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
           sudo install -m755 repro-env -t /usr/bin
 
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
       - name: Build and push node image
         run: |
           export NODE_IMAGE_NAME=mpc-node

--- a/.github/workflows/docker_build_node_gcp.yml
+++ b/.github/workflows/docker_build_node_gcp.yml
@@ -38,6 +38,11 @@ jobs:
           echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
           sudo install -m755 repro-env -t /usr/bin
 
+      - name: Install skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
       - name: Build and push node gcp image
         run: |
           export NODE_GCP_IMAGE_NAME=mpc-node-gcp

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -181,18 +181,22 @@ if $USE_PUSH; then
 
     if $USE_NODE; then
         temp_dir=$(mktemp -d)
-        skopeo copy --all --dest-compress docker-daemon:$NODE_IMAGE_NAME:latest dir:$temp_dir
-        skopeo copy --preserve-digests dir:$temp_dir docker://docker.io/nearone/$NODE_IMAGE_NAME:$image_tag
-        node_manifest_digest="sha256:$(sha256sum $temp_dir/manifest.json | cut -d' ' -f1)"
-        rm -rf "$temp_dir"
+        trap 'rm -rf -- "$temp_dir"' EXIT
+        skopeo copy --all --dest-compress "docker-daemon:$NODE_IMAGE_NAME:latest" "dir:$temp_dir"
+        skopeo copy --preserve-digests "dir:$temp_dir" "docker://docker.io/nearone/$NODE_IMAGE_NAME:$image_tag"
+        node_manifest_digest="sha256:$(sha256sum "$temp_dir/manifest.json" | cut -d' ' -f1)"
+        rm -rf -- "$temp_dir"
+        trap - EXIT
     fi
 
     if $USE_NODE_GCP; then
         temp_dir=$(mktemp -d)
-        skopeo copy --all --dest-compress docker-daemon:$NODE_GCP_IMAGE_NAME:latest dir:$temp_dir
-        skopeo copy --preserve-digests dir:$temp_dir docker://docker.io/nearone/$NODE_GCP_IMAGE_NAME:$image_tag
-        node_gcp_manifest_digest="sha256:$(sha256sum $temp_dir/manifest.json | cut -d' ' -f1)"
-        rm -rf "$temp_dir"
+        trap 'rm -rf -- "$temp_dir"' EXIT
+        skopeo copy --all --dest-compress "docker-daemon:$NODE_GCP_IMAGE_NAME:latest" "dir:$temp_dir"
+        skopeo copy --preserve-digests "dir:$temp_dir" "docker://docker.io/nearone/$NODE_GCP_IMAGE_NAME:$image_tag"
+        node_gcp_manifest_digest="sha256:$(sha256sum "$temp_dir/manifest.json" | cut -d' ' -f1)"
+        rm -rf -- "$temp_dir"
+        trap - EXIT
     fi
 
     if $USE_RUST_LAUNCHER; then

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -70,6 +70,10 @@ if $USE_NODE || $USE_RUST_LAUNCHER; then
     require_cmds repro-env podman
 fi
 
+if $USE_PUSH; then
+    require_cmds skopeo
+fi
+
 if ! docker buildx &>/dev/null; then
   die "Please install docker-buildx"
 fi
@@ -176,13 +180,19 @@ if $USE_PUSH; then
     fi
 
     if $USE_NODE; then
-        docker tag $NODE_IMAGE_NAME nearone/$NODE_IMAGE_NAME:$image_tag
-        docker push nearone/$NODE_IMAGE_NAME:$image_tag
+        temp_dir=$(mktemp -d)
+        skopeo copy --all --dest-compress docker-daemon:$NODE_IMAGE_NAME:latest dir:$temp_dir
+        skopeo copy --preserve-digests dir:$temp_dir docker://docker.io/nearone/$NODE_IMAGE_NAME:$image_tag
+        node_manifest_digest="sha256:$(sha256sum $temp_dir/manifest.json | cut -d' ' -f1)"
+        rm -rf "$temp_dir"
     fi
 
     if $USE_NODE_GCP; then
-        docker tag $NODE_GCP_IMAGE_NAME nearone/$NODE_GCP_IMAGE_NAME:$image_tag
-        docker push nearone/$NODE_GCP_IMAGE_NAME:$image_tag
+        temp_dir=$(mktemp -d)
+        skopeo copy --all --dest-compress docker-daemon:$NODE_GCP_IMAGE_NAME:latest dir:$temp_dir
+        skopeo copy --preserve-digests dir:$temp_dir docker://docker.io/nearone/$NODE_GCP_IMAGE_NAME:$image_tag
+        node_gcp_manifest_digest="sha256:$(sha256sum $temp_dir/manifest.json | cut -d' ' -f1)"
+        rm -rf "$temp_dir"
     fi
 
     if $USE_RUST_LAUNCHER; then
@@ -200,9 +210,15 @@ if $USE_NODE || $USE_NODE_GCP; then
 fi
 if $USE_NODE; then
     echo "node docker image hash: $node_image_hash"
+    if $USE_PUSH; then
+        echo "node manifest digest: $node_manifest_digest"
+    fi
 fi
 if $USE_NODE_GCP; then
     echo "node gcp docker image hash: $node_gcp_image_hash"
+    if $USE_PUSH; then
+        echo "node gcp manifest digest: $node_gcp_manifest_digest"
+    fi
 fi
 if $USE_LAUNCHER; then
     echo "launcher docker image hash: $launcher_image_hash"

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -177,12 +177,9 @@ if $USE_PUSH; then
         local tag="$2"
         local td
         td=$(mktemp -d)
-        trap 'rm -rf -- "$td"' EXIT
         skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td"
         skopeo copy --preserve-digests "dir:$td" "docker://docker.io/nearone/${image_name}:${tag}"
         echo "sha256:$(sha256sum "$td/manifest.json" | cut -d' ' -f1)"
-        rm -rf -- "$td"
-        trap - EXIT
     }
 
     if $USE_LAUNCHER; then

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -177,7 +177,10 @@ if $USE_PUSH; then
         local tag="$2"
         local td
         td=$(mktemp -d)
+        # Compress the built image to a local directory, which implicitly computes
+        # the manifest digest in $td/manifest.json
         skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td"
+        # Publish the image from the directory, making sure the manifest digest does not change
         skopeo copy --preserve-digests "dir:$td" "docker://docker.io/nearone/${image_name}:${tag}"
         echo "sha256:$(sha256sum "$td/manifest.json" | cut -d' ' -f1)"
     }

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -169,41 +169,36 @@ if $USE_PUSH; then
     image_tag="$sanitized_branch_name-$short_hash"
     echo "Using branch-hash tag: $image_tag"
 
+    # Push an image via skopeo with preserved manifest digests.
+    # Usage: skopeo_push <local_image_name> <remote_tag>
+    # Prints the manifest digest to stdout.
+    skopeo_push() {
+        local image_name="$1"
+        local tag="$2"
+        local td
+        td=$(mktemp -d)
+        trap 'rm -rf -- "$td"' EXIT
+        skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td"
+        skopeo copy --preserve-digests "dir:$td" "docker://docker.io/nearone/${image_name}:${tag}"
+        echo "sha256:$(sha256sum "$td/manifest.json" | cut -d' ' -f1)"
+        rm -rf -- "$td"
+        trap - EXIT
+    }
+
     if $USE_LAUNCHER; then
-        temp_dir=$(mktemp -d)
-        echo "using $temp_dir"
-        # This compresses the built image to a local directory, which implicitly computes the manifest
-        # digest in $temp_dir/manifest.json
-        skopeo copy --all --dest-compress docker-daemon:$LAUNCHER_IMAGE_NAME:latest dir:$temp_dir
-        # Then we publish the image from the directory, making sure the manifest digest does not change
-        skopeo copy --preserve-digests dir:$temp_dir docker://docker.io/nearone/$LAUNCHER_IMAGE_NAME:$image_tag
+        launcher_manifest_digest="$(skopeo_push "$LAUNCHER_IMAGE_NAME" "$image_tag")"
     fi
 
     if $USE_NODE; then
-        temp_dir=$(mktemp -d)
-        trap 'rm -rf -- "$temp_dir"' EXIT
-        skopeo copy --all --dest-compress "docker-daemon:$NODE_IMAGE_NAME:latest" "dir:$temp_dir"
-        skopeo copy --preserve-digests "dir:$temp_dir" "docker://docker.io/nearone/$NODE_IMAGE_NAME:$image_tag"
-        node_manifest_digest="sha256:$(sha256sum "$temp_dir/manifest.json" | cut -d' ' -f1)"
-        rm -rf -- "$temp_dir"
-        trap - EXIT
+        node_manifest_digest="$(skopeo_push "$NODE_IMAGE_NAME" "$image_tag")"
     fi
 
     if $USE_NODE_GCP; then
-        temp_dir=$(mktemp -d)
-        trap 'rm -rf -- "$temp_dir"' EXIT
-        skopeo copy --all --dest-compress "docker-daemon:$NODE_GCP_IMAGE_NAME:latest" "dir:$temp_dir"
-        skopeo copy --preserve-digests "dir:$temp_dir" "docker://docker.io/nearone/$NODE_GCP_IMAGE_NAME:$image_tag"
-        node_gcp_manifest_digest="sha256:$(sha256sum "$temp_dir/manifest.json" | cut -d' ' -f1)"
-        rm -rf -- "$temp_dir"
-        trap - EXIT
+        node_gcp_manifest_digest="$(skopeo_push "$NODE_GCP_IMAGE_NAME" "$image_tag")"
     fi
 
     if $USE_RUST_LAUNCHER; then
-        temp_dir=$(mktemp -d)
-        echo "using $temp_dir"
-        skopeo copy --all --dest-compress docker-daemon:$RUST_LAUNCHER_IMAGE_NAME:latest dir:$temp_dir
-        skopeo copy --preserve-digests dir:$temp_dir docker://docker.io/nearone/$RUST_LAUNCHER_IMAGE_NAME:$image_tag
+        rust_launcher_manifest_digest="$(skopeo_push "$RUST_LAUNCHER_IMAGE_NAME" "$image_tag")"
     fi
 fi
 
@@ -226,8 +221,14 @@ if $USE_NODE_GCP; then
 fi
 if $USE_LAUNCHER; then
     echo "launcher docker image hash: $launcher_image_hash"
+    if $USE_PUSH; then
+        echo "launcher manifest digest: $launcher_manifest_digest"
+    fi
 fi
 if $USE_RUST_LAUNCHER; then
     echo "rust launcher binary hash: $rust_launcher_binary_hash"
     echo "rust launcher docker image hash: $rust_launcher_image_hash"
+    if $USE_PUSH; then
+        echo "rust launcher manifest digest: $rust_launcher_manifest_digest"
+    fi
 fi


### PR DESCRIPTION
## Summary

- Switch MPC node and node-gcp image push from `docker push` to `skopeo copy --preserve-digests`, matching the pattern already used for launcher images
- Add `skopeo` to required commands when `--push` is used
- Output manifest digest after push for both node images

Closes #2778

## Test plan

- [x] CI passes
- [x] `./deployment/build-images.sh --node --push` uses skopeo and outputs manifest digest
- [x] check https://github.com/near/mpc/actions/workflows/docker_build_node_gcp.yml and https://github.com/near/mpc/actions/workflows/docker_build_node.yml work