### PR TITLE
fix: Use `curve` instead of `scheme` in `vote_add_domain` parameters for localnet

### DIFF
--- a/docs/localnet/args/add_domain.json
+++ b/docs/localnet/args/add_domain.json
@@ -2,22 +2,22 @@
   "domains": [
     {
       "id": 0,
-      "scheme": "Secp256k1",
+      "curve": "Secp256k1",
       "purpose": "Sign"
     },
     {
       "id": 1,
-      "scheme": "Ed25519",
+      "curve": "Edwards25519",
       "purpose": "Sign"
     },
     {
       "id": 2,
-      "scheme": "Bls12381",
+      "curve": "Bls12381",
       "purpose": "CKD"
     },
     {
       "id": 3,
-      "scheme": "Secp256k1",
+      "curve": "Secp256k1",
       "purpose": "ForeignTx"
     }
   ]


### PR DESCRIPTION
closes #2891 