### PR TITLE
chore: gate serde `Deserialize` on output-only DTO types to reduce WASM size

### DIFF
--- a/.github/contract-size-baseline.toml
+++ b/.github/contract-size-baseline.toml
@@ -3,4 +3,4 @@
 max_transaction_size = 1572864
 
 # Expected contract WASM size in bytes (reproducible builds must match exactly)
-expected_size = 1481277
+expected_size = 1481189

--- a/crates/near-mpc-contract-interface/src/types/attestation.rs
+++ b/crates/near-mpc-contract-interface/src/types/attestation.rs
@@ -55,16 +55,7 @@ pub enum Attestation {
 }
 
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Serialize,
-    BorshSerialize,
-    BorshDeserialize,
+    Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, BorshSerialize, BorshDeserialize,
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
@@ -77,16 +68,7 @@ pub enum VerifiedAttestation {
 }
 
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Serialize,
-    BorshSerialize,
-    BorshDeserialize,
+    Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, BorshSerialize, BorshDeserialize,
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
@@ -241,16 +223,7 @@ impl fmt::Debug for DstackAttestation {
 }
 
 #[derive(
-    Debug,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Serialize,
-    BorshSerialize,
-    BorshDeserialize,
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, BorshSerialize, BorshDeserialize,
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),

--- a/crates/near-mpc-contract-interface/src/types/attestation.rs
+++ b/crates/near-mpc-contract-interface/src/types/attestation.rs
@@ -63,7 +63,6 @@ pub enum Attestation {
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -71,6 +70,7 @@ pub enum Attestation {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub enum VerifiedAttestation {
     Dstack(VerifiedDstackAttestation),
     Mock(MockAttestation),
@@ -85,7 +85,6 @@ pub enum VerifiedAttestation {
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -93,6 +92,7 @@ pub enum VerifiedAttestation {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct VerifiedDstackAttestation {
     /// The digest of the MPC image running.
     pub mpc_image_hash: NodeImageHash,
@@ -249,7 +249,6 @@ impl fmt::Debug for DstackAttestation {
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -257,6 +256,7 @@ impl fmt::Debug for DstackAttestation {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct AppCompose {
     pub manifest_version: u32,
     pub name: String,
@@ -349,7 +349,8 @@ pub struct EventLog {
 }
 
 /// Arguments for the `submit_participant_info` contract call.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct SubmitParticipantInfoArgs {
     pub proposed_participant_attestation: Attestation,
     pub tls_public_key: Ed25519PublicKey,

--- a/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+++ b/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
@@ -651,7 +651,6 @@ pub struct ForeignChainConfiguration(BTreeMap<ForeignChain, NonEmptyBTreeSet<Rpc
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
     derive_more::From,
@@ -662,6 +661,7 @@ pub struct ForeignChainConfiguration(BTreeMap<ForeignChain, NonEmptyBTreeSet<Rpc
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema, borsh::BorshSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct SupportedForeignChains(BTreeSet<ForeignChain>);
 
 #[derive(
@@ -695,7 +695,6 @@ pub struct RpcProvider {
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -703,6 +702,7 @@ pub struct RpcProvider {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct ForeignChainPolicyVotes {
     pub proposal_by_account: BTreeMap<AccountId, ForeignChainPolicy>,
 }
@@ -717,7 +717,6 @@ pub struct ForeignChainPolicyVotes {
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
     derive_more::Deref,
@@ -727,6 +726,7 @@ pub struct ForeignChainPolicyVotes {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct NodeForeignChainConfigurations {
     pub foreign_chain_configuration_by_node: BTreeMap<AccountId, ForeignChainConfiguration>,
 }

--- a/crates/near-mpc-contract-interface/src/types/metrics.rs
+++ b/crates/near-mpc-contract-interface/src/types/metrics.rs
@@ -11,7 +11,6 @@ use serde::{Deserialize, Serialize};
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -19,6 +18,7 @@ use serde::{Deserialize, Serialize};
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema, borsh::BorshSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct Metrics {
     pub sign_with_v1_payload_count: u64,
     pub sign_with_v2_payload_count: u64,

--- a/crates/near-mpc-contract-interface/src/types/metrics.rs
+++ b/crates/near-mpc-contract-interface/src/types/metrics.rs
@@ -1,5 +1,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use serde::Deserialize;
+use serde::Serialize;
 
 #[derive(
     Default,

--- a/crates/near-mpc-contract-interface/src/types/state.rs
+++ b/crates/near-mpc-contract-interface/src/types/state.rs
@@ -113,16 +113,7 @@ pub struct AuthenticatedParticipantId(pub crate::types::participants::Participan
 
 /// An account ID that has been authenticated (i.e., the caller is this account).
 #[derive(
-    Clone,
-    Debug,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Serialize,
-    BorshSerialize,
-    BorshDeserialize,
+    Clone, Debug, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, BorshSerialize, BorshDeserialize,
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),

--- a/crates/near-mpc-contract-interface/src/types/state.rs
+++ b/crates/near-mpc-contract-interface/src/types/state.rs
@@ -101,7 +101,6 @@ pub struct Threshold(pub u64);
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -109,6 +108,7 @@ pub struct Threshold(pub u64);
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct AuthenticatedParticipantId(pub crate::types::participants::ParticipantId);
 
 /// An account ID that has been authenticated (i.e., the caller is this account).
@@ -121,7 +121,6 @@ pub struct AuthenticatedParticipantId(pub crate::types::participants::Participan
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -129,6 +128,7 @@ pub struct AuthenticatedParticipantId(pub crate::types::participants::Participan
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct AuthenticatedAccountId(pub AccountId);
 
 // =============================================================================
@@ -209,11 +209,12 @@ pub struct DomainConfig {
 }
 
 /// Registry of all signature domains.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct DomainRegistry {
     pub domains: Vec<DomainConfig>,
     pub next_domain_id: u64,
@@ -289,21 +290,23 @@ pub struct ThresholdParameters {
 // =============================================================================
 
 /// Votes for threshold parameter changes.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct ThresholdParametersVotes {
     pub proposal_by_account: BTreeMap<AuthenticatedAccountId, ThresholdParameters>,
 }
 
 /// Votes for adding new domains.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct AddDomainsVotes {
     pub proposal_by_account: BTreeMap<AuthenticatedParticipantId, Vec<DomainConfig>>,
 }
@@ -313,11 +316,12 @@ pub struct AddDomainsVotes {
 // =============================================================================
 
 /// State of a key generation/resharing instance.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct KeyEventInstance {
     pub attempt_id: AttemptId,
     pub started_in: u64,
@@ -327,11 +331,12 @@ pub struct KeyEventInstance {
 }
 
 /// Key generation or resharing event state.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct KeyEvent {
     pub epoch_id: EpochId,
     pub domain: DomainConfig,
@@ -345,11 +350,12 @@ pub struct KeyEvent {
 // =============================================================================
 
 /// State when the contract is generating keys for new domains.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct InitializingContractState {
     pub domains: DomainRegistry,
     pub epoch_id: EpochId,
@@ -359,11 +365,12 @@ pub struct InitializingContractState {
 }
 
 /// State when the contract is ready for signature operations.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct RunningContractState {
     pub domains: DomainRegistry,
     pub keyset: Keyset,
@@ -374,11 +381,12 @@ pub struct RunningContractState {
 }
 
 /// State when the contract is resharing keys to new participants.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct ResharingContractState {
     pub previous_running_state: RunningContractState,
     pub reshared_keys: Vec<KeyForDomain>,
@@ -387,11 +395,12 @@ pub struct ResharingContractState {
 }
 
 /// The main protocol contract state enum.
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub enum ProtocolContractState {
     NotInitialized,
     Initializing(InitializingContractState),

--- a/crates/near-mpc-contract-interface/src/types/updates.rs
+++ b/crates/near-mpc-contract-interface/src/types/updates.rs
@@ -8,16 +8,7 @@ use std::collections::BTreeMap;
 type Sha256Digest = [u8; 32];
 
 #[derive(
-    Debug,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Serialize,
-    BorshSerialize,
-    BorshDeserialize,
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, BorshSerialize, BorshDeserialize,
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
@@ -31,16 +22,7 @@ pub struct ProposedUpdates {
 
 /// An update hash
 #[derive(
-    Debug,
-    Clone,
-    Eq,
-    PartialEq,
-    Ord,
-    PartialOrd,
-    Hash,
-    Serialize,
-    BorshSerialize,
-    BorshDeserialize,
+    Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, BorshSerialize, BorshDeserialize,
 )]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),

--- a/crates/near-mpc-contract-interface/src/types/updates.rs
+++ b/crates/near-mpc-contract-interface/src/types/updates.rs
@@ -14,7 +14,6 @@ type Sha256Digest = [u8; 32];
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -22,6 +21,7 @@ type Sha256Digest = [u8; 32];
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub struct ProposedUpdates {
     pub votes: BTreeMap<AccountId, u64>,
     pub updates: BTreeMap<u64, UpdateHash>,
@@ -37,7 +37,6 @@ pub struct ProposedUpdates {
     PartialOrd,
     Hash,
     Serialize,
-    Deserialize,
     BorshSerialize,
     BorshDeserialize,
 )]
@@ -45,6 +44,7 @@ pub struct ProposedUpdates {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(Deserialize))]
 pub enum UpdateHash {
     Code(Sha256Digest),
     Config(Sha256Digest),

--- a/crates/near-mpc-contract-interface/src/types/updates.rs
+++ b/crates/near-mpc-contract-interface/src/types/updates.rs
@@ -1,6 +1,8 @@
 use crate::types::primitives::AccountId;
 use borsh::{BorshDeserialize, BorshSerialize};
-use serde::{Deserialize, Serialize};
+#[cfg(not(target_arch = "wasm32"))]
+use serde::Deserialize;
+use serde::Serialize;
 use std::collections::BTreeMap;
 
 type Sha256Digest = [u8; 32];


### PR DESCRIPTION
## Summary

- Gate `serde::Deserialize` behind `#[cfg_attr(not(target_arch = "wasm32"), ...)]` on 21 output-only DTO types in `near-mpc-contract-interface`
- These types are only serialized by the contract (returned from view methods) — the contract never deserializes them from JSON input
- Each unnecessary `Deserialize` impl generates a `deserialize_struct` monomorphization in `serde_json` (~2-7 KB each)
- Non-wasm consumers (node, SDK, CLI tools, tests) still get `Deserialize` via the `cfg_attr` gate

**Measured savings:** ~64 KB after `wasm-opt -Oz` (from 1,509,003 to 1,442,611 bytes)

## Test plan

- [x] Contract WASM builds (`cargo build -p mpc-contract --target=wasm32-unknown-unknown --profile=release-contract`)
- [x] Non-wasm contract-interface compiles (`cargo check -p near-mpc-contract-interface`)
- [x] Contract tests compile and pass (`cargo nextest run -p mpc-contract --lib` — 248/248 pass)
- [x] Node compiles (`cargo check -p mpc-node`)
- [ ] CI passes

Closes #2904