### PR TITLE
fix: remove stale foreign chain votes from non-participants

### DIFF
--- a/crates/contract/src/config.rs
+++ b/crates/contract/src/config.rs
@@ -28,6 +28,8 @@ const DEFAULT_CLEAN_TEE_STATUS_TERA_GAS: u64 = 10;
 const DEFAULT_CLEANUP_ORPHANED_NODE_MIGRATIONS_TERA_GAS: u64 = 3;
 /// Prepaid gas for a `remove_non_participant_update_votes` call
 const DEFAULT_REMOVE_NON_PARTICIPANT_UPDATE_VOTES_TERA_GAS: u64 = 5;
+/// Prepaid gas for a `clean_foreign_chain_data` call
+const DEFAULT_CLEAN_FOREIGN_CHAIN_DATA_TERA_GAS: u64 = 5;
 
 /// Config for V2 of the contract.
 #[near(serializers=[borsh, json])]
@@ -56,6 +58,8 @@ pub(crate) struct Config {
     pub(crate) cleanup_orphaned_node_migrations_tera_gas: u64,
     /// Prepaid gas for a `remove_non_participant_update_votes` call.
     pub(crate) remove_non_participant_update_votes_tera_gas: u64,
+    /// Prepaid gas for a `clean_foreign_chain_data` call.
+    pub(crate) clean_foreign_chain_data_tera_gas: u64,
 }
 
 impl Default for Config {
@@ -78,6 +82,7 @@ impl Default for Config {
                 DEFAULT_CLEANUP_ORPHANED_NODE_MIGRATIONS_TERA_GAS,
             remove_non_participant_update_votes_tera_gas:
                 DEFAULT_REMOVE_NON_PARTICIPANT_UPDATE_VOTES_TERA_GAS,
+            clean_foreign_chain_data_tera_gas: DEFAULT_CLEAN_FOREIGN_CHAIN_DATA_TERA_GAS,
         }
     }
 }

--- a/crates/contract/src/dto_mapping.rs
+++ b/crates/contract/src/dto_mapping.rs
@@ -424,6 +424,9 @@ impl From<near_mpc_contract_interface::types::InitConfig> for Config {
         if let Some(v) = config_ext.remove_non_participant_update_votes_tera_gas {
             config.remove_non_participant_update_votes_tera_gas = v;
         }
+        if let Some(v) = config_ext.clean_foreign_chain_data_tera_gas {
+            config.clean_foreign_chain_data_tera_gas = v;
+        }
 
         config
     }
@@ -449,6 +452,7 @@ impl From<&Config> for near_mpc_contract_interface::types::Config {
                 .cleanup_orphaned_node_migrations_tera_gas,
             remove_non_participant_update_votes_tera_gas: value
                 .remove_non_participant_update_votes_tera_gas,
+            clean_foreign_chain_data_tera_gas: value.clean_foreign_chain_data_tera_gas,
         }
     }
 }
@@ -473,6 +477,7 @@ impl From<near_mpc_contract_interface::types::Config> for Config {
                 .cleanup_orphaned_node_migrations_tera_gas,
             remove_non_participant_update_votes_tera_gas: value
                 .remove_non_participant_update_votes_tera_gas,
+            clean_foreign_chain_data_tera_gas: value.clean_foreign_chain_data_tera_gas,
         }
     }
 }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1136,7 +1136,6 @@ impl MpcContract {
 
         self.assert_caller_is_attested_participant_and_protocol_active();
 
-        // TODO(#2769): clean up supported foreign chain votes from non participants
         if let Some(new_state) = self.protocol_state.vote_reshared(key_event_id)? {
             // Resharing has concluded, transition to running state
             self.protocol_state = new_state;
@@ -1167,6 +1166,15 @@ impl MpcContract {
                     vec![],
                     NearToken::from_yoctonear(0),
                     Gas::from_tgas(self.config.cleanup_orphaned_node_migrations_tera_gas),
+                )
+                .detach();
+            // Spawn a promise to clean up foreign chain data for non-participants
+            Promise::new(env::current_account_id())
+                .function_call(
+                    method_names::CLEAN_FOREIGN_CHAIN_DATA.to_string(),
+                    vec![],
+                    NearToken::from_yoctonear(0),
+                    Gas::from_tgas(self.config.clean_foreign_chain_data_tera_gas),
                 )
                 .detach();
         }
@@ -1630,6 +1638,59 @@ impl MpcContract {
         };
 
         self.tee_state.clean_non_participants(participants);
+        Ok(())
+    }
+
+    /// Private endpoint to clean up foreign chain policy votes and node configurations
+    /// for non-participants after resharing.
+    /// This can only be called by the contract itself via a promise.
+    #[private]
+    #[handle_result]
+    pub fn clean_foreign_chain_data(&mut self) -> Result<(), Error> {
+        log!(
+            "clean_foreign_chain_data: signer={}",
+            env::signer_account_id()
+        );
+
+        let participants = match &self.protocol_state {
+            ProtocolContractState::Running(state) => state.parameters.participants(),
+            _ => {
+                return Err(InvalidState::ProtocolStateNotRunning.into());
+            }
+        };
+
+        let participant_accounts: std::collections::HashSet<dtos::AccountId> = participants
+            .participants()
+            .iter()
+            .map(|(account_id, _, _)| dtos::AccountId(account_id.to_string()))
+            .collect();
+
+        let non_participant_accounts: Vec<dtos::AccountId> = self
+            .foreign_chain_policy_votes
+            .proposal_by_account
+            .keys()
+            .filter(|account| !participant_accounts.contains(account))
+            .cloned()
+            .collect();
+        for account in &non_participant_accounts {
+            self.foreign_chain_policy_votes
+                .proposal_by_account
+                .remove(account);
+        }
+
+        let non_participant_configs: Vec<dtos::AccountId> = self
+            .node_foreign_chain_configurations
+            .foreign_chain_configuration_by_node
+            .keys()
+            .filter(|account| !participant_accounts.contains(account))
+            .cloned()
+            .collect();
+        for account in &non_participant_configs {
+            self.node_foreign_chain_configurations
+                .foreign_chain_configuration_by_node
+                .remove(account);
+        }
+
         Ok(())
     }
 }

--- a/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
+++ b/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
@@ -262,6 +262,10 @@ BorshSchemaContainer {
                         "remove_non_participant_update_votes_tera_gas",
                         "u64",
                     ),
+                    (
+                        "clean_foreign_chain_data_tera_gas",
+                        "u64",
+                    ),
                 ],
             ),
         },

--- a/crates/contract/src/v3_8_1_state.rs
+++ b/crates/contract/src/v3_8_1_state.rs
@@ -20,7 +20,7 @@ use crate::{
     state::ProtocolContractState,
     tee::tee_state::TeeState,
     update::ProposedUpdates,
-    Config, ForeignChainPolicyVotes, IntoInterfaceType, NodeForeignChainConfigurations, StaleData,
+    ForeignChainPolicyVotes, IntoInterfaceType, NodeForeignChainConfigurations, StaleData,
 };
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
@@ -33,7 +33,7 @@ pub struct MpcContract {
     proposed_updates: ProposedUpdates,
     foreign_chain_policy: dtos::ForeignChainPolicy,
     foreign_chain_policy_votes: ForeignChainPolicyVotes,
-    config: Config,
+    config: OldConfig,
     tee_state: TeeState,
     accept_requests: bool,
     node_migrations: NodeMigrations,
@@ -87,13 +87,55 @@ impl From<MpcContract> for crate::MpcContract {
             proposed_updates: value.proposed_updates,
             foreign_chain_policy,
             foreign_chain_policy_votes: value.foreign_chain_policy_votes,
-            config: value.config,
+            config: value.config.into(),
             tee_state: value.tee_state,
             accept_requests: value.accept_requests,
             node_migrations: value.node_migrations,
             stale_data: value.stale_data,
             metrics: value.metrics,
             node_foreign_chain_configurations: foreign_chain_support,
+        }
+    }
+}
+
+/// Previous Config layout without `clean_foreign_chain_data_tera_gas`.
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+struct OldConfig {
+    key_event_timeout_blocks: u64,
+    tee_upgrade_deadline_duration_seconds: u64,
+    contract_upgrade_deposit_tera_gas: u64,
+    sign_call_gas_attachment_requirement_tera_gas: u64,
+    ckd_call_gas_attachment_requirement_tera_gas: u64,
+    return_signature_and_clean_state_on_success_call_tera_gas: u64,
+    return_ck_and_clean_state_on_success_call_tera_gas: u64,
+    fail_on_timeout_tera_gas: u64,
+    clean_tee_status_tera_gas: u64,
+    cleanup_orphaned_node_migrations_tera_gas: u64,
+    remove_non_participant_update_votes_tera_gas: u64,
+}
+
+impl From<OldConfig> for crate::Config {
+    fn from(old: OldConfig) -> Self {
+        let defaults = crate::Config::default();
+        crate::Config {
+            key_event_timeout_blocks: old.key_event_timeout_blocks,
+            tee_upgrade_deadline_duration_seconds: old.tee_upgrade_deadline_duration_seconds,
+            contract_upgrade_deposit_tera_gas: old.contract_upgrade_deposit_tera_gas,
+            sign_call_gas_attachment_requirement_tera_gas: old
+                .sign_call_gas_attachment_requirement_tera_gas,
+            ckd_call_gas_attachment_requirement_tera_gas: old
+                .ckd_call_gas_attachment_requirement_tera_gas,
+            return_signature_and_clean_state_on_success_call_tera_gas: old
+                .return_signature_and_clean_state_on_success_call_tera_gas,
+            return_ck_and_clean_state_on_success_call_tera_gas: old
+                .return_ck_and_clean_state_on_success_call_tera_gas,
+            fail_on_timeout_tera_gas: old.fail_on_timeout_tera_gas,
+            clean_tee_status_tera_gas: old.clean_tee_status_tera_gas,
+            cleanup_orphaned_node_migrations_tera_gas: old
+                .cleanup_orphaned_node_migrations_tera_gas,
+            remove_non_participant_update_votes_tera_gas: old
+                .remove_non_participant_update_votes_tera_gas,
+            clean_foreign_chain_data_tera_gas: defaults.clean_foreign_chain_data_tera_gas,
         }
     }
 }

--- a/crates/contract/tests/sandbox/contract_configuration.rs
+++ b/crates/contract/tests/sandbox/contract_configuration.rs
@@ -94,6 +94,7 @@ async fn contract_configuration_can_be_set_on_initialization() {
         clean_tee_status_tera_gas: Some(99),
         cleanup_orphaned_node_migrations_tera_gas: Some(11),
         remove_non_participant_update_votes_tera_gas: Some(12),
+        clean_foreign_chain_data_tera_gas: Some(13),
     };
 
     let number_of_participants: usize = 2;

--- a/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
+++ b/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
@@ -108,6 +108,7 @@ async fn test_propose_update_config() {
         clean_tee_status_tera_gas: 99,
         cleanup_orphaned_node_migrations_tera_gas: 11,
         remove_non_participant_update_votes_tera_gas: 12,
+        clean_foreign_chain_data_tera_gas: 13,
     };
 
     let mut proposals = Vec::with_capacity(mpc_signer_accounts.len());

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -70,6 +70,20 @@ expression: abi
         }
       },
       {
+        "name": "clean_foreign_chain_data",
+        "doc": " Private endpoint to clean up foreign chain policy votes and node configurations\n for non-participants after resharing.\n This can only be called by the contract itself via a promise.",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "null"
+          }
+        }
+      },
+      {
         "name": "clean_tee_status",
         "doc": " Private endpoint to clean up TEE information for non-participants after resharing.\n This can only be called by the contract itself via a promise.",
         "kind": "call",
@@ -618,6 +632,10 @@ expression: abi
                       ],
                       [
                         "remove_non_participant_update_votes_tera_gas",
+                        "u64"
+                      ],
+                      [
+                        "clean_foreign_chain_data_tera_gas",
                         "u64"
                       ]
                     ]
@@ -1813,6 +1831,7 @@ expression: abi
           "type": "object",
           "required": [
             "ckd_call_gas_attachment_requirement_tera_gas",
+            "clean_foreign_chain_data_tera_gas",
             "clean_tee_status_tera_gas",
             "cleanup_orphaned_node_migrations_tera_gas",
             "contract_upgrade_deposit_tera_gas",
@@ -1827,6 +1846,12 @@ expression: abi
           "properties": {
             "ckd_call_gas_attachment_requirement_tera_gas": {
               "description": "Prepaid gas for a `return_signature_and_clean_state_on_success` call.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "clean_foreign_chain_data_tera_gas": {
+              "description": "Prepaid gas for a `clean_foreign_chain_data` call.",
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
@@ -2344,6 +2369,15 @@ expression: abi
           "properties": {
             "ckd_call_gas_attachment_requirement_tera_gas": {
               "description": "Prepaid gas for a `return_signature_and_clean_state_on_success` call.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "clean_foreign_chain_data_tera_gas": {
+              "description": "Prepaid gas for a `clean_foreign_chain_data` call.",
               "type": [
                 "integer",
                 "null"

--- a/crates/near-mpc-contract-interface/src/method_names.rs
+++ b/crates/near-mpc-contract-interface/src/method_names.rs
@@ -50,6 +50,7 @@ pub const START_NODE_MIGRATION: &str = "start_node_migration";
 pub const REGISTER_BACKUP_SERVICE: &str = "register_backup_service";
 pub const CLEANUP_ORPHANED_NODE_MIGRATIONS: &str = "cleanup_orphaned_node_migrations";
 pub const CLEAN_TEE_STATUS: &str = "clean_tee_status";
+pub const CLEAN_FOREIGN_CHAIN_DATA: &str = "clean_foreign_chain_data";
 
 // Callbacks (used in promise_yield_create and indexed by the node)
 pub const RETURN_SIGNATURE_AND_CLEAN_STATE_ON_SUCCESS: &str =

--- a/crates/near-mpc-contract-interface/src/types/config.rs
+++ b/crates/near-mpc-contract-interface/src/types/config.rs
@@ -43,6 +43,8 @@ pub struct InitConfig {
     pub cleanup_orphaned_node_migrations_tera_gas: Option<u64>,
     /// Prepaid gas for a `remove_non_participant_update_votes` call.
     pub remove_non_participant_update_votes_tera_gas: Option<u64>,
+    /// Prepaid gas for a `clean_foreign_chain_data` call.
+    pub clean_foreign_chain_data_tera_gas: Option<u64>,
 }
 
 /// Configuration parameters of the contract.
@@ -87,6 +89,8 @@ pub struct Config {
     pub cleanup_orphaned_node_migrations_tera_gas: u64,
     /// Prepaid gas for a `remove_non_participant_update_votes` call.
     pub remove_non_participant_update_votes_tera_gas: u64,
+    /// Prepaid gas for a `clean_foreign_chain_data` call.
+    pub clean_foreign_chain_data_tera_gas: u64,
 }
 
 #[cfg(test)]
@@ -108,6 +112,7 @@ mod tests {
             clean_tee_status_tera_gas: Some(10),
             cleanup_orphaned_node_migrations_tera_gas: Some(3),
             remove_non_participant_update_votes_tera_gas: Some(5),
+            clean_foreign_chain_data_tera_gas: Some(5),
         };
         let json = serde_json::to_string(&original_config).unwrap();
         let serialized_and_deserialized_config: InitConfig = serde_json::from_str(&json).unwrap();
@@ -155,6 +160,7 @@ mod tests {
             clean_tee_status_tera_gas: None,
             cleanup_orphaned_node_migrations_tera_gas: None,
             remove_non_participant_update_votes_tera_gas: None,
+            clean_foreign_chain_data_tera_gas: None,
         };
 
         assert_eq!(default_config, config_with_all_values_as_none);

--- a/crates/test-utils/src/contract_types.rs
+++ b/crates/test-utils/src/contract_types.rs
@@ -12,5 +12,6 @@ pub fn dummy_config(value: u64) -> near_mpc_contract_interface::types::Config {
         clean_tee_status_tera_gas: value + 8,
         cleanup_orphaned_node_migrations_tera_gas: value + 9,
         remove_non_participant_update_votes_tera_gas: value + 10,
+        clean_foreign_chain_data_tera_gas: value + 11,
     }
 }


### PR DESCRIPTION
Closes #2769 

before
```
❯ ls -l /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
-rw------- 1 rey rey 1538703 Apr 14 09:02 /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
```

after
```
❯ ls -l /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
-rw------- 1 rey rey 1546077 Apr 14 09:00 /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
```

delta: +8KB, IMO could be fine, we are not yet close to the limit after this PR