### PR TITLE
chore: reduce contract WASM size and add CI size check

### DIFF
--- a/.github/contract-size-baseline.toml
+++ b/.github/contract-size-baseline.toml
@@ -1,0 +1,6 @@
+# NEAR max_transaction_size since protocol v69
+# https://github.com/near/nearcore/blob/master/core/parameters/res/runtime_configs/69.yaml
+max_transaction_size = 1572864
+
+# Expected contract WASM size in bytes (reproducible builds must match exactly)
+expected_size = 1474361

--- a/.github/contract-size-baseline.toml
+++ b/.github/contract-size-baseline.toml
@@ -3,4 +3,4 @@
 max_transaction_size = 1572864
 
 # Expected contract WASM size in bytes (reproducible builds must match exactly)
-expected_size = 1477608
+expected_size = 1481277

--- a/.github/contract-size-baseline.toml
+++ b/.github/contract-size-baseline.toml
@@ -3,4 +3,4 @@
 max_transaction_size = 1572864
 
 # Expected contract WASM size in bytes (reproducible builds must match exactly)
-expected_size = 1474361
+expected_size = 1477608

--- a/.github/scripts/check-contract-wasm-size.sh
+++ b/.github/scripts/check-contract-wasm-size.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Checks the contract WASM binary size against:
+# 1. NEAR's max_transaction_size hard limit
+# 2. A committed baseline that ratchets down over time
+#
+# Usage: bash .github/scripts/check-contract-wasm-size.sh <path-to-wasm>
+
+WASM_PATH="${1:?Usage: $0 <path-to-wasm>}"
+BASELINE_FILE=".github/contract-size-baseline.toml"
+
+read_toml_value() {
+    grep "^$1 " "$BASELINE_FILE" | sed 's/.*= *//'
+}
+
+if [[ ! -f "$WASM_PATH" ]]; then
+    echo "❌ WASM file not found: $WASM_PATH"
+    exit 1
+fi
+
+if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "❌ Baseline file not found: $BASELINE_FILE"
+    exit 1
+fi
+
+MAX_TX_SIZE=$(read_toml_value "max_transaction_size")
+BASELINE=$(read_toml_value "expected_size")
+
+if [[ -z "$MAX_TX_SIZE" || -z "$BASELINE" ]]; then
+    echo "❌ Failed to read max_transaction_size or expected_size from $BASELINE_FILE"
+    exit 1
+fi
+
+SIZE=$(wc -c < "$WASM_PATH" | tr -d ' ')
+HEADROOM=$(( MAX_TX_SIZE - SIZE ))
+DELTA=$(( SIZE - BASELINE ))
+
+echo "Contract WASM size report"
+echo "========================="
+echo "  Binary:     $WASM_PATH"
+echo "  Size:       $SIZE bytes"
+echo "  Hard limit: $MAX_TX_SIZE bytes (NEAR max_transaction_size)"
+echo "  Headroom:   $HEADROOM bytes"
+echo "  Baseline:   $BASELINE bytes"
+if [[ "$DELTA" -gt 0 ]]; then
+    echo "  Delta:      +$DELTA bytes"
+elif [[ "$DELTA" -lt 0 ]]; then
+    echo "  Delta:      $DELTA bytes"
+fi
+echo ""
+
+# Hard limit check
+if [[ "$SIZE" -gt "$MAX_TX_SIZE" ]]; then
+    OVER=$(( SIZE - MAX_TX_SIZE ))
+    echo "❌ EXCEEDS hard limit by $OVER bytes"
+    echo "   The contract binary is too large to deploy in a single transaction"
+    echo "   Reduce size by removing methods, shrinking dependencies,"
+    echo "   or optimizing the build profile"
+    exit 1
+fi
+
+# Baseline check
+if [[ "$DELTA" -gt 0 ]]; then
+    echo "❌ Contract grew by $DELTA bytes"
+    echo "   If this growth is intentional, update the baseline in $BASELINE_FILE:"
+    echo "   expected_size = $SIZE"
+    exit 1
+elif [[ "$DELTA" -lt 0 ]]; then
+    SHRINK=$(( BASELINE - SIZE ))
+    echo "🎉 Contract shrank by $SHRINK bytes — please update the baseline in $BASELINE_FILE:"
+    echo "   expected_size = $SIZE"
+    exit 1
+else
+    echo "✅ Contract size matches baseline"
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,7 +363,7 @@ jobs:
             --manifest-path crates/contract/Cargo.toml
 
       - name: Check contract WASM size
-        run: bash .github/scripts/check-contract-wasm-size.sh target/near/mpc_contract/mpc_contract.wasm
+        run: bash scripts/check-contract-wasm-size.sh
 
   mpc-pytests:
     name: "MPC pytests: ${{ matrix.group }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,9 @@ jobs:
           cargo near build reproducible-wasm \
             --manifest-path crates/contract/Cargo.toml
 
+      - name: Check contract WASM size
+        run: bash .github/scripts/check-contract-wasm-size.sh target/near/mpc_contract/mpc_contract.wasm
+
   mpc-pytests:
     name: "MPC pytests: ${{ matrix.group }}"
     needs: mpc-pytest-build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -287,7 +287,7 @@ strip = true
 panic = "abort"
 # Optimize for binary size.
 # See https://doc.rust-lang.org/rustc/codegen-options/index.html#opt-level
-opt-level = "s"
+opt-level = "z"
 
 [profile.reproducible]
 inherits = "release"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -97,6 +97,11 @@ args = ["scripts/check-kebab-case-files.sh"]
 command = "bash"
 args = ["scripts/check-todo-format.sh"]
 
+[tasks.check-contract-size]
+description = "Check reproducible contract WASM size against baseline"
+command = "bash"
+args = ["scripts/check-contract-wasm-size.sh"]
+
 [tasks.assert-matches]
 description = "Check for assert!(matches!(...)) — use assert_matches!() instead"
 command = "bash"

--- a/crates/contract/src/config.rs
+++ b/crates/contract/src/config.rs
@@ -25,7 +25,7 @@ const DEFAULT_FAIL_ON_TIMEOUT_TERA_GAS: u64 = 2;
 const DEFAULT_CLEAN_TEE_STATUS_TERA_GAS: u64 = 10;
 /// Prepaid gas for a `cleanup_orphaned_node_migrations` call
 /// TODO(#1164): benchmark
-const DEFAULT_CLEANUP_ORPHANED_NODE_MIGRATIONS_TERA_GAS: u64 = 3;
+const DEFAULT_CLEANUP_ORPHANED_NODE_MIGRATIONS_TERA_GAS: u64 = 4;
 /// Prepaid gas for a `remove_non_participant_update_votes` call
 const DEFAULT_REMOVE_NON_PARTICIPANT_UPDATE_VOTES_TERA_GAS: u64 = 5;
 /// Prepaid gas for a `clean_foreign_chain_data` call

--- a/crates/contract/tests/sandbox/gas_thresholds.json
+++ b/crates/contract/tests/sandbox/gas_thresholds.json
@@ -30,7 +30,7 @@
       "update_info": 4823
     },
     "100": {
-      "len": 4865,
+      "len": 4880,
       "is_participant": 4924,
       "info": 4924,
       "validate": 5444,
@@ -40,10 +40,10 @@
     },
     "400": {
       "len": 11500,
-      "is_participant": 11500,
-      "info": 11500,
-      "validate": 13701,
-      "serialization": 12050,
+      "is_participant": 12440,
+      "info": 12440,
+      "validate": 14114,
+      "serialization": 13048,
       "insert": 20449,
       "update_info": 20612
     }

--- a/crates/contract/tests/sandbox/gas_thresholds.json
+++ b/crates/contract/tests/sandbox/gas_thresholds.json
@@ -3,49 +3,49 @@
   "buffer_percent": 25.0,
   "thresholds": {
     "10": {
-      "len": 3052,
-      "is_participant": 3074,
-      "info": 3074,
-      "validate": 3083,
-      "serialization": 3067,
-      "insert": 3477,
-      "update_info": 3495
+      "len": 3250,
+      "is_participant": 3280,
+      "info": 3280,
+      "validate": 3290,
+      "serialization": 3270,
+      "insert": 3700,
+      "update_info": 3720
     },
     "30": {
-      "len": 3445,
-      "is_participant": 3475,
-      "info": 3475,
-      "validate": 3576,
-      "serialization": 3500,
-      "insert": 4356,
-      "update_info": 4384
+      "len": 3660,
+      "is_participant": 3700,
+      "info": 3700,
+      "validate": 3810,
+      "serialization": 3730,
+      "insert": 4600,
+      "update_info": 4630
     },
     "40": {
-      "len": 3659,
-      "is_participant": 3690,
-      "info": 3690,
-      "validate": 3858,
-      "serialization": 3728,
-      "insert": 4793,
-      "update_info": 4823
+      "len": 3900,
+      "is_participant": 3940,
+      "info": 3940,
+      "validate": 4120,
+      "serialization": 3980,
+      "insert": 5100,
+      "update_info": 5130
     },
     "100": {
-      "len": 4880,
-      "is_participant": 4924,
-      "info": 4924,
-      "validate": 5444,
-      "serialization": 5060,
-      "insert": 7386,
-      "update_info": 7448
+      "len": 5300,
+      "is_participant": 5400,
+      "info": 5400,
+      "validate": 5900,
+      "serialization": 5500,
+      "insert": 7800,
+      "update_info": 7870
     },
     "400": {
-      "len": 11500,
-      "is_participant": 12440,
-      "info": 12440,
-      "validate": 14114,
-      "serialization": 13048,
-      "insert": 20449,
-      "update_info": 20612
+      "len": 13600,
+      "is_participant": 13600,
+      "info": 13600,
+      "validate": 15400,
+      "serialization": 14200,
+      "insert": 21600,
+      "update_info": 21800
     }
   }
 }

--- a/scripts/check-contract-wasm-size.sh
+++ b/scripts/check-contract-wasm-size.sh
@@ -5,9 +5,9 @@ set -euo pipefail
 # 1. NEAR's max_transaction_size hard limit
 # 2. A committed baseline that ratchets down over time
 #
-# Usage: bash .github/scripts/check-contract-wasm-size.sh <path-to-wasm>
+# Usage: bash scripts/check-contract-wasm-size.sh [path-to-wasm]
 
-WASM_PATH="${1:?Usage: $0 <path-to-wasm>}"
+WASM_PATH="${1:-target/near/mpc_contract/mpc_contract.wasm}"
 BASELINE_FILE=".github/contract-size-baseline.toml"
 
 read_toml_value() {


### PR DESCRIPTION
## Summary

Three changes to address the contract binary approaching NEAR's `max_transaction_size` limit (1,572,864 bytes since [protocol v69](https://github.com/near/nearcore/blob/master/core/parameters/res/runtime_configs/69.yaml)):

1. **Switch `opt-level` from `"s"` to `"z"`** in the `release-contract` profile

   | opt-level | WASM size | Headroom |
   |---|---|---|
   | `"s"` (before) | 1,550,594 | 22,270 |
   | `"z"` (after) | 1,481,277 | 91,587 |
   | **Savings** | **69,317 (4.5%)** | |

   The [Rust docs](https://doc.rust-lang.org/rustc/codegen-options/index.html#opt-level) describe `"s"` as "optimize for binary size" and `"z"` as "optimize for binary size, but more aggressively. Often results in larger binaries than `s`". In practice this is not always true — in our case `"z"` produces a 4.5% smaller binary.

2. **Add CI size check** after the reproducible contract build
   - Reads the hard limit and expected size from `.github/contract-size-baseline.toml`
   - Fails if the binary size differs from the baseline (grew or shrank)
   - When the contract grows, the developer must explicitly update the baseline
   - When the contract shrinks, the developer updates the baseline to lock in the improvement

3. **Adjust gas thresholds and config** — `opt-level "z"` produces smaller but slightly slower code
   - Update gas regression test thresholds
   - Bump `DEFAULT_CLEANUP_ORPHANED_NODE_MIGRATIONS_TERA_GAS` from 3 to 4 TGas (promise exceeded prepaid gas during resharing)

Closes #2868

## Test plan
- [x] Verified WASM sizes back-to-back with same toolchain
- [x] Script tested locally
- [x] Baseline updated to match reproducible build output
- [x] Gas regression tests pass (3 consecutive runs)
- [x] Resharing tests pass (3 consecutive runs)
- [x] CI passes