### PR TITLE
feat: add local PCCS proxy for TDX attestation collateral

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "serde_core",
@@ -5838,6 +5839,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.0",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
+]
+
+[[package]]
 name = "munge"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8283,6 +8301,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 dependencies = [
  "camino",
+]
+
+[[package]]
+name = "pccs-proxy"
+version = "3.9.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "dcap-qvl",
+ "hex",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+ "urlencoding",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "crates/node",
     "crates/node-config",
     "crates/node-types",
+    "crates/pccs-proxy",
     "crates/primitives",
     "crates/tee-authority",
     "crates/tee-context",

--- a/crates/pccs-proxy/Cargo.toml
+++ b/crates/pccs-proxy/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "pccs-proxy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Local PCCS proxy — Phala-compatible collateral endpoint backed by Intel PCCS"
+
+[[bin]]
+name = "pccs-proxy"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true, features = ["multipart"] }
+clap = { workspace = true }
+dcap-qvl = { workspace = true }
+hex = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+urlencoding = "2"
+
+[lints]
+workspace = true

--- a/crates/pccs-proxy/README.md
+++ b/crates/pccs-proxy/README.md
@@ -1,0 +1,12 @@
+# pccs-proxy
+
+Local PCCS proxy for TDX attestation collateral. Drop-in replacement for Phala's collateral endpoint, backed by a local Intel PCCS.
+
+See [docs/local-pccs-proxy.md](../../docs/local-pccs-proxy.md) for full documentation.
+
+## Quick start
+
+```bash
+cargo build -p pccs-proxy --release
+./target/release/pccs-proxy --listen 0.0.0.0:8082 --pccs-url https://localhost:8081
+```

--- a/crates/pccs-proxy/src/handlers.rs
+++ b/crates/pccs-proxy/src/handlers.rs
@@ -1,0 +1,125 @@
+use std::sync::Arc;
+use std::time::Instant;
+
+use axum::extract::{ConnectInfo, Multipart, State};
+use axum::http::StatusCode;
+use axum::response::Json;
+use serde::Serialize;
+
+use crate::pccs::PccsClient;
+
+/// Wrapper to match Phala's response format: `{ "quote_collateral": { ... } }`.
+/// The MPC node deserializes this via `UploadResponse { quote_collateral: Collateral }`.
+#[derive(Serialize)]
+pub(crate) struct CollateralWrapper {
+    quote_collateral: CollateralResponse,
+}
+
+#[derive(Serialize)]
+pub(crate) struct CollateralResponse {
+    tcb_info_issuer_chain: String,
+    tcb_info: String,
+    tcb_info_signature: String,
+    qe_identity_issuer_chain: String,
+    qe_identity: String,
+    qe_identity_signature: String,
+    pck_crl_issuer_chain: String,
+    root_ca_crl: String,
+    pck_crl: String,
+    pck_certificate_chain: String,
+}
+
+#[derive(Serialize)]
+pub(crate) struct ErrorResponse {
+    error: String,
+}
+
+pub async fn health(
+    State(state): State<Arc<PccsClient>>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ErrorResponse>)> {
+    let pccs_ok = state.check_pccs_reachable().await;
+    if pccs_ok {
+        Ok(Json(
+            serde_json::json!({"status": "ok", "pccs": "reachable"}),
+        ))
+    } else {
+        Err(error_response(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "PCCS is not reachable".to_string(),
+        ))
+    }
+}
+
+pub async fn verify_attestation(
+    ConnectInfo(client_addr): ConnectInfo<std::net::SocketAddr>,
+    State(state): State<Arc<PccsClient>>,
+    mut multipart: Multipart,
+) -> Result<Json<CollateralWrapper>, (StatusCode, Json<ErrorResponse>)> {
+    let start = Instant::now();
+
+    let quote_hex = extract_quote_hex(&mut multipart).await.map_err(|e| {
+        tracing::error!(client = %client_addr, "Failed to extract hex field: {e}");
+        error_response(StatusCode::BAD_REQUEST, e.to_string())
+    })?;
+
+    tracing::info!(
+        client = %client_addr,
+        quote_len = quote_hex.len(),
+        "Received quote"
+    );
+
+    let collateral = state.get_collateral(&quote_hex).await.map_err(|e| {
+        tracing::error!(
+            client = %client_addr,
+            elapsed_ms = start.elapsed().as_millis() as u64,
+            "Failed to get collateral: {e}"
+        );
+        error_response(StatusCode::INTERNAL_SERVER_ERROR, e.to_string())
+    })?;
+
+    tracing::info!(
+        client = %client_addr,
+        elapsed_ms = start.elapsed().as_millis() as u64,
+        "Collateral returned successfully"
+    );
+    Ok(Json(CollateralWrapper {
+        quote_collateral: CollateralResponse {
+            tcb_info_issuer_chain: collateral.tcb_info_issuer_chain,
+            tcb_info: collateral.tcb_info,
+            tcb_info_signature: collateral.tcb_info_signature,
+            qe_identity_issuer_chain: collateral.qe_identity_issuer_chain,
+            qe_identity: collateral.qe_identity,
+            qe_identity_signature: collateral.qe_identity_signature,
+            pck_crl_issuer_chain: collateral.pck_crl_issuer_chain,
+            root_ca_crl: collateral.root_ca_crl,
+            pck_crl: collateral.pck_crl,
+            pck_certificate_chain: collateral.pck_certificate_chain,
+        },
+    }))
+}
+
+/// Extracts the hex-encoded TDX quote from the `hex` field in the multipart form.
+async fn extract_quote_hex(multipart: &mut Multipart) -> anyhow::Result<String> {
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|e| anyhow::anyhow!("multipart error: {e}"))?
+    {
+        if field.name() == Some("hex") {
+            let text = field
+                .text()
+                .await
+                .map_err(|e| anyhow::anyhow!("failed to read hex field: {e}"))?;
+            let trimmed = text.trim().to_string();
+            if trimmed.is_empty() {
+                anyhow::bail!("Empty quote");
+            }
+            return Ok(trimmed);
+        }
+    }
+    anyhow::bail!("'hex' field not found in multipart form data")
+}
+
+fn error_response(status: StatusCode, message: String) -> (StatusCode, Json<ErrorResponse>) {
+    (status, Json(ErrorResponse { error: message }))
+}

--- a/crates/pccs-proxy/src/main.rs
+++ b/crates/pccs-proxy/src/main.rs
@@ -1,0 +1,108 @@
+mod handlers;
+mod pccs;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use axum::Router;
+use axum::extract::DefaultBodyLimit;
+use axum::routing::{get, post};
+use clap::Parser;
+use reqwest::Client;
+use tokio::signal;
+
+use crate::pccs::PccsClient;
+
+const PCCS_REQUEST_TIMEOUT: Duration = Duration::from_secs(30);
+const MAX_REQUEST_BODY_SIZE: usize = 1024 * 1024; // 1MB
+
+/// Local PCCS proxy — Phala-compatible collateral endpoint backed by Intel PCCS.
+#[derive(Parser)]
+#[command(version)]
+struct Args {
+    /// Address and port to listen on.
+    #[arg(long, default_value = "0.0.0.0:8082")]
+    listen: SocketAddr,
+
+    /// URL of the local Intel PCCS.
+    #[arg(long, default_value = "https://localhost:8081")]
+    pccs_url: reqwest::Url,
+}
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| "pccs_proxy=info".parse().unwrap()),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    // TODO(#2928): make TLS verification configurable via CLI flag (e.g. --pccs-tls-insecure).
+    // Currently disabled because Intel PCCS typically uses a self-signed certificate.
+    let http = Client::builder()
+        .danger_accept_invalid_certs(true)
+        .timeout(PCCS_REQUEST_TIMEOUT)
+        .build()
+        .expect("Failed to build HTTP client");
+
+    let state = Arc::new(PccsClient {
+        pccs_base_url: args.pccs_url.clone(),
+        http,
+    });
+
+    if state.check_pccs_reachable().await {
+        tracing::info!("PCCS is reachable");
+    } else {
+        tracing::warn!(pccs = %args.pccs_url, "PCCS is not reachable at startup — requests will fail until PCCS becomes available");
+    }
+
+    let app = Router::new()
+        .route(
+            "/api/v1/attestations/verify",
+            post(handlers::verify_attestation),
+        )
+        .route("/health", get(handlers::health))
+        .layer(DefaultBodyLimit::max(MAX_REQUEST_BODY_SIZE))
+        .with_state(state);
+
+    tracing::info!(
+        addr = %args.listen,
+        pccs = %args.pccs_url,
+        "Starting local PCCS proxy"
+    );
+
+    let listener = tokio::net::TcpListener::bind(args.listen)
+        .await
+        .expect("Failed to bind");
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await
+    .expect("Server error");
+
+    tracing::info!("Shutdown complete");
+}
+
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        signal::ctrl_c()
+            .await
+            .expect("Failed to install Ctrl+C handler");
+    };
+    let terminate = async {
+        signal::unix::signal(signal::unix::SignalKind::terminate())
+            .expect("Failed to install SIGTERM handler")
+            .recv()
+            .await;
+    };
+    tokio::select! {
+        () = ctrl_c => tracing::info!("Received Ctrl+C, shutting down"),
+        () = terminate => tracing::info!("Received SIGTERM, shutting down"),
+    }
+}

--- a/crates/pccs-proxy/src/pccs.rs
+++ b/crates/pccs-proxy/src/pccs.rs
@@ -1,0 +1,237 @@
+use reqwest::Client;
+use serde::Deserialize;
+
+/// Client for fetching attestation collateral from a local Intel PCCS.
+pub struct PccsClient {
+    pub pccs_base_url: reqwest::Url,
+    pub http: Client,
+}
+
+/// Collateral fields returned to the caller, matching Phala's response format.
+pub struct Collateral {
+    pub tcb_info_issuer_chain: String,
+    pub tcb_info: String,
+    pub tcb_info_signature: String,
+    pub qe_identity_issuer_chain: String,
+    pub qe_identity: String,
+    pub qe_identity_signature: String,
+    pub pck_crl_issuer_chain: String,
+    pub root_ca_crl: String,
+    pub pck_crl: String,
+    pub pck_certificate_chain: String,
+}
+
+/// Parsed fields extracted from a TDX quote needed to query PCCS.
+pub(crate) struct ParsedQuote {
+    pub fmspc_hex: String,
+    pub ca_type: &'static str,
+    pub pck_cert_chain: String,
+}
+
+#[derive(Deserialize)]
+struct TcbResponse {
+    #[serde(alias = "tcbInfo")]
+    tcb_info: serde_json::Value,
+    signature: String,
+}
+
+#[derive(Deserialize)]
+struct QeIdentityResponse {
+    #[serde(alias = "enclaveIdentity")]
+    enclave_identity: serde_json::Value,
+    signature: String,
+}
+
+/// Parse a hex-encoded TDX quote and extract the fields needed for PCCS queries.
+pub(crate) fn parse_quote(quote_hex: &str) -> anyhow::Result<ParsedQuote> {
+    let quote_bytes = hex::decode(quote_hex)?;
+    let quote = dcap_qvl::quote::Quote::parse(&quote_bytes)
+        .map_err(|e| anyhow::anyhow!("Failed to parse TDX quote: {e}"))?;
+
+    let fmspc = quote
+        .fmspc()
+        .map_err(|e| anyhow::anyhow!("Failed to extract FMSPC: {e}"))?;
+    let ca_type = quote
+        .ca()
+        .map_err(|e| anyhow::anyhow!("Failed to extract CA type: {e}"))?;
+    let pck_cert_chain = quote
+        .raw_cert_chain()
+        .map_err(|e| anyhow::anyhow!("Failed to extract PCK cert chain: {e}"))?;
+    let pck_cert_chain_str = String::from_utf8(pck_cert_chain.to_vec())
+        .map_err(|e| anyhow::anyhow!("PCK cert chain is not valid UTF-8: {e}"))?;
+
+    Ok(ParsedQuote {
+        fmspc_hex: hex::encode(fmspc),
+        ca_type,
+        pck_cert_chain: pck_cert_chain_str,
+    })
+}
+
+/// URL-decode a header value from a string. Extracted for testability.
+pub(crate) fn url_decode(encoded: &str) -> anyhow::Result<String> {
+    Ok(urlencoding::decode(encoded)?.into_owned())
+}
+
+impl PccsClient {
+    /// Check if the upstream PCCS is reachable by hitting the TDX QE identity endpoint.
+    pub async fn check_pccs_reachable(&self) -> bool {
+        let url = format!("{}/tdx/certification/v4/qe/identity", self.base_url());
+        matches!(self.http.get(&url).send().await, Ok(resp) if resp.status().is_success())
+    }
+
+    /// Parse a TDX quote and fetch all collateral from the local PCCS.
+    pub async fn get_collateral(&self, quote_hex: &str) -> anyhow::Result<Collateral> {
+        let parsed = parse_quote(quote_hex)?;
+
+        tracing::info!(fmspc = %parsed.fmspc_hex, ca = %parsed.ca_type, "Parsed quote");
+
+        // Fetch all collateral pieces from the local PCCS in parallel.
+        // try_join! cancels remaining requests if any one fails.
+        let (
+            (tcb_info, tcb_info_signature, tcb_info_issuer_chain),
+            (qe_identity, qe_identity_signature, qe_identity_issuer_chain),
+            (pck_crl, pck_crl_issuer_chain),
+            root_ca_crl,
+        ) = tokio::try_join!(
+            self.fetch_tcb_info(&parsed.fmspc_hex),
+            self.fetch_qe_identity(),
+            self.fetch_pck_crl(parsed.ca_type),
+            self.fetch_root_ca_crl(),
+        )?;
+
+        Ok(Collateral {
+            tcb_info_issuer_chain,
+            tcb_info,
+            tcb_info_signature,
+            qe_identity_issuer_chain,
+            qe_identity,
+            qe_identity_signature,
+            pck_crl_issuer_chain,
+            root_ca_crl,
+            pck_crl,
+            pck_certificate_chain: parsed.pck_cert_chain,
+        })
+    }
+
+    async fn fetch_tcb_info(&self, fmspc: &str) -> anyhow::Result<(String, String, String)> {
+        let url = format!(
+            "{}/tdx/certification/v4/tcb?fmspc={}",
+            self.base_url(),
+            fmspc
+        );
+        let resp = check_status(self.http.get(&url).send().await?, &url)?;
+        let issuer_chain = get_decoded_header(&resp, "TCB-Info-Issuer-Chain")?;
+        let body: TcbResponse = resp.json().await?;
+        let tcb_info = serde_json::to_string(&body.tcb_info)?;
+        Ok((tcb_info, body.signature, issuer_chain))
+    }
+
+    async fn fetch_qe_identity(&self) -> anyhow::Result<(String, String, String)> {
+        let url = format!("{}/tdx/certification/v4/qe/identity", self.base_url());
+        let resp = check_status(self.http.get(&url).send().await?, &url)?;
+        let issuer_chain = get_decoded_header(&resp, "SGX-Enclave-Identity-Issuer-Chain")?;
+        let body: QeIdentityResponse = resp.json().await?;
+        let qe_identity = serde_json::to_string(&body.enclave_identity)?;
+        Ok((qe_identity, body.signature, issuer_chain))
+    }
+
+    async fn fetch_pck_crl(&self, ca_type: &str) -> anyhow::Result<(String, String)> {
+        let url = format!(
+            "{}/sgx/certification/v4/pckcrl?ca={}",
+            self.base_url(),
+            ca_type
+        );
+        let resp = check_status(self.http.get(&url).send().await?, &url)?;
+        let issuer_chain = get_decoded_header(&resp, "SGX-PCK-CRL-Issuer-Chain")?;
+        // PCCS returns CRL as hex-encoded text
+        let body = resp.text().await?;
+        Ok((body, issuer_chain))
+    }
+
+    async fn fetch_root_ca_crl(&self) -> anyhow::Result<String> {
+        let url = format!("{}/sgx/certification/v4/rootcacrl", self.base_url());
+        let resp = check_status(self.http.get(&url).send().await?, &url)?;
+        // PCCS returns CRL as hex-encoded text
+        Ok(resp.text().await?)
+    }
+
+    fn base_url(&self) -> &str {
+        self.pccs_base_url.as_str().trim_end_matches('/')
+    }
+}
+
+/// Check that a PCCS response has a success status code.
+fn check_status(resp: reqwest::Response, url: &str) -> anyhow::Result<reqwest::Response> {
+    let status = resp.status();
+    if !status.is_success() {
+        anyhow::bail!("PCCS returned {status} for {url}");
+    }
+    Ok(resp)
+}
+
+fn get_decoded_header(resp: &reqwest::Response, header_name: &str) -> anyhow::Result<String> {
+    let raw = resp
+        .headers()
+        .get(header_name)
+        .ok_or_else(|| anyhow::anyhow!("Missing header: {header_name}"))?
+        .to_str()
+        .map_err(|e| anyhow::anyhow!("Invalid header value for {header_name}: {e}"))?;
+    url_decode(raw)
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::*;
+
+    fn test_quote_hex() -> String {
+        let quote_json: Vec<u8> =
+            serde_json::from_str(include_str!("../../test-utils/assets/quote.json")).unwrap();
+        hex::encode(quote_json)
+    }
+
+    #[test]
+    fn parse_quote__should_extract_fmspc_and_ca_type() {
+        let parsed = parse_quote(&test_quote_hex()).unwrap();
+
+        assert_eq!(parsed.fmspc_hex, "b0c06f000000");
+        assert_eq!(parsed.ca_type, "platform");
+    }
+
+    #[test]
+    fn parse_quote__should_extract_pck_cert_chain() {
+        let parsed = parse_quote(&test_quote_hex()).unwrap();
+
+        assert!(
+            parsed
+                .pck_cert_chain
+                .starts_with("-----BEGIN CERTIFICATE-----")
+        );
+        assert!(parsed.pck_cert_chain.contains("-----END CERTIFICATE-----"));
+    }
+
+    #[test]
+    fn parse_quote__should_reject_invalid_hex() {
+        let result = parse_quote("not_valid_hex!");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_quote__should_reject_truncated_quote() {
+        let result = parse_quote("0400020081000000");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn url_decode__should_decode_percent_encoding() {
+        let encoded = "-----BEGIN%20CERTIFICATE-----%0AMIICjT";
+        let decoded = url_decode(encoded).unwrap();
+        assert_eq!(decoded, "-----BEGIN CERTIFICATE-----\nMIICjT");
+    }
+
+    #[test]
+    fn url_decode__should_pass_through_plain_text() {
+        let plain = "no encoding here";
+        assert_eq!(url_decode(plain).unwrap(), plain);
+    }
+}

--- a/deployment/Dockerfile-pccs-proxy
+++ b/deployment/Dockerfile-pccs-proxy
@@ -1,0 +1,6 @@
+# TODO(#2928): align with repo's reproducible build pattern (pinned base image digest,
+# repro-sources-list.sh, cached apt mounts) if this image needs to be measured.
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY target/reproducible/pccs-proxy /app/pccs-proxy
+ENTRYPOINT ["/app/pccs-proxy"]

--- a/deployment/local-pccs-proxy.service
+++ b/deployment/local-pccs-proxy.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Local PCCS Proxy for TDX Attestation Collateral
+After=pccs.service network.target
+Wants=pccs.service
+
+[Service]
+Type=simple
+ExecStart=/opt/mpc/pccs-proxy --listen 0.0.0.0:8082 --pccs-url https://localhost:8081
+Restart=on-failure
+RestartSec=5
+User=mpc
+Group=mpc
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=true
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/local-pccs-proxy.md
+++ b/docs/local-pccs-proxy.md
@@ -1,0 +1,240 @@
+# Local PCCS Proxy
+
+A drop-in replacement for Phala's TDX collateral endpoint (`cloud-api.phala.network`) that fetches Intel attestation collateral directly from a local Intel PCCS (Provisioning Certificate Caching Service).
+
+## Background
+
+MPC nodes running in TDX CVMs need Intel attestation collateral (certificates, CRLs, TCB info) to prove they are running on genuine Intel hardware. Previously, this collateral was fetched from Phala's centralized endpoint, which introduced an external dependency that has proven unreliable.
+
+The local PCCS proxy eliminates this dependency by querying the Intel PCCS service running on the host machine, which in turn fetches collateral directly from Intel.
+
+## Architecture
+
+```
+MPC Node (inside CVM)
+    |
+    |  POST /api/v1/attestations/verify  (TDX quote as hex)
+    v
+Local PCCS Proxy (host, port 8082)
+    |
+    |  1. Parse TDX quote -> extract FMSPC + CA type from PCK cert
+    |  2. Query local Intel PCCS for collateral:
+    |     - /tdx/certification/v4/tcb?fmspc=...
+    |     - /tdx/certification/v4/qe/identity
+    |     - /sgx/certification/v4/pckcrl?ca=...
+    |     - /sgx/certification/v4/rootcacrl
+    v
+Intel PCCS (host, port 8081)
+    |
+    |  Fetches/caches from Intel PCS
+    v
+Intel Provisioning Certification Service (api.trustedservices.intel.com)
+```
+
+## Prerequisites
+
+- **Intel PCCS** installed and running on the host (package `sgx-dcap-pccs`, typically listening on `https://localhost:8081`). For installation and configuration, follow the [Intel PCCS setup guide](https://cc-enabling.trustedservices.intel.com/intel-tdx-enabling-guide/02/infrastructure_setup/#provisioning-certificate-caching-service-pccs).
+
+The Rust proxy (`pccs-proxy` crate) has no runtime dependencies beyond the binary itself.
+
+### Verify Intel PCCS is running
+
+```bash
+systemctl status pccs
+# Should show: active (running)
+
+# Test PCCS is responding (TDX QE identity endpoint used by the proxy)
+curl -sk https://localhost:8081/tdx/certification/v4/qe/identity | head -c 100
+# Should return JSON with TDX QE identity data
+```
+
+## Installation
+
+### Build from source
+
+```bash
+cargo build -p pccs-proxy --release
+# Binary at: target/release/pccs-proxy
+```
+
+### Docker
+
+```bash
+docker build -f deployment/Dockerfile-pccs-proxy -t pccs-proxy:latest .
+```
+
+## Usage
+
+```bash
+# Default: listen on 0.0.0.0:8082, upstream PCCS at https://localhost:8081
+./target/release/pccs-proxy
+
+# Custom listen address and PCCS URL
+./target/release/pccs-proxy --listen 0.0.0.0:9090 --pccs-url https://localhost:8081
+
+# Show version
+./target/release/pccs-proxy --version
+```
+
+### Adjust log verbosity
+
+```bash
+# Debug logging
+RUST_LOG=pccs_proxy=debug ./target/release/pccs-proxy
+
+# Trace logging (includes all HTTP details)
+RUST_LOG=pccs_proxy=trace ./target/release/pccs-proxy
+```
+
+### Run as a systemd service
+
+See `deployment/local-pccs-proxy.service` for a sample systemd unit file.
+
+### Verify it's working
+
+```bash
+curl http://localhost:8082/health
+# {"status":"ok","pccs":"reachable"}
+```
+
+If PCCS is not reachable, the health check returns HTTP 503:
+```json
+{"error": "PCCS is not reachable"}
+```
+
+## Log output
+
+The proxy logs client IP and request duration for every request:
+
+```
+INFO pccs_proxy: Starting local PCCS proxy addr=0.0.0.0:8082 pccs=https://localhost:8081/
+INFO pccs_proxy: PCCS is reachable
+INFO pccs_proxy::handlers: Received quote client=51.68.219.1:18432 quote_len=10012
+INFO pccs_proxy: Parsed quote fmspc=b0c06f000000 ca=platform
+INFO pccs_proxy::handlers: Collateral returned successfully client=51.68.219.1:18432 elapsed_ms=42
+```
+
+If PCCS is not reachable at startup, a warning is logged but the proxy still starts:
+
+```
+WARN pccs_proxy: PCCS is not reachable at startup — requests will fail until PCCS becomes available pccs=https://localhost:8081/
+```
+
+## Configuring the MPC node
+
+The MPC node's `quote_upload_url` must point to the proxy. Since the node runs inside a CVM, it cannot reach `localhost` on the host -- use the host's external IP instead.
+
+### Via node TOML config (recommended)
+
+Add `quote_upload_url` to the `[mpc_node_config]` section of the dstack user config:
+
+```toml
+[mpc_node_config]
+home_dir = "/data"
+quote_upload_url = "http://<HOST_IP>:8082/api/v1/attestations/verify"
+```
+
+If `quote_upload_url` is omitted, the node defaults to Phala's public endpoint.
+
+## API
+
+### `POST /api/v1/attestations/verify`
+
+Accepts a TDX quote and returns Intel attestation collateral. API-compatible with Phala's endpoint.
+
+**Request:**
+- Content-Type: `multipart/form-data`
+- Field: `hex` -- the TDX quote as a hex-encoded string
+
+**Response (200):**
+```json
+{
+  "quote_collateral": {
+    "tcb_info_issuer_chain": "<PEM certificate chain>",
+    "tcb_info": "<JSON string>",
+    "tcb_info_signature": "<hex-encoded signature>",
+    "qe_identity_issuer_chain": "<PEM certificate chain>",
+    "qe_identity": "<JSON string>",
+    "qe_identity_signature": "<hex-encoded signature>",
+    "pck_crl_issuer_chain": "<PEM certificate chain>",
+    "root_ca_crl": "<hex-encoded DER CRL>",
+    "pck_crl": "<hex-encoded DER CRL>",
+    "pck_certificate_chain": "<PEM certificate chain>"
+  }
+}
+```
+
+**Error (500):**
+```json
+{
+  "error": "<error message>"
+}
+```
+
+### `GET /health`
+
+Returns 200 if the proxy and upstream PCCS are both healthy:
+```json
+{"status": "ok", "pccs": "reachable"}
+```
+
+Returns 503 if PCCS is not reachable:
+```json
+{"error": "PCCS is not reachable"}
+```
+
+## Testing
+
+### Manual test with curl
+
+```bash
+# Using the test quote from the repo
+QUOTE_HEX=$(python3 -c "
+import json
+with open('crates/test-utils/assets/quote.json') as f:
+    print(bytes(json.load(f)).hex())
+")
+
+curl -s -X POST http://localhost:8082/api/v1/attestations/verify \
+  -F "hex=$QUOTE_HEX" | python3 -m json.tool | head -20
+```
+
+### Unit tests
+
+```bash
+cargo test -p pccs-proxy
+```
+
+### E2E test (2-node CVM cluster)
+
+See the [TEE testing guide](../localnet/tee/scripts/rust-launcher/how-to-run-localnet-tee-setup-script.md) for deploying a full 2-node cluster with the local proxy.
+
+## Troubleshooting
+
+### Proxy starts but CVM can't reach it
+
+The proxy must be reachable from inside the CVM. Common issues:
+- **Binding**: Ensure the proxy listens on `0.0.0.0` (default), not `127.0.0.1`
+- **Firewall**: Port 8082 must be open for inbound connections
+- **URL**: Use the host's external IP (e.g. `http://51.68.219.1:8082`), not `localhost`
+
+### PCCS returns errors
+
+```bash
+# Check PCCS is running
+systemctl status pccs
+
+# Test PCCS directly
+curl -sk https://localhost:8081/sgx/certification/v4/qe/identity
+
+# Check PCCS logs
+journalctl -u pccs --tail 20
+```
+
+### Health check returns 503
+
+The upstream PCCS is not responding. Check that the PCCS service is running and the `--pccs-url` argument is correct.
+
+### Quote parsing fails
+
+The proxy only supports TDX v4 quotes (TEE type 0x81). SGX quotes are not supported. Check the error message in the proxy logs for details.


### PR DESCRIPTION
## Summary

Add `pccs-proxy` crate — a drop-in replacement for Phala's collateral endpoint backed by a local Intel PCCS. Eliminates the dependency on Phala's centralized service for TDX attestation collateral.

## How it works

1. Receives a TDX quote from the MPC node (`POST /api/v1/attestations/verify`)
2. Parses the quote using `dcap-qvl` to extract FMSPC, CA type, and PCK cert chain
3. Fetches TCB Info, QE Identity, PCK CRL, and Root CA CRL from the local Intel PCCS in parallel
4. Returns assembled collateral in Phala-compatible JSON format

## What's included

- **`crates/pccs-proxy/`** — Rust binary with module structure (main, pccs, handlers)
- **Unit tests** — quote parsing, URL decoding, error cases
- **Production features** — health check with PCCS reachability, graceful shutdown, client IP + duration logging, PCCS response status validation, startup PCCS check
- **`docs/local-pccs-proxy.md`** — operator guide (architecture, setup, configuration, API, troubleshooting)
- **`deployment/Dockerfile-pccs-proxy`** — Docker image
- **`deployment/local-pccs-proxy.service`** — systemd unit file

## Usage

```bash
cargo build -p pccs-proxy --release
./target/release/pccs-proxy --listen 0.0.0.0:8082 --pccs-url https://localhost:8081
```

Configure the node to use it via `quote_upload_url` in `[mpc_node_config]` (see #2893).

## Test plan

- [x] Unit tests pass (`cargo test -p pccs-proxy`)
- [x] Manual curl test with real TDX quote returns valid collateral
- [x] E2E tested with 2-node CVM cluster — attestation, key generation, signature (see #2714)
- [x] Health check returns 503 when PCCS is down

Closes #467