### PR TITLE
refactor: make StartConfig::quote_upload_url required

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -215,7 +215,7 @@ tracing-subscriber = { version = "0.3.23", features = [
     "json",
 ] }
 tracing-test = "0.2.6"
-url = "2"
+url = { version = "2", features = ["serde"] }
 x509-parser = "0.18.1"
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zstd = "0.13.3"

--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -399,6 +399,7 @@ impl MpcNodeSetup {
                 keygen: KeygenConfig { timeout_sec: 60 },
                 foreign_chains: Default::default(),
             },
+            quote_upload_url: mpc_node_config::default_quote_upload_url(),
         };
 
         let toml_string =

--- a/crates/node-config/src/lib.rs
+++ b/crates/node-config/src/lib.rs
@@ -10,7 +10,7 @@ pub use foreign_chains::{
 };
 pub use start::{
     ChainId, DownloadConfigType, GcpStartConfig, LogConfig, LogFormat, NearInitConfig,
-    SecretsStartConfig, StartConfig,
+    SecretsStartConfig, StartConfig, default_quote_upload_url,
 };
 
 use anyhow::Context;

--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -24,6 +24,15 @@ pub struct StartConfig {
     /// Node configuration (indexer, protocol parameters, etc.).
     pub node: ConfigFile,
     pub log: LogConfig,
+    /// TDX quote collateral endpoint URL. Defaults to Phala's public endpoint
+    #[serde(default = "default_quote_upload_url")]
+    pub quote_upload_url: url::Url,
+}
+
+pub fn default_quote_upload_url() -> url::Url {
+    launcher_interface::DEFAULT_PHALA_TDX_QUOTE_UPLOAD_URL
+        .parse()
+        .expect("default quote upload URL is valid")
 }
 
 impl StartConfig {

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -143,6 +143,7 @@ impl StartCmd {
                 format: log_format,
                 filter: std::env::var("RUST_LOG").ok(),
             },
+            quote_upload_url: mpc_node_config::default_quote_upload_url(),
         }
     }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -8,22 +8,16 @@ use tee_authority::tee_authority::{
 use url::Url;
 
 pub trait TeeAuthorityImpl {
-    fn into_tee_authority(self) -> anyhow::Result<TeeAuthority>;
+    fn into_tee_authority(self, quote_upload_url: &Url) -> anyhow::Result<TeeAuthority>;
 }
 
 impl TeeAuthorityImpl for TeeConfig {
-    fn into_tee_authority(self) -> anyhow::Result<TeeAuthority> {
+    fn into_tee_authority(self, quote_upload_url: &Url) -> anyhow::Result<TeeAuthority> {
         Ok(match self.authority {
             TeeAuthorityConfig::Local => LocalTeeAuthorityConfig::default().into(),
             TeeAuthorityConfig::Dstack {
-                dstack_endpoint,
-                quote_upload_url,
-            } => {
-                let url: Url = quote_upload_url
-                    .parse()
-                    .context("invalid quote_upload_url")?;
-                DstackTeeAuthorityConfig::new(dstack_endpoint, url).into()
-            }
+                dstack_endpoint, ..
+            } => DstackTeeAuthorityConfig::new(dstack_endpoint, quote_upload_url.clone()).into(),
         })
     }
 }

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -58,12 +58,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             launcher_interface::types::TeeAuthorityConfig::Local => "local",
         },
         image_hash = %config.tee.image_hash,
-        quote_upload_url = %match &config.tee.authority {
-            launcher_interface::types::TeeAuthorityConfig::Dstack { .. } => {
-                config.quote_upload_url.as_str()
-            },
-            launcher_interface::types::TeeAuthorityConfig::Local => "n/a",
-        },
+        quote_upload_url = %config.quote_upload_url,
         "TEE config"
     );
     if let Some(ref near_init) = config.near_init {

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -58,6 +58,12 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             launcher_interface::types::TeeAuthorityConfig::Local => "local",
         },
         image_hash = %config.tee.image_hash,
+        quote_upload_url = %match &config.tee.authority {
+            launcher_interface::types::TeeAuthorityConfig::Dstack { .. } => {
+                config.quote_upload_url.as_str()
+            },
+            launcher_interface::types::TeeAuthorityConfig::Local => "n/a",
+        },
         "TEE config"
     );
     if let Some(ref near_init) = config.near_init {
@@ -101,7 +107,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     )?;
 
     // Generate attestation
-    let tee_authority = config.tee.clone().into_tee_authority()?;
+    let tee_authority = config.tee.clone().into_tee_authority(&config.quote_upload_url)?;
     let tls_public_key = &secrets.persistent_secrets.p2p_private_key.verifying_key();
 
     let account_public_key = &secrets.persistent_secrets.near_signer_key.verifying_key();


### PR DESCRIPTION
## Summary
- Add `quote_upload_url` field to `StartConfig` as a required `Url` with a serde default (Phala's public endpoint)
- Simplify `into_tee_authority` — the node config is now the single source of truth for the collateral endpoint URL, removing the override/fallback dance with the launcher's `TeeAuthorityConfig::Dstack`
- Enable `serde` feature on workspace `url` dependency

## Test plan
- [x] `cargo clippy -p mpc-node-config -p mpc-node -p e2e-tests --locked -- -D warnings` passes
- [ ] CI passes
- [ ] Existing TOML configs that omit `quote_upload_url` still work (serde default kicks in)

🤖 Generated with [Claude Code](https://claude.com/claude-code)