### PR TITLE
build: add make targets that run tests on fresh checkout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,19 +248,19 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install cargo-make
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
+        with:
+          tool: cargo-make@0.37.24
+
       - name: Build mpc-node
-        run: |
-          cargo build -p mpc-node --release --features network-hardship-simulation,test-utils --locked
+        run: cargo make build-mpc-node
 
       # We run this build step on main as well to cache the contract build.
       # The non reproducible build will not be used on main since it will be overwritten by the reproducible
       # step below.
       - name: Build mpc-contract
-        run: |
-          cargo build -p mpc-contract --target=wasm32-unknown-unknown --profile=release-contract --locked
-          wasm-opt -Oz \
-            target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm \
-            -o target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm
+        run: cargo make build-mpc-contract
 
       - name: Build mpc-contract reproducibly
         if: github.ref == 'refs/heads/main'
@@ -270,11 +270,7 @@ jobs:
             --out-dir target/wasm32-unknown-unknown/release-contract
 
       - name: Build test-parallel-contract
-        run: |
-          cargo build -p test-parallel-contract --target=wasm32-unknown-unknown --profile=release-contract --locked
-          wasm-opt -Oz \
-            target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm \
-            -o target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm
+        run: cargo make build-test-parallel-contract
 
       - name: Build backup-cli
         run: |
@@ -623,12 +619,15 @@ jobs:
         with:
           tool: nextest@0.9.126
 
+      - name: Install cargo-make
+        uses: taiki-e/install-action@d4422f254e595ee762a758628fe4f16ce050fa2e # v2.67.28
+        with:
+          tool: cargo-make@0.37.24
+
       - name: Run E2E tests
-        run: |
-          RUST_LOG=info,e2e_tests=debug cargo nextest run --cargo-profile=test-release --profile ci-e2e -p e2e-tests --all-features --locked 2>&1
+        run: cargo make e2e-tests-skip-build
         env:
-          MPC_CONTRACT_WASM: ${{ github.workspace }}/target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm
-          MPC_PARALLEL_CONTRACT_WASM: ${{ github.workspace }}/target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm
+          RUST_LOG: info,e2e_tests=debug
 
   ci-extra:
     name: "Extra CI checks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,13 +254,13 @@ jobs:
           tool: cargo-make@0.37.24
 
       - name: Build mpc-node
-        run: cargo make build-mpc-node
+        run: cargo make build-mpc-node-network-hardship-simulation
 
       # We run this build step on main as well to cache the contract build.
       # The non reproducible build will not be used on main since it will be overwritten by the reproducible
       # step below.
       - name: Build mpc-contract
-        run: cargo make build-mpc-contract
+        run: cargo make build-mpc-contract-optimized
 
       - name: Build mpc-contract reproducibly
         if: github.ref == 'refs/heads/main'
@@ -270,7 +270,7 @@ jobs:
             --out-dir target/wasm32-unknown-unknown/release-contract
 
       - name: Build test-parallel-contract
-        run: cargo make build-test-parallel-contract
+        run: cargo make build-test-parallel-contract-optimized
 
       - name: Build backup-cli
         run: |

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -143,9 +143,9 @@ description = "Check that sandbox Docker image version matches nearcore"
 command = "bash"
 args = ["scripts/check-sandbox-image-version.sh"]
 
-# Build flags below mirror `.github/workflows/ci.yml` so local runs match CI.
-# All three build tasks are skipped when `E2E_SKIP_BUILD` is set (used by
-# `e2e-tests-skip-build`).
+# These build tasks are the single source of truth for both local and CI builds.
+# CI (`mpc-pytest-build` and `mpc-e2e-tests` jobs) invokes them via `cargo make`.
+# All three are skipped when `E2E_SKIP_BUILD` is set (used by `e2e-tests-skip-build`).
 
 [tasks.build-mpc-node]
 description = "Build the mpc-node binary used by the E2E tests"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -143,5 +143,85 @@ description = "Check that sandbox Docker image version matches nearcore"
 command = "bash"
 args = ["scripts/check-sandbox-image-version.sh"]
 
+# Build flags below mirror `.github/workflows/ci.yml` so local runs match CI.
+# All three build tasks are skipped when `E2E_SKIP_BUILD` is set (used by
+# `e2e-tests-skip-build`).
+
+[tasks.build-mpc-node]
+description = "Build the mpc-node binary used by the E2E tests"
+condition = { env_not_set = ["E2E_SKIP_BUILD"] }
+command = "cargo"
+args = [
+  "build",
+  "-p",
+  "mpc-node",
+  "--release",
+  "--features",
+  "network-hardship-simulation,test-utils",
+  "--locked",
+]
+
+[tasks.build-mpc-contract]
+description = "Build the mpc-contract WASM used by the E2E tests"
+condition = { env_not_set = ["E2E_SKIP_BUILD"] }
+script = [
+  "cargo build -p mpc-contract --target=wasm32-unknown-unknown --profile=release-contract --locked",
+  "wasm-opt -Oz target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm -o target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm",
+]
+
+[tasks.build-test-parallel-contract]
+description = "Build the test-parallel-contract WASM used by the E2E tests"
+condition = { env_not_set = ["E2E_SKIP_BUILD"] }
+script = [
+  "cargo build -p test-parallel-contract --target=wasm32-unknown-unknown --profile=release-contract --locked",
+  "wasm-opt -Oz target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm -o target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm",
+]
+
+# Kill orphan mpc-node processes left over from interrupted test runs.
+[tasks._kill-orphan-mpc-nodes]
+private = true
+script = [
+  "pids=$(pgrep -f 'mpc-node start-with-config-file' || true)",
+  "if [ -n \"$pids\" ]; then echo \"Killing orphan mpc-node processes: $pids\"; kill $pids; sleep 1; fi",
+]
+
+# Shared logic for `e2e-tests` and `e2e-tests-skip-build`. Dependencies are
+# skipped automatically when `E2E_SKIP_BUILD` is set.
+[tasks._run-e2e-logic]
+private = true
+dependencies = [
+  "_kill-orphan-mpc-nodes",
+  "build-mpc-node",
+  "build-mpc-contract",
+  "build-test-parallel-contract",
+]
+command = "cargo"
+args = [
+  "nextest",
+  "run",
+  "--cargo-profile=test-release",
+  "-p",
+  "e2e-tests",
+  "--all-features",
+  "--locked",
+  "-j",
+  "4",
+]
+
+[tasks._run-e2e-logic.env]
+MPC_CONTRACT_WASM = "${CARGO_MAKE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm"
+MPC_PARALLEL_CONTRACT_WASM = "${CARGO_MAKE_WORKING_DIRECTORY}/target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm"
+
+# Build the mpc-node binary and both contract WASMs, then run the E2E tests.
+[tasks.e2e-tests]
+description = "Build required binaries and run the E2E tests"
+run_task = "_run-e2e-logic"
+
+# Reuse the binaries from a previous `cargo make e2e-tests` run.
+[tasks.e2e-tests-skip-build]
+description = "Run the E2E tests using previously built binaries"
+env = { "E2E_SKIP_BUILD" = "true" }
+run_task = "_run-e2e-logic"
+
 [config]
 default_to_workspace = false

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -204,8 +204,8 @@ args = [
   "e2e-tests",
   "--all-features",
   "--locked",
-  "-j",
-  "4",
+  "--profile",
+  "ci-e2e",
 ]
 
 [tasks._run-e2e-logic.env]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -147,7 +147,7 @@ args = ["scripts/check-sandbox-image-version.sh"]
 # CI (`mpc-pytest-build` and `mpc-e2e-tests` jobs) invokes them via `cargo make`.
 # All three are skipped when `E2E_SKIP_BUILD` is set (used by `e2e-tests-skip-build`).
 
-[tasks.build-mpc-node]
+[tasks.build-mpc-node-network-hardship-simulation]
 description = "Build the mpc-node binary used by the E2E tests"
 condition = { env_not_set = ["E2E_SKIP_BUILD"] }
 command = "cargo"
@@ -161,7 +161,7 @@ args = [
   "--locked",
 ]
 
-[tasks.build-mpc-contract]
+[tasks.build-mpc-contract-optimized]
 description = "Build the mpc-contract WASM used by the E2E tests"
 condition = { env_not_set = ["E2E_SKIP_BUILD"] }
 script = [
@@ -169,7 +169,7 @@ script = [
   "wasm-opt -Oz target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm -o target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm",
 ]
 
-[tasks.build-test-parallel-contract]
+[tasks.build-test-parallel-contract-optimized]
 description = "Build the test-parallel-contract WASM used by the E2E tests"
 condition = { env_not_set = ["E2E_SKIP_BUILD"] }
 script = [
@@ -191,9 +191,9 @@ script = [
 private = true
 dependencies = [
   "_kill-orphan-mpc-nodes",
-  "build-mpc-node",
-  "build-mpc-contract",
-  "build-test-parallel-contract",
+  "build-mpc-node-network-hardship-simulation",
+  "build-mpc-contract-optimized",
+  "build-test-parallel-contract-optimized",
 ]
 command = "cargo"
 args = [

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -178,11 +178,12 @@ script = [
 ]
 
 # Kill orphan mpc-node processes left over from interrupted test runs.
-[tasks._kill-orphan-mpc-nodes]
-private = true
+# Ports are deterministic per test, so orphans from a previous run block the next one.
+[tasks.kill-orphan-mpc-nodes]
+description = "Kill orphan mpc-node processes left over from interrupted E2E test runs"
 script = [
   "pids=$(pgrep -f 'mpc-node start-with-config-file' || true)",
-  "if [ -n \"$pids\" ]; then echo \"Killing orphan mpc-node processes: $pids\"; kill $pids; sleep 1; fi",
+  "if [ -n \"$pids\" ]; then echo \"Killing orphan mpc-node processes: $pids\"; kill $pids; sleep 1; else echo \"No orphan mpc-node processes found\"; fi",
 ]
 
 # Shared logic for `e2e-tests` and `e2e-tests-skip-build`. Dependencies are
@@ -190,7 +191,6 @@ script = [
 [tasks._run-e2e-logic]
 private = true
 dependencies = [
-  "_kill-orphan-mpc-nodes",
   "build-mpc-node-network-hardship-simulation",
   "build-mpc-contract-optimized",
   "build-test-parallel-contract-optimized",

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -44,7 +44,12 @@ times up to 10 nodes = 82 ports total.
 cargo make e2e-tests                           # Rebuild binaries then run all tests
 cargo make e2e-tests-skip-build                # Reuse binaries from a previous run
 cargo make e2e-tests-skip-build -- <test>      # Run a single test (name filter passed to nextest)
+cargo make kill-orphan-mpc-nodes              # Kill mpc-node processes left over from interrupted runs
 ```
+
+> **Tip:** Ports are deterministic per test, so orphan `mpc-node` processes from an
+> interrupted run will hold the exact ports the next run needs. If tests fail with
+> "address already in use", run `cargo make kill-orphan-mpc-nodes` first.
 
 ## Design Reference
 

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -38,6 +38,16 @@ node (P2P, web UI, migration UI, pprof, near RPC, near network, 2 reserved)
 times up to 10 nodes = 82 ports total.
 
 
+## Running the tests
+
+```bash
+cargo make e2e-tests                           # Rebuild binaries then run all tests
+cargo make e2e-tests-skip-build                # Reuse binaries from a previous run
+cargo make e2e-tests-skip-build -- <test>      # Run a single test (name filter passed to nextest)
+```
+
+Build flags mirror `.github/workflows/ci.yml`.
+
 ## Design Reference
 
 See `docs/pytest-deprecation.md` (PR #2446) for the full design document

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -46,8 +46,6 @@ cargo make e2e-tests-skip-build                # Reuse binaries from a previous 
 cargo make e2e-tests-skip-build -- <test>      # Run a single test (name filter passed to nextest)
 ```
 
-Build flags mirror `.github/workflows/ci.yml`.
-
 ## Design Reference
 
 See `docs/pytest-deprecation.md` (PR #2446) for the full design document

--- a/flake.nix
+++ b/flake.nix
@@ -142,10 +142,6 @@
             binaryen
             jq
             perl
-          ] ++ lib.optionals stdenv.isLinux [
-            # pgrep is used by the kill-orphan-mpc-nodes cargo-make task.
-            # On macOS pgrep is a built-in system utility with no nix equivalent.
-            pkgs.procps
           ];
 
           buildLibs =

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,7 @@
             binaryen
             jq
             perl
+            procps  # pgrep, used by the kill-orphan-mpc-nodes cargo-make task
           ];
 
           buildLibs =

--- a/flake.nix
+++ b/flake.nix
@@ -142,6 +142,10 @@
             binaryen
             jq
             perl
+          ] ++ lib.optionals stdenv.isLinux [
+            # pgrep is used by the kill-orphan-mpc-nodes cargo-make task.
+            # On macOS pgrep is a built-in system utility with no nix equivalent.
+            pkgs.procps
           ];
 
           buildLibs =


### PR DESCRIPTION
- Add cargo make targets for building E2E test binaries (build-mpc-node-network-hardship-simulation, build-mpc-contract-optimized, build-test-parallel-contract-optimized) and running E2E tests (e2e-tests, e2e-tests-skip-build) 
- Replace raw cargo build / cargo nextest run commands in CI with the corresponding cargo make targets, making Makefile.toml the single source of truth for build flags                                                            
- Add running instructions to crates/e2e-tests/README.md

Closes https://github.com/near/mpc/issues/2875