### PR TITLE
docs: Refer to the bug bounty program instead of our security email

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -5,9 +5,9 @@ responsible disclosure of security vulnerabilities helps us ensure the security
 and privacy of all our users.
 
 Please do NOT raise a GitHub Issue to report a security vulnerability. If you
-believe you have found a security vulnerability, please submit a report to
-<security@nearone.org>, preferably with a proof of concept. We ask that you
-do not use other channels or contact project contributors directly.
+believe you have found a security vulnerability, please submit a report through
+the NEAR Intents' bug bounty program on HackenProof:
+https://hackenproof.com/programs/near-intents-bridges
 
 Non-vulnerability-related security issues, such as new ideas for security
 features, are welcome on GitHub Issues.


### PR DESCRIPTION
closes #2860 