### PR TITLE
chore: do not embed abi to reduce contract size

### DIFF
--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -29,8 +29,8 @@ container_build_command = [
     "non-reproducible-wasm",
     "--locked",
     "--profile=release-contract",
-    "--features",
-    "abi",
+    "--no-embed-abi",
+    "--no-abi",
 ]
 
 [lib]


### PR DESCRIPTION
Disabling the embedded abi removes 11KB

before:
```
❯ ls -l /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
-rw------- 1 rey rey 1538703 Apr 14 09:02 /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
```

after:
```
❯ ls -l /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
-rw------- 1 rey rey 1527108 Apr 14 09:17 /home/rey/opt/near/mpc/target/near/mpc_contract/mpc_contract.wasm
```