### PR TITLE
build: compute manifest digest locally without requiring --push

### DIFF
--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -70,9 +70,7 @@ if $USE_NODE || $USE_RUST_LAUNCHER; then
     require_cmds repro-env podman
 fi
 
-if $USE_PUSH; then
-    require_cmds skopeo
-fi
+require_cmds skopeo
 
 if ! docker buildx &>/dev/null; then
   die "Please install docker-buildx"
@@ -128,9 +126,26 @@ get_image_hash() {
     docker inspect $image_name | jq -r .[0].Id
 }
 
+# Compress a locally built image via skopeo and compute its manifest digest.
+# Sets two global variables: <prefix>_manifest_digest and <prefix>_skopeo_dir
+# Usage: skopeo_compress <image_name> <variable_prefix>
+skopeo_compress() {
+    local image_name="$1"
+    local prefix="$2"
+    local td
+    td=$(mktemp -d)
+    # Compress the built image to a local directory, which implicitly computes
+    # the manifest digest in $td/manifest.json
+    skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td"
+    local digest="sha256:$(sha256sum "$td/manifest.json" | cut -d' ' -f1)"
+    eval "${prefix}_manifest_digest=\"$digest\""
+    eval "${prefix}_skopeo_dir=\"$td\""
+}
+
 if $USE_LAUNCHER; then
     build_reproducible_image $LAUNCHER_IMAGE_NAME $DOCKERFILE_LAUNCHER
     launcher_image_hash=$(get_image_hash $LAUNCHER_IMAGE_NAME)
+    skopeo_compress "$LAUNCHER_IMAGE_NAME" launcher
 fi
 
 if $USE_RUST_LAUNCHER; then
@@ -139,6 +154,7 @@ if $USE_RUST_LAUNCHER; then
 
     build_reproducible_image $RUST_LAUNCHER_IMAGE_NAME $DOCKERFILE_RUST_LAUNCHER
     rust_launcher_image_hash=$(get_image_hash $RUST_LAUNCHER_IMAGE_NAME)
+    skopeo_compress "$RUST_LAUNCHER_IMAGE_NAME" rust_launcher
 fi
 
 if $USE_NODE || $USE_NODE_GCP; then
@@ -149,11 +165,13 @@ fi
 if $USE_NODE; then
     build_reproducible_image $NODE_IMAGE_NAME $DOCKERFILE_NODE
     node_image_hash=$(get_image_hash $NODE_IMAGE_NAME)
+    skopeo_compress "$NODE_IMAGE_NAME" node
 fi
 
 if $USE_NODE_GCP; then
     build_reproducible_image $NODE_GCP_IMAGE_NAME $DOCKERFILE_NODE_GCP
     node_gcp_image_hash=$(get_image_hash $NODE_GCP_IMAGE_NAME)
+    skopeo_compress "$NODE_GCP_IMAGE_NAME" node_gcp
 fi
 
 if $USE_PUSH; then
@@ -169,36 +187,21 @@ if $USE_PUSH; then
     image_tag="$sanitized_branch_name-$short_hash"
     echo "Using branch-hash tag: $image_tag"
 
-    # Push an image via skopeo with preserved manifest digests.
-    # Usage: skopeo_push <local_image_name> <remote_tag>
-    # Prints the manifest digest to stdout.
-    skopeo_push() {
-        local image_name="$1"
-        local tag="$2"
-        local td
-        td=$(mktemp -d)
-        # Compress the built image to a local directory, which implicitly computes
-        # the manifest digest in $td/manifest.json
-        skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td"
-        # Publish the image from the directory, making sure the manifest digest does not change
-        skopeo copy --preserve-digests "dir:$td" "docker://docker.io/nearone/${image_name}:${tag}"
-        echo "sha256:$(sha256sum "$td/manifest.json" | cut -d' ' -f1)"
-    }
-
+    # Push from the already-compressed local directory, preserving the manifest digest.
     if $USE_LAUNCHER; then
-        launcher_manifest_digest="$(skopeo_push "$LAUNCHER_IMAGE_NAME" "$image_tag")"
+        skopeo copy --preserve-digests "dir:$launcher_skopeo_dir" "docker://docker.io/nearone/$LAUNCHER_IMAGE_NAME:$image_tag"
     fi
 
     if $USE_NODE; then
-        node_manifest_digest="$(skopeo_push "$NODE_IMAGE_NAME" "$image_tag")"
+        skopeo copy --preserve-digests "dir:$node_skopeo_dir" "docker://docker.io/nearone/$NODE_IMAGE_NAME:$image_tag"
     fi
 
     if $USE_NODE_GCP; then
-        node_gcp_manifest_digest="$(skopeo_push "$NODE_GCP_IMAGE_NAME" "$image_tag")"
+        skopeo copy --preserve-digests "dir:$node_gcp_skopeo_dir" "docker://docker.io/nearone/$NODE_GCP_IMAGE_NAME:$image_tag"
     fi
 
     if $USE_RUST_LAUNCHER; then
-        rust_launcher_manifest_digest="$(skopeo_push "$RUST_LAUNCHER_IMAGE_NAME" "$image_tag")"
+        skopeo copy --preserve-digests "dir:$rust_launcher_skopeo_dir" "docker://docker.io/nearone/$RUST_LAUNCHER_IMAGE_NAME:$image_tag"
     fi
 fi
 
@@ -209,26 +212,18 @@ if $USE_NODE || $USE_NODE_GCP; then
 fi
 if $USE_NODE; then
     echo "node docker image hash: $node_image_hash"
-    if $USE_PUSH; then
-        echo "node manifest digest: $node_manifest_digest"
-    fi
+    echo "node manifest digest: $node_manifest_digest"
 fi
 if $USE_NODE_GCP; then
     echo "node gcp docker image hash: $node_gcp_image_hash"
-    if $USE_PUSH; then
-        echo "node gcp manifest digest: $node_gcp_manifest_digest"
-    fi
+    echo "node gcp manifest digest: $node_gcp_manifest_digest"
 fi
 if $USE_LAUNCHER; then
     echo "launcher docker image hash: $launcher_image_hash"
-    if $USE_PUSH; then
-        echo "launcher manifest digest: $launcher_manifest_digest"
-    fi
+    echo "launcher manifest digest: $launcher_manifest_digest"
 fi
 if $USE_RUST_LAUNCHER; then
     echo "rust launcher binary hash: $rust_launcher_binary_hash"
     echo "rust launcher docker image hash: $rust_launcher_image_hash"
-    if $USE_PUSH; then
-        echo "rust launcher manifest digest: $rust_launcher_manifest_digest"
-    fi
+    echo "rust launcher manifest digest: $rust_launcher_manifest_digest"
 fi

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -65,13 +65,11 @@ require_cmds() {
   [[ "${missing}" -eq 0 ]] || die "Please install the missing dependencies above."
 }
 
-require_cmds docker jq git find touch
+require_cmds docker jq git find touch skopeo
 
 if $USE_NODE || $USE_RUST_LAUNCHER; then
     require_cmds repro-env podman
 fi
-
-require_cmds skopeo
 
 if ! docker buildx &>/dev/null; then
   die "Please install docker-buildx"
@@ -127,26 +125,28 @@ get_image_hash() {
     docker inspect $image_name | jq -r .[0].Id
 }
 
-# Compress a locally built image via skopeo and compute its manifest digest.
-# Sets two global variables: <prefix>_manifest_digest and <prefix>_skopeo_dir
-# Usage: skopeo_compress <image_name> <variable_prefix>
+# Compress a locally built image via skopeo to a temp directory.
+# Prints the temp dir path to stdout. The manifest digest can be
+# computed from $dir/manifest.json.
 skopeo_compress() {
     local image_name="$1"
-    local prefix="$2"
     local td
     td=$(mktemp -d)
     # Compress the built image to a local directory, which implicitly computes
     # the manifest digest in $td/manifest.json
-    skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td"
-    local digest="sha256:$(sha256sum "$td/manifest.json" | cut -d' ' -f1)"
-    printf -v "${prefix}_manifest_digest" '%s' "$digest"
-    printf -v "${prefix}_skopeo_dir" '%s' "$td"
+    skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td" >&2
+    echo "$td"
+}
+
+manifest_digest_from_dir() {
+    echo "sha256:$(sha256sum "$1/manifest.json" | cut -d' ' -f1)"
 }
 
 if $USE_LAUNCHER; then
     build_reproducible_image $LAUNCHER_IMAGE_NAME $DOCKERFILE_LAUNCHER
     launcher_image_hash=$(get_image_hash $LAUNCHER_IMAGE_NAME)
-    skopeo_compress "$LAUNCHER_IMAGE_NAME" launcher
+    launcher_skopeo_dir="$(skopeo_compress "$LAUNCHER_IMAGE_NAME")"
+    launcher_manifest_digest="$(manifest_digest_from_dir "$launcher_skopeo_dir")"
 fi
 
 if $USE_RUST_LAUNCHER; then
@@ -155,7 +155,8 @@ if $USE_RUST_LAUNCHER; then
 
     build_reproducible_image $RUST_LAUNCHER_IMAGE_NAME $DOCKERFILE_RUST_LAUNCHER
     rust_launcher_image_hash=$(get_image_hash $RUST_LAUNCHER_IMAGE_NAME)
-    skopeo_compress "$RUST_LAUNCHER_IMAGE_NAME" rust_launcher
+    rust_launcher_skopeo_dir="$(skopeo_compress "$RUST_LAUNCHER_IMAGE_NAME")"
+    rust_launcher_manifest_digest="$(manifest_digest_from_dir "$rust_launcher_skopeo_dir")"
 fi
 
 if $USE_NODE || $USE_NODE_GCP; then
@@ -166,13 +167,15 @@ fi
 if $USE_NODE; then
     build_reproducible_image $NODE_IMAGE_NAME $DOCKERFILE_NODE
     node_image_hash=$(get_image_hash $NODE_IMAGE_NAME)
-    skopeo_compress "$NODE_IMAGE_NAME" node
+    node_skopeo_dir="$(skopeo_compress "$NODE_IMAGE_NAME")"
+    node_manifest_digest="$(manifest_digest_from_dir "$node_skopeo_dir")"
 fi
 
 if $USE_NODE_GCP; then
     build_reproducible_image $NODE_GCP_IMAGE_NAME $DOCKERFILE_NODE_GCP
     node_gcp_image_hash=$(get_image_hash $NODE_GCP_IMAGE_NAME)
-    skopeo_compress "$NODE_GCP_IMAGE_NAME" node_gcp
+    node_gcp_skopeo_dir="$(skopeo_compress "$NODE_GCP_IMAGE_NAME")"
+    node_gcp_manifest_digest="$(manifest_digest_from_dir "$node_gcp_skopeo_dir")"
 fi
 
 if $USE_PUSH; then

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -1,13 +1,14 @@
 #! /usr/bin/env bash
-# Script to reproducibly the docker images for the node and launcher
+# Script to reproducibly build the docker images for the node and launcher
 #
-# Requirements: docker, docker-buildx, jq, git, find, touch
-# Extra requirements if using --node: repro-env, podman
+# Requirements: docker, docker-buildx, jq, git, find, touch, skopeo
+# Extra requirements if using --node or --rust-launcher: repro-env, podman
+# Extra requirements if using --push: docker must be logged in to registry
 #
 # Usage:
-#   ./deployment/build-images.sh [--node] [--launcher] [--push]
-# If neither --node nor --launcher are used, both images are built
-# If using --pushed, docker must be logged in to registry
+#   ./deployment/build-images.sh [--node] [--node-gcp] [--launcher] [--rust-launcher] [--push]
+# If no image flags are used, all images are built
+# Manifest digests are always computed and printed (skopeo required)
 
 
 set -euo pipefail
@@ -138,8 +139,8 @@ skopeo_compress() {
     # the manifest digest in $td/manifest.json
     skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td"
     local digest="sha256:$(sha256sum "$td/manifest.json" | cut -d' ' -f1)"
-    eval "${prefix}_manifest_digest=\"$digest\""
-    eval "${prefix}_skopeo_dir=\"$td\""
+    printf -v "${prefix}_manifest_digest" '%s' "$digest"
+    printf -v "${prefix}_skopeo_dir" '%s' "$td"
 }
 
 if $USE_LAUNCHER; then

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1198,7 +1198,7 @@ git checkout 828f816be36aed6f0d2438e0131b3e9d7d0931ad
 ```
 
 * Compile it using the reproduce build script. For this you need to install
-  `repro-env` and `docker-buildx`, and have the `docker` daemon
+  `repro-env`, `docker-buildx`, and `skopeo`, and have the `docker` daemon
   running.
 
 ```bash

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1211,7 +1211,7 @@ node docker image hash: sha256:0e48003c0ac6ec01e79ce47aa094379e7a8fac428512dfeb1
 node manifest digest: sha256:331cfec941671ac343c52847e255eb36a280da65535d2a1e4d002c4c64686e19
 ```
 
-The `node manifest digest` is what you vote for. The launcher pulls the image directly by this digest — Docker verifies the content matches during the pull.
+The `node manifest digest` is what you vote for. When submitting the `code_hash` value in the voting command, strip the `sha256:` prefix and provide only the hex digest. The launcher pulls the image directly by this digest — Docker verifies the content matches during the pull.
 
 * Do your own due diligence on the code/binary
 

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1208,10 +1208,10 @@ commit hash: 828f816be36aed6f0d2438e0131b3e9d7d0931ad
 SOURCE_DATE_EPOCH used: 0
 node binary hash: 86c8f7d8913d6fe37a6992bba165d15a3a1d88fbf6cdff605e4827d5183721bc
 node docker image hash: sha256:0e48003c0ac6ec01e79ce47aa094379e7a8fac428512dfeb18d49d558e100a53
+node manifest digest: sha256:331cfec941671ac343c52847e255eb36a280da65535d2a1e4d002c4c64686e19
 ```
 
-<!-- TODO(#2843): build script should output manifest digest without --push -->
-The `node docker image hash` is the config digest of the locally built image. To get the manifest digest (what you vote for), look it up on DockerHub for the same image tag. The launcher pulls the image directly by manifest digest — Docker verifies the content matches during the pull.
+The `node manifest digest` is what you vote for. The launcher pulls the image directly by this digest — Docker verifies the content matches during the pull.
 
 * Do your own due diligence on the code/binary
 


### PR DESCRIPTION
### Summary

Always compute the manifest digest after building a Docker image, even without `--push`. Operators can now verify the manifest digest locally without Docker Hub credentials.

### Changes

- Add `skopeo_compress()` function that compresses the image to a temp dir and computes the manifest digest
- Call it after every image build (launcher, rust-launcher, node, node-gcp)
- The `--push` step reuses the existing temp dir (no double compress)
- `skopeo` is now always required (was only required with `--push`)
- Manifest digest is always printed in the output
- Updated operator guide to show manifest digest in build output, removed TODO(#2843)

### Before

```bash
$ ./deployment/build-images.sh --node
node docker image hash: sha256:0e48003c...
# No manifest digest without --push
```

### After

```bash
$ ./deployment/build-images.sh --node
node docker image hash: sha256:0e48003c...
node manifest digest: sha256:331cfec9...
```

Closes #2843

### Test plan

- [x] `./deployment/build-images.sh --node` outputs manifest digest
- [x] `./deployment/build-images.sh --node --push` still pushes correctly
- [x] CI docker build jobs pass