### PR TITLE
docs: fix scheme to curve in contract README vote_add_domains example

### DIFF
--- a/crates/contract/README.md
+++ b/crates/contract/README.md
@@ -205,15 +205,15 @@ To generate a new threshold signature key, all participants must vote for it to 
   "domains":[
     {
       "id":2,
-      "scheme":"Secp256k1"
+      "curve":"Secp256k1"
     },
     {
       "id":3,
-      "scheme":"Ed25519"
+      "curve":"Edwards25519"
     },
     {
       "id":4,
-      "scheme":"Bls12381"
+      "curve":"Bls12381"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Fix stale `vote_add_domains` JSON example in `crates/contract/README.md`:
- `"scheme"` → `"curve"` (field was renamed in #2831)
- `"Ed25519"` → `"Edwards25519"` (enum variant renamed in #2831)

Follow-up to PR #2892 which fixed the same issue in `docs/localnet/args/add_domain.json`.

Note: Other docs (`tee-localnet.md`, `localnet.md`) also have `"scheme"` but those are in **sign response** output where `SignatureResponse` correctly uses `#[serde(tag = "scheme")]` — not a bug.