### PR TITLE
refactor: replace tee launcher hash votes with generics

### DIFF
--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -70,7 +70,6 @@ use primitives::{
     votes::types::{ProposalHash, ProposalId},
 };
 use tee::measurements::{ContractExpectedMeasurements, MeasurementVoteAction};
-use tee::proposal::CodeHashesVotes;
 
 use state::{running::RunningContractState, ProtocolContractState};
 use tee::{
@@ -1386,14 +1385,26 @@ impl MpcContract {
         };
 
         let participant = AuthenticatedParticipantId::new(threshold_parameters.participants())?;
-        let votes = self.tee_state.vote(code_hash, &participant);
+        let votes = self.tee_state.vote(code_hash, participant);
 
         let tee_upgrade_deadline_duration =
             Duration::from_secs(self.config.tee_upgrade_deadline_duration_seconds);
 
+        let num_votes = votes.count_for(|authenticated_participant_id| {
+            threshold_parameters
+                .participants()
+                .is_participant_given_participant_id(&authenticated_participant_id.get())
+        });
+
         // If the vote threshold is met and the new Docker hash is allowed by the TEE's RTMR3,
         // update the state
-        if votes >= self.threshold()?.value() {
+        if num_votes
+            >= self
+                .threshold()?
+                .value()
+                .try_into()
+                .expect("threshold must not exceed usize limit")
+        {
             self.tee_state
                 .whitelist_tee_proposal(code_hash, tee_upgrade_deadline_duration);
         }
@@ -1952,8 +1963,16 @@ impl MpcContract {
     }
 
     /// Returns the current code hash votes, showing each participant's vote.
-    pub fn code_hash_votes(&self) -> CodeHashesVotes {
-        self.tee_state.votes.clone()
+    pub fn code_hash_votes(
+        &self,
+    ) -> BTreeMap<
+        ProposalId,
+        (
+            (ProposalHash, NodeImageHash),
+            BTreeSet<AuthenticatedParticipantId>,
+        ),
+    > {
+        self.tee_state.votes.snapshot()
     }
 
     pub fn get_pending_request(&self, request: &SignatureRequest) -> Option<YieldIndex> {
@@ -5688,8 +5707,12 @@ mod tests {
         let participant_list = participants.participants();
         let code_hash = NodeImageHash::from([0xAB; 32]);
 
-        assert!(contract.code_hash_votes().proposal_by_account.is_empty());
+        assert!(contract.code_hash_votes().is_empty());
 
+        let expected_hash: [u8; PROPOSAL_HASH_BYTES] =
+            sha2::Sha256::digest(borsh::to_vec(&code_hash).unwrap()).into();
+        let expected_hash = ProposalHash::new(expected_hash);
+        let mut expected_voter_set = BTreeSet::new();
         for (i, (account, _, _)) in participant_list[..threshold as usize].iter().enumerate() {
             testing_env!(VMContextBuilder::new()
                 .signer_account_id(account.clone())
@@ -5699,10 +5722,19 @@ mod tests {
                 .vote_code_hash(code_hash)
                 .expect("vote should succeed");
 
-            let votes = &contract.code_hash_votes().proposal_by_account;
+            let auth_p_id = AuthenticatedParticipantId::new(&participants).unwrap();
+            expected_voter_set.insert(auth_p_id.clone());
+            let votes = contract.code_hash_votes();
+
             if i < (threshold - 1) as usize {
-                assert_eq!(votes.len(), i + 1);
-                assert!(votes.values().all(|v| *v == code_hash));
+                let expected = BTreeMap::from([(
+                    0.into(),
+                    (
+                        (expected_hash, code_hash.clone()),
+                        expected_voter_set.clone(),
+                    ),
+                )]);
+                assert_eq!(votes, expected);
             } else {
                 assert!(
                     votes.is_empty(),

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -11,7 +11,6 @@ pub mod tee;
 pub mod update;
 #[cfg(feature = "dev-utils")]
 pub mod utils;
-
 pub mod v3_8_1_state;
 
 #[cfg(feature = "bench-contract-methods")]
@@ -68,9 +67,10 @@ use primitives::{
     key_state::{AuthenticatedAccountId, AuthenticatedParticipantId, EpochId, KeyEventId, Keyset},
     signature::{SignRequest, SignRequestArgs, SignatureRequest, YieldIndex},
     thresholds::{Threshold, ThresholdParameters},
+    votes::types::{ProposalHash, ProposalId},
 };
 use tee::measurements::{ContractExpectedMeasurements, MeasurementVoteAction, MeasurementVotes};
-use tee::proposal::{CodeHashesVotes, LauncherHashVotes};
+use tee::proposal::CodeHashesVotes;
 
 use state::{running::RunningContractState, ProtocolContractState};
 use tee::{
@@ -1427,10 +1427,22 @@ impl MpcContract {
         let action = LauncherVoteAction::Add(launcher_hash);
         let votes = self.tee_state.vote_launcher(action, &participant);
 
+        let num_votes = votes.count_for(|authenticated_participant_id| {
+            threshold_parameters
+                .participants()
+                .is_participant_given_participant_id(&authenticated_participant_id.get())
+        });
+
         let tee_upgrade_deadline_duration =
             Duration::from_secs(self.config.tee_upgrade_deadline_duration_seconds);
 
-        if votes >= self.threshold()?.value() {
+        if num_votes
+            >= self
+                .threshold()?
+                .value()
+                .try_into()
+                .expect("expect cast from u64 to usize for threshold to succeed")
+        {
             let added = self
                 .tee_state
                 .add_launcher_image(launcher_hash, tee_upgrade_deadline_duration);
@@ -1464,10 +1476,15 @@ impl MpcContract {
         let participant = AuthenticatedParticipantId::new(threshold_parameters.participants())?;
         let action = LauncherVoteAction::Remove(launcher_hash);
         let votes = self.tee_state.vote_launcher(action, &participant);
+        let num_votes = votes.count_for(|authenticated_participant_id| {
+            threshold_parameters
+                .participants()
+                .is_participant_given_participant_id(&authenticated_participant_id.get())
+        });
 
         // Removal requires ALL participants to vote
-        let total_participants = threshold_parameters.participants().len() as u64;
-        if votes >= total_participants {
+        let total_participants = threshold_parameters.participants().len();
+        if num_votes >= total_participants {
             let removed = self.tee_state.remove_launcher_image(&launcher_hash);
             log!("launcher hash remove result: {}", removed);
         }
@@ -1897,8 +1914,16 @@ impl MpcContract {
     }
 
     /// Returns the current launcher hash votes, showing each participant's vote.
-    pub fn launcher_hash_votes(&self) -> LauncherHashVotes {
-        self.tee_state.launcher_votes.clone()
+    pub fn launcher_hash_votes(
+        &self,
+    ) -> BTreeMap<
+        ProposalId,
+        (
+            (ProposalHash, LauncherVoteAction),
+            BTreeSet<AuthenticatedParticipantId>,
+        ),
+    > {
+        self.tee_state.launcher_votes.snapshot()
     }
 
     /// Returns the current code hash votes, showing each participant's vote.
@@ -2378,7 +2403,6 @@ mod tests {
     };
 
     use super::*;
-    use crate::errors::NodeMigrationError;
     use crate::primitives::participants::{ParticipantId, ParticipantInfo};
     use crate::primitives::test_utils::{
         bogus_ed25519_near_public_key, bogus_ed25519_public_key, gen_account_id, gen_participant,
@@ -2400,6 +2424,7 @@ mod tests {
     };
     use crate::tee::proposal::{get_docker_compose_hash, LauncherVoteAction};
     use crate::tee::tee_state::NodeId;
+    use crate::{errors::NodeMigrationError, primitives::votes::types::PROPOSAL_HASH_BYTES};
     use assert_matches::assert_matches;
     use dtos::{Attestation, Ed25519PublicKey, ForeignTxSignPayload, MockAttestation};
     use elliptic_curve::Field as _;
@@ -5551,10 +5576,10 @@ mod tests {
         let participant_list = participants.participants();
         let launcher_hash = make_launcher_hash(0xCC);
 
-        assert!(contract.launcher_hash_votes().vote_by_account.is_empty());
+        assert!(contract.launcher_hash_votes().is_empty());
 
         // First vote
-        let (account_0, _, _) = &participant_list[0];
+        let (account_0, p_id_0, _) = &participant_list[0];
         testing_env!(VMContextBuilder::new()
             .signer_account_id(account_0.clone())
             .predecessor_account_id(account_0.clone())
@@ -5563,13 +5588,29 @@ mod tests {
             .vote_add_launcher_hash(launcher_hash)
             .expect("vote should succeed");
 
-        let votes = &contract.launcher_hash_votes().vote_by_account;
-        assert_eq!(votes.len(), 1);
+        let auth_p_id_0 = AuthenticatedParticipantId::new(&participants).unwrap();
+        assert_eq!(auth_p_id_0.get(), *p_id_0);
+
         let expected_action = LauncherVoteAction::Add(launcher_hash);
-        assert!(votes.values().all(|v| *v == expected_action));
+        let expected_hash: [u8; PROPOSAL_HASH_BYTES] =
+            sha2::Sha256::digest(borsh::to_vec(&expected_action).unwrap()).into();
+        let expected_hash = ProposalHash::new(expected_hash);
+        {
+            let votes = contract.launcher_hash_votes();
+            assert_eq!(
+                votes,
+                BTreeMap::from([(
+                    0.into(),
+                    (
+                        (expected_hash, expected_action.clone()),
+                        BTreeSet::from([auth_p_id_0.clone()])
+                    )
+                )])
+            );
+        }
 
         // Second vote
-        let (account_1, _, _) = &participant_list[1];
+        let (account_1, p_id_1, _) = &participant_list[1];
         testing_env!(VMContextBuilder::new()
             .signer_account_id(account_1.clone())
             .predecessor_account_id(account_1.clone())
@@ -5578,9 +5619,21 @@ mod tests {
             .vote_add_launcher_hash(launcher_hash)
             .expect("vote should succeed");
 
-        let votes = &contract.launcher_hash_votes().vote_by_account;
-        assert_eq!(votes.len(), 2);
-        assert!(votes.values().all(|v| *v == expected_action));
+        let auth_p_id_1 = AuthenticatedParticipantId::new(&participants).unwrap();
+        assert_eq!(auth_p_id_1.get(), *p_id_1);
+        {
+            let votes = contract.launcher_hash_votes();
+            assert_eq!(
+                votes,
+                BTreeMap::from([(
+                    0.into(),
+                    (
+                        (expected_hash, expected_action.clone()),
+                        BTreeSet::from([auth_p_id_0, auth_p_id_1])
+                    )
+                )])
+            );
+        }
 
         // Third vote reaches threshold — votes should be cleared
         let (account_2, _, _) = &participant_list[2];
@@ -5593,7 +5646,7 @@ mod tests {
             .expect("vote should succeed");
 
         assert!(
-            contract.launcher_hash_votes().vote_by_account.is_empty(),
+            contract.launcher_hash_votes().is_empty(),
             "votes should be cleared after threshold reached"
         );
     }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -69,7 +69,7 @@ use primitives::{
     thresholds::{Threshold, ThresholdParameters},
     votes::types::{ProposalHash, ProposalId},
 };
-use tee::measurements::{ContractExpectedMeasurements, MeasurementVoteAction, MeasurementVotes};
+use tee::measurements::{ContractExpectedMeasurements, MeasurementVoteAction};
 use tee::proposal::CodeHashesVotes;
 
 use state::{running::RunningContractState, ProtocolContractState};
@@ -1514,9 +1514,21 @@ impl MpcContract {
 
         let participant = AuthenticatedParticipantId::new(threshold_parameters.participants())?;
         let action = MeasurementVoteAction::Add(measurement.clone());
-        let votes = self.tee_state.vote_measurement(action, &participant);
+        let votes = self.tee_state.vote_measurement(action, participant);
 
-        if votes >= self.threshold()?.value() {
+        let num_votes = votes.count_for(|authenticated_participant_id| {
+            threshold_parameters
+                .participants()
+                .is_participant_given_participant_id(&authenticated_participant_id.get())
+        });
+
+        if num_votes
+            >= self
+                .threshold()?
+                .value()
+                .try_into()
+                .expect("converting threshold to usize must succeed")
+        {
             let added = self.tee_state.add_measurement(measurement);
             log!("OS measurement add result: {}", added);
         }
@@ -1547,11 +1559,16 @@ impl MpcContract {
 
         let participant = AuthenticatedParticipantId::new(threshold_parameters.participants())?;
         let action = MeasurementVoteAction::Remove(measurement.clone());
-        let votes = self.tee_state.vote_measurement(action, &participant);
+        let votes = self.tee_state.vote_measurement(action, participant);
 
+        let num_votes = votes.count_for(|authenticated_participant_id| {
+            threshold_parameters
+                .participants()
+                .is_participant_given_participant_id(&authenticated_participant_id.get())
+        });
         // Removal requires ALL participants to vote
-        let total_participants = threshold_parameters.participants().len() as u64;
-        if votes >= total_participants {
+        let total_participants = threshold_parameters.participants().len();
+        if num_votes >= total_participants {
             let removed = self.tee_state.remove_measurement(&measurement);
             log!("OS measurement remove result: {}", removed);
         }
@@ -1560,9 +1577,17 @@ impl MpcContract {
     }
 
     /// Returns the current OS measurement votes, showing each participant's vote.
-    pub fn os_measurement_votes(&self) -> MeasurementVotes {
+    pub fn os_measurement_votes(
+        &self,
+    ) -> BTreeMap<
+        ProposalId,
+        (
+            (ProposalHash, MeasurementVoteAction),
+            BTreeSet<AuthenticatedParticipantId>,
+        ),
+    > {
         log!("os_measurement_votes");
-        self.tee_state.measurement_votes.clone()
+        self.tee_state.measurement_votes.snapshot()
     }
 
     /// Returns all currently allowed OS measurements.
@@ -5993,10 +6018,10 @@ mod tests {
         let measurement = make_measurement(0xCC);
 
         // Initially empty
-        assert!(contract.os_measurement_votes().vote_by_account.is_empty());
+        assert!(contract.os_measurement_votes().is_empty());
 
         // Cast one vote
-        let (account_id, _, _) = &participant_list[0];
+        let (account_id, p_id, _) = &participant_list[0];
         testing_env!(VMContextBuilder::new()
             .signer_account_id(account_id.clone())
             .predecessor_account_id(account_id.clone())
@@ -6005,10 +6030,26 @@ mod tests {
             .vote_add_os_measurement(measurement.clone())
             .expect("add vote should succeed");
 
-        let votes = contract.os_measurement_votes();
-        assert_eq!(votes.vote_by_account.len(), 1);
-        let (_, action) = votes.vote_by_account.iter().next().unwrap();
-        assert_eq!(*action, MeasurementVoteAction::Add(measurement));
+        let expected_action = MeasurementVoteAction::Add(measurement);
+        let expected_hash: [u8; PROPOSAL_HASH_BYTES] =
+            sha2::Sha256::digest(borsh::to_vec(&expected_action).unwrap()).into();
+        let expected_hash = ProposalHash::new(expected_hash);
+
+        let auth_p_id = AuthenticatedParticipantId::new(&participants).unwrap();
+        assert_eq!(auth_p_id.get(), *p_id);
+        {
+            let votes = contract.os_measurement_votes();
+            assert_eq!(
+                votes,
+                BTreeMap::from([(
+                    0.into(),
+                    (
+                        (expected_hash, expected_action),
+                        BTreeSet::from([auth_p_id])
+                    )
+                )])
+            );
+        }
     }
 
     /// Tests the allowed_os_measurements view method returns the full structs

--- a/crates/contract/src/primitives/votes/types.rs
+++ b/crates/contract/src/primitives/votes/types.rs
@@ -14,7 +14,7 @@ pub trait VoterBounds: BorshSerialize + BorshDeserialize + Ord + Clone {}
 impl<T: BorshSerialize + BorshDeserialize + Ord + Clone> ProposalBounds for T {}
 impl<T: BorshSerialize + BorshDeserialize + Ord + Clone> VoterBounds for T {}
 
-#[near(serializers=[borsh])]
+#[near(serializers=[borsh, json])]
 #[derive(Debug, PartialEq, PartialOrd, Eq, Ord, Clone, Copy, From, Deref, Into)]
 pub struct ProposalId(pub(crate) u64);
 

--- a/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
+++ b/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
@@ -27,16 +27,16 @@ BorshSchemaContainer {
                 "DockerImageHash",
             ],
         },
-        "(AuthenticatedParticipantId, LauncherVoteAction)": Tuple {
-            elements: [
-                "AuthenticatedParticipantId",
-                "LauncherVoteAction",
-            ],
-        },
         "(AuthenticatedParticipantId, MeasurementVoteAction)": Tuple {
             elements: [
                 "AuthenticatedParticipantId",
                 "MeasurementVoteAction",
+            ],
+        },
+        "(AuthenticatedParticipantId, ProposalId)": Tuple {
+            elements: [
+                "AuthenticatedParticipantId",
+                "ProposalId",
             ],
         },
         "(AuthenticatedParticipantId, Vec<DomainConfig>)": Tuple {
@@ -49,6 +49,18 @@ BorshSchemaContainer {
             elements: [
                 "ForeignChain",
                 "NonEmptyBTreeSet<RpcProvider>",
+            ],
+        },
+        "(ProposalHash, ProposalId)": Tuple {
+            elements: [
+                "ProposalHash",
+                "ProposalId",
+            ],
+        },
+        "(ProposalId, VoterSet<AuthenticatedParticipantId>)": Tuple {
+            elements: [
+                "ProposalId",
+                "VoterSet<AuthenticatedParticipantId>",
             ],
         },
         "(PublicKey, NodeAttestation)": Tuple {
@@ -163,15 +175,15 @@ BorshSchemaContainer {
             length_range: 0..=4294967295,
             elements: "(AuthenticatedParticipantId, DockerImageHash)",
         },
-        "BTreeMap<AuthenticatedParticipantId, LauncherVoteAction>": Sequence {
-            length_width: 4,
-            length_range: 0..=4294967295,
-            elements: "(AuthenticatedParticipantId, LauncherVoteAction)",
-        },
         "BTreeMap<AuthenticatedParticipantId, MeasurementVoteAction>": Sequence {
             length_width: 4,
             length_range: 0..=4294967295,
             elements: "(AuthenticatedParticipantId, MeasurementVoteAction)",
+        },
+        "BTreeMap<AuthenticatedParticipantId, ProposalId>": Sequence {
+            length_width: 4,
+            length_range: 0..=4294967295,
+            elements: "(AuthenticatedParticipantId, ProposalId)",
         },
         "BTreeMap<AuthenticatedParticipantId, Vec<DomainConfig>>": Sequence {
             length_width: 4,
@@ -182,6 +194,16 @@ BorshSchemaContainer {
             length_width: 4,
             length_range: 0..=4294967295,
             elements: "(ForeignChain, NonEmptyBTreeSet<RpcProvider>)",
+        },
+        "BTreeMap<ProposalHash, ProposalId>": Sequence {
+            length_width: 4,
+            length_range: 0..=4294967295,
+            elements: "(ProposalHash, ProposalId)",
+        },
+        "BTreeMap<ProposalId, VoterSet<AuthenticatedParticipantId>>": Sequence {
+            length_width: 4,
+            length_range: 0..=4294967295,
+            elements: "(ProposalId, VoterSet<AuthenticatedParticipantId>)",
         },
         "BTreeMap<PublicKey, NodeAttestation>": Sequence {
             length_width: 4,
@@ -677,49 +699,10 @@ BorshSchemaContainer {
                 ],
             ),
         },
-        "LauncherHashVotes": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "vote_by_account",
-                        "BTreeMap<AuthenticatedParticipantId, LauncherVoteAction>",
-                    ),
-                ],
-            ),
-        },
         "LauncherImageHash": Struct {
             fields: UnnamedFields(
                 [
                     "[u8; 32]",
-                ],
-            ),
-        },
-        "LauncherVoteAction": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "Add",
-                    "LauncherVoteAction__Add",
-                ),
-                (
-                    1,
-                    "Remove",
-                    "LauncherVoteAction__Remove",
-                ),
-            ],
-        },
-        "LauncherVoteAction__Add": Struct {
-            fields: UnnamedFields(
-                [
-                    "LauncherImageHash",
-                ],
-            ),
-        },
-        "LauncherVoteAction__Remove": Struct {
-            fields: UnnamedFields(
-                [
-                    "LauncherImageHash",
                 ],
             ),
         },
@@ -1161,6 +1144,38 @@ BorshSchemaContainer {
                 ],
             ),
         },
+        "ProposalHash": Struct {
+            fields: UnnamedFields(
+                [
+                    "[u8; 32]",
+                ],
+            ),
+        },
+        "ProposalId": Struct {
+            fields: UnnamedFields(
+                [
+                    "u64",
+                ],
+            ),
+        },
+        "ProposalRegistry<LauncherVoteAction>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "id_by_proposal",
+                        "BTreeMap<ProposalHash, ProposalId>",
+                    ),
+                    (
+                        "proposals_by_id",
+                        "IterableMap",
+                    ),
+                    (
+                        "next_id",
+                        "ProposalId",
+                    ),
+                ],
+            ),
+        },
         "ProposedUpdates": Struct {
             fields: NamedFields(
                 [
@@ -1421,7 +1436,7 @@ BorshSchemaContainer {
                     ),
                     (
                         "launcher_votes",
-                        "LauncherHashVotes",
+                        "Votes<AuthenticatedParticipantId, LauncherVoteAction>",
                     ),
                     (
                         "stored_attestations",
@@ -1585,6 +1600,41 @@ BorshSchemaContainer {
             fields: UnnamedFields(
                 [
                     "MockAttestation",
+                ],
+            ),
+        },
+        "VoteRegistry<AuthenticatedParticipantId>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "votes_by_voter",
+                        "BTreeMap<AuthenticatedParticipantId, ProposalId>",
+                    ),
+                    (
+                        "votes_by_proposal",
+                        "BTreeMap<ProposalId, VoterSet<AuthenticatedParticipantId>>",
+                    ),
+                ],
+            ),
+        },
+        "VoterSet<AuthenticatedParticipantId>": Struct {
+            fields: UnnamedFields(
+                [
+                    "BTreeSet<AuthenticatedParticipantId>",
+                ],
+            ),
+        },
+        "Votes<AuthenticatedParticipantId, LauncherVoteAction>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "proposal_registry",
+                        "ProposalRegistry<LauncherVoteAction>",
+                    ),
+                    (
+                        "vote_registry",
+                        "VoteRegistry<AuthenticatedParticipantId>",
+                    ),
                 ],
             ),
         },

--- a/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
+++ b/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
@@ -27,12 +27,6 @@ BorshSchemaContainer {
                 "DockerImageHash",
             ],
         },
-        "(AuthenticatedParticipantId, MeasurementVoteAction)": Tuple {
-            elements: [
-                "AuthenticatedParticipantId",
-                "MeasurementVoteAction",
-            ],
-        },
         "(AuthenticatedParticipantId, ProposalId)": Tuple {
             elements: [
                 "AuthenticatedParticipantId",
@@ -174,11 +168,6 @@ BorshSchemaContainer {
             length_width: 4,
             length_range: 0..=4294967295,
             elements: "(AuthenticatedParticipantId, DockerImageHash)",
-        },
-        "BTreeMap<AuthenticatedParticipantId, MeasurementVoteAction>": Sequence {
-            length_width: 4,
-            length_range: 0..=4294967295,
-            elements: "(AuthenticatedParticipantId, MeasurementVoteAction)",
         },
         "BTreeMap<AuthenticatedParticipantId, ProposalId>": Sequence {
             length_width: 4,
@@ -716,45 +705,6 @@ BorshSchemaContainer {
                 ],
             ),
         },
-        "MeasurementVoteAction": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "Add",
-                    "MeasurementVoteAction__Add",
-                ),
-                (
-                    1,
-                    "Remove",
-                    "MeasurementVoteAction__Remove",
-                ),
-            ],
-        },
-        "MeasurementVoteAction__Add": Struct {
-            fields: UnnamedFields(
-                [
-                    "ContractExpectedMeasurements",
-                ],
-            ),
-        },
-        "MeasurementVoteAction__Remove": Struct {
-            fields: UnnamedFields(
-                [
-                    "ContractExpectedMeasurements",
-                ],
-            ),
-        },
-        "MeasurementVotes": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "vote_by_account",
-                        "BTreeMap<AuthenticatedParticipantId, MeasurementVoteAction>",
-                    ),
-                ],
-            ),
-        },
         "Measurements": Struct {
             fields: NamedFields(
                 [
@@ -1176,6 +1126,24 @@ BorshSchemaContainer {
                 ],
             ),
         },
+        "ProposalRegistry<MeasurementVoteAction>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "id_by_proposal",
+                        "BTreeMap<ProposalHash, ProposalId>",
+                    ),
+                    (
+                        "proposals_by_id",
+                        "IterableMap",
+                    ),
+                    (
+                        "next_id",
+                        "ProposalId",
+                    ),
+                ],
+            ),
+        },
         "ProposedUpdates": Struct {
             fields: NamedFields(
                 [
@@ -1448,7 +1416,7 @@ BorshSchemaContainer {
                     ),
                     (
                         "measurement_votes",
-                        "MeasurementVotes",
+                        "Votes<AuthenticatedParticipantId, MeasurementVoteAction>",
                     ),
                 ],
             ),
@@ -1630,6 +1598,20 @@ BorshSchemaContainer {
                     (
                         "proposal_registry",
                         "ProposalRegistry<LauncherVoteAction>",
+                    ),
+                    (
+                        "vote_registry",
+                        "VoteRegistry<AuthenticatedParticipantId>",
+                    ),
+                ],
+            ),
+        },
+        "Votes<AuthenticatedParticipantId, MeasurementVoteAction>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "proposal_registry",
+                        "ProposalRegistry<MeasurementVoteAction>",
                     ),
                     (
                         "vote_registry",

--- a/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
+++ b/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
@@ -21,12 +21,6 @@ BorshSchemaContainer {
                 "ThresholdParameters",
             ],
         },
-        "(AuthenticatedParticipantId, DockerImageHash)": Tuple {
-            elements: [
-                "AuthenticatedParticipantId",
-                "DockerImageHash",
-            ],
-        },
         "(AuthenticatedParticipantId, ProposalId)": Tuple {
             elements: [
                 "AuthenticatedParticipantId",
@@ -164,11 +158,6 @@ BorshSchemaContainer {
             length_range: 0..=4294967295,
             elements: "(AuthenticatedAccountId, ThresholdParameters)",
         },
-        "BTreeMap<AuthenticatedParticipantId, DockerImageHash>": Sequence {
-            length_width: 4,
-            length_range: 0..=4294967295,
-            elements: "(AuthenticatedParticipantId, DockerImageHash)",
-        },
         "BTreeMap<AuthenticatedParticipantId, ProposalId>": Sequence {
             length_width: 4,
             length_range: 0..=4294967295,
@@ -213,16 +202,6 @@ BorshSchemaContainer {
             fields: UnnamedFields(
                 [
                     "[u8; 96]",
-                ],
-            ),
-        },
-        "CodeHashesVotes": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "proposal_by_account",
-                        "BTreeMap<AuthenticatedParticipantId, DockerImageHash>",
-                    ),
                 ],
             ),
         },
@@ -1108,6 +1087,24 @@ BorshSchemaContainer {
                 ],
             ),
         },
+        "ProposalRegistry<DockerImageHash>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "id_by_proposal",
+                        "BTreeMap<ProposalHash, ProposalId>",
+                    ),
+                    (
+                        "proposals_by_id",
+                        "IterableMap",
+                    ),
+                    (
+                        "next_id",
+                        "ProposalId",
+                    ),
+                ],
+            ),
+        },
         "ProposalRegistry<LauncherVoteAction>": Struct {
             fields: NamedFields(
                 [
@@ -1400,7 +1397,7 @@ BorshSchemaContainer {
                     ),
                     (
                         "votes",
-                        "CodeHashesVotes",
+                        "Votes<AuthenticatedParticipantId, DockerImageHash>",
                     ),
                     (
                         "launcher_votes",
@@ -1589,6 +1586,20 @@ BorshSchemaContainer {
             fields: UnnamedFields(
                 [
                     "BTreeSet<AuthenticatedParticipantId>",
+                ],
+            ),
+        },
+        "Votes<AuthenticatedParticipantId, DockerImageHash>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "proposal_registry",
+                        "ProposalRegistry<DockerImageHash>",
+                    ),
+                    (
+                        "vote_registry",
+                        "VoteRegistry<AuthenticatedParticipantId>",
+                    ),
                 ],
             ),
         },

--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -23,4 +23,5 @@ pub enum StorageKey {
     SupportedForeignChainsVotes,
     PendingSignatureRequestsV3,
     LauncherHashVotes,
+    MeasurementVotes,
 }

--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -24,4 +24,5 @@ pub enum StorageKey {
     PendingSignatureRequestsV3,
     LauncherHashVotes,
     MeasurementVotes,
+    CodeHashVotes,
 }

--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -22,4 +22,5 @@ pub enum StorageKey {
     PendingCKDRequestsV2,
     SupportedForeignChainsVotes,
     PendingSignatureRequestsV3,
+    LauncherHashVotes,
 }

--- a/crates/contract/src/tee/measurements.rs
+++ b/crates/contract/src/tee/measurements.rs
@@ -1,9 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use mpc_attestation::attestation::{ExpectedMeasurements, Measurements};
 use near_sdk::{log, near};
-use std::collections::BTreeMap;
 
-use crate::primitives::{key_state::AuthenticatedParticipantId, participants::Participants};
+use crate::primitives::{key_state::AuthenticatedParticipantId, votes::Votes};
 
 mpc_primitives::define_hash!(
     /// SHA-384 digest of the MRTD (Module Run-Time Data) TDX measurement.
@@ -26,69 +25,11 @@ mpc_primitives::define_hash!(
     KeyProviderEventDigest, 48
 );
 
-/// Tracks votes for adding or removing OS measurements.
-/// Each participant can have at most one active vote at a time.
-#[near(serializers=[borsh, json])]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct MeasurementVotes {
-    pub vote_by_account: BTreeMap<AuthenticatedParticipantId, MeasurementVoteAction>,
-}
-
-impl MeasurementVotes {
-    /// Casts a vote for the given action and returns the total number of participants
-    /// who have voted for the same action. Replaces any previous vote by this participant.
-    pub fn vote(
-        &mut self,
-        action: MeasurementVoteAction,
-        participant: &AuthenticatedParticipantId,
-    ) -> u64 {
-        if self
-            .vote_by_account
-            .insert(participant.clone(), action.clone())
-            .is_some()
-        {
-            log!("removed old measurement vote for signer");
-        }
-        let total = self.count_votes(&action);
-        log!("total measurement votes for action: {}", total);
-        total
-    }
-
-    /// Counts the total number of participants who have voted for the given action.
-    fn count_votes(&self, action: &MeasurementVoteAction) -> u64 {
-        u64::try_from(
-            self.vote_by_account
-                .values()
-                .filter(|a| *a == action)
-                .count(),
-        )
-        .expect("participant count should not overflow u64")
-    }
-
-    /// Clears all measurement votes.
-    pub fn clear_votes(&mut self) {
-        self.vote_by_account.clear();
-    }
-
-    /// Returns a new `MeasurementVotes` containing only votes from current participants.
-    pub fn get_remaining_votes(&self, participants: &Participants) -> Self {
-        let remaining = self
-            .vote_by_account
-            .iter()
-            .filter(|(participant_id, _)| {
-                participants.is_participant_given_participant_id(&participant_id.get())
-            })
-            .map(|(participant_id, vote)| (participant_id.clone(), vote.clone()))
-            .collect();
-        MeasurementVotes {
-            vote_by_account: remaining,
-        }
-    }
-}
+pub type MeasurementVotes = Votes<AuthenticatedParticipantId, MeasurementVoteAction>;
 
 /// The action a participant is voting for on an OS measurement set.
 #[near(serializers=[borsh, json])]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub enum MeasurementVoteAction {
     Add(ContractExpectedMeasurements),
     Remove(ContractExpectedMeasurements),
@@ -154,6 +95,8 @@ impl AllowedMeasurements {
     Clone,
     PartialEq,
     Eq,
+    Ord,
+    PartialOrd,
     serde::Serialize,
     serde::Deserialize,
     BorshSerialize,

--- a/crates/contract/src/tee/proposal.rs
+++ b/crates/contract/src/tee/proposal.rs
@@ -4,6 +4,7 @@ use std::{collections::BTreeMap, time::Duration};
 
 use crate::primitives::{
     key_state::AuthenticatedParticipantId, participants::Participants, time::Timestamp,
+    votes::Votes,
 };
 
 pub use mpc_primitives::hash::{LauncherDockerComposeHash, LauncherImageHash, NodeImageHash};
@@ -74,71 +75,13 @@ impl CodeHashesVotes {
 
 /// The action a participant is voting for on a launcher image hash.
 #[near(serializers=[borsh, json])]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub enum LauncherVoteAction {
     Add(LauncherImageHash),
     Remove(LauncherImageHash),
 }
 
-/// Tracks votes for adding or removing launcher image hashes.
-/// Each participant can have at most one active vote at a time.
-#[near(serializers=[borsh, json])]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct LauncherHashVotes {
-    pub vote_by_account: BTreeMap<AuthenticatedParticipantId, LauncherVoteAction>,
-}
-
-impl LauncherHashVotes {
-    /// Casts a vote for the given action and returns the total number of participants
-    /// who have voted for the same action. Replaces any previous vote by this participant.
-    pub fn vote(
-        &mut self,
-        action: LauncherVoteAction,
-        participant: &AuthenticatedParticipantId,
-    ) -> u64 {
-        if self
-            .vote_by_account
-            .insert(participant.clone(), action.clone())
-            .is_some()
-        {
-            log!("removed old launcher vote for signer");
-        }
-        let total = self.count_votes(&action);
-        log!("total launcher votes for action: {}", total);
-        total
-    }
-
-    /// Counts the total number of participants who have voted for the given action.
-    fn count_votes(&self, action: &LauncherVoteAction) -> u64 {
-        u64::try_from(
-            self.vote_by_account
-                .values()
-                .filter(|a| *a == action)
-                .count(),
-        )
-        .expect("participant count should not overflow u64")
-    }
-
-    /// Clears all launcher votes.
-    pub fn clear_votes(&mut self) {
-        self.vote_by_account.clear();
-    }
-
-    /// Returns a new `LauncherHashVotes` containing only votes from current participants.
-    pub fn get_remaining_votes(&self, participants: &Participants) -> Self {
-        let remaining = self
-            .vote_by_account
-            .iter()
-            .filter(|(participant_id, _)| {
-                participants.is_participant_given_participant_id(&participant_id.get())
-            })
-            .map(|(participant_id, vote)| (participant_id.clone(), vote.clone()))
-            .collect();
-        LauncherHashVotes {
-            vote_by_account: remaining,
-        }
-    }
-}
+pub type LauncherHashVotes = Votes<AuthenticatedParticipantId, LauncherVoteAction>;
 
 /// An allowed Docker image configuration entry containing the MPC image hash
 /// and when it was added to the allowlist.

--- a/crates/contract/src/tee/proposal.rs
+++ b/crates/contract/src/tee/proposal.rs
@@ -1,11 +1,8 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_sdk::{env::sha256, log, near};
-use std::{collections::BTreeMap, time::Duration};
+use std::time::Duration;
 
-use crate::primitives::{
-    key_state::AuthenticatedParticipantId, participants::Participants, time::Timestamp,
-    votes::Votes,
-};
+use crate::primitives::{key_state::AuthenticatedParticipantId, time::Timestamp, votes::Votes};
 
 pub use mpc_primitives::hash::{LauncherDockerComposeHash, LauncherImageHash, NodeImageHash};
 
@@ -16,62 +13,7 @@ pub use mpc_primitives::hash::{LauncherDockerComposeHash, LauncherImageHash, Nod
 const LAUNCHER_DOCKER_COMPOSE_YAML_TEMPLATE: &str =
     include_str!("../../assets/launcher_docker_compose.yaml.template");
 
-/// Tracks votes to add whitelisted TEE code hashes. Each participant can at any given time vote for
-/// a code hash to add.
-#[near(serializers=[borsh, json])]
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct CodeHashesVotes {
-    pub proposal_by_account: BTreeMap<AuthenticatedParticipantId, NodeImageHash>,
-}
-
-impl CodeHashesVotes {
-    /// Casts a vote for the proposal and returns the total number of participants who have voted
-    /// for the same code hash. If the participant already voted, their previous vote is replaced.
-    pub fn vote(
-        &mut self,
-        proposal: NodeImageHash,
-        participant: &AuthenticatedParticipantId,
-    ) -> u64 {
-        if self
-            .proposal_by_account
-            .insert(participant.clone(), proposal)
-            .is_some()
-        {
-            log!("removed old vote for signer");
-        }
-        let total = self.count_votes(&proposal);
-        log!("total votes for proposal: {}", total);
-        total
-    }
-
-    /// Counts the total number of participants who have voted for the given code hash.
-    fn count_votes(&self, proposal: &NodeImageHash) -> u64 {
-        self.proposal_by_account
-            .values()
-            .filter(|&prop| prop == proposal)
-            .count() as u64
-    }
-
-    /// Clears all proposals.
-    pub fn clear_votes(&mut self) {
-        self.proposal_by_account.clear();
-    }
-
-    /// Returns a new `CodeHashesVotes` containing only votes from current participants.
-    pub fn get_remaining_votes(&self, participants: &Participants) -> Self {
-        let remaining = self
-            .proposal_by_account
-            .iter()
-            .filter(|(participant_id, _)| {
-                participants.is_participant_given_participant_id(&participant_id.get())
-            })
-            .map(|(participant_id, vote)| (participant_id.clone(), *vote))
-            .collect();
-        CodeHashesVotes {
-            proposal_by_account: remaining,
-        }
-    }
-}
+pub type CodeHashesVotes = Votes<AuthenticatedParticipantId, NodeImageHash>;
 
 /// The action a participant is voting for on a launcher image hash.
 #[near(serializers=[borsh, json])]

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -1,11 +1,17 @@
 use crate::{
-    primitives::{key_state::AuthenticatedParticipantId, participants::Participants},
-    tee::measurements::{
-        AllowedMeasurements, ContractExpectedMeasurements, MeasurementVoteAction, MeasurementVotes,
+    primitives::{
+        key_state::AuthenticatedParticipantId, participants::Participants, votes::types::VoterSet,
     },
-    tee::proposal::{
-        AllowedDockerImageHashes, AllowedLauncherImages, AllowedMpcDockerImage, CodeHashesVotes,
-        LauncherHashVotes, LauncherVoteAction, NodeImageHash,
+    storage_keys::StorageKey,
+    tee::{
+        measurements::{
+            AllowedMeasurements, ContractExpectedMeasurements, MeasurementVoteAction,
+            MeasurementVotes,
+        },
+        proposal::{
+            AllowedDockerImageHashes, AllowedLauncherImages, AllowedMpcDockerImage,
+            CodeHashesVotes, LauncherHashVotes, LauncherVoteAction, NodeImageHash,
+        },
     },
 };
 use borsh::{BorshDeserialize, BorshSerialize};
@@ -95,7 +101,7 @@ pub(crate) struct NodeAttestation {
     pub(crate) verified_attestation: VerifiedAttestation,
 }
 
-#[derive(Default, Debug, BorshSerialize, BorshDeserialize)]
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(borsh::BorshSchema)
@@ -113,7 +119,25 @@ pub struct TeeState {
     pub(crate) measurement_votes: MeasurementVotes,
 }
 
+impl Default for TeeState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl TeeState {
+    fn new() -> Self {
+        Self {
+            allowed_docker_image_hashes: AllowedDockerImageHashes::default(),
+            allowed_launcher_images: AllowedLauncherImages::default(),
+            allowed_measurements: AllowedMeasurements::default(),
+            measurement_votes: MeasurementVotes::default(),
+            votes: CodeHashesVotes::default(),
+            launcher_votes: LauncherHashVotes::new(StorageKey::LauncherHashVotes),
+            stored_attestations: BTreeMap::new(),
+        }
+    }
+
     /// Creates a [`TeeState`] with an initial set of participants that will receive a valid mocked attestation.
     pub(crate) fn with_mocked_participant_attestations(participants: &Participants) -> Self {
         let mut participants_attestations = BTreeMap::new();
@@ -141,7 +165,7 @@ impl TeeState {
 
         Self {
             stored_attestations: participants_attestations,
-            ..Default::default()
+            ..Self::default()
         }
     }
 
@@ -333,13 +357,14 @@ impl TeeState {
     }
 
     /// Casts a vote for adding or removing a launcher image hash.
-    /// Returns the total number of votes for the same action.
+    /// Returns the set of votes for the same action.
     pub fn vote_launcher(
         &mut self,
         action: LauncherVoteAction,
         participant: &AuthenticatedParticipantId,
-    ) -> u64 {
-        self.launcher_votes.vote(action, participant)
+    ) -> &VoterSet<AuthenticatedParticipantId> {
+        let (_, res) = self.launcher_votes.vote(participant.clone(), action);
+        res
     }
 
     /// Adds a new launcher image to the allowed set, computing compose hashes
@@ -349,7 +374,7 @@ impl TeeState {
         launcher_hash: LauncherImageHash,
         tee_upgrade_deadline_duration: Duration,
     ) -> bool {
-        self.launcher_votes.clear_votes();
+        self.launcher_votes.clear();
         let mpc_image_hashes = self
             .allowed_docker_image_hashes
             .get_image_hashes(tee_upgrade_deadline_duration);
@@ -359,7 +384,7 @@ impl TeeState {
 
     /// Removes a launcher image from the allowed set. Clears launcher votes.
     pub fn remove_launcher_image(&mut self, launcher_hash: &LauncherImageHash) -> bool {
-        self.launcher_votes.clear_votes();
+        self.launcher_votes.clear();
         self.allowed_launcher_images.remove(launcher_hash)
     }
 
@@ -404,6 +429,8 @@ impl TeeState {
 
     /// Removes TEE information and stale votes for nodes that are not in the provided
     /// participants list. Used to clean up storage after a resharing concludes.
+    /// todo: do we require participant ids to be preserved across resharings??
+    /// if not, we have a logic bug
     pub fn clean_non_participants(&mut self, participants: &Participants) {
         // Collect all allowed TLS public keys from current participants
         let active_tls_keys: HashSet<&near_sdk::PublicKey> = participants
@@ -427,7 +454,11 @@ impl TeeState {
 
         // Remove stale votes from non-participants
         self.votes = self.votes.get_remaining_votes(participants);
-        self.launcher_votes = self.launcher_votes.get_remaining_votes(participants);
+        self.launcher_votes
+            .retain_votes(|authenticated_participant_id| {
+                participants
+                    .is_participant_given_participant_id(&authenticated_participant_id.get())
+            });
         self.measurement_votes = self.measurement_votes.get_remaining_votes(participants);
     }
 
@@ -496,6 +527,8 @@ mod tests {
     use crate::primitives::test_utils::bogus_ed25519_near_public_key;
     use crate::primitives::test_utils::gen_participant;
     use crate::primitives::test_utils::gen_participants;
+    use crate::primitives::votes::types::ProposalHash;
+    use crate::primitives::votes::types::PROPOSAL_HASH_BYTES;
     use crate::tee::test_utils::set_block_timestamp;
     use assert_matches::assert_matches;
     use mpc_attestation::attestation::{Attestation, MockAttestation};
@@ -503,6 +536,8 @@ mod tests {
     use near_account_id::AccountId;
     use near_sdk::test_utils::VMContextBuilder;
     use near_sdk::testing_env;
+    use sha2::Digest;
+    use std::collections::BTreeSet;
     use std::time::Duration;
 
     /// Helper to set up the testing environment with a specific signer
@@ -1317,14 +1352,26 @@ mod tests {
         testing_env!(ctx.build());
         let auth_id = AuthenticatedParticipantId::new(&all_participants).unwrap();
         let launcher_action = LauncherVoteAction::Add(LauncherImageHash::from([0xBB; 32]));
-        tee_state.launcher_votes.vote(launcher_action, &auth_id);
+        tee_state
+            .launcher_votes
+            .vote(auth_id.clone(), launcher_action.clone());
 
-        assert_eq!(tee_state.launcher_votes.vote_by_account.len(), 1);
+        let state = tee_state.launcher_votes.snapshot();
+        let expected_hash: [u8; PROPOSAL_HASH_BYTES] =
+            sha2::Sha256::digest(borsh::to_vec(&launcher_action).unwrap()).into();
+        let expected_hash = ProposalHash::new(expected_hash);
+        assert_eq!(
+            state,
+            BTreeMap::from([(
+                0.into(),
+                ((expected_hash, launcher_action), BTreeSet::from([auth_id]))
+            )])
+        );
 
         // New participant set excludes P0
         let new_participants = all_participants.subset(1..3);
         tee_state.clean_non_participants(&new_participants);
-
-        assert_eq!(tee_state.launcher_votes.vote_by_account.len(), 0);
+        let state = tee_state.launcher_votes.snapshot();
+        assert_eq!(state, BTreeMap::new());
     }
 }

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -131,7 +131,7 @@ impl TeeState {
             allowed_docker_image_hashes: AllowedDockerImageHashes::default(),
             allowed_launcher_images: AllowedLauncherImages::default(),
             allowed_measurements: AllowedMeasurements::default(),
-            measurement_votes: MeasurementVotes::default(),
+            measurement_votes: MeasurementVotes::new(StorageKey::MeasurementVotes),
             votes: CodeHashesVotes::default(),
             launcher_votes: LauncherHashVotes::new(StorageKey::LauncherHashVotes),
             stored_attestations: BTreeMap::new(),
@@ -398,20 +398,20 @@ impl TeeState {
     pub fn vote_measurement(
         &mut self,
         action: MeasurementVoteAction,
-        participant: &AuthenticatedParticipantId,
-    ) -> u64 {
-        self.measurement_votes.vote(action, participant)
+        participant: AuthenticatedParticipantId,
+    ) -> &VoterSet<AuthenticatedParticipantId> {
+        self.measurement_votes.vote(participant, action).1
     }
 
     /// Adds a new measurement set to the allowed list. Clears measurement votes.
     pub fn add_measurement(&mut self, measurement: ContractExpectedMeasurements) -> bool {
-        self.measurement_votes.clear_votes();
+        self.measurement_votes.clear();
         self.allowed_measurements.add(measurement)
     }
 
     /// Removes a measurement set from the allowed list. Clears measurement votes.
     pub fn remove_measurement(&mut self, measurement: &ContractExpectedMeasurements) -> bool {
-        self.measurement_votes.clear_votes();
+        self.measurement_votes.clear();
         self.allowed_measurements.remove(measurement)
     }
 
@@ -459,7 +459,11 @@ impl TeeState {
                 participants
                     .is_participant_given_participant_id(&authenticated_participant_id.get())
             });
-        self.measurement_votes = self.measurement_votes.get_remaining_votes(participants);
+        self.launcher_votes
+            .retain_votes(|authenticated_participant_id| {
+                participants
+                    .is_participant_given_participant_id(&authenticated_participant_id.get())
+            });
     }
 
     /// Returns the list of accounts that currently have TEE attestations stored.

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -132,7 +132,7 @@ impl TeeState {
             allowed_launcher_images: AllowedLauncherImages::default(),
             allowed_measurements: AllowedMeasurements::default(),
             measurement_votes: MeasurementVotes::new(StorageKey::MeasurementVotes),
-            votes: CodeHashesVotes::default(),
+            votes: CodeHashesVotes::new(StorageKey::CodeHashVotes),
             launcher_votes: LauncherHashVotes::new(StorageKey::LauncherHashVotes),
             stored_attestations: BTreeMap::new(),
         }
@@ -315,9 +315,9 @@ impl TeeState {
     pub fn vote(
         &mut self,
         code_hash: NodeImageHash,
-        participant: &AuthenticatedParticipantId,
-    ) -> u64 {
-        self.votes.vote(code_hash, participant)
+        participant: AuthenticatedParticipantId,
+    ) -> &VoterSet<AuthenticatedParticipantId> {
+        self.votes.vote(participant, code_hash).1
     }
 
     pub fn get_allowed_mpc_docker_image_hashes(
@@ -343,7 +343,7 @@ impl TeeState {
         tee_proposal: NodeImageHash,
         tee_upgrade_deadline_duration: Duration,
     ) {
-        self.votes.clear_votes();
+        self.votes.clear();
         // Add compose hashes for the new MPC image across all allowed launcher images
         self.allowed_launcher_images
             .add_mpc_image_compose_hashes(&tee_proposal);
@@ -453,7 +453,10 @@ impl TeeState {
         }
 
         // Remove stale votes from non-participants
-        self.votes = self.votes.get_remaining_votes(participants);
+        self.votes.retain_votes(|authenticated_participant_id| {
+            participants.is_participant_given_participant_id(&authenticated_participant_id.get())
+        });
+
         self.launcher_votes
             .retain_votes(|authenticated_participant_id| {
                 participants
@@ -1314,9 +1317,12 @@ mod tests {
             ctx.signer_account_id(account_id.clone());
             testing_env!(ctx.build());
             let auth_id = AuthenticatedParticipantId::new(&all_participants).unwrap();
-            tee_state.votes.vote(malicious_hash, &auth_id);
+            tee_state.votes.vote(auth_id, malicious_hash);
         }
-        assert_eq!(tee_state.votes.proposal_by_account.len(), 2);
+        assert_eq!(
+            tee_state.votes.snapshot().pop_first().unwrap().1 .1.len(),
+            2
+        );
 
         // Resharing removes P0 and P1. New participant set: {P2, P3, P4}.
         let new_participants = all_participants.subset(2..5);
@@ -1325,7 +1331,7 @@ mod tests {
         tee_state.clean_non_participants(&new_participants);
 
         // Stale votes must be removed
-        assert_eq!(tee_state.votes.proposal_by_account.len(), 0);
+        assert_eq!(tee_state.votes.snapshot().len(), 0);
 
         // P2 votes for the same malicious hash — should be only 1 vote, not 3
         let p2_account = &account_ids[2];
@@ -1333,8 +1339,12 @@ mod tests {
         ctx.signer_account_id(p2_account.clone());
         testing_env!(ctx.build());
         let auth_id = AuthenticatedParticipantId::new(&new_participants).unwrap();
-        let vote_count = tee_state.votes.vote(malicious_hash, &auth_id);
-        assert_eq!(vote_count, 1, "Only the fresh vote from P2 should count");
+        let (_, vote_count) = tee_state.votes.vote(auth_id.clone(), malicious_hash);
+        assert_eq!(
+            vote_count.count_for(|p| p.get() == auth_id.get()),
+            1,
+            "Only the fresh vote from P2 should count"
+        );
     }
 
     /// Verifies that clean_non_participants also removes stale launcher and measurement votes.

--- a/crates/contract/src/v3_8_1_state.rs
+++ b/crates/contract/src/v3_8_1_state.rs
@@ -10,6 +10,7 @@
 use std::collections::BTreeMap;
 
 use borsh::{BorshDeserialize, BorshSerialize};
+use mpc_primitives::hash::NodeImageHash;
 use near_mpc_contract_interface::types as dtos;
 use near_sdk::{env, near, store::LookupMap};
 
@@ -47,12 +48,18 @@ pub struct OldMeasurementVotes {
     pub vote_by_account: BTreeMap<AuthenticatedParticipantId, MeasurementVoteAction>,
 }
 
+#[near(serializers=[borsh, json])]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OldCodeHashesVotes {
+    pub proposal_by_account: BTreeMap<AuthenticatedParticipantId, NodeImageHash>,
+}
+
 /// Previous TeeState layout — without `allowed_measurements` and `measurement_votes` fields.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 struct OldTeeState {
     allowed_docker_image_hashes: AllowedDockerImageHashes,
     allowed_launcher_images: AllowedLauncherImages,
-    votes: CodeHashesVotes,
+    votes: OldCodeHashesVotes,
     launcher_votes: OldLauncherHashVotes,
     stored_attestations: BTreeMap<near_sdk::PublicKey, NodeAttestation>,
     allowed_measurements: AllowedMeasurements,
@@ -121,17 +128,22 @@ impl From<MpcContract> for crate::MpcContract {
             new_launcher_votes.vote(authenticated_id, launcher_vote);
         }
 
-        let mut new_measurement_votes = MeasurementVotes::new(StorageKey::LauncherHashVotes);
+        let mut new_measurement_votes = MeasurementVotes::new(StorageKey::MeasurementVotes);
         for (authenticated_id, measurement_vote) in
             value.tee_state.measurement_votes.vote_by_account
         {
             new_measurement_votes.vote(authenticated_id, measurement_vote);
         }
 
+        let mut new_code_hash_votes = CodeHashesVotes::new(StorageKey::CodeHashVotes);
+        for (authenticated_id, code_hash_vote) in value.tee_state.votes.proposal_by_account {
+            new_code_hash_votes.vote(authenticated_id, code_hash_vote);
+        }
+
         let new_tee_state = crate::tee::tee_state::TeeState {
             allowed_docker_image_hashes: value.tee_state.allowed_docker_image_hashes,
             allowed_launcher_images: value.tee_state.allowed_launcher_images,
-            votes: value.tee_state.votes,
+            votes: new_code_hash_votes,
             launcher_votes: new_launcher_votes,
             stored_attestations: value.tee_state.stored_attestations,
             allowed_measurements: value.tee_state.allowed_measurements,

--- a/crates/contract/src/v3_8_1_state.rs
+++ b/crates/contract/src/v3_8_1_state.rs
@@ -7,6 +7,8 @@
 //! However, this approach (a) requires manual effort from a developer and (b) increases the binary size.
 //! A better approach: only copy the structures that have changed and import the rest from the existing codebase.
 
+use std::collections::BTreeMap;
+
 use borsh::{BorshDeserialize, BorshSerialize};
 use near_mpc_contract_interface::types as dtos;
 use near_sdk::{env, near, store::LookupMap};
@@ -17,14 +19,39 @@ use crate::{
     primitives::{
         ckd::CKDRequest,
         domain::DomainId,
+        key_state::AuthenticatedParticipantId,
         signature::{Tweak, YieldIndex},
     },
     state::ProtocolContractState,
     storage_keys::StorageKey,
-    tee::tee_state::TeeState,
+    tee::{
+        measurements::{AllowedMeasurements, MeasurementVotes},
+        proposal::{
+            AllowedDockerImageHashes, AllowedLauncherImages, CodeHashesVotes, LauncherHashVotes,
+            LauncherVoteAction,
+        },
+        tee_state::NodeAttestation,
+    },
     update::ProposedUpdates,
     ForeignChainPolicyVotes, IntoInterfaceType, NodeForeignChainConfigurations,
 };
+
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+pub struct OldLauncherHashVotes {
+    pub vote_by_account: BTreeMap<AuthenticatedParticipantId, LauncherVoteAction>,
+}
+
+/// Previous TeeState layout — without `allowed_measurements` and `measurement_votes` fields.
+#[derive(Debug, BorshSerialize, BorshDeserialize)]
+struct OldTeeState {
+    allowed_docker_image_hashes: AllowedDockerImageHashes,
+    allowed_launcher_images: AllowedLauncherImages,
+    votes: CodeHashesVotes,
+    launcher_votes: OldLauncherHashVotes,
+    stored_attestations: BTreeMap<near_sdk::PublicKey, NodeAttestation>,
+    allowed_measurements: AllowedMeasurements,
+    measurement_votes: MeasurementVotes,
+}
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 pub struct MpcContract {
@@ -37,7 +64,7 @@ pub struct MpcContract {
     foreign_chain_policy: dtos::ForeignChainPolicy,
     foreign_chain_policy_votes: ForeignChainPolicyVotes,
     config: OldConfig,
-    tee_state: TeeState,
+    tee_state: OldTeeState,
     accept_requests: bool,
     node_migrations: NodeMigrations,
     stale_data: OldStaleData,
@@ -82,6 +109,21 @@ impl From<MpcContract> for crate::MpcContract {
                     proposed_policy.chains.clone().into(),
                 );
         }
+
+        let mut new_launcher_votes = LauncherHashVotes::new(StorageKey::LauncherHashVotes);
+        for (authenticated_id, launcher_vote) in value.tee_state.launcher_votes.vote_by_account {
+            new_launcher_votes.vote(authenticated_id, launcher_vote);
+        }
+
+        let new_tee_state = crate::tee::tee_state::TeeState {
+            allowed_docker_image_hashes: value.tee_state.allowed_docker_image_hashes,
+            allowed_launcher_images: value.tee_state.allowed_launcher_images,
+            votes: value.tee_state.votes,
+            launcher_votes: new_launcher_votes,
+            stored_attestations: value.tee_state.stored_attestations,
+            allowed_measurements: value.tee_state.allowed_measurements,
+            measurement_votes: Default::default(),
+        };
         Self {
             protocol_state: value.protocol_state,
             pending_signature_requests: LookupMap::new(StorageKey::PendingSignatureRequestsV3),
@@ -91,7 +133,7 @@ impl From<MpcContract> for crate::MpcContract {
             foreign_chain_policy,
             foreign_chain_policy_votes: value.foreign_chain_policy_votes,
             config: value.config.into(),
-            tee_state: value.tee_state,
+            tee_state: new_tee_state,
             accept_requests: value.accept_requests,
             node_migrations: value.node_migrations,
             stale_data: crate::StaleData {

--- a/crates/contract/src/v3_8_1_state.rs
+++ b/crates/contract/src/v3_8_1_state.rs
@@ -25,7 +25,7 @@ use crate::{
     state::ProtocolContractState,
     storage_keys::StorageKey,
     tee::{
-        measurements::{AllowedMeasurements, MeasurementVotes},
+        measurements::{AllowedMeasurements, MeasurementVoteAction, MeasurementVotes},
         proposal::{
             AllowedDockerImageHashes, AllowedLauncherImages, CodeHashesVotes, LauncherHashVotes,
             LauncherVoteAction,
@@ -41,6 +41,12 @@ pub struct OldLauncherHashVotes {
     pub vote_by_account: BTreeMap<AuthenticatedParticipantId, LauncherVoteAction>,
 }
 
+#[near(serializers=[borsh, json])]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct OldMeasurementVotes {
+    pub vote_by_account: BTreeMap<AuthenticatedParticipantId, MeasurementVoteAction>,
+}
+
 /// Previous TeeState layout — without `allowed_measurements` and `measurement_votes` fields.
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 struct OldTeeState {
@@ -50,7 +56,7 @@ struct OldTeeState {
     launcher_votes: OldLauncherHashVotes,
     stored_attestations: BTreeMap<near_sdk::PublicKey, NodeAttestation>,
     allowed_measurements: AllowedMeasurements,
-    measurement_votes: MeasurementVotes,
+    measurement_votes: OldMeasurementVotes,
 }
 
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
@@ -115,6 +121,13 @@ impl From<MpcContract> for crate::MpcContract {
             new_launcher_votes.vote(authenticated_id, launcher_vote);
         }
 
+        let mut new_measurement_votes = MeasurementVotes::new(StorageKey::LauncherHashVotes);
+        for (authenticated_id, measurement_vote) in
+            value.tee_state.measurement_votes.vote_by_account
+        {
+            new_measurement_votes.vote(authenticated_id, measurement_vote);
+        }
+
         let new_tee_state = crate::tee::tee_state::TeeState {
             allowed_docker_image_hashes: value.tee_state.allowed_docker_image_hashes,
             allowed_launcher_images: value.tee_state.allowed_launcher_images,
@@ -122,7 +135,7 @@ impl From<MpcContract> for crate::MpcContract {
             launcher_votes: new_launcher_votes,
             stored_attestations: value.tee_state.stored_attestations,
             allowed_measurements: value.tee_state.allowed_measurements,
-            measurement_votes: Default::default(),
+            measurement_votes: new_measurement_votes,
         };
         Self {
             protocol_state: value.protocol_state,

--- a/crates/contract/tests/abi.rs
+++ b/crates/contract/tests/abi.rs
@@ -14,8 +14,10 @@ fn compile_project() -> (Vec<u8>, serde_json::Value) {
     };
 
     let contract_path = test_utils::contract_build::build_contract_path(opts);
+    println!("path: {:?}", contract_path);
 
     let wasm = std::fs::read(&contract_path).unwrap();
+    println!("size: {:?}", wasm.len());
     let abi_path = out_dir.join("mpc_contract_abi.json");
     let abi_str = std::fs::read_to_string(abi_path).unwrap();
     let abi = serde_json::from_str::<serde_json::Value>(&abi_str).unwrap();

--- a/crates/contract/tests/sandbox/utils/consts.rs
+++ b/crates/contract/tests/sandbox/utils/consts.rs
@@ -27,7 +27,7 @@ pub const GAS_FOR_INIT: Gas = Gas::from_tgas(300);
 /// TODO(#1571): Gas cost for voting on contract updates. Reduced somewhat after
 /// optimization (#1617) by avoiding full contract code deserialization; there’s likely still
 /// room for further optimization.
-pub const GAS_FOR_VOTE_UPDATE: Gas = Gas::from_tgas(260);
+pub const GAS_FOR_VOTE_UPDATE: Gas = Gas::from_tgas(270);
 /// Gas required for votes cast before the threshold is reached (votes 1 through N-1).
 /// These votes are cheap because they only record the vote without triggering the actual
 /// contract update deployment and migration.
@@ -35,7 +35,7 @@ pub const GAS_FOR_VOTE_BEFORE_THRESHOLD: Gas = Gas::from_tgas(5);
 /// Maximum gas expected for the threshold vote that triggers the contract update.
 /// This vote is more expensive because it deploys the new contract code and executes
 /// the migration function.
-pub const MAX_GAS_FOR_THRESHOLD_VOTE: Gas = Gas::from_tgas(185);
+pub const MAX_GAS_FOR_THRESHOLD_VOTE: Gas = Gas::from_tgas(300);
 
 /* --- Deposit constants --- */
 /// This is the current deposit required for a contract deploy. This is subject to change but make

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -499,7 +499,34 @@ expression: abi
         "result": {
           "serialization_type": "json",
           "type_schema": {
-            "$ref": "#/definitions/LauncherHashVotes"
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/ProposalHash"
+                    },
+                    {
+                      "$ref": "#/definitions/LauncherVoteAction"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/AuthenticatedParticipantId2"
+                  },
+                  "uniqueItems": true
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
           }
         }
       },
@@ -1589,6 +1616,14 @@ expression: abi
           "allOf": [
             {
               "$ref": "#/definitions/ParticipantId2"
+            }
+          ]
+        },
+        "AuthenticatedParticipantId2": {
+          "description": "This struct is supposed to contain the participant id associated to the account `env::signer_account_id()`, but is only constructible given a set of participants that includes the signer, thus acting as a type system-based enforcement mechanism (albeit a best-effort one) for authenticating the signer.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ParticipantId"
             }
           ]
         },
@@ -2775,21 +2810,6 @@ expression: abi
           "minLength": 64,
           "pattern": "^[0-9a-fA-F]+$"
         },
-        "LauncherHashVotes": {
-          "description": "Tracks votes for adding or removing launcher image hashes. Each participant can have at most one active vote at a time.",
-          "type": "object",
-          "required": [
-            "vote_by_account"
-          ],
-          "properties": {
-            "vote_by_account": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/LauncherVoteAction"
-              }
-            }
-          }
-        },
         "LauncherImageHash": {
           "type": "string",
           "maxLength": 64,
@@ -3224,6 +3244,12 @@ expression: abi
               "$ref": "#/definitions/SignatureResponse"
             }
           }
+        },
+        "ProposalHash": {
+          "type": "string",
+          "maxLength": 64,
+          "minLength": 64,
+          "pattern": "^[0-9a-fA-F]+$"
         },
         "ProposedUpdates": {
           "type": "object",

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -117,7 +117,34 @@ expression: abi
         "result": {
           "serialization_type": "json",
           "type_schema": {
-            "$ref": "#/definitions/CodeHashesVotes"
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/ProposalHash"
+                    },
+                    {
+                      "$ref": "#/definitions/DockerImageHash"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/AuthenticatedParticipantId2"
+                  },
+                  "uniqueItems": true
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
           }
         }
       },
@@ -1819,21 +1846,6 @@ expression: abi
           },
           "maxItems": 32,
           "minItems": 32
-        },
-        "CodeHashesVotes": {
-          "description": "Tracks votes to add whitelisted TEE code hashes. Each participant can at any given time vote for a code hash to add.",
-          "type": "object",
-          "required": [
-            "proposal_by_account"
-          ],
-          "properties": {
-            "proposal_by_account": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/DockerImageHash"
-              }
-            }
-          }
         },
         "Collateral": {
           "type": "object",

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -593,7 +593,34 @@ expression: abi
         "result": {
           "serialization_type": "json",
           "type_schema": {
-            "$ref": "#/definitions/MeasurementVotes"
+            "type": "object",
+            "additionalProperties": {
+              "type": "array",
+              "items": [
+                {
+                  "type": "array",
+                  "items": [
+                    {
+                      "$ref": "#/definitions/ProposalHash"
+                    },
+                    {
+                      "$ref": "#/definitions/MeasurementVoteAction"
+                    }
+                  ],
+                  "maxItems": 2,
+                  "minItems": 2
+                },
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/definitions/AuthenticatedParticipantId"
+                  },
+                  "uniqueItems": true
+                }
+              ],
+              "maxItems": 2,
+              "minItems": 2
+            }
           }
         }
       },
@@ -1612,10 +1639,10 @@ expression: abi
           ]
         },
         "AuthenticatedParticipantId": {
-          "description": "A participant ID that has been authenticated (i.e., the caller is this participant).",
+          "description": "This struct is supposed to contain the participant id associated to the account `env::signer_account_id()`, but is only constructible given a set of participants that includes the signer, thus acting as a type system-based enforcement mechanism (albeit a best-effort one) for authenticating the signer.",
           "allOf": [
             {
-              "$ref": "#/definitions/ParticipantId2"
+              "$ref": "#/definitions/ParticipantId"
             }
           ]
         },
@@ -2873,21 +2900,6 @@ expression: abi
               "additionalProperties": false
             }
           ]
-        },
-        "MeasurementVotes": {
-          "description": "Tracks votes for adding or removing OS measurements. Each participant can have at most one active vote at a time.",
-          "type": "object",
-          "required": [
-            "vote_by_account"
-          ],
-          "properties": {
-            "vote_by_account": {
-              "type": "object",
-              "additionalProperties": {
-                "$ref": "#/definitions/MeasurementVoteAction"
-              }
-            }
-          }
         },
         "Metrics": {
           "type": "object",


### PR DESCRIPTION
This is a draft, to showcase how to use the abstract voting structs.
Follow-up to #2739 

Currently failing due to:
- exceeding contract size limit.
- one new TODO, questioning the existing use of `ParticipantId`. To be addressed before merge. 