### PR TITLE
test: port test_cleanup_lagging_node from pytest to Rust e2e

### DIFF
--- a/crates/e2e-tests/src/metrics.rs
+++ b/crates/e2e-tests/src/metrics.rs
@@ -18,3 +18,5 @@ pub const CKDS_QUEUE_REQUESTS_INDEXED: &str = "mpc_pending_ckds_queue_requests_i
 pub const CKDS_QUEUE_RESPONSES_INDEXED: &str = "mpc_pending_ckds_queue_responses_indexed";
 pub const CKDS_QUEUE_MATCHING_RESPONSES: &str = "mpc_pending_ckds_queue_matching_responses_indexed";
 pub const CKDS_QUEUE_ATTEMPTS: &str = "mpc_pending_ckds_queue_attempts_generated";
+
+pub const INDEXER_LATEST_BLOCK_HEIGHT: &str = "mpc_indexer_latest_block_height";

--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -19,7 +19,7 @@ use crate::port_allocator::E2ePortAllocator;
 const DUMMY_IMAGE_HASH: &str =
     "sha256:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
 
-const LISTEN_BLOCKS_FILE: &str = "listen_blocks";
+const LISTEN_BLOCKS_FILE: &str = "listen_blocks.flag";
 
 const TEMP_KEYS_FILE: &str = "temporary_keys";
 

--- a/crates/e2e-tests/tests/cleanup_lagging_node.rs
+++ b/crates/e2e-tests/tests/cleanup_lagging_node.rs
@@ -20,12 +20,6 @@ async fn cleanup_lagging_node_should_purge_offline_presignatures_and_keep_signin
     let (cluster, running) =
         common::setup_cluster(common::CLEANUP_LAGGING_NODE_PORT_SEED, |_| {}).await;
 
-    assert_eq!(cluster.nodes.len(), 3, "expected 3 nodes");
-    assert!(
-        !running.domains.domains.is_empty(),
-        "expected at least one domain"
-    );
-
     // Wait for all nodes to have presignatures buffered.
     common::wait_for_presignatures(&cluster, &[0, 1, 2], DEFAULT_PRESIGNATURES_TO_BUFFER).await;
 
@@ -109,9 +103,4 @@ async fn cleanup_lagging_node_should_purge_offline_presignatures_and_keep_signin
             );
         }
     }
-
-    // Re-enable block ingestion.
-    cluster
-        .set_block_ingestion(&[faulty_node_idx], true)
-        .expect("failed to re-enable block ingestion");
 }

--- a/crates/e2e-tests/tests/cleanup_lagging_node.rs
+++ b/crates/e2e-tests/tests/cleanup_lagging_node.rs
@@ -1,0 +1,117 @@
+use crate::common;
+
+use backon::Retryable;
+use e2e_tests::{CLUSTER_WAIT_TIMEOUT, DEFAULT_PRESIGNATURES_TO_BUFFER, metrics};
+use near_mpc_contract_interface::types::{Curve, DomainPurpose};
+use rand::SeedableRng;
+
+/// Maximum block delay before an MPC node is considered offline by its peers.
+/// Must match `MAX_HEIGHT_DIFF` in `crates/node/src/network.rs`.
+const INDEXER_MAX_HEIGHT_DIFF: i64 = 50;
+
+/// Verify that when a node falls behind in block ingestion past the
+/// `INDEXER_MAX_HEIGHT_DIFF` threshold, the other nodes clean up all
+/// presignatures that involved it (offline presignatures go to 0),
+/// retain their own presignatures, and can still handle signature requests.
+#[tokio::test]
+async fn cleanup_lagging_node_should_purge_offline_presignatures_and_keep_signing() {
+    // given
+    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let (cluster, running) =
+        common::setup_cluster(common::CLEANUP_LAGGING_NODE_PORT_SEED, |_| {}).await;
+
+    assert_eq!(cluster.nodes.len(), 3, "expected 3 nodes");
+    assert!(
+        !running.domains.domains.is_empty(),
+        "expected at least one domain"
+    );
+
+    // Wait for all nodes to have presignatures buffered.
+    common::wait_for_presignatures(&cluster, &[0, 1, 2], DEFAULT_PRESIGNATURES_TO_BUFFER).await;
+
+    // when — disable block ingestion on one node to simulate lagging
+    let faulty_node_idx = 0;
+    let alive: Vec<usize> = vec![1, 2];
+    cluster
+        .set_block_ingestion(&[faulty_node_idx], false)
+        .expect("failed to disable block ingestion");
+
+    // Wait until alive nodes are at least INDEXER_MAX_HEIGHT_DIFF blocks ahead
+    // of the faulty node. The faulty node may still process a few buffered blocks
+    // after ingestion is disabled, so we compare heights dynamically each poll.
+    (|| async {
+        let heights = cluster
+            .get_metric_all_nodes(metrics::INDEXER_LATEST_BLOCK_HEIGHT)
+            .await
+            .expect("failed to get metrics");
+        let faulty = heights[faulty_node_idx].unwrap_or(0);
+        for &idx in &alive {
+            anyhow::ensure!(
+                heights[idx].unwrap_or(0) >= faulty + INDEXER_MAX_HEIGHT_DIFF,
+                "node {idx} not yet {} blocks ahead of faulty node (alive={:?}, faulty={faulty})",
+                INDEXER_MAX_HEIGHT_DIFF,
+                heights[idx],
+            );
+        }
+        Ok(())
+    })
+    .retry(
+        backon::ConstantBuilder::default()
+            .with_delay(common::POLL_INTERVAL)
+            .with_max_times(
+                (CLUSTER_WAIT_TIMEOUT.as_millis() / common::POLL_INTERVAL.as_millis()) as usize,
+            ),
+    )
+    .await
+    .expect("alive nodes did not pull ahead of faulty node");
+
+    // Wait for offline presignatures to be cleaned up on alive nodes.
+    common::wait_metric_on_nodes(
+        &cluster,
+        &alive,
+        metrics::OWNED_PRESIGNATURES_OFFLINE,
+        |v| v == 0,
+        CLUSTER_WAIT_TIMEOUT,
+    )
+    .await;
+
+    // then — online presignatures should remain at buffer amount on alive nodes
+    common::wait_metric_on_nodes(
+        &cluster,
+        &alive,
+        metrics::OWNED_PRESIGNATURES_ONLINE,
+        |v| v >= DEFAULT_PRESIGNATURES_TO_BUFFER as i64,
+        CLUSTER_WAIT_TIMEOUT,
+    )
+    .await;
+
+    // Verify nodes can still handle signature requests by depleting their asset stores.
+    if let Some(domain) = running
+        .domains
+        .domains
+        .iter()
+        .find(|d| matches!(d.purpose, DomainPurpose::Sign))
+    {
+        for _ in 0..2 * DEFAULT_PRESIGNATURES_TO_BUFFER {
+            let payload = match domain.curve {
+                Curve::Secp256k1 | Curve::V2Secp256k1 => common::generate_ecdsa_payload(&mut rng),
+                Curve::Edwards25519 => common::generate_eddsa_payload(&mut rng),
+                _ => break,
+            };
+            let outcome = cluster
+                .send_sign_request(domain.id, payload, cluster.default_user_account())
+                .await
+                .expect("sign request failed");
+            assert!(
+                outcome.is_success(),
+                "sign request failed: {:?}",
+                outcome.failure_message()
+            );
+        }
+    }
+
+    // Re-enable block ingestion.
+    cluster
+        .set_block_ingestion(&[faulty_node_idx], true)
+        .expect("failed to re-enable block ingestion");
+}

--- a/crates/e2e-tests/tests/cleanup_lagging_node.rs
+++ b/crates/e2e-tests/tests/cleanup_lagging_node.rs
@@ -1,16 +1,12 @@
 use crate::common;
 
-use backon::Retryable;
 use e2e_tests::{CLUSTER_WAIT_TIMEOUT, DEFAULT_PRESIGNATURES_TO_BUFFER, metrics};
+use mpc_node_config::MAX_INDEXER_HEIGHT_DIFF;
 use near_mpc_contract_interface::types::{Curve, DomainPurpose};
 use rand::SeedableRng;
 
-/// Maximum block delay before an MPC node is considered offline by its peers.
-/// Must match `MAX_HEIGHT_DIFF` in `crates/node/src/network.rs`.
-const INDEXER_MAX_HEIGHT_DIFF: i64 = 50;
-
 /// Verify that when a node falls behind in block ingestion past the
-/// `INDEXER_MAX_HEIGHT_DIFF` threshold, the other nodes clean up all
+/// `MAX_INDEXER_HEIGHT_DIFF` threshold, the other nodes clean up all
 /// presignatures that involved it (offline presignatures go to 0),
 /// retain their own presignatures, and can still handle signature requests.
 #[tokio::test]
@@ -31,34 +27,17 @@ async fn cleanup_lagging_node__should_purge_offline_presignatures_and_keep_signi
         .set_block_ingestion(&[faulty_node_idx], false)
         .expect("failed to disable block ingestion");
 
-    // Wait until alive nodes are at least INDEXER_MAX_HEIGHT_DIFF blocks ahead
+    // Wait until alive nodes are at least MAX_INDEXER_HEIGHT_DIFF blocks ahead
     // of the faulty node. The faulty node may still process a few buffered blocks
     // after ingestion is disabled, so we compare heights dynamically each poll.
-    (|| async {
-        let heights = cluster
-            .get_metric_all_nodes(metrics::INDEXER_LATEST_BLOCK_HEIGHT)
-            .await
-            .expect("failed to get metrics");
-        let faulty = heights[faulty_node_idx].unwrap_or(0);
-        for &idx in &alive {
-            anyhow::ensure!(
-                heights[idx].unwrap_or(0) >= faulty + INDEXER_MAX_HEIGHT_DIFF,
-                "node {idx} not yet {} blocks ahead of faulty node (alive={:?}, faulty={faulty})",
-                INDEXER_MAX_HEIGHT_DIFF,
-                heights[idx],
-            );
-        }
-        Ok(())
-    })
-    .retry(
-        backon::ConstantBuilder::default()
-            .with_delay(common::POLL_INTERVAL)
-            .with_max_times(
-                (CLUSTER_WAIT_TIMEOUT.as_millis() / common::POLL_INTERVAL.as_millis()) as usize,
-            ),
+    common::wait_for_indexer_lag(
+        &cluster,
+        faulty_node_idx,
+        &alive,
+        MAX_INDEXER_HEIGHT_DIFF as i64,
+        CLUSTER_WAIT_TIMEOUT,
     )
-    .await
-    .expect("alive nodes did not pull ahead of faulty node");
+    .await;
 
     // Wait for offline presignatures to be cleaned up on alive nodes.
     common::wait_metric_on_nodes(
@@ -81,27 +60,26 @@ async fn cleanup_lagging_node__should_purge_offline_presignatures_and_keep_signi
     .await;
 
     // Verify nodes can still handle signature requests by depleting their asset stores.
-    if let Some(domain) = running
+    let domain = running
         .domains
         .domains
         .iter()
         .find(|d| matches!(d.purpose, DomainPurpose::Sign))
-    {
-        for _ in 0..2 * DEFAULT_PRESIGNATURES_TO_BUFFER {
-            let payload = match domain.curve {
-                Curve::Secp256k1 | Curve::V2Secp256k1 => common::generate_ecdsa_payload(&mut rng),
-                Curve::Edwards25519 => common::generate_eddsa_payload(&mut rng),
-                _ => break,
-            };
-            let outcome = cluster
-                .send_sign_request(domain.id, payload, cluster.default_user_account())
-                .await
-                .expect("sign request failed");
-            assert!(
-                outcome.is_success(),
-                "sign request failed: {:?}",
-                outcome.failure_message()
-            );
-        }
+        .expect("cluster must have at least one signable domain");
+    for _ in 0..2 * DEFAULT_PRESIGNATURES_TO_BUFFER {
+        let payload = match domain.curve {
+            Curve::Secp256k1 | Curve::V2Secp256k1 => common::generate_ecdsa_payload(&mut rng),
+            Curve::Edwards25519 => common::generate_eddsa_payload(&mut rng),
+            _ => break,
+        };
+        let outcome = cluster
+            .send_sign_request(domain.id, payload, cluster.default_user_account())
+            .await
+            .expect("sign request failed");
+        assert!(
+            outcome.is_success(),
+            "sign request failed: {:?}",
+            outcome.failure_message()
+        );
     }
 }

--- a/crates/e2e-tests/tests/cleanup_lagging_node.rs
+++ b/crates/e2e-tests/tests/cleanup_lagging_node.rs
@@ -14,7 +14,8 @@ const INDEXER_MAX_HEIGHT_DIFF: i64 = 50;
 /// presignatures that involved it (offline presignatures go to 0),
 /// retain their own presignatures, and can still handle signature requests.
 #[tokio::test]
-async fn cleanup_lagging_node_should_purge_offline_presignatures_and_keep_signing() {
+#[expect(non_snake_case)]
+async fn cleanup_lagging_node__should_purge_offline_presignatures_and_keep_signing() {
     // given
     let mut rng = rand::rngs::StdRng::seed_from_u64(0);
     let (cluster, running) =

--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -146,6 +146,40 @@ pub async fn wait_metric_on_nodes(
     .unwrap_or_else(|e| panic!("{e}"));
 }
 
+/// Wait until every node in `alive_nodes` is at least `min_height_diff` blocks
+/// ahead of `faulty_node` according to the indexer block-height metric.
+pub async fn wait_for_indexer_lag(
+    cluster: &MpcCluster,
+    faulty_node: usize,
+    alive_nodes: &[usize],
+    min_height_diff: i64,
+    timeout: Duration,
+) {
+    let max_times = (timeout.as_millis() / POLL_INTERVAL.as_millis()) as usize;
+    (|| async {
+        let heights = cluster
+            .get_metric_all_nodes(metrics::INDEXER_LATEST_BLOCK_HEIGHT)
+            .await
+            .expect("failed to get metrics");
+        let faulty = heights[faulty_node].unwrap_or(0);
+        for &idx in alive_nodes {
+            anyhow::ensure!(
+                heights[idx].unwrap_or(0) >= faulty + min_height_diff,
+                "node {idx} not yet {min_height_diff} blocks ahead of faulty node (alive={:?}, faulty={faulty})",
+                heights[idx],
+            );
+        }
+        Ok(())
+    })
+    .retry(
+        ConstantBuilder::default()
+            .with_delay(POLL_INTERVAL)
+            .with_max_times(max_times),
+    )
+    .await
+    .unwrap_or_else(|e| panic!("{e}"));
+}
+
 /// Sum a metric across all running nodes (stopped nodes contribute 0).
 pub async fn sum_metric(cluster: &MpcCluster, name: &str) -> i64 {
     cluster

--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -24,6 +24,7 @@ pub const PARALLEL_SIGN_CALLS_PORT_SEED: u16 = 8;
 pub const CKD_VERIFICATION_PORT_SEED: u16 = 9;
 pub const LOST_ASSETS_PORT_SEED: u16 = 10;
 pub const CKD_PV_VERIFICATION_PORT_SEED: u16 = 11;
+pub const CLEANUP_LAGGING_NODE_PORT_SEED: u16 = 12;
 
 /// Start a cluster, wait for Running state and presignatures to buffer.
 ///

--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -1,5 +1,6 @@
 mod cancellation_of_resharing;
 mod ckd_verification;
+mod cleanup_lagging_node;
 mod common;
 mod key_resharing;
 mod lost_assets;

--- a/crates/node-config/src/lib.rs
+++ b/crates/node-config/src/lib.rs
@@ -25,6 +25,11 @@ use std::{
 
 const DEFAULT_PPROF_PORT: u16 = 34001;
 
+/// The maximum block-height difference between two nodes before one is
+/// considered offline / lagging. Used by the mesh network to filter out
+/// participants that are too far behind in the indexer height.
+pub const MAX_INDEXER_HEIGHT_DIFF: u64 = 50;
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct TripleConfig {
     pub concurrency: usize,

--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -108,9 +108,6 @@ impl NetworkTaskChannelManager {
 const LRU_CAPACITY: usize = 10000;
 
 impl MeshNetworkClient {
-    /// The maximum height difference that we are willing to accept.
-    /// This is used to filter out participants that are too far behind in the indexer height.
-    const MAX_HEIGHT_DIFF: u64 = 50;
     fn new(
         transport_sender: Arc<dyn MeshNetworkTransportSender>,
         channels: Arc<Mutex<NetworkTaskChannelManager>>,
@@ -194,7 +191,7 @@ impl MeshNetworkClient {
                 continue;
             }
             let peer_height = *indexer_heights.get(&participant).unwrap_or(&0);
-            if my_height <= peer_height + Self::MAX_HEIGHT_DIFF
+            if my_height <= peer_height + mpc_node_config::MAX_INDEXER_HEIGHT_DIFF
                 && self
                     .transport_sender
                     .connectivity(participant)


### PR DESCRIPTION
Port the lagging node asset cleanup test. Verifies that when a node falls behind in block ingestion past the threshold, other nodes clean up all presignatures involving it and can still handle sign requests.

Renaming `listen_blocks` → `listen_blocks.flag` is a bugfix for the existing test utility, not just incidental to the new test. The node reads [listen_blocks.flag](https://github.com/near/mpc/blob/5614c68fa12159a1e315351567c30a24fe4a23bf/crates/node/src/config.rs#L429), so any previous e2e test that called set_block_ingestion would have written to the wrong path and silently had no effect.

Work towards: #2889