### PR TITLE
refactor: make monitor_attestation_removal infallible

### DIFF
--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -299,7 +299,7 @@ where
     let allowed_launcher_compose_receiver_clone =
         indexer_api.allowed_launcher_compose_receiver.clone();
     tokio::spawn(async move {
-        if let Err(e) = monitor_attestation_removal(
+        monitor_attestation_removal(
             account_id_clone,
             tee_authority,
             tx_sender_clone,
@@ -309,13 +309,7 @@ where
             allowed_launcher_compose_receiver_clone,
             tee_accounts_receiver,
         )
-        .await
-        {
-            tracing::error!(
-                error = ?e,
-                "attestation removal monitoring task failed"
-            );
-        }
+        .await;
     });
 
     let keyshare_storage: Arc<RwLock<KeyshareStorage>> =

--- a/crates/node/src/tee/remote_attestation.rs
+++ b/crates/node/src/tee/remote_attestation.rs
@@ -217,7 +217,7 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
     allowed_image_hashes_in_contract: watch::Receiver<Vec<NodeImageHash>>,
     allowed_launcher_compose_hashes_in_contract: watch::Receiver<Vec<LauncherDockerComposeHash>>,
     mut tee_accounts_receiver: watch::Receiver<Vec<NodeId>>,
-) -> anyhow::Result<()> {
+) {
     let node_id = NodeId {
         account_id: node_account_id.clone(),
         tls_public_key: near_sdk::PublicKey::from(tls_public_key.clone()),
@@ -269,7 +269,7 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
                         .inc();
                     tracing::warn!(
                         error = ?e,
-                        "TEE attestation failed, periodic attestation task will retry",
+                        "TEE attestation failed (collateral upload), will retry on next check",
                     );
                     was_available = is_available;
                     continue;
@@ -278,16 +278,18 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
                     crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
                         .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
                         .inc();
-                    return Err(
-                        anyhow::anyhow!(e).context("TEE attestation failed, cannot continue")
+                    tracing::error!(
+                        error = ?e,
+                        "TEE attestation failed with unrecoverable error, shutting down node"
                     );
+                    panic!("TEE attestation failed with unrecoverable error: {e}");
                 }
             };
             let allowed_image_hashes_in_contract =
                 allowed_image_hashes_in_contract.borrow().clone();
             let allowed_launcher_compose_hashes_in_contract =
                 allowed_launcher_compose_hashes_in_contract.borrow().clone();
-            validate_and_submit_remote_attestation(
+            if let Err(e) = validate_and_submit_remote_attestation(
                 tx_sender.clone(),
                 fresh_attestation.clone(),
                 tls_public_key.clone(),
@@ -295,13 +297,19 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
                 &allowed_image_hashes_in_contract,
                 &allowed_launcher_compose_hashes_in_contract,
             )
-            .await?;
+            .await
+            {
+                tracing::error!(
+                    error = ?e,
+                    %node_account_id,
+                    "failed to submit attestation after removal, shutting down node"
+                );
+                panic!("Failed to submit remote attestation: {e}");
+            }
         }
 
         was_available = is_available;
     }
-
-    Ok(())
 }
 
 /// Allows repeatedly awaiting for something, like a `tokio::time::Interval`.


### PR DESCRIPTION
Fixes #2782

**Problem:** `monitor_attestation_removal` returns `anyhow::Result<()>`, and when it returns `Err` the tokio task dies silently, leaving the node in a partially broken state.

**Solution:** Changed the return type to `()` (infallible). Errors are now handled internally:
- **Recoverable** (`CollateralUpload`): log warning, retry on next watch cycle
- **Unrecoverable** (other attestation errors): `panic!` to shut down the node
- **Submission failures**: `panic!` to shut down the node

The call site in `run.rs` is simplified since the function can no longer fail.

**Files changed:**
- `crates/node/src/tee/remote_attestation.rs` — function signature + error handling
- `crates/node/src/run.rs` — simplified call site