### PR TITLE
docs: update SECURITY.md to refer to bug bounty program

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -5,9 +5,12 @@ responsible disclosure of security vulnerabilities helps us ensure the security
 and privacy of all our users.
 
 Please do NOT raise a GitHub Issue to report a security vulnerability. If you
-believe you have found a security vulnerability, please submit a report to
-<security@nearone.org>, preferably with a proof of concept. We ask that you
-do not use other channels or contact project contributors directly.
+believe you have found a security vulnerability, please report it through our
+bug bounty program:
+
+**[NEAR Intents Bug Bounty (HackenProof)](https://hackenproof.com/programs/near-intents-bridges)**
+
+We ask that you do not use other channels or contact project contributors directly.
 
 Non-vulnerability-related security issues, such as new ideas for security
 features, are welcome on GitHub Issues.


### PR DESCRIPTION
Fixes #2860

## Summary
Updated `SECURITY.md` to reference the NEAR Intents bug bounty program on HackenProof instead of the direct email address. This reduces LLM spam on the security@nearone.org mail group while directing researchers to the proper vulnerability disclosure channel.

## Changes
- Replaced `security@nearone.org` email with a link to [HackenProof bug bounty program](https://hackenproof.com/programs/near-intents-bridges)
- Kept all other security guidance intact

## Verification
Review `.github/SECURITY.md` — it now points to the HackenProof bounty page instead of the email address.