### PR TITLE
feat: make quote_upload_url configurable in MPC node config

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,4 +18,4 @@ filter = 'package(e2e-tests)'
 test-group = 'e2e'
 
 [profile.ci-other]
-default-filter = 'not package(mpc-node) and not package(mpc-contract) and not package(e2e-tests) and not package(contract-history) and not test(=tee_authority::tests::test_upload_quote_for_collateral_with_phala_endpoint) and not (test(/^registry::integration_tests::/) and package(tee-launcher))'
+default-filter = 'not package(mpc-node) and not package(mpc-contract) and not package(e2e-tests) and not package(contract-history) and not test(/^tee_authority::tests::test_upload_quote_for_collateral/) and not (test(/^registry::integration_tests::/) and package(tee-launcher))'

--- a/.github/workflows/external-services-tests.yml
+++ b/.github/workflows/external-services-tests.yml
@@ -49,6 +49,6 @@ jobs:
         if: always()
         run: cargo nextest run -p tee-launcher --features external-services-tests --cargo-profile test-release --locked
 
-      - name: Run tee-authority tests
+      - name: Run tee-authority Phala collateral tests
         if: always()
-        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(test_upload_quote_for_collateral_with_phala_endpoint)'
+        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(/test_upload_quote_for_collateral::case_[0-9]+_phala/)'

--- a/.github/workflows/external-services-tests.yml
+++ b/.github/workflows/external-services-tests.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Run tee-authority Phala collateral tests
         if: always()
-        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(/test_upload_quote_for_collateral::case_[0-9]+_phala/)'
+        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(test_upload_quote_for_collateral::case_1_phala_endpoint) | test(test_upload_quote_for_collateral::case_2_phala_via_override)'

--- a/.github/workflows/external-services-tests.yml
+++ b/.github/workflows/external-services-tests.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Run tee-authority Phala collateral tests
         if: always()
-        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(test_upload_quote_for_collateral::case_1_phala_endpoint) | test(test_upload_quote_for_collateral::case_2_phala_via_override)'
+        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(/test_upload_quote_for_collateral::case_[0-9]+_phala/)'

--- a/.github/workflows/external-services-tests.yml
+++ b/.github/workflows/external-services-tests.yml
@@ -51,4 +51,4 @@ jobs:
 
       - name: Run tee-authority Phala collateral tests
         if: always()
-        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(test_upload_quote_for_collateral::case_1_phala_endpoint) | test(test_upload_quote_for_collateral::case_2_phala_via_override)'
+        run: cargo nextest run -p tee-authority --features external-services-tests --cargo-profile test-release --locked -E 'test(/test_upload_quote_for_collateral::case_[0-9]+_phala_/)'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,13 +45,37 @@ license = "MIT"
 repository = "https://github.com/near/mpc"
 
 [workspace.dependencies]
+#workspace members
+attestation = { path = "crates/attestation" }
+chain-gateway = { path = "crates/chain-gateway" }
+chain-gateway-test-contract = { path = "crates/chain-gateway-test-contract" }
+contract-history = { path = "crates/contract-history" }
+foreign-chain-inspector = { path = "crates/foreign-chain-inspector" }
+foreign-chain-rpc-interfaces = { path = "crates/foreign-chain-rpc-interfaces" }
+include-measurements = { path = "crates/include-measurements" }
+launcher-interface = { path = "crates/launcher-interface" }
+mpc-attestation = { path = "crates/mpc-attestation" }
+mpc-contract = { path = "crates/contract", features = ["dev-utils"] }
+mpc-node = { path = "crates/node" }
+mpc-node-config = { path = "crates/node-config" }
+mpc-primitives = { path = "crates/primitives", features = ["abi"] }
+mpc-tls = { path = "crates/tls" }
+near-mpc-bounded-collections = { path = "crates/near-mpc-bounded-collections", version = "0.0.1" }
+near-mpc-contract-interface = { path = "crates/near-mpc-contract-interface", version = "0.0.1" }
+near-mpc-crypto-types = { path = "crates/near-mpc-crypto-types", version = "0.0.1" }
+near-mpc-sdk = { path = "crates/near-mpc-sdk", version = "0.0.1" }
+near-mpc-signature-verifier = { path = "crates/near-mpc-signature-verifier", version = "0.0.1" }
+node-types = { path = "crates/node-types" }
+tee-authority = { path = "crates/tee-authority" }
+test-port-allocator = { path = "crates/test-port-allocator" }
+test-utils = { path = "crates/test-utils" }
+threshold-signatures = { path = "crates/threshold-signatures" }
+utilities = { path = "crates/utilities" }
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
-#workspace members
-attestation = { path = "crates/attestation" }
 auto_ops = "0.3.0"
 average = "0.16"
 axum = "0.8.8"
@@ -64,10 +88,7 @@ built = { version = "0.8", features = ["git2", "chrono"] }
 byteorder = "1.5.0"
 bytes = { version = "1.11.1" }
 cargo-near-build = "0.11.1"
-chain-gateway = { path = "crates/chain-gateway" }
-chain-gateway-test-contract = { path = "crates/chain-gateway-test-contract" }
 clap = { version = "4.6.0", features = ["derive", "env"] }
-contract-history = { path = "crates/contract-history" }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 curve25519-dalek = { version = "4.1.3", features = [
     "group",
@@ -103,8 +124,6 @@ either = "1.15.0"
 elliptic-curve = "0.13.8"
 ethereum-types = "0.16.0"
 flume = "0.12.0"
-foreign-chain-inspector = { path = "crates/foreign-chain-inspector" }
-foreign-chain-rpc-interfaces = { path = "crates/foreign-chain-rpc-interfaces" }
 frost-core = { version = "2.2.0", default-features = false, features = [
     "serde",
 ] }
@@ -116,58 +135,26 @@ gcloud-sdk = { version = "0.29.0", default-features = false, features = [
     "google-cloud-secretmanager-v1",
     "tls-webpki-roots",
 ] }
-
-# These dependencies need to be upgraded in tandem
-getrandom = "0.2.12"
 group = "0.13"
 hex = { version = "0.4.3", features = ["serde"] }
 hkdf = "0.12.4"
 http = "1.4.0"
-
-## Outdated dependencies we cannot upgrade ##
-# Version 0.8.3 requires rustc 1.88
-httpmock = "0.8.2"
 humantime = "2.3.0"
 # TODO(#1299): updating this brings considerable breaking changes
 hyper = { version = "0.14.32", features = ["server", "http1", "tcp", "stream"] }
-include-measurements = { path = "crates/include-measurements" }
 insta = { version = "1.46.3", features = ["json", "redactions"] }
 itertools = "0.14.0"
 jsonrpsee = { version = "0.26.0", features = ["http-client"] }
 k256 = "0.13.4"
 keccak = "0.1.5"
-launcher-interface = { path = "crates/launcher-interface" }
 lru = "0.16.3"
 mockall = "0.14.0"
-mpc-attestation = { path = "crates/mpc-attestation" }
-mpc-contract = { path = "crates/contract", features = ["dev-utils"] }
-mpc-node = { path = "crates/node" }
-mpc-node-config = { path = "crates/node-config" }
-mpc-primitives = { path = "crates/primitives", features = ["abi"] }
-mpc-tls = { path = "crates/tls" }
 named-lock = "0.4.1"
 near-abi = "0.4.4"
 near-account-id = "2.5.0"
-
-# This can be removed once the workspace `utilities` crate is removed
-near-account-id-v1 = { version = "1.1.4", package = "near-account-id" }
-
-# NEAR CORE DEPENDENCIES:
-near-async = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
 near-jsonrpc-client = "0.20.0"
 near-jsonrpc-primitives = "0.34.6"
 near-kit = { version = "0.7.1", default-features = false }
-near-mpc-bounded-collections = { path = "crates/near-mpc-bounded-collections", version = "0.0.1" }
-near-mpc-contract-interface = { path = "crates/near-mpc-contract-interface", version = "0.0.1" }
-near-mpc-crypto-types = { path = "crates/near-mpc-crypto-types", version = "0.0.1" }
-near-mpc-sdk = { path = "crates/near-mpc-sdk", version = "0.0.1" }
-near-mpc-signature-verifier = { path = "crates/near-mpc-signature-verifier", version = "0.0.1" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
 near-primitives = "0.34.6"
 near-sandbox = "0.3.9"
 near-sdk = { version = "5.24.1", features = [
@@ -175,11 +162,7 @@ near-sdk = { version = "5.24.1", features = [
     "unit-testing",
     "unstable",
 ] }
-near-store = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
 near-workspaces = { version = "0.22.1" }
-nearcore = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-node-types = { path = "crates/node-types" }
 num_enum = { version = "0.7.6", features = ["complex-expressions"] }
 pairing = { version = "0.23.0" }
 pprof = { version = "0.15.0", features = [
@@ -187,13 +170,7 @@ pprof = { version = "0.15.0", features = [
     "flamegraph",
 ], default-features = false }
 proc-macro2 = "1.0"
-
-# This cannot be upgraded because it conflicts the prometheus version required by nearcore
-prometheus = { version = "0.13.4", default-features = false }
 quote = "1.0"
-rand = "0.8.5"
-rand_chacha = "0.3"
-rand_core = "0.6.4"
 # TODO(#2051): updating this brings considerable breaking changes
 rcgen = "0.13.2"
 # This project has been forked due to incompatibility problems with cheater detection feature activated on the original Zcash repo
@@ -203,25 +180,16 @@ reddsa = { git = "https://github.com/near/reddsa", rev = "c7cd92a55f7399d8d7f8c0
 regex = "1.12.3"
 reqwest = { version = "0.13.2", features = ["multipart", "json"] }
 rmp-serde = "1.3.1"
-
-# TODO(#690): This cannot be upgraded until nearcore does
-rocksdb = "0.21.0"
 rstest = { version = "0.26.1" }
 rustls = { version = "0.23.37", default-features = false, features = [
     "ring",
     "std",
 ] }
-
-# This version needs to be exactly the same as in `near_sdk::schemars`
-schemars = "0.8.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.19"
 serde_json = "1.0"
 serde_repr = "0.1.20"
 serde_with = { version = "3.17.0", features = ["hex"] }
-
-# This is deprecated, we should find an alterantive
-serde_yaml = "0.9.34"
 serial_test = "3.4.0"
 sha2 = "0.10.9"
 sha3 = "0.10.8"
@@ -229,16 +197,9 @@ signature = "2.2.0"
 socket2 = "0.6.3"
 subtle = "2.6.1"
 syn = "2.0"
-tee-authority = { path = "crates/tee-authority" }
 tempfile = "3.27.0"
 test-log = "0.2.19"
-test-port-allocator = { path = "crates/test-port-allocator" }
-test-utils = { path = "crates/test-utils" }
 thiserror = "2.0.18"
-threshold-signatures = { path = "crates/threshold-signatures" }
-
-# Cannot be upgraded until we get MSVR 1.88
-time = "0.3.45"
 tokio = { version = "1.51.0", features = ["full", "test-util"] }
 tokio-metrics = { version = "0.4.8" }
 tokio-rustls = { version = "0.26.4", default-features = false }
@@ -255,10 +216,49 @@ tracing-subscriber = { version = "0.3.23", features = [
 ] }
 tracing-test = "0.2.6"
 url = "2"
-utilities = { path = "crates/utilities" }
 x509-parser = "0.18.1"
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zstd = "0.13.3"
+
+# NEAR CORE DEPENDENCIES:
+near-async = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-store = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+nearcore = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+
+## Outdated dependencies we cannot upgrade ##
+# Version 0.8.3 requires rustc 1.88
+httpmock = "0.8.2"
+
+# This can be removed once the workspace `utilities` crate is removed
+near-account-id-v1 = { version = "1.1.4", package = "near-account-id" }
+
+# This cannot be upgraded because it conflicts the prometheus version required by nearcore
+prometheus = { version = "0.13.4", default-features = false }
+
+# TODO(#690): This cannot be upgraded until nearcore does
+rocksdb = "0.21.0"
+
+# This version needs to be exactly the same as in `near_sdk::schemars`
+schemars = "0.8.22"
+
+# This is deprecated, we should find an alterantive
+serde_yaml = "0.9.34"
+
+# These dependencies need to be upgraded in tandem
+getrandom = "0.2.12"
+rand = "0.8.5"
+rand_chacha = "0.3"
+rand_core = "0.6.4"
+
+# Cannot be upgraded until we get MSVR 1.88
+time = "0.3.45"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,37 +45,13 @@ license = "MIT"
 repository = "https://github.com/near/mpc"
 
 [workspace.dependencies]
-#workspace members
-attestation = { path = "crates/attestation" }
-chain-gateway = { path = "crates/chain-gateway" }
-chain-gateway-test-contract = { path = "crates/chain-gateway-test-contract" }
-contract-history = { path = "crates/contract-history" }
-foreign-chain-inspector = { path = "crates/foreign-chain-inspector" }
-foreign-chain-rpc-interfaces = { path = "crates/foreign-chain-rpc-interfaces" }
-include-measurements = { path = "crates/include-measurements" }
-launcher-interface = { path = "crates/launcher-interface" }
-mpc-attestation = { path = "crates/mpc-attestation" }
-mpc-contract = { path = "crates/contract", features = ["dev-utils"] }
-mpc-node = { path = "crates/node" }
-mpc-node-config = { path = "crates/node-config" }
-mpc-primitives = { path = "crates/primitives", features = ["abi"] }
-mpc-tls = { path = "crates/tls" }
-near-mpc-bounded-collections = { path = "crates/near-mpc-bounded-collections", version = "0.0.1" }
-near-mpc-contract-interface = { path = "crates/near-mpc-contract-interface", version = "0.0.1" }
-near-mpc-crypto-types = { path = "crates/near-mpc-crypto-types", version = "0.0.1" }
-near-mpc-sdk = { path = "crates/near-mpc-sdk", version = "0.0.1" }
-near-mpc-signature-verifier = { path = "crates/near-mpc-signature-verifier", version = "0.0.1" }
-node-types = { path = "crates/node-types" }
-tee-authority = { path = "crates/tee-authority" }
-test-port-allocator = { path = "crates/test-port-allocator" }
-test-utils = { path = "crates/test-utils" }
-threshold-signatures = { path = "crates/threshold-signatures" }
-utilities = { path = "crates/utilities" }
 
 aes-gcm = "0.10.3"
 anyhow = "1.0.102"
 assert_matches = "1.5.0"
 async-trait = "0.1.89"
+#workspace members
+attestation = { path = "crates/attestation" }
 auto_ops = "0.3.0"
 average = "0.16"
 axum = "0.8.8"
@@ -88,7 +64,10 @@ built = { version = "0.8", features = ["git2", "chrono"] }
 byteorder = "1.5.0"
 bytes = { version = "1.11.1" }
 cargo-near-build = "0.11.1"
+chain-gateway = { path = "crates/chain-gateway" }
+chain-gateway-test-contract = { path = "crates/chain-gateway-test-contract" }
 clap = { version = "4.6.0", features = ["derive", "env"] }
+contract-history = { path = "crates/contract-history" }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 curve25519-dalek = { version = "4.1.3", features = [
     "group",
@@ -124,6 +103,8 @@ either = "1.15.0"
 elliptic-curve = "0.13.8"
 ethereum-types = "0.16.0"
 flume = "0.12.0"
+foreign-chain-inspector = { path = "crates/foreign-chain-inspector" }
+foreign-chain-rpc-interfaces = { path = "crates/foreign-chain-rpc-interfaces" }
 frost-core = { version = "2.2.0", default-features = false, features = [
     "serde",
 ] }
@@ -135,26 +116,58 @@ gcloud-sdk = { version = "0.29.0", default-features = false, features = [
     "google-cloud-secretmanager-v1",
     "tls-webpki-roots",
 ] }
+
+# These dependencies need to be upgraded in tandem
+getrandom = "0.2.12"
 group = "0.13"
 hex = { version = "0.4.3", features = ["serde"] }
 hkdf = "0.12.4"
 http = "1.4.0"
+
+## Outdated dependencies we cannot upgrade ##
+# Version 0.8.3 requires rustc 1.88
+httpmock = "0.8.2"
 humantime = "2.3.0"
 # TODO(#1299): updating this brings considerable breaking changes
 hyper = { version = "0.14.32", features = ["server", "http1", "tcp", "stream"] }
+include-measurements = { path = "crates/include-measurements" }
 insta = { version = "1.46.3", features = ["json", "redactions"] }
 itertools = "0.14.0"
 jsonrpsee = { version = "0.26.0", features = ["http-client"] }
 k256 = "0.13.4"
 keccak = "0.1.5"
+launcher-interface = { path = "crates/launcher-interface" }
 lru = "0.16.3"
 mockall = "0.14.0"
+mpc-attestation = { path = "crates/mpc-attestation" }
+mpc-contract = { path = "crates/contract", features = ["dev-utils"] }
+mpc-node = { path = "crates/node" }
+mpc-node-config = { path = "crates/node-config" }
+mpc-primitives = { path = "crates/primitives", features = ["abi"] }
+mpc-tls = { path = "crates/tls" }
 named-lock = "0.4.1"
 near-abi = "0.4.4"
 near-account-id = "2.5.0"
+
+# This can be removed once the workspace `utilities` crate is removed
+near-account-id-v1 = { version = "1.1.4", package = "near-account-id" }
+
+# NEAR CORE DEPENDENCIES:
+near-async = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
 near-jsonrpc-client = "0.20.0"
 near-jsonrpc-primitives = "0.34.6"
 near-kit = { version = "0.7.1", default-features = false }
+near-mpc-bounded-collections = { path = "crates/near-mpc-bounded-collections", version = "0.0.1" }
+near-mpc-contract-interface = { path = "crates/near-mpc-contract-interface", version = "0.0.1" }
+near-mpc-crypto-types = { path = "crates/near-mpc-crypto-types", version = "0.0.1" }
+near-mpc-sdk = { path = "crates/near-mpc-sdk", version = "0.0.1" }
+near-mpc-signature-verifier = { path = "crates/near-mpc-signature-verifier", version = "0.0.1" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
 near-primitives = "0.34.6"
 near-sandbox = "0.3.9"
 near-sdk = { version = "5.24.1", features = [
@@ -162,7 +175,11 @@ near-sdk = { version = "5.24.1", features = [
     "unit-testing",
     "unstable",
 ] }
+near-store = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
 near-workspaces = { version = "0.22.1" }
+nearcore = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
+node-types = { path = "crates/node-types" }
 num_enum = { version = "0.7.6", features = ["complex-expressions"] }
 pairing = { version = "0.23.0" }
 pprof = { version = "0.15.0", features = [
@@ -170,7 +187,13 @@ pprof = { version = "0.15.0", features = [
     "flamegraph",
 ], default-features = false }
 proc-macro2 = "1.0"
+
+# This cannot be upgraded because it conflicts the prometheus version required by nearcore
+prometheus = { version = "0.13.4", default-features = false }
 quote = "1.0"
+rand = "0.8.5"
+rand_chacha = "0.3"
+rand_core = "0.6.4"
 # TODO(#2051): updating this brings considerable breaking changes
 rcgen = "0.13.2"
 # This project has been forked due to incompatibility problems with cheater detection feature activated on the original Zcash repo
@@ -180,16 +203,25 @@ reddsa = { git = "https://github.com/near/reddsa", rev = "c7cd92a55f7399d8d7f8c0
 regex = "1.12.3"
 reqwest = { version = "0.13.2", features = ["multipart", "json"] }
 rmp-serde = "1.3.1"
+
+# TODO(#690): This cannot be upgraded until nearcore does
+rocksdb = "0.21.0"
 rstest = { version = "0.26.1" }
 rustls = { version = "0.23.37", default-features = false, features = [
     "ring",
     "std",
 ] }
+
+# This version needs to be exactly the same as in `near_sdk::schemars`
+schemars = "0.8.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11.19"
 serde_json = "1.0"
 serde_repr = "0.1.20"
 serde_with = { version = "3.17.0", features = ["hex"] }
+
+# This is deprecated, we should find an alterantive
+serde_yaml = "0.9.34"
 serial_test = "3.4.0"
 sha2 = "0.10.9"
 sha3 = "0.10.8"
@@ -197,9 +229,16 @@ signature = "2.2.0"
 socket2 = "0.6.3"
 subtle = "2.6.1"
 syn = "2.0"
+tee-authority = { path = "crates/tee-authority" }
 tempfile = "3.27.0"
 test-log = "0.2.19"
+test-port-allocator = { path = "crates/test-port-allocator" }
+test-utils = { path = "crates/test-utils" }
 thiserror = "2.0.18"
+threshold-signatures = { path = "crates/threshold-signatures" }
+
+# Cannot be upgraded until we get MSVR 1.88
+time = "0.3.45"
 tokio = { version = "1.51.0", features = ["full", "test-util"] }
 tokio-metrics = { version = "0.4.8" }
 tokio-rustls = { version = "0.26.4", default-features = false }
@@ -216,49 +255,10 @@ tracing-subscriber = { version = "0.3.23", features = [
 ] }
 tracing-test = "0.2.6"
 url = "2"
+utilities = { path = "crates/utilities" }
 x509-parser = "0.18.1"
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zstd = "0.13.3"
-
-# NEAR CORE DEPENDENCIES:
-near-async = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-store = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-nearcore = { git = "https://github.com/near/nearcore", tag = "2.11.0" }
-
-## Outdated dependencies we cannot upgrade ##
-# Version 0.8.3 requires rustc 1.88
-httpmock = "0.8.2"
-
-# This can be removed once the workspace `utilities` crate is removed
-near-account-id-v1 = { version = "1.1.4", package = "near-account-id" }
-
-# This cannot be upgraded because it conflicts the prometheus version required by nearcore
-prometheus = { version = "0.13.4", default-features = false }
-
-# TODO(#690): This cannot be upgraded until nearcore does
-rocksdb = "0.21.0"
-
-# This version needs to be exactly the same as in `near_sdk::schemars`
-schemars = "0.8.22"
-
-# This is deprecated, we should find an alterantive
-serde_yaml = "0.9.34"
-
-# These dependencies need to be upgraded in tandem
-getrandom = "0.2.12"
-rand = "0.8.5"
-rand_chacha = "0.3"
-rand_core = "0.6.4"
-
-# Cannot be upgraded until we get MSVR 1.88
-time = "0.3.45"
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "allow", check-cfg = [

--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -399,7 +399,7 @@ impl MpcNodeSetup {
                 keygen: KeygenConfig { timeout_sec: 60 },
                 foreign_chains: Default::default(),
             },
-            quote_upload_url: mpc_node_config::default_quote_upload_url(),
+            quote_upload_url: None,
         };
 
         let toml_string =

--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -399,7 +399,7 @@ impl MpcNodeSetup {
                 keygen: KeygenConfig { timeout_sec: 60 },
                 foreign_chains: Default::default(),
             },
-            quote_upload_url: None,
+            quote_upload_url: mpc_node_config::default_quote_upload_url(),
         };
 
         let toml_string =

--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -399,6 +399,7 @@ impl MpcNodeSetup {
                 keygen: KeygenConfig { timeout_sec: 60 },
                 foreign_chains: Default::default(),
             },
+            quote_upload_url: None,
         };
 
         let toml_string =

--- a/crates/launcher-interface/src/lib.rs
+++ b/crates/launcher-interface/src/lib.rs
@@ -2,6 +2,3 @@ pub mod types;
 
 /// event name for image digest
 pub const MPC_IMAGE_HASH_EVENT: &str = "mpc-image-digest";
-
-pub const DEFAULT_PHALA_TDX_QUOTE_UPLOAD_URL: &str =
-    "https://cloud-api.phala.network/api/v1/attestations/verify";

--- a/crates/launcher-interface/src/types.rs
+++ b/crates/launcher-interface/src/types.rs
@@ -19,11 +19,7 @@ pub struct TeeConfig {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum TeeAuthorityConfig {
     Local,
-    Dstack {
-        dstack_endpoint: String,
-        // TODO(#2333): use URL type for this type
-        quote_upload_url: String,
-    },
+    Dstack { dstack_endpoint: String },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/node-config/Cargo.toml
+++ b/crates/node-config/Cargo.toml
@@ -18,7 +18,7 @@ serde = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
 toml = { workspace = true }
-url = { workspace = true }
+url = { workspace = true, features = ["serde"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/node-config/src/lib.rs
+++ b/crates/node-config/src/lib.rs
@@ -10,7 +10,7 @@ pub use foreign_chains::{
 };
 pub use start::{
     ChainId, DownloadConfigType, GcpStartConfig, LogConfig, LogFormat, NearInitConfig,
-    SecretsStartConfig, StartConfig, default_quote_upload_url,
+    SecretsStartConfig, StartConfig,
 };
 
 use anyhow::Context;

--- a/crates/node-config/src/lib.rs
+++ b/crates/node-config/src/lib.rs
@@ -10,7 +10,7 @@ pub use foreign_chains::{
 };
 pub use start::{
     ChainId, DownloadConfigType, GcpStartConfig, LogConfig, LogFormat, NearInitConfig,
-    SecretsStartConfig, StartConfig,
+    SecretsStartConfig, StartConfig, default_quote_upload_url,
 };
 
 use anyhow::Context;

--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -24,15 +24,10 @@ pub struct StartConfig {
     /// Node configuration (indexer, protocol parameters, etc.).
     pub node: ConfigFile,
     pub log: LogConfig,
-    /// TDX quote collateral endpoint URL. Defaults to Phala's public endpoint
-    #[serde(default = "default_quote_upload_url")]
-    pub quote_upload_url: url::Url,
-}
-
-pub fn default_quote_upload_url() -> url::Url {
-    launcher_interface::DEFAULT_PHALA_TDX_QUOTE_UPLOAD_URL
-        .parse()
-        .expect("default quote upload URL is valid")
+    /// Optional override for the TDX quote collateral endpoint URL.
+    /// When set, overrides the URL injected by the launcher in the `[tee]` section.
+    #[serde(default)]
+    pub quote_upload_url: Option<url::Url>,
 }
 
 impl StartConfig {

--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -26,9 +26,6 @@ pub struct StartConfig {
     pub log: LogConfig,
     /// Optional override for the TDX quote collateral endpoint URL.
     /// When set, overrides the URL injected by the launcher in the `[tee]` section.
-    /// This does not affect attestation security — the collateral data is
-    /// cryptographically signed by Intel regardless of where it is fetched from.
-    /// Example: `"http://51.68.219.1:8082/api/v1/attestations/verify"`
     #[serde(default)]
     pub quote_upload_url: Option<url::Url>,
 }

--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -24,10 +24,16 @@ pub struct StartConfig {
     /// Node configuration (indexer, protocol parameters, etc.).
     pub node: ConfigFile,
     pub log: LogConfig,
-    /// Optional override for the TDX quote collateral endpoint URL.
-    /// When set, overrides the URL injected by the launcher in the `[tee]` section.
-    #[serde(default)]
-    pub quote_upload_url: Option<url::Url>,
+    /// TDX quote collateral endpoint URL.
+    /// Defaults to Phala's public endpoint if not set in config.
+    #[serde(default = "default_quote_upload_url")]
+    pub quote_upload_url: url::Url,
+}
+
+pub fn default_quote_upload_url() -> url::Url {
+    "https://cloud-api.phala.network/api/v1/attestations/verify"
+        .parse()
+        .expect("default quote upload URL is valid")
 }
 
 impl StartConfig {

--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -24,6 +24,13 @@ pub struct StartConfig {
     /// Node configuration (indexer, protocol parameters, etc.).
     pub node: ConfigFile,
     pub log: LogConfig,
+    /// Optional override for the TDX quote collateral endpoint URL.
+    /// When set, overrides the URL injected by the launcher in the `[tee]` section.
+    /// This does not affect attestation security — the collateral data is
+    /// cryptographically signed by Intel regardless of where it is fetched from.
+    /// Example: `"http://51.68.219.1:8082/api/v1/attestations/verify"`
+    #[serde(default)]
+    pub quote_upload_url: Option<url::Url>,
 }
 
 impl StartConfig {

--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -24,10 +24,15 @@ pub struct StartConfig {
     /// Node configuration (indexer, protocol parameters, etc.).
     pub node: ConfigFile,
     pub log: LogConfig,
-    /// Optional override for the TDX quote collateral endpoint URL.
-    /// When set, overrides the URL injected by the launcher in the `[tee]` section.
-    #[serde(default)]
-    pub quote_upload_url: Option<url::Url>,
+    /// TDX quote collateral endpoint URL. Defaults to Phala's public endpoint
+    #[serde(default = "default_quote_upload_url")]
+    pub quote_upload_url: url::Url,
+}
+
+pub fn default_quote_upload_url() -> url::Url {
+    launcher_interface::DEFAULT_PHALA_TDX_QUOTE_UPLOAD_URL
+        .parse()
+        .expect("default quote upload URL is valid")
 }
 
 impl StartConfig {

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -143,6 +143,7 @@ impl StartCmd {
                 format: log_format,
                 filter: std::env::var("RUST_LOG").ok(),
             },
+            quote_upload_url: None,
         }
     }
 }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -143,7 +143,7 @@ impl StartCmd {
                 format: log_format,
                 filter: std::env::var("RUST_LOG").ok(),
             },
-            quote_upload_url: None,
+            quote_upload_url: mpc_node_config::default_quote_upload_url(),
         }
     }
 }

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -143,7 +143,7 @@ impl StartCmd {
                 format: log_format,
                 filter: std::env::var("RUST_LOG").ok(),
             },
-            quote_upload_url: mpc_node_config::default_quote_upload_url(),
+            quote_upload_url: None,
         }
     }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -10,29 +10,20 @@ use url::Url;
 pub trait TeeAuthorityImpl {
     fn into_tee_authority(
         self,
-        quote_upload_url_override: Option<&Url>,
+        quote_upload_url: &Url,
     ) -> anyhow::Result<TeeAuthority>;
 }
 
 impl TeeAuthorityImpl for TeeConfig {
     fn into_tee_authority(
         self,
-        quote_upload_url_override: Option<&Url>,
+        quote_upload_url: &Url,
     ) -> anyhow::Result<TeeAuthority> {
         Ok(match self.authority {
             TeeAuthorityConfig::Local => LocalTeeAuthorityConfig::default().into(),
             TeeAuthorityConfig::Dstack {
-                dstack_endpoint,
-                quote_upload_url,
-            } => {
-                let url = match quote_upload_url_override {
-                    Some(u) => u.clone(),
-                    None => quote_upload_url
-                        .parse()
-                        .context("invalid quote_upload_url")?,
-                };
-                DstackTeeAuthorityConfig::new(dstack_endpoint, url).into()
-            }
+                dstack_endpoint, ..
+            } => DstackTeeAuthorityConfig::new(dstack_endpoint, quote_upload_url.clone()).into(),
         })
     }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -8,20 +8,29 @@ use tee_authority::tee_authority::{
 use url::Url;
 
 pub trait TeeAuthorityImpl {
-    fn into_tee_authority(self) -> anyhow::Result<TeeAuthority>;
+    fn into_tee_authority(
+        self,
+        quote_upload_url_override: Option<&Url>,
+    ) -> anyhow::Result<TeeAuthority>;
 }
 
 impl TeeAuthorityImpl for TeeConfig {
-    fn into_tee_authority(self) -> anyhow::Result<TeeAuthority> {
+    fn into_tee_authority(
+        self,
+        quote_upload_url_override: Option<&Url>,
+    ) -> anyhow::Result<TeeAuthority> {
         Ok(match self.authority {
             TeeAuthorityConfig::Local => LocalTeeAuthorityConfig::default().into(),
             TeeAuthorityConfig::Dstack {
                 dstack_endpoint,
                 quote_upload_url,
             } => {
-                let url: Url = quote_upload_url
-                    .parse()
-                    .context("invalid quote_upload_url")?;
+                let url = match quote_upload_url_override {
+                    Some(u) => u.clone(),
+                    None => quote_upload_url
+                        .parse()
+                        .context("invalid quote_upload_url")?,
+                };
                 DstackTeeAuthorityConfig::new(dstack_endpoint, url).into()
             }
         })

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -8,30 +8,15 @@ use tee_authority::tee_authority::{
 use url::Url;
 
 pub trait TeeAuthorityImpl {
-    fn into_tee_authority(
-        self,
-        quote_upload_url_override: Option<&Url>,
-    ) -> anyhow::Result<TeeAuthority>;
+    fn into_tee_authority(self, quote_upload_url: &Url) -> anyhow::Result<TeeAuthority>;
 }
 
 impl TeeAuthorityImpl for TeeConfig {
-    fn into_tee_authority(
-        self,
-        quote_upload_url_override: Option<&Url>,
-    ) -> anyhow::Result<TeeAuthority> {
+    fn into_tee_authority(self, quote_upload_url: &Url) -> anyhow::Result<TeeAuthority> {
         Ok(match self.authority {
             TeeAuthorityConfig::Local => LocalTeeAuthorityConfig::default().into(),
-            TeeAuthorityConfig::Dstack {
-                dstack_endpoint,
-                quote_upload_url,
-            } => {
-                let url = match quote_upload_url_override {
-                    Some(u) => u.clone(),
-                    None => quote_upload_url
-                        .parse()
-                        .context("invalid quote_upload_url")?,
-                };
-                DstackTeeAuthorityConfig::new(dstack_endpoint, url).into()
+            TeeAuthorityConfig::Dstack { dstack_endpoint } => {
+                DstackTeeAuthorityConfig::new(dstack_endpoint, quote_upload_url.clone()).into()
             }
         })
     }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -10,20 +10,29 @@ use url::Url;
 pub trait TeeAuthorityImpl {
     fn into_tee_authority(
         self,
-        quote_upload_url: &Url,
+        quote_upload_url_override: Option<&Url>,
     ) -> anyhow::Result<TeeAuthority>;
 }
 
 impl TeeAuthorityImpl for TeeConfig {
     fn into_tee_authority(
         self,
-        quote_upload_url: &Url,
+        quote_upload_url_override: Option<&Url>,
     ) -> anyhow::Result<TeeAuthority> {
         Ok(match self.authority {
             TeeAuthorityConfig::Local => LocalTeeAuthorityConfig::default().into(),
             TeeAuthorityConfig::Dstack {
-                dstack_endpoint, ..
-            } => DstackTeeAuthorityConfig::new(dstack_endpoint, quote_upload_url.clone()).into(),
+                dstack_endpoint,
+                quote_upload_url,
+            } => {
+                let url = match quote_upload_url_override {
+                    Some(u) => u.clone(),
+                    None => quote_upload_url
+                        .parse()
+                        .context("invalid quote_upload_url")?,
+                };
+                DstackTeeAuthorityConfig::new(dstack_endpoint, url).into()
+            }
         })
     }
 }

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -59,8 +59,8 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         },
         image_hash = %config.tee.image_hash,
         quote_upload_url = %match &config.tee.authority {
-            launcher_interface::types::TeeAuthorityConfig::Dstack { .. } => {
-                config.quote_upload_url.as_str()
+            launcher_interface::types::TeeAuthorityConfig::Dstack { quote_upload_url, .. } => {
+                config.quote_upload_url.as_ref().map_or(quote_upload_url.as_str(), |u| u.as_str())
             },
             launcher_interface::types::TeeAuthorityConfig::Local => "n/a",
         },
@@ -110,7 +110,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     let tee_authority = config
         .tee
         .clone()
-        .into_tee_authority(&config.quote_upload_url)?;
+        .into_tee_authority(config.quote_upload_url.as_ref())?;
     let tls_public_key = &secrets.persistent_secrets.p2p_private_key.verifying_key();
 
     let account_public_key = &secrets.persistent_secrets.near_signer_key.verifying_key();

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -58,10 +58,11 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             launcher_interface::types::TeeAuthorityConfig::Local => "local",
         },
         image_hash = %config.tee.image_hash,
-        quote_upload_url = %match (&config.quote_upload_url, &config.tee.authority) {
-            (Some(url), _) => url.as_str(),
-            (None, launcher_interface::types::TeeAuthorityConfig::Dstack { quote_upload_url, .. }) => quote_upload_url.as_str(),
-            (None, launcher_interface::types::TeeAuthorityConfig::Local) => "n/a",
+        quote_upload_url = %match &config.tee.authority {
+            launcher_interface::types::TeeAuthorityConfig::Dstack { quote_upload_url, .. } => {
+                config.quote_upload_url.as_ref().map_or(quote_upload_url.as_str(), |u| u.as_str())
+            },
+            launcher_interface::types::TeeAuthorityConfig::Local => "n/a",
         },
         "TEE config"
     );

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -59,9 +59,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         },
         image_hash = %config.tee.image_hash,
         quote_upload_url = %match &config.tee.authority {
-            launcher_interface::types::TeeAuthorityConfig::Dstack { quote_upload_url, .. } => {
-                config.quote_upload_url.as_ref().map_or(quote_upload_url.as_str(), |u| u.as_str())
-            },
+            launcher_interface::types::TeeAuthorityConfig::Dstack { .. } => config.quote_upload_url.as_str(),
             launcher_interface::types::TeeAuthorityConfig::Local => "n/a",
         },
         "TEE config"
@@ -110,7 +108,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     let tee_authority = config
         .tee
         .clone()
-        .into_tee_authority(config.quote_upload_url.as_ref())?;
+        .into_tee_authority(&config.quote_upload_url)?;
     let tls_public_key = &secrets.persistent_secrets.p2p_private_key.verifying_key();
 
     let account_public_key = &secrets.persistent_secrets.near_signer_key.verifying_key();

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -59,8 +59,8 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         },
         image_hash = %config.tee.image_hash,
         quote_upload_url = %match &config.tee.authority {
-            launcher_interface::types::TeeAuthorityConfig::Dstack { quote_upload_url, .. } => {
-                config.quote_upload_url.as_ref().map_or(quote_upload_url.as_str(), |u| u.as_str())
+            launcher_interface::types::TeeAuthorityConfig::Dstack { .. } => {
+                config.quote_upload_url.as_str()
             },
             launcher_interface::types::TeeAuthorityConfig::Local => "n/a",
         },
@@ -110,7 +110,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     let tee_authority = config
         .tee
         .clone()
-        .into_tee_authority(config.quote_upload_url.as_ref())?;
+        .into_tee_authority(&config.quote_upload_url)?;
     let tls_public_key = &secrets.persistent_secrets.p2p_private_key.verifying_key();
 
     let account_public_key = &secrets.persistent_secrets.near_signer_key.verifying_key();

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -101,7 +101,10 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     )?;
 
     // Generate attestation
-    let tee_authority = config.tee.clone().into_tee_authority()?;
+    let tee_authority = config
+        .tee
+        .clone()
+        .into_tee_authority(config.quote_upload_url.as_ref())?;
     let tls_public_key = &secrets.persistent_secrets.p2p_private_key.verifying_key();
 
     let account_public_key = &secrets.persistent_secrets.near_signer_key.verifying_key();

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -58,6 +58,11 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             launcher_interface::types::TeeAuthorityConfig::Local => "local",
         },
         image_hash = %config.tee.image_hash,
+        quote_upload_url = %match (&config.quote_upload_url, &config.tee.authority) {
+            (Some(url), _) => url.as_str(),
+            (None, launcher_interface::types::TeeAuthorityConfig::Dstack { quote_upload_url, .. }) => quote_upload_url.as_str(),
+            (None, launcher_interface::types::TeeAuthorityConfig::Local) => "n/a",
+        },
         "TEE config"
     );
     if let Some(ref near_init) = config.near_init {

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -479,11 +479,13 @@ mod tests {
 
     /// Parameterized test for collateral upload endpoints.
     ///
-    /// - `phala_endpoint`: Tests against Phala's default endpoint.
+    /// - `phala_endpoint`: Tests against Phala using the default config path.
+    /// - `phala_via_override`: Tests against Phala using the URL override path.
     /// - `local_pccs_proxy`: Tests against the local PCCS proxy.
     ///   Requires the proxy to be running. Override URL via `LOCAL_PCCS_PROXY_URL`.
     #[rstest::rstest]
     #[case::phala_endpoint(None)]
+    #[case::phala_via_override(Some("https://cloud-api.phala.network/api/v1/attestations/verify"))]
     #[case::local_pccs_proxy(Some("http://localhost:8082/api/v1/attestations/verify"))]
     #[tokio::test]
     #[cfg(feature = "external-services-tests")]

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -169,7 +169,7 @@ impl TeeAuthority {
 
             if status != StatusCode::OK {
                 bail!(
-                    "Got unexpected HTTP status code: response from phala endpoint: {:?}, expected: {:?}",
+                    "Got unexpected HTTP status code: response from collateral endpoint: {:?}, expected: {:?}",
                     status,
                     StatusCode::OK
                 );
@@ -477,9 +477,17 @@ mod tests {
         assert!(elapsed >= Duration::from_secs(total_expected_secs));
     }
 
+    /// Parameterized test for collateral upload endpoints.
+    ///
+    /// - `phala_endpoint`: Tests against Phala's default endpoint.
+    /// - `local_pccs_proxy`: Tests against the local PCCS proxy.
+    ///   Requires the proxy to be running. Override URL via `LOCAL_PCCS_PROXY_URL`.
+    #[rstest::rstest]
+    #[case::phala_endpoint(None)]
+    #[case::local_pccs_proxy(Some("http://localhost:8082/api/v1/attestations/verify"))]
     #[tokio::test]
     #[cfg(feature = "external-services-tests")]
-    async fn test_upload_quote_for_collateral_with_phala_endpoint() {
+    async fn test_upload_quote_for_collateral(#[case] url_override: Option<&str>) {
         let quote_data = quote();
         let quote_hex: String = serde_json::from_str::<Vec<u8>>(
             &serde_json::to_string(&quote_data).expect("Valid quote data"),
@@ -487,12 +495,19 @@ mod tests {
         .expect("Is valid json")
         .encode_hex();
 
+        let url: Url = match url_override {
+            Some(default) => std::env::var("LOCAL_PCCS_PROXY_URL")
+                .unwrap_or_else(|_| default.to_string())
+                .parse()
+                .expect("LOCAL_PCCS_PROXY_URL must be a valid URL"),
+            None => DstackTeeAuthorityConfig::default().quote_upload_url,
+        };
+
         let tee_authority = TeeAuthority::Dstack(DstackTeeAuthorityConfig::default());
-        let config = DstackTeeAuthorityConfig::default();
 
         let result = tokio::time::timeout(
             Duration::from_secs(10),
-            tee_authority.upload_quote_for_collateral(&config.quote_upload_url, &quote_hex),
+            tee_authority.upload_quote_for_collateral(&url, &quote_hex),
         )
         .await;
 
@@ -504,9 +519,12 @@ mod tests {
                 assert!(!collateral.qe_identity_issuer_chain.is_empty());
                 assert!(!collateral.qe_identity.is_empty());
                 assert!(!collateral.qe_identity_signature.is_empty());
+                assert!(!collateral.pck_crl_issuer_chain.is_empty());
+                assert!(!collateral.root_ca_crl.is_empty());
+                assert!(!collateral.pck_crl.is_empty());
             }
-            Ok(Err(e)) => panic!("Test failed: {e:?}"),
-            Err(e) => panic!("Test timed out: {e:?}"),
+            Ok(Err(e)) => panic!("Collateral upload failed ({url}): {e:?}"),
+            Err(e) => panic!("Collateral upload timed out ({url}): {e:?}"),
         }
     }
 }

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -525,8 +525,8 @@ mod tests {
                 assert!(!collateral.root_ca_crl.is_empty());
                 assert!(!collateral.pck_crl.is_empty());
             }
-            Ok(Err(e)) => panic!("Collateral upload failed ({url}): {e:?}"),
-            Err(e) => panic!("Collateral upload timed out ({url}): {e:?}"),
+            Ok(Err(e)) => panic!("quote upload failed ({url}): {e:?}"),
+            Err(e) => panic!("quote upload timed out ({url}): {e:?}"),
         }
     }
 }

--- a/crates/tee-launcher/src/config.rs
+++ b/crates/tee-launcher/src/config.rs
@@ -109,7 +109,6 @@ mod tests {
         TeeConfig {
             authority: TeeAuthorityConfig::Dstack {
                 dstack_endpoint: "/var/run/dstack.sock".to_string(),
-                quote_upload_url: "https://example.com/quote".to_string(),
             },
             image_hash: sample_digest(),
             latest_allowed_hash_file_path: "/mnt/shared/image-digest.bin".into(),
@@ -191,7 +190,6 @@ key = "value"
         let tee = TeeConfig {
             authority: TeeAuthorityConfig::Dstack {
                 dstack_endpoint: "/my/socket".to_string(),
-                quote_upload_url: "https://example.com".to_string(),
             },
             image_hash: sample_digest(),
             latest_allowed_hash_file_path: "/mnt/shared/image-digest.bin".into(),
@@ -204,10 +202,6 @@ key = "value"
         let tee_table = result["tee"].as_table().unwrap();
         let authority = tee_table["authority"].as_table().unwrap();
         assert_eq!(authority["dstack_endpoint"].as_str(), Some("/my/socket"));
-        assert_eq!(
-            authority["quote_upload_url"].as_str(),
-            Some("https://example.com")
-        );
     }
 
     #[test]
@@ -237,7 +231,6 @@ key = "value"
         let tee = TeeConfig {
             authority: TeeAuthorityConfig::Dstack {
                 dstack_endpoint: "/var/run/dstack.sock".to_string(),
-                quote_upload_url: "https://example.com/quote".to_string(),
             },
             image_hash: digest('b'),
             latest_allowed_hash_file_path: "/some/path".into(),

--- a/crates/tee-launcher/src/lib.rs
+++ b/crates/tee-launcher/src/lib.rs
@@ -2,10 +2,10 @@ use std::io::Write;
 use std::path::Path;
 
 use clap::Parser;
+use launcher_interface::MPC_IMAGE_HASH_EVENT;
 use launcher_interface::types::{
     ApprovedHashes, DockerSha256Digest, TeeAuthorityConfig, TeeConfig,
 };
-use launcher_interface::{DEFAULT_PHALA_TDX_QUOTE_UPLOAD_URL, MPC_IMAGE_HASH_EVENT};
 
 use compose::launch_mpc_container;
 use config::{intercept_node_config, validate_image_reference};
@@ -139,7 +139,6 @@ fn build_tee_config(platform: Platform, image_hash: DockerSha256Digest) -> TeeCo
     let authority = match platform {
         Platform::Tee => TeeAuthorityConfig::Dstack {
             dstack_endpoint: DSTACK_UNIX_SOCKET.to_string(),
-            quote_upload_url: DEFAULT_PHALA_TDX_QUOTE_UPLOAD_URL.to_string(),
         },
         Platform::NonTee => TeeAuthorityConfig::Local,
     };

--- a/deployment/cvm-deployment/user-config.toml
+++ b/deployment/cvm-deployment/user-config.toml
@@ -11,6 +11,8 @@ port_mappings = [
 
 [mpc_node_config]
 home_dir = "/data"
+# Override the collateral endpoint URL. Defaults to Phala's endpoint if omitted.
+# quote_upload_url = "http://<HOST_IP>:8082/api/v1/attestations/verify"
 
 [mpc_node_config.log]
 format = "plain"

--- a/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl
@@ -9,7 +9,6 @@ ${PORTS_TOML}]
 [mpc_node_config]
 home_dir = "/data"
 # Override the collateral endpoint URL. Defaults to Phala's endpoint if omitted.
-# To use the local PCCS proxy: "http://${MACHINE_IP}:8082/api/v1/attestations/verify"
 # quote_upload_url = "http://${MACHINE_IP}:8082/api/v1/attestations/verify"
 
 [mpc_node_config.log]

--- a/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl
@@ -8,6 +8,9 @@ ${PORTS_TOML}]
 
 [mpc_node_config]
 home_dir = "/data"
+# Override the collateral endpoint URL. Defaults to Phala's endpoint if omitted.
+# To use the local PCCS proxy: "http://${MACHINE_IP}:8082/api/v1/attestations/verify"
+# quote_upload_url = "http://${MACHINE_IP}:8082/api/v1/attestations/verify"
 
 [mpc_node_config.log]
 format = "plain"


### PR DESCRIPTION
## Summary
- Add optional `quote_upload_url` field to `StartConfig` (`[mpc_node_config]` section)
- When set, overrides the default Phala endpoint injected by the launcher
- Lets operators point at a local PCCS proxy or any alternative collateral endpoint
- Collateral is cryptographically signed by Intel regardless of source — no security impact

## Changes
- `crates/node-config/` — new `quote_upload_url: Option<url::Url>` field with serde default
- `crates/node/src/config/start.rs` — `into_tee_authority` accepts URL override
- `crates/node/src/run.rs` — passes override through
- `crates/tee-authority/` — refactored tests with rstest, updated error message
- `.config/nextest.toml` — updated filter for renamed tests
- `localnet/tee/scripts/` — commented-out config example

## Test plan
- [x] `cargo check` passes for mpc-node, mpc-node-config, tee-launcher
- [x] Existing tests pass
- [x] E2E tested with local PCCS proxy on TDX CVM (see near/mpc#2714)

Relates to #467, #1545


Closes #1545