### PR TITLE
chore(localnet): use slirp gateway for NEAR_BOOT_NODES so CVMs reach neard on loopback

### DIFF
--- a/localnet/tee/scripts/rust-launcher/deploy-tee-localnet.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-localnet.sh
@@ -779,7 +779,10 @@ render_node_files_range() {
     export PORTS="8080:8080,24566:24566,${future_port}:${future_port}"
     export PORTS_TOML
     PORTS_TOML="$(ports_to_toml "$PORTS")"
-    export NEAR_BOOT_NODES="ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@${MACHINE_IP}:24566"
+    # Use QEMU slirp gateway (10.0.2.2) so the CVM reaches the host's neard
+    # over loopback — works regardless of whether neard binds to 0.0.0.0 or
+    # 127.0.0.1 on the host.
+    export NEAR_BOOT_NODES="ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
 
     envsubst <"$ENV_TPL" >"$env_out"
     envsubst <"$CONF_TPL" >"$conf_out"

--- a/localnet/tee/scripts/rust-launcher/how-to-run-localnet-tee-setup-script.md
+++ b/localnet/tee/scripts/rust-launcher/how-to-run-localnet-tee-setup-script.md
@@ -232,3 +232,8 @@ bash localnet/tee/scripts/rust-launcher/test-verify-and-upgrade.sh verify
 - Script is designed for iterative debugging and safe restarts
 - The launcher uses TOML config
 - MPC node image must support `start-with-config-file` (commit `9515e18` or later)
+- `NEAR_BOOT_NODES` points the CVM at `10.0.2.2:24566` — the QEMU slirp gateway
+  that routes to the host's loopback. This works regardless of whether `neard`
+  binds to `0.0.0.0` or `127.0.0.1`, so the same config works across localnet
+  variants. `MACHINE_IP` is still used elsewhere (public-data endpoints,
+  telemetry) and should remain set to the host's external IP.

--- a/localnet/tee/scripts/rust-launcher/single-node.sh
+++ b/localnet/tee/scripts/rust-launcher/single-node.sh
@@ -171,9 +171,11 @@ create_node_account() {
 }
 
 render_env_and_conf() {
-  # Correct bootnode format for localnet
+  # Correct bootnode format for localnet.
+  # Use QEMU slirp gateway (10.0.2.2) so the CVM reaches the host's neard over
+  # loopback — works regardless of whether neard binds to 0.0.0.0 or 127.0.0.1.
   local node_pubkey="${NODE_PUBKEY:-$(jq -r .public_key "$HOME/.near/mpc-localnet/node_key.json")}"
-  export NEAR_BOOT_NODES="${NEAR_BOOT_NODES:-${node_pubkey}@${MACHINE_IP}:${NEAR_P2P_PORT}}"
+  export NEAR_BOOT_NODES="${NEAR_BOOT_NODES:-${node_pubkey}@10.0.2.2:${NEAR_P2P_PORT}}"
 
   export APP_NAME="${APP_NAME:-mpc-localnet-one-node-$(date +%s)}"
   export VMM_RPC OS_IMAGE SEALING_KEY_TYPE DISK


### PR DESCRIPTION
Closes #2950.

## Summary

Point `NEAR_BOOT_NODES` in the rust-launcher localnet scripts at `10.0.2.2:24566` (QEMU slirp's host-loopback gateway) instead of `${MACHINE_IP}:24566`. The CVM now reaches the host's `neard` regardless of whether it binds to `0.0.0.0` or `127.0.0.1` — removing the need for the undocumented `jq`-patch workaround that #2903 introduced.

Same slirp pattern the localnet TEE config already uses for PCCS.

## Changes

- `deploy-tee-localnet.sh`, `single-node.sh` — `NEAR_BOOT_NODES` uses `10.0.2.2`
- `how-to-run-localnet-tee-setup-script.md` — short note explaining the address choice

The Python-launcher path (`.conf` files + `docs/localnet/tee-localnet.md`) was originally touched too, but since main has now deleted those `.conf` files as part of the Python-launcher cleanup, that commit was dropped on rebase.

## Test plan

- [x] Fresh run of `bash localnet/tee/scripts/rust-launcher/deploy-tee-localnet.sh` against the default (127.0.0.1-bound) `deployment/localnet/config.json` — no `jq` patch required
- [x] End-to-end verify passes (Running contract, 2 real Dstack attestations, ECDSA signature, both nodes syncing via `10.0.2.2:24566`)