### PR TITLE
fix: cleanup of stored attestations

### DIFF
--- a/.github/contract-size-baseline.toml
+++ b/.github/contract-size-baseline.toml
@@ -3,4 +3,4 @@
 max_transaction_size = 1572864
 
 # Expected contract WASM size in bytes (reproducible builds must match exactly)
-expected_size = 1481703
+expected_size = 1490000

--- a/crates/contract/src/config.rs
+++ b/crates/contract/src/config.rs
@@ -23,6 +23,8 @@ const DEFAULT_RETURN_CK_AND_CLEAN_STATE_ON_SUCCESS_CALL_TERA_GAS: u64 = 7;
 const DEFAULT_FAIL_ON_TIMEOUT_TERA_GAS: u64 = 2;
 /// Prepaid gas for a `clean_tee_status` call
 const DEFAULT_CLEAN_TEE_STATUS_TERA_GAS: u64 = 10;
+/// Prepaid gas for the reshare-time `clean_invalid_attestations` promise.
+const DEFAULT_CLEAN_INVALID_ATTESTATIONS_TERA_GAS: u64 = 10;
 /// Prepaid gas for a `cleanup_orphaned_node_migrations` call
 /// TODO(#1164): benchmark
 const DEFAULT_CLEANUP_ORPHANED_NODE_MIGRATIONS_TERA_GAS: u64 = 4;
@@ -54,6 +56,8 @@ pub(crate) struct Config {
     pub(crate) fail_on_timeout_tera_gas: u64,
     /// Prepaid gas for a `clean_tee_status` call.
     pub(crate) clean_tee_status_tera_gas: u64,
+    /// Prepaid gas for the reshare-time `clean_invalid_attestations` promise.
+    pub(crate) clean_invalid_attestations_tera_gas: u64,
     /// Prepaid gas for a `cleanup_orphaned_node_migrations` call.
     pub(crate) cleanup_orphaned_node_migrations_tera_gas: u64,
     /// Prepaid gas for a `remove_non_participant_update_votes` call.
@@ -78,6 +82,7 @@ impl Default for Config {
                 DEFAULT_RETURN_CK_AND_CLEAN_STATE_ON_SUCCESS_CALL_TERA_GAS,
             fail_on_timeout_tera_gas: DEFAULT_FAIL_ON_TIMEOUT_TERA_GAS,
             clean_tee_status_tera_gas: DEFAULT_CLEAN_TEE_STATUS_TERA_GAS,
+            clean_invalid_attestations_tera_gas: DEFAULT_CLEAN_INVALID_ATTESTATIONS_TERA_GAS,
             cleanup_orphaned_node_migrations_tera_gas:
                 DEFAULT_CLEANUP_ORPHANED_NODE_MIGRATIONS_TERA_GAS,
             remove_non_participant_update_votes_tera_gas:

--- a/crates/contract/src/dto_mapping.rs
+++ b/crates/contract/src/dto_mapping.rs
@@ -439,6 +439,9 @@ impl From<near_mpc_contract_interface::types::InitConfig> for Config {
         if let Some(v) = config_ext.clean_tee_status_tera_gas {
             config.clean_tee_status_tera_gas = v;
         }
+        if let Some(v) = config_ext.clean_invalid_attestations_tera_gas {
+            config.clean_invalid_attestations_tera_gas = v;
+        }
         if let Some(v) = config_ext.cleanup_orphaned_node_migrations_tera_gas {
             config.cleanup_orphaned_node_migrations_tera_gas = v;
         }
@@ -469,6 +472,7 @@ impl From<&Config> for near_mpc_contract_interface::types::Config {
                 .return_ck_and_clean_state_on_success_call_tera_gas,
             fail_on_timeout_tera_gas: value.fail_on_timeout_tera_gas,
             clean_tee_status_tera_gas: value.clean_tee_status_tera_gas,
+            clean_invalid_attestations_tera_gas: value.clean_invalid_attestations_tera_gas,
             cleanup_orphaned_node_migrations_tera_gas: value
                 .cleanup_orphaned_node_migrations_tera_gas,
             remove_non_participant_update_votes_tera_gas: value
@@ -494,6 +498,7 @@ impl From<near_mpc_contract_interface::types::Config> for Config {
                 .return_ck_and_clean_state_on_success_call_tera_gas,
             fail_on_timeout_tera_gas: value.fail_on_timeout_tera_gas,
             clean_tee_status_tera_gas: value.clean_tee_status_tera_gas,
+            clean_invalid_attestations_tera_gas: value.clean_invalid_attestations_tera_gas,
             cleanup_orphaned_node_migrations_tera_gas: value
                 .cleanup_orphaned_node_migrations_tera_gas,
             remove_non_participant_update_votes_tera_gas: value

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -85,6 +85,10 @@ const MINIMUM_SIGN_REQUEST_DEPOSIT: NearToken = NearToken::from_yoctonear(1);
 /// Minimum deposit required for CKD requests
 const MINIMUM_CKD_REQUEST_DEPOSIT: NearToken = NearToken::from_yoctonear(1);
 
+/// Entries to scan in the post-reshare `clean_invalid_attestations` sweep. External
+/// callers may pick a different value; this only governs the automatic invocation.
+const RESHARE_CLEAN_INVALID_ATTESTATIONS_MAX_SCAN: u32 = 100;
+
 /// Checks that the caller attached at least `minimum_deposit` and refunds any excess.
 ///
 /// A non-zero deposit is required so that the transaction must be signed by a
@@ -1173,13 +1177,25 @@ impl MpcContract {
                     Gas::from_tgas(self.config.remove_non_participant_update_votes_tera_gas),
                 )
                 .detach();
-            // Spawn a promise to clean up TEE information for non-participants
+            // Spawn a promise to drop votes cast by non-participants.
             Promise::new(env::current_account_id())
                 .function_call(
                     method_names::CLEAN_TEE_STATUS.to_string(),
                     vec![],
                     NearToken::from_yoctonear(0),
                     Gas::from_tgas(self.config.clean_tee_status_tera_gas),
+                )
+                .detach();
+            // Spawn a bounded sweep over stored attestations to prune invalid / expired entries.
+            Promise::new(env::current_account_id())
+                .function_call(
+                    method_names::CLEAN_INVALID_ATTESTATIONS.to_string(),
+                    serde_json::to_vec(&serde_json::json!({
+                        "max_scan": RESHARE_CLEAN_INVALID_ATTESTATIONS_MAX_SCAN
+                    }))
+                    .unwrap(),
+                    NearToken::from_yoctonear(0),
+                    Gas::from_tgas(self.config.clean_invalid_attestations_tera_gas),
                 )
                 .detach();
             // Spawn a promise to clean up orphaned node migrations for non-participants
@@ -1646,8 +1662,8 @@ impl MpcContract {
         Ok(())
     }
 
-    /// Private endpoint to clean up TEE information for non-participants after resharing.
-    /// This can only be called by the contract itself via a promise.
+    /// Private endpoint to drop votes cast by non-participants after resharing.
+    /// Attestation cleanup is handled separately by [`MpcContract::clean_invalid_attestations`].
     #[private]
     #[handle_result]
     pub fn clean_tee_status(&mut self) -> Result<(), Error> {
@@ -1660,8 +1676,30 @@ impl MpcContract {
             }
         };
 
-        self.tee_state.clean_non_participants(participants);
+        self.tee_state.clean_non_participant_votes(participants);
         Ok(())
+    }
+
+    /// Prunes up to `max_scan` stored attestations that fail re-verification (expired or
+    /// referencing stale whitelists). Returns the number of entries removed. Callable by
+    /// anyone while the protocol is in `Running`.
+    #[handle_result]
+    pub fn clean_invalid_attestations(&mut self, max_scan: u32) -> Result<u32, Error> {
+        log!(
+            "clean_invalid_attestations: signer={}, max_scan={}",
+            env::signer_account_id(),
+            max_scan
+        );
+        // Running-only: keygen / resharing may reference attestations that have not yet
+        // been activated, so cleanup is off-limits during those phases.
+        if !matches!(self.protocol_state, ProtocolContractState::Running(_)) {
+            return Err(InvalidState::ProtocolStateNotRunning.into());
+        }
+        let tee_upgrade_deadline_duration =
+            Duration::from_secs(self.config.tee_upgrade_deadline_duration_seconds);
+        Ok(self
+            .tee_state
+            .clean_invalid_attestations(tee_upgrade_deadline_duration, max_scan as usize))
     }
 
     /// Private endpoint to clean up foreign chain policy votes and node configurations

--- a/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
+++ b/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
@@ -51,12 +51,6 @@ BorshSchemaContainer {
                 "NonEmptyBTreeSet<RpcProvider>",
             ],
         },
-        "(PublicKey, NodeAttestation)": Tuple {
-            elements: [
-                "PublicKey",
-                "NodeAttestation",
-            ],
-        },
         "AccountId": Struct {
             fields: UnnamedFields(
                 [
@@ -183,11 +177,6 @@ BorshSchemaContainer {
             length_range: 0..=4294967295,
             elements: "(ForeignChain, NonEmptyBTreeSet<RpcProvider>)",
         },
-        "BTreeMap<PublicKey, NodeAttestation>": Sequence {
-            length_width: 4,
-            length_range: 0..=4294967295,
-            elements: "(PublicKey, NodeAttestation)",
-        },
         "BTreeSet<AuthenticatedParticipantId>": Sequence {
             length_width: 4,
             length_range: 0..=4294967295,
@@ -252,6 +241,10 @@ BorshSchemaContainer {
                     ),
                     (
                         "clean_tee_status_tera_gas",
+                        "u64",
+                    ),
+                    (
+                        "clean_invalid_attestations_tera_gas",
                         "u64",
                     ),
                     (
@@ -418,20 +411,6 @@ BorshSchemaContainer {
             fields: UnnamedFields(
                 [
                     "u64",
-                ],
-            ),
-        },
-        "ExpectedMeasurements": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "rtmrs",
-                        "Measurements",
-                    ),
-                    (
-                        "key_provider_event_digest",
-                        "[u8; 48]",
-                    ),
                 ],
             ),
         },
@@ -772,28 +751,6 @@ BorshSchemaContainer {
                 ],
             ),
         },
-        "Measurements": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "mrtd",
-                        "[u8; 48]",
-                    ),
-                    (
-                        "rtmr0",
-                        "[u8; 48]",
-                    ),
-                    (
-                        "rtmr1",
-                        "[u8; 48]",
-                    ),
-                    (
-                        "rtmr2",
-                        "[u8; 48]",
-                    ),
-                ],
-            ),
-        },
         "Metrics": Struct {
             fields: NamedFields(
                 [
@@ -804,54 +761,6 @@ BorshSchemaContainer {
                     (
                         "sign_with_v2_payload_count",
                         "u64",
-                    ),
-                ],
-            ),
-        },
-        "MockAttestation": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "Valid",
-                    "MockAttestation__Valid",
-                ),
-                (
-                    1,
-                    "Invalid",
-                    "MockAttestation__Invalid",
-                ),
-                (
-                    2,
-                    "WithConstraints",
-                    "MockAttestation__WithConstraints",
-                ),
-            ],
-        },
-        "MockAttestation__Invalid": Struct {
-            fields: Empty,
-        },
-        "MockAttestation__Valid": Struct {
-            fields: Empty,
-        },
-        "MockAttestation__WithConstraints": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "mpc_docker_image_hash",
-                        "Option<DockerImageHash>",
-                    ),
-                    (
-                        "launcher_docker_compose_hash",
-                        "Option<LauncherDockerComposeHash>",
-                    ),
-                    (
-                        "expiry_timestamp_seconds",
-                        "Option<u64>",
-                    ),
-                    (
-                        "expected_measurements",
-                        "Option<ExpectedMeasurements>",
                     ),
                 ],
             ),
@@ -945,44 +854,12 @@ BorshSchemaContainer {
                 ],
             ),
         },
-        "NodeAttestation": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "node_id",
-                        "NodeId",
-                    ),
-                    (
-                        "verified_attestation",
-                        "VerifiedAttestation",
-                    ),
-                ],
-            ),
-        },
         "NodeForeignChainConfigurations": Struct {
             fields: NamedFields(
                 [
                     (
                         "foreign_chain_configuration_by_node",
                         "IterableMap",
-                    ),
-                ],
-            ),
-        },
-        "NodeId": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "account_id",
-                        "AccountId",
-                    ),
-                    (
-                        "tls_public_key",
-                        "PublicKey",
-                    ),
-                    (
-                        "account_public_key",
-                        "Option<PublicKey>",
                     ),
                 ],
             ),
@@ -1006,21 +883,6 @@ BorshSchemaContainer {
             length_range: 1..=4294967295,
             elements: "RpcProvider",
         },
-        "Option<DockerImageHash>": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "None",
-                    "()",
-                ),
-                (
-                    1,
-                    "Some",
-                    "DockerImageHash",
-                ),
-            ],
-        },
         "Option<EpochId>": Enum {
             tag_width: 1,
             variants: [
@@ -1033,21 +895,6 @@ BorshSchemaContainer {
                     1,
                     "Some",
                     "EpochId",
-                ),
-            ],
-        },
-        "Option<ExpectedMeasurements>": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "None",
-                    "()",
-                ),
-                (
-                    1,
-                    "Some",
-                    "ExpectedMeasurements",
                 ),
             ],
         },
@@ -1066,36 +913,6 @@ BorshSchemaContainer {
                 ),
             ],
         },
-        "Option<LauncherDockerComposeHash>": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "None",
-                    "()",
-                ),
-                (
-                    1,
-                    "Some",
-                    "LauncherDockerComposeHash",
-                ),
-            ],
-        },
-        "Option<PublicKey>": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "None",
-                    "()",
-                ),
-                (
-                    1,
-                    "Some",
-                    "PublicKey",
-                ),
-            ],
-        },
         "Option<PublicKeyExtended>": Enum {
             tag_width: 1,
             variants: [
@@ -1108,21 +925,6 @@ BorshSchemaContainer {
                     1,
                     "Some",
                     "PublicKeyExtended",
-                ),
-            ],
-        },
-        "Option<u64>": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "None",
-                    "()",
-                ),
-                (
-                    1,
-                    "Some",
-                    "u64",
                 ),
             ],
         },
@@ -1425,7 +1227,7 @@ BorshSchemaContainer {
                     ),
                     (
                         "stored_attestations",
-                        "BTreeMap<PublicKey, NodeAttestation>",
+                        "IterableMap",
                     ),
                     (
                         "allowed_measurements",
@@ -1483,28 +1285,6 @@ BorshSchemaContainer {
                 ],
             ),
         },
-        "ValidatedDstackAttestation": Struct {
-            fields: NamedFields(
-                [
-                    (
-                        "mpc_image_hash",
-                        "DockerImageHash",
-                    ),
-                    (
-                        "launcher_compose_hash",
-                        "LauncherDockerComposeHash",
-                    ),
-                    (
-                        "expiry_timestamp_seconds",
-                        "u64",
-                    ),
-                    (
-                        "measurements",
-                        "ExpectedMeasurements",
-                    ),
-                ],
-            ),
-        },
         "Vec<(AccountId, ParticipantId, ParticipantInfo)>": Sequence {
             length_width: 4,
             length_range: 0..=4294967295,
@@ -1559,43 +1339,9 @@ BorshSchemaContainer {
                 ],
             ),
         },
-        "VerifiedAttestation": Enum {
-            tag_width: 1,
-            variants: [
-                (
-                    0,
-                    "Dstack",
-                    "VerifiedAttestation__Dstack",
-                ),
-                (
-                    1,
-                    "Mock",
-                    "VerifiedAttestation__Mock",
-                ),
-            ],
-        },
-        "VerifiedAttestation__Dstack": Struct {
-            fields: UnnamedFields(
-                [
-                    "ValidatedDstackAttestation",
-                ],
-            ),
-        },
-        "VerifiedAttestation__Mock": Struct {
-            fields: UnnamedFields(
-                [
-                    "MockAttestation",
-                ],
-            ),
-        },
         "[u8; 32]": Sequence {
             length_width: 0,
             length_range: 32..=32,
-            elements: "u8",
-        },
-        "[u8; 48]": Sequence {
-            length_width: 0,
-            length_range: 48..=48,
             elements: "u8",
         },
         "[u8; 64]": Sequence {

--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -22,4 +22,5 @@ pub enum StorageKey {
     PendingCKDRequestsV2,
     SupportedForeignChainsVotes,
     PendingSignatureRequestsV3,
+    StoredAttestations,
 }

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -427,25 +427,25 @@ impl TeeState {
         tee_upgrade_deadline_duration: Duration,
         max_scan: usize,
     ) -> u32 {
+        let has_invalid_attestation = |node_id: &NodeId| {
+            !matches!(
+                self.reverify_participants(node_id, tee_upgrade_deadline_duration),
+                TeeQuoteStatus::Valid
+            )
+        };
+
         // Materialize candidates before any mutation to avoid iterator invalidation.
-        let candidates: Vec<NodeId> = self
+        let invalid_tls_keys: Vec<near_sdk::PublicKey> = self
             .stored_attestations
             .iter()
             .take(max_scan)
-            .map(|(_, node_attestation)| node_attestation.node_id.clone())
+            .filter(|(_, node_attestation)| has_invalid_attestation(&node_attestation.node_id))
+            .map(|(tls_pk, _)| tls_pk.clone())
             .collect();
 
-        let mut invalid_tls_keys: Vec<near_sdk::PublicKey> = Vec::new();
-        for node_id in candidates {
-            if !matches!(
-                self.reverify_participants(&node_id, tee_upgrade_deadline_duration),
-                TeeQuoteStatus::Valid
-            ) {
-                invalid_tls_keys.push(node_id.tls_public_key);
-            }
-        }
+        let removed = u32::try_from(invalid_tls_keys.len())
+            .expect("u32 should always be convertible from usize on wasm32");
 
-        let removed = invalid_tls_keys.len() as u32;
         for tls_pk in invalid_tls_keys {
             self.stored_attestations.remove(&tls_pk);
         }

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -1,5 +1,6 @@
 use crate::{
     primitives::{key_state::AuthenticatedParticipantId, participants::Participants},
+    storage_keys::StorageKey,
     tee::measurements::{
         AllowedMeasurements, ContractExpectedMeasurements, MeasurementVoteAction, MeasurementVotes,
     },
@@ -15,12 +16,9 @@ use mpc_attestation::{
 };
 use mpc_primitives::hash::{LauncherDockerComposeHash, LauncherImageHash};
 use near_account_id::AccountId;
-use near_sdk::{env, near};
-use std::{
-    collections::BTreeMap,
-    hash::{Hash, Hasher},
-};
-use std::{collections::HashSet, time::Duration};
+use near_sdk::{env, near, store::IterableMap};
+use std::hash::{Hash, Hasher};
+use std::time::Duration;
 
 #[near(serializers=[borsh, json])]
 #[derive(Debug, Ord, PartialOrd, Clone)]
@@ -95,11 +93,8 @@ pub(crate) struct NodeAttestation {
     pub(crate) verified_attestation: VerifiedAttestation,
 }
 
-#[derive(Default, Debug, BorshSerialize, BorshDeserialize)]
-#[cfg_attr(
-    all(feature = "abi", not(target_arch = "wasm32")),
-    derive(borsh::BorshSchema)
-)]
+#[near(serializers=[borsh])]
+#[derive(Debug)]
 pub struct TeeState {
     pub(crate) allowed_docker_image_hashes: AllowedDockerImageHashes,
     pub(crate) allowed_launcher_images: AllowedLauncherImages,
@@ -107,16 +102,31 @@ pub struct TeeState {
     pub(crate) launcher_votes: LauncherHashVotes,
     /// Mapping of TLS public key of a participant to its [`NodeAttestation`].
     /// Attestations are stored for any valid participant that has submitted one, not
-    /// just for the currently active participants.
-    pub(crate) stored_attestations: BTreeMap<near_sdk::PublicKey, NodeAttestation>,
+    /// just for the currently active participants. Callers must not assume this map is
+    /// small; use the key-indexed accessors rather than scanning the whole collection.
+    pub(crate) stored_attestations: IterableMap<near_sdk::PublicKey, NodeAttestation>,
     pub(crate) allowed_measurements: AllowedMeasurements,
     pub(crate) measurement_votes: MeasurementVotes,
+}
+
+impl Default for TeeState {
+    fn default() -> Self {
+        Self {
+            allowed_docker_image_hashes: Default::default(),
+            allowed_launcher_images: Default::default(),
+            votes: Default::default(),
+            launcher_votes: Default::default(),
+            stored_attestations: IterableMap::new(StorageKey::StoredAttestations),
+            allowed_measurements: Default::default(),
+            measurement_votes: Default::default(),
+        }
+    }
 }
 
 impl TeeState {
     /// Creates a [`TeeState`] with an initial set of participants that will receive a valid mocked attestation.
     pub(crate) fn with_mocked_participant_attestations(participants: &Participants) -> Self {
-        let mut participants_attestations = BTreeMap::new();
+        let mut tee_state = Self::default();
 
         participants
             .participants()
@@ -128,7 +138,7 @@ impl TeeState {
                     account_public_key: None,
                 };
 
-                participants_attestations.insert(
+                tee_state.stored_attestations.insert(
                     participant_info.sign_pk.clone(),
                     NodeAttestation {
                         node_id,
@@ -139,10 +149,7 @@ impl TeeState {
                 );
             });
 
-        Self {
-            stored_attestations: participants_attestations,
-            ..Default::default()
-        }
+        tee_state
     }
 
     fn current_time_seconds() -> u64 {
@@ -402,33 +409,47 @@ impl TeeState {
         self.allowed_measurements.to_attestation_measurements()
     }
 
-    /// Removes TEE information and stale votes for nodes that are not in the provided
-    /// participants list. Used to clean up storage after a resharing concludes.
-    pub fn clean_non_participants(&mut self, participants: &Participants) {
-        // Collect all allowed TLS public keys from current participants
-        let active_tls_keys: HashSet<&near_sdk::PublicKey> = participants
-            .participants()
-            .iter()
-            .map(|(_, _, p_info)| &p_info.sign_pk)
-            .collect();
-
-        // Collect TLS keys that are *not* in the active participants list
-        let stale_keys: Vec<near_sdk::PublicKey> = self
-            .stored_attestations
-            .keys()
-            .filter(|tls_pk| !active_tls_keys.contains(*tls_pk))
-            .cloned()
-            .collect();
-
-        // Remove all stale TEE entries
-        for tls_pk in stale_keys {
-            self.stored_attestations.remove(&tls_pk);
-        }
-
-        // Remove stale votes from non-participants
+    /// Drops votes cast by nodes that are no longer participants. Used after a resharing
+    /// concludes. Attestation cleanup is handled separately by
+    /// [`TeeState::clean_invalid_attestations`].
+    pub fn clean_non_participant_votes(&mut self, participants: &Participants) {
         self.votes = self.votes.get_remaining_votes(participants);
         self.launcher_votes = self.launcher_votes.get_remaining_votes(participants);
         self.measurement_votes = self.measurement_votes.get_remaining_votes(participants);
+    }
+
+    /// Scans up to `max_scan` entries from `stored_attestations` and removes any whose
+    /// attestation no longer passes `re_verify` under the current docker-hash /
+    /// launcher-hash / measurement whitelists, or whose attestation has expired.
+    /// Returns the number of entries removed.
+    pub fn clean_invalid_attestations(
+        &mut self,
+        tee_upgrade_deadline_duration: Duration,
+        max_scan: usize,
+    ) -> u32 {
+        // Materialize candidates before any mutation to avoid iterator invalidation.
+        let candidates: Vec<NodeId> = self
+            .stored_attestations
+            .iter()
+            .take(max_scan)
+            .map(|(_, node_attestation)| node_attestation.node_id.clone())
+            .collect();
+
+        let mut invalid_tls_keys: Vec<near_sdk::PublicKey> = Vec::new();
+        for node_id in candidates {
+            if !matches!(
+                self.reverify_participants(&node_id, tee_upgrade_deadline_duration),
+                TeeQuoteStatus::Valid
+            ) {
+                invalid_tls_keys.push(node_id.tls_public_key);
+            }
+        }
+
+        let removed = invalid_tls_keys.len() as u32;
+        for tls_pk in invalid_tls_keys {
+            self.stored_attestations.remove(&tls_pk);
+        }
+        removed
     }
 
     /// Returns the list of accounts that currently have TEE attestations stored.
@@ -490,6 +511,7 @@ pub(crate) enum AttestationCheckError {
 }
 
 #[cfg(test)]
+#[expect(non_snake_case)]
 mod tests {
     use super::*;
     use crate::primitives::key_state::AuthenticatedParticipantId;
@@ -515,7 +537,8 @@ mod tests {
     }
 
     #[test]
-    fn test_clean_non_participants() {
+    fn clean_non_participant_votes__should_not_touch_attestations() {
+        // Given
         const TEE_UPGRADE_DURATION: Duration = Duration::from_secs(10000);
 
         let mut tee_state = TeeState::default();
@@ -545,28 +568,29 @@ mod tests {
         };
 
         for node_id in &participant_nodes {
-            let insertion_result = tee_state.add_participant(
-                node_id.clone(),
+            tee_state
+                .add_participant(
+                    node_id.clone(),
+                    local_attestation.clone(),
+                    TEE_UPGRADE_DURATION,
+                )
+                .unwrap();
+        }
+        tee_state
+            .add_participant(
+                non_participant_uid.clone(),
                 local_attestation.clone(),
                 TEE_UPGRADE_DURATION,
-            );
-
-            assert_matches!(
-                insertion_result,
-                Ok(ParticipantInsertion::NewlyInsertedParticipant)
-            );
-        }
-        let insertion_result = tee_state.add_participant(
-            non_participant_uid.clone(),
-            local_attestation.clone(),
-            TEE_UPGRADE_DURATION,
-        );
-        assert_matches!(
-            insertion_result,
-            Ok(ParticipantInsertion::NewlyInsertedParticipant)
-        );
+            )
+            .unwrap();
 
         // Verify all 4 accounts have TEE info initially
+        assert_eq!(tee_state.stored_attestations.len(), 4);
+
+        // When: the vote-cleanup path runs for the current participant set.
+        tee_state.clean_non_participant_votes(&participants);
+
+        // Then: attestations are left untouched (attestation cleanup is a separate path).
         assert_eq!(tee_state.stored_attestations.len(), 4);
         for node_id in &participant_nodes {
             assert!(tee_state
@@ -576,20 +600,144 @@ mod tests {
         assert!(tee_state
             .stored_attestations
             .contains_key(&non_participant_uid.tls_public_key));
+    }
 
-        // Clean non-participants
-        tee_state.clean_non_participants(&participants);
+    #[test]
+    fn clean_invalid_attestations__should_remove_expired_entries() {
+        // Given: one fresh and one already-expired attestation stored.
+        const FRESH_EXPIRY_SECONDS: u64 = 10_000;
+        const STALE_EXPIRY_SECONDS: u64 = 1_000;
+        const NOW_SECONDS: u64 = 5_000;
 
-        // Verify only participants remain
-        assert_eq!(tee_state.stored_attestations.len(), 3);
-        for node_id in &participant_nodes {
-            assert!(tee_state
-                .stored_attestations
-                .contains_key(&node_id.tls_public_key));
-        }
+        testing_env!(VMContextBuilder::new().block_timestamp(0).build());
+
+        let mut tee_state = TeeState::default();
+
+        let fresh_node = NodeId {
+            account_id: "fresh.near".parse().unwrap(),
+            tls_public_key: bogus_ed25519_near_public_key(),
+            account_public_key: Some(bogus_ed25519_near_public_key()),
+        };
+        let stale_node = NodeId {
+            account_id: "stale.near".parse().unwrap(),
+            tls_public_key: bogus_ed25519_near_public_key(),
+            account_public_key: Some(bogus_ed25519_near_public_key()),
+        };
+
+        let fresh = Attestation::Mock(MockAttestation::WithConstraints {
+            mpc_docker_image_hash: None,
+            launcher_docker_compose_hash: None,
+            expiry_timestamp_seconds: Some(FRESH_EXPIRY_SECONDS),
+            expected_measurements: None,
+        });
+        let stale = Attestation::Mock(MockAttestation::WithConstraints {
+            mpc_docker_image_hash: None,
+            launcher_docker_compose_hash: None,
+            expiry_timestamp_seconds: Some(STALE_EXPIRY_SECONDS),
+            expected_measurements: None,
+        });
+
+        tee_state
+            .add_participant(fresh_node.clone(), fresh, Duration::from_secs(0))
+            .unwrap();
+        tee_state
+            .add_participant(stale_node.clone(), stale, Duration::from_secs(0))
+            .unwrap();
+
+        assert_eq!(tee_state.stored_attestations.len(), 2);
+
+        // When: the clock advances past the stale entry's expiry and cleanup runs.
+        set_block_timestamp(NOW_SECONDS * 1_000_000_000);
+        let removed = tee_state.clean_invalid_attestations(Duration::from_secs(0), 100);
+
+        // Then: only the expired entry is removed.
+        assert_eq!(removed, 1);
+        assert!(tee_state
+            .stored_attestations
+            .contains_key(&fresh_node.tls_public_key));
         assert!(!tee_state
             .stored_attestations
-            .contains_key(&non_participant_uid.tls_public_key));
+            .contains_key(&stale_node.tls_public_key));
+    }
+
+    #[test]
+    fn clean_invalid_attestations__should_honor_max_scan() {
+        // Given: ten expired attestations stored.
+        const EXPIRY_SECONDS: u64 = 1_000;
+        const NOW_SECONDS: u64 = 5_000;
+
+        testing_env!(VMContextBuilder::new().block_timestamp(0).build());
+
+        let mut tee_state = TeeState::default();
+
+        let expired = Attestation::Mock(MockAttestation::WithConstraints {
+            mpc_docker_image_hash: None,
+            launcher_docker_compose_hash: None,
+            expiry_timestamp_seconds: Some(EXPIRY_SECONDS),
+            expected_measurements: None,
+        });
+
+        for idx in 0..10 {
+            let node_id = NodeId {
+                account_id: format!("node{idx}.near").parse().unwrap(),
+                tls_public_key: bogus_ed25519_near_public_key(),
+                account_public_key: Some(bogus_ed25519_near_public_key()),
+            };
+            tee_state
+                .add_participant(node_id, expired.clone(), Duration::from_secs(0))
+                .unwrap();
+        }
+        assert_eq!(tee_state.stored_attestations.len(), 10);
+
+        set_block_timestamp(NOW_SECONDS * 1_000_000_000);
+
+        // When: cleanup is called repeatedly with a scan limit of 3 until no progress is made.
+        let mut total_removed = 0u32;
+        loop {
+            let removed = tee_state.clean_invalid_attestations(Duration::from_secs(0), 3);
+            total_removed += removed;
+            if removed == 0 {
+                break;
+            }
+            assert!(removed <= 3);
+        }
+
+        // Then: all ten entries are removed across multiple calls, each bounded by max_scan.
+        assert_eq!(total_removed, 10);
+        assert_eq!(tee_state.stored_attestations.len(), 0);
+    }
+
+    #[test]
+    fn clean_invalid_attestations__should_keep_valid_entries() {
+        // Given: a single attestation whose expiry is in the future.
+        const FUTURE_EXPIRY_SECONDS: u64 = 10_000;
+
+        testing_env!(VMContextBuilder::new().block_timestamp(0).build());
+
+        let mut tee_state = TeeState::default();
+        let node_id = NodeId {
+            account_id: "alice.near".parse().unwrap(),
+            tls_public_key: bogus_ed25519_near_public_key(),
+            account_public_key: Some(bogus_ed25519_near_public_key()),
+        };
+        let attestation = Attestation::Mock(MockAttestation::WithConstraints {
+            mpc_docker_image_hash: None,
+            launcher_docker_compose_hash: None,
+            expiry_timestamp_seconds: Some(FUTURE_EXPIRY_SECONDS),
+            expected_measurements: None,
+        });
+        tee_state
+            .add_participant(node_id.clone(), attestation, Duration::from_secs(0))
+            .unwrap();
+
+        // When: cleanup runs while the attestation is still valid.
+        let removed = tee_state.clean_invalid_attestations(Duration::from_secs(0), 100);
+
+        // Then: nothing is removed.
+        assert_eq!(removed, 0);
+        assert!(tee_state
+            .stored_attestations
+            .contains_key(&node_id.tls_public_key));
     }
 
     #[test]
@@ -1253,10 +1401,10 @@ mod tests {
     /// Scenario (N=5, T=3):
     /// 1. P1 and P2 vote for malicious hash before resharing.
     /// 2. Resharing removes P1 and P2. New set: {P3, P4, P5}.
-    /// 3. clean_non_participants removes stale votes.
+    /// 3. clean_non_participant_votes removes stale votes.
     /// 4. P3 votes for the same hash — only 1 vote, not 3.
     #[test]
-    fn test_clean_non_participants_removes_stale_votes() {
+    fn test_clean_non_participant_votes_removes_stale_votes() {
         // Build 5 participants
         let mut all_participants = Participants::new();
         let mut account_ids = Vec::new();
@@ -1283,7 +1431,7 @@ mod tests {
         let new_participants = all_participants.subset(2..5);
 
         // Clean non-participants (as done by CLEAN_TEE_STATUS after resharing)
-        tee_state.clean_non_participants(&new_participants);
+        tee_state.clean_non_participant_votes(&new_participants);
 
         // Stale votes must be removed
         assert_eq!(tee_state.votes.proposal_by_account.len(), 0);
@@ -1323,7 +1471,7 @@ mod tests {
 
         // New participant set excludes P0
         let new_participants = all_participants.subset(1..3);
-        tee_state.clean_non_participants(&new_participants);
+        tee_state.clean_non_participant_votes(&new_participants);
 
         assert_eq!(tee_state.launcher_votes.vote_by_account.len(), 0);
     }

--- a/crates/contract/src/v3_8_1_state.rs
+++ b/crates/contract/src/v3_8_1_state.rs
@@ -11,6 +11,8 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use near_mpc_contract_interface::types as dtos;
 use near_sdk::{env, near, store::LookupMap};
 
+use std::collections::BTreeMap;
+
 use crate::{
     errors::{Error, InvalidParameters},
     node_migrations::NodeMigrations,
@@ -21,7 +23,13 @@ use crate::{
     },
     state::ProtocolContractState,
     storage_keys::StorageKey,
-    tee::tee_state::TeeState,
+    tee::{
+        measurements::{AllowedMeasurements, MeasurementVotes},
+        proposal::{
+            AllowedDockerImageHashes, AllowedLauncherImages, CodeHashesVotes, LauncherHashVotes,
+        },
+        tee_state::{NodeAttestation, TeeState},
+    },
     update::ProposedUpdates,
     ForeignChainPolicyVotes, IntoInterfaceType, NodeForeignChainConfigurations,
 };
@@ -37,7 +45,7 @@ pub struct MpcContract {
     foreign_chain_policy: dtos::ForeignChainPolicy,
     foreign_chain_policy_votes: ForeignChainPolicyVotes,
     config: OldConfig,
-    tee_state: TeeState,
+    tee_state: OldTeeState,
     accept_requests: bool,
     node_migrations: NodeMigrations,
     stale_data: OldStaleData,
@@ -91,7 +99,7 @@ impl From<MpcContract> for crate::MpcContract {
             foreign_chain_policy,
             foreign_chain_policy_votes: value.foreign_chain_policy_votes,
             config: value.config.into(),
-            tee_state: value.tee_state,
+            tee_state: value.tee_state.into(),
             accept_requests: value.accept_requests,
             node_migrations: value.node_migrations,
             stale_data: crate::StaleData {
@@ -136,12 +144,42 @@ impl From<OldConfig> for crate::Config {
                 .return_ck_and_clean_state_on_success_call_tera_gas,
             fail_on_timeout_tera_gas: old.fail_on_timeout_tera_gas,
             clean_tee_status_tera_gas: old.clean_tee_status_tera_gas,
+            clean_invalid_attestations_tera_gas: defaults.clean_invalid_attestations_tera_gas,
             cleanup_orphaned_node_migrations_tera_gas: old
                 .cleanup_orphaned_node_migrations_tera_gas,
             remove_non_participant_update_votes_tera_gas: old
                 .remove_non_participant_update_votes_tera_gas,
             clean_foreign_chain_data_tera_gas: defaults.clean_foreign_chain_data_tera_gas,
         }
+    }
+}
+
+#[derive(Debug, Default, BorshSerialize, BorshDeserialize)]
+pub struct OldTeeState {
+    allowed_docker_image_hashes: AllowedDockerImageHashes,
+    allowed_launcher_images: AllowedLauncherImages,
+    votes: CodeHashesVotes,
+    launcher_votes: LauncherHashVotes,
+    stored_attestations: BTreeMap<near_sdk::PublicKey, NodeAttestation>,
+    allowed_measurements: AllowedMeasurements,
+    measurement_votes: MeasurementVotes,
+}
+
+impl From<OldTeeState> for TeeState {
+    fn from(old: OldTeeState) -> Self {
+        let mut new = TeeState {
+            allowed_docker_image_hashes: old.allowed_docker_image_hashes,
+            allowed_launcher_images: old.allowed_launcher_images,
+            votes: old.votes,
+            launcher_votes: old.launcher_votes,
+            stored_attestations: near_sdk::store::IterableMap::new(StorageKey::StoredAttestations),
+            allowed_measurements: old.allowed_measurements,
+            measurement_votes: old.measurement_votes,
+        };
+        for (tls_pk, attestation) in old.stored_attestations {
+            new.stored_attestations.insert(tls_pk, attestation);
+        }
+        new
     }
 }
 

--- a/crates/contract/tests/inprocess/attestation_submission.rs
+++ b/crates/contract/tests/inprocess/attestation_submission.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use mpc_contract::{
     crypto_shared::types::PublicKeyExtended,
     primitives::{
@@ -268,11 +270,12 @@ fn set_system_time(nano_seconds_since_unix_epoch: u64) {
         .build());
 }
 
-/// ** Test for TEE cleanup of non-participants** - Tests that `clean_tee_status()` removes
-/// TEE accounts for accounts that are no longer in the participant list.
-/// This simulates cleanup after participant removal (e.g., post-resharing).
+/// **Test that `clean_tee_status()` is vote-only** — attestations for non-participants
+/// remain in `stored_attestations` after the call. Attestation pruning is handled by the
+/// separate `clean_invalid_attestations` endpoint.
 #[test]
-fn test_clean_tee_status_removes_non_participants() {
+fn clean_tee_status__should_not_touch_attestations() {
+    // Given
     const PARTICIPANT_COUNT: usize = 2; // After resharing removed one participant
     const THRESHOLD: u64 = 2;
 
@@ -291,7 +294,7 @@ fn test_clean_tee_status_removes_non_participants() {
     let participant_nodes: Vec<NodeId> = setup
         .participants_list
         .iter()
-        .take(2)
+        .take(PARTICIPANT_COUNT)
         .cloned()
         .map(|(account_id, _, participant_info)| NodeId {
             account_id,
@@ -309,13 +312,14 @@ fn test_clean_tee_status_removes_non_participants() {
         tls_public_key: bogus_ed25519_near_public_key(),
         account_public_key: Some(bogus_ed25519_near_public_key()),
     };
-
     setup.submit_attestation_for_node(&removed_participant_node, valid_attestation);
 
     // Verify initial state: 2 participants but 3 TEE accounts
     const INITIAL_TEE_ACCOUNTS: usize = PARTICIPANT_COUNT + 1; // 2 current + 1 stale
-    let tee_accounts_before = setup.contract.get_tee_accounts().len();
-    assert_eq!(tee_accounts_before, INITIAL_TEE_ACCOUNTS);
+    assert_eq!(
+        setup.contract.get_tee_accounts().len(),
+        INITIAL_TEE_ACCOUNTS
+    );
 
     let running_state = match setup.contract.state() {
         ProtocolContractState::Running(r) => r,
@@ -324,24 +328,115 @@ fn test_clean_tee_status_removes_non_participants() {
     let participant_count = running_state.parameters.participants.participants.len();
     assert_eq!(participant_count, PARTICIPANT_COUNT);
 
-    // Test cleanup: should remove TEE account for non-participant
+    // When: clean_tee_status runs.
     setup.contract.clean_tee_status().unwrap();
 
-    // Verify cleanup worked: TEE accounts reduced to match participant count
-    let tee_accounts_after = setup.contract.get_tee_accounts().len();
-    assert_eq!(tee_accounts_after, PARTICIPANT_COUNT);
+    // Then: stored attestations are unchanged — only vote maps are touched by this endpoint.
+    assert_eq!(
+        setup.contract.get_tee_accounts().len(),
+        INITIAL_TEE_ACCOUNTS
+    );
 
     // State should remain Running with same participant count
     let final_running_state = match setup.contract.state() {
         ProtocolContractState::Running(r) => r,
         _ => panic!("Should still be Running after cleanup"),
     };
-    let final_participant_count = final_running_state
-        .parameters
-        .participants
-        .participants
-        .len();
-    assert_eq!(final_participant_count, PARTICIPANT_COUNT);
+    assert_eq!(
+        final_running_state
+            .parameters
+            .participants
+            .participants
+            .len(),
+        PARTICIPANT_COUNT
+    );
+}
+
+/// **Test that `clean_invalid_attestations()` prunes expired attestations end-to-end via
+/// the public endpoint**, including attestations that belong to current participants.
+/// Restores the cleanup-path coverage that lived in the old `clean_tee_status` test.
+#[test]
+fn clean_invalid_attestations__should_remove_expired_entries() {
+    // Given
+    const PARTICIPANT_COUNT: usize = 2;
+    const THRESHOLD: u64 = 2;
+    const EXPIRY_SECONDS: u64 = 1_000;
+    const NOW_NS: u64 = 5_000 * NANOS_IN_SECOND;
+
+    testing_env!(VMContextBuilder::new()
+        .attached_deposit(NearToken::from_near(1))
+        .block_timestamp(0)
+        .build());
+
+    let mut setup = TestSetupBuilder::new()
+        .with_partcipant_count(PARTICIPANT_COUNT)
+        .with_threshold(THRESHOLD)
+        .build();
+
+    let expiring_attestation = Attestation::Mock(MockAttestation::WithConstraints {
+        mpc_docker_image_hash: None,
+        launcher_docker_compose_hash: None,
+        expiry_timestamp_seconds: Some(EXPIRY_SECONDS),
+        expected_measurements: None,
+    });
+
+    // init_running seeds one mock `Valid` attestation per participant. Overwrite the
+    // first participant's entry with an expiring one, and add a brand-new entry for an
+    // outsider account.
+    let participant_node = {
+        let (account_id, _, info) = &setup.participants_list[0];
+        NodeId {
+            account_id: account_id.clone(),
+            tls_public_key: info.sign_pk.clone(),
+            account_public_key: Some(bogus_ed25519_near_public_key()),
+        }
+    };
+    setup.submit_attestation_for_node(&participant_node, expiring_attestation.clone());
+
+    let stale_node = NodeId {
+        account_id: "stale.near".parse().unwrap(),
+        tls_public_key: bogus_ed25519_near_public_key(),
+        account_public_key: Some(bogus_ed25519_near_public_key()),
+    };
+    setup.submit_attestation_for_node(&stale_node, expiring_attestation);
+
+    const EXPECTED_STORED: usize = PARTICIPANT_COUNT + 1; // original mocks + outsider entry
+    assert_eq!(setup.contract.get_tee_accounts().len(), EXPECTED_STORED);
+
+    // When: time advances past the expiry and cleanup runs with a generous max_scan.
+    set_system_time(NOW_NS);
+    let removed = setup.contract.clean_invalid_attestations(100).unwrap();
+
+    // Then: both entries with `expiry_timestamp_seconds` in the past are evicted; the
+    // second participant's un-overwritten `Valid` mock remains.
+    const EXPECTED_REMOVED: u32 = 2;
+    assert_eq!(removed, EXPECTED_REMOVED);
+    assert_eq!(
+        setup.contract.get_tee_accounts().len(),
+        EXPECTED_STORED - EXPECTED_REMOVED as usize
+    );
+}
+
+/// **Test that `clean_invalid_attestations()` rejects calls outside `Running` state** so
+/// that keygen / resharing flows (which may reference not-yet-activated attestations)
+/// aren't disrupted.
+#[test]
+fn clean_invalid_attestations__should_reject_when_not_running() {
+    // Given: contract sitting in Initializing state.
+    testing_env!(VMContextBuilder::new()
+        .attached_deposit(NearToken::from_near(1))
+        .block_timestamp(0)
+        .build());
+
+    let mut setup = TestSetupBuilder::new()
+        .with_contract_protocol_state(ContractProtocolState::Initializing)
+        .build();
+
+    // When: the cleanup endpoint is invoked.
+    let result = setup.contract.clean_invalid_attestations(100);
+
+    // Then: the call errors without mutating state.
+    assert_matches!(result, Err(_));
 }
 
 macro_rules! assert_allowed_docker_image_hashes {

--- a/crates/contract/tests/sandbox/contract_configuration.rs
+++ b/crates/contract/tests/sandbox/contract_configuration.rs
@@ -92,6 +92,7 @@ async fn contract_configuration_can_be_set_on_initialization() {
         return_ck_and_clean_state_on_success_call_tera_gas: Some(77),
         fail_on_timeout_tera_gas: Some(88),
         clean_tee_status_tera_gas: Some(99),
+        clean_invalid_attestations_tera_gas: Some(101),
         cleanup_orphaned_node_migrations_tera_gas: Some(11),
         remove_non_participant_update_votes_tera_gas: Some(12),
         clean_foreign_chain_data_tera_gas: Some(13),

--- a/crates/contract/tests/sandbox/tee.rs
+++ b/crates/contract/tests/sandbox/tee.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::sandbox::{
     common::{gen_accounts, init_env, submit_tee_attestations, SandboxTestSetup},
     utils::{
@@ -277,11 +279,13 @@ async fn test_clean_tee_status_denies_external_account_access() -> Result<()> {
     Ok(())
 }
 
-/// **TEE cleanup functionality** - Tests that the clean_tee_status contract method works correctly when called by the contract itself.
-/// Unlike the access control test above, this demonstrates the positive case: the contract can successfully clean up
-/// TEE data for accounts that are no longer participants. Uses the test method to populate initial TEE state.
+/// **`clean_tee_status` when called by the contract itself** — the call succeeds and the
+/// endpoint leaves `stored_attestations` untouched. Attestation pruning is handled by the
+/// separate `clean_invalid_attestations` endpoint.
 #[tokio::test]
-async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<()> {
+async fn clean_tee_status__should_succeed_when_contract_calls_itself_and_leave_attestations_alone(
+) -> Result<()> {
+    // Given
     let SandboxTestSetup {
         worker,
         contract,
@@ -308,12 +312,10 @@ async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<(
 
     // Verify we have TEE data for all accounts before cleanup
     let tee_participants_before = get_tee_accounts(&contract).await?;
-    assert_eq!(
-        tee_participants_before,
-        &additional_uids | &participant_uids
-    );
+    let expected_union = &additional_uids | &participant_uids;
+    assert_eq!(tee_participants_before, expected_union);
 
-    // Contract should be able to call clean_tee_status on itself
+    // When: contract calls clean_tee_status on itself.
     let result = contract
         .as_account()
         .call(contract.id(), method_names::CLEAN_TEE_STATUS)
@@ -323,10 +325,84 @@ async fn test_clean_tee_status_succeeds_when_contract_calls_itself() -> Result<(
 
     assert!(result.is_success());
 
-    // Verify cleanup worked: only current participants should have TEE data
+    // Then: stored attestations are unchanged — vote-only cleanup.
     let tee_participants_after = get_tee_accounts(&contract).await?;
-    assert_eq!(tee_participants_after.len(), mpc_signer_accounts.len());
-    assert_eq!(participant_uids, tee_participants_after);
+    assert_eq!(tee_participants_after, expected_union);
+
+    Ok(())
+}
+
+/// **`clean_invalid_attestations` end-to-end** — an attestation whose expiry has passed
+/// is evicted from `stored_attestations` when the endpoint is invoked. Restores the
+/// functional cleanup-path coverage previously asserted via `clean_tee_status`.
+#[tokio::test]
+async fn clean_invalid_attestations__should_remove_expired_entries() -> Result<()> {
+    // `verify()` at insert time rejects attestations that are already expired, so the
+    // expiring attestation is submitted with an expiry a few seconds in the future and
+    // the test then fast-forwards past it. 100 blocks is enough that the block
+    // timestamp reliably advances past a 5-second expiry window.
+    const ATTESTATION_EXPIRY_SECONDS: u64 = 5;
+    const BLOCKS_TO_FAST_FORWARD: u64 = 100;
+
+    // Given
+    let SandboxTestSetup {
+        worker,
+        contract,
+        mut mpc_signer_accounts,
+        ..
+    } = init_env(ALL_CURVES, PARTICIPANT_LEN).await;
+
+    // Submit a structurally-valid attestation for every current participant so those
+    // entries survive the sweep.
+    let participant_uids = {
+        let p: Participants =
+            (&assert_running_return_participants(&contract).await?).into_contract_type();
+        p.get_node_ids()
+    };
+    submit_tee_attestations(&contract, &mut mpc_signer_accounts, &participant_uids).await?;
+
+    // Submit an attestation from a non-participant that will expire shortly.
+    let (stale_accounts, _stale_participants) = gen_accounts(&worker, 1).await;
+    let stale_account = &stale_accounts[0];
+    let stale_tls_key: dtos::Ed25519PublicKey = p2p_tls_key().into();
+    let block_info = worker.view_block().await?;
+    let expiry_timestamp_seconds =
+        block_info.timestamp() / 1_000_000_000 + ATTESTATION_EXPIRY_SECONDS;
+    let expiring_attestation = Attestation::Mock(MockAttestation::WithConstraints {
+        mpc_docker_image_hash: None,
+        launcher_docker_compose_hash: None,
+        expiry_timestamp_seconds: Some(expiry_timestamp_seconds),
+        expected_measurements: None,
+    });
+    let submit_result = submit_participant_info(
+        stale_account,
+        &contract,
+        &expiring_attestation,
+        &stale_tls_key,
+    )
+    .await?;
+    assert!(submit_result.is_success());
+
+    let before_cleanup = get_tee_accounts(&contract).await?;
+    assert_eq!(before_cleanup.len(), participant_uids.len() + 1);
+
+    // Advance past the expiry.
+    worker.fast_forward(BLOCKS_TO_FAST_FORWARD).await?;
+
+    // When: any account calls `clean_invalid_attestations` with a scan budget large enough
+    // to cover every stored entry.
+    let scan_budget: u32 = (before_cleanup.len() as u32) + 1;
+    let result = contract
+        .as_account()
+        .call(contract.id(), method_names::CLEAN_INVALID_ATTESTATIONS)
+        .args_json(serde_json::json!({ "max_scan": scan_budget }))
+        .transact()
+        .await?;
+    assert!(result.is_success());
+
+    // Then: the expired entry is evicted while the valid participant entries remain.
+    let after_cleanup = get_tee_accounts(&contract).await?;
+    assert_eq!(after_cleanup, participant_uids);
 
     Ok(())
 }

--- a/crates/contract/tests/sandbox/tee_cleanup_after_resharing.rs
+++ b/crates/contract/tests/sandbox/tee_cleanup_after_resharing.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use crate::sandbox::{
     common::{gen_accounts, init_env, submit_tee_attestations, SandboxTestSetup},
     utils::{
@@ -19,18 +21,23 @@ use mpc_contract::{
     tee::tee_state::NodeId,
 };
 use near_mpc_contract_interface::types::{self as dtos, Attestation, MockAttestation};
+use test_utils::attestation::p2p_tls_key;
 
-/// Integration test that validates the complete E2E flow of TEE cleanup after resharing.
+/// Integration test that validates the end-to-end behavior of the TEE attestation store
+/// through a full resharing cycle.
 ///
 /// This test:
 /// 1. Sets up an initial participant set with TEE attestations
-/// 2. Adds additional TEE participants (simulating stale data)
+/// 2. Adds additional TEE attestations that do not belong to any participant
 /// 3. Initiates a new resharing with a subset of the original participants
 /// 4. Completes the resharing process by voting
-/// 5. Verifies that vote_reshared triggered cleanup of stale TEE attestations
-/// 6. Confirms only the new participant set remains in TEE state
+/// 5. Verifies that after `vote_reshared` the contract returns to `Running` with the reduced set
+/// 6. Confirms valid non-participant attestations remain in TEE storage: the post-resharing
+///    `clean_invalid_attestations` sweep only evicts entries failing re-verification
+///    (expired, stale docker/launcher/measurement whitelists), and mock `Valid`
+///    attestations never fail re-verification.
 #[tokio::test]
-async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
+async fn reshare__should_leave_valid_non_participant_attestations_in_storage() -> Result<()> {
     let SandboxTestSetup {
         worker,
         contract,
@@ -101,7 +108,7 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
             .expect("Failed to insert participant");
     }
 
-    let expected_tee_post_resharing = new_participants.get_node_ids();
+    let post_reshare_participants = new_participants.get_node_ids();
     let new_threshold_parameters = ThresholdParameters::new(
         new_participants,
         mpc_contract::primitives::thresholds::Threshold::new(threshold.0),
@@ -125,13 +132,108 @@ async fn test_tee_cleanup_after_full_resharing_flow() -> Result<()> {
 
     // Get current participants to compare
     let final_participants_node_ids = (&final_participants).into_contract_type().get_node_ids();
-    // Verify only the new participants remain
-    assert_eq!(final_participants_node_ids, expected_tee_post_resharing);
-    // Verify TEE participants are properly cleaned up
-    let tee_participants_after_cleanup = get_tee_accounts(&contract).await.unwrap();
+    // Verify only the new participants are current
+    assert_eq!(final_participants_node_ids, post_reshare_participants);
 
-    // Verify that the remaining TEE participants match exactly the new contract participants
-    assert_eq!(tee_participants_after_cleanup, expected_tee_post_resharing);
+    // Verify TEE storage: valid attestations previously stored are still present — the
+    // post-reshare `clean_invalid_attestations` sweep only evicts invalid / expired entries.
+    let tee_participants_after_reshare = get_tee_accounts(&contract).await.unwrap();
+    assert_eq!(tee_participants_after_reshare, expected_node_ids);
+
+    Ok(())
+}
+
+/// Companion to the test above: verifies that the post-resharing promise chain actually
+/// invokes `clean_invalid_attestations` and evicts entries that fail re-verification.
+/// `verify()` rejects attestations that are already expired at insert time, so this test
+/// submits an attestation with an expiry a few seconds in the future and then fast-forwards
+/// past it before triggering the reshare.
+#[tokio::test]
+async fn reshare__should_evict_expired_attestations_via_post_reshare_sweep() -> Result<()> {
+    const ATTESTATION_EXPIRY_SECONDS: u64 = 5;
+    const BLOCKS_TO_FAST_FORWARD: u64 = 100;
+
+    let SandboxTestSetup {
+        worker,
+        contract,
+        mpc_signer_accounts,
+        ..
+    } = init_env(&[Curve::Secp256k1], PARTICIPANT_LEN).await;
+
+    let initial_participants = assert_running_return_participants(&contract).await?;
+    let threshold = assert_running_return_threshold(&contract).await;
+    let initial_participants_count = initial_participants.participants.len();
+
+    // Insert an attestation from an outsider whose expiry is a few seconds away.
+    let (stale_accounts, _) = gen_accounts(&worker, 1).await;
+    let stale_account = &stale_accounts[0];
+    let stale_tls_key: dtos::Ed25519PublicKey = p2p_tls_key().into();
+    let block_info = worker.view_block().await?;
+    let expiry_timestamp_seconds =
+        block_info.timestamp() / 1_000_000_000 + ATTESTATION_EXPIRY_SECONDS;
+    let expiring_attestation = Attestation::Mock(MockAttestation::WithConstraints {
+        mpc_docker_image_hash: None,
+        launcher_docker_compose_hash: None,
+        expiry_timestamp_seconds: Some(expiry_timestamp_seconds),
+        expected_measurements: None,
+    });
+    let submit_result = submit_participant_info(
+        stale_account,
+        &contract,
+        &expiring_attestation,
+        &stale_tls_key,
+    )
+    .await?;
+    assert!(submit_result.is_success());
+    assert_eq!(
+        get_tee_accounts(&contract).await.unwrap().len(),
+        initial_participants_count + 1
+    );
+
+    // Advance past the expiry before triggering the reshare so that the post-reshare
+    // sweep sees the outsider entry as invalid.
+    worker.fast_forward(BLOCKS_TO_FAST_FORWARD).await?;
+
+    // Reshare to the threshold subset; this triggers the post-reshare cleanup promise.
+    let mut new_participants = Participants::new();
+    for (account_id, participant_id, participant_info) in initial_participants
+        .participants
+        .iter()
+        .take(threshold.0 as usize)
+    {
+        new_participants
+            .insert_with_id(
+                account_id.0.parse::<near_account_id::AccountId>().unwrap(),
+                mpc_contract::primitives::participants::ParticipantInfo {
+                    url: participant_info.url.clone(),
+                    sign_pk: participant_info.sign_pk.parse().unwrap(),
+                },
+                mpc_contract::primitives::participants::ParticipantId((*participant_id).into()),
+            )
+            .expect("Failed to insert participant");
+    }
+    let new_threshold_parameters = ThresholdParameters::new(
+        new_participants,
+        mpc_contract::primitives::thresholds::Threshold::new(threshold.0),
+    )
+    .unwrap();
+    do_resharing(
+        &mpc_signer_accounts[..threshold.0 as usize],
+        &contract,
+        new_threshold_parameters,
+        dtos::EpochId(6),
+    )
+    .await?;
+
+    // The expired outsider attestation is evicted by the `clean_invalid_attestations`
+    // promise spawned from `vote_reshared`.
+    let tee_accounts_after_reshare = get_tee_accounts(&contract).await.unwrap();
+    assert!(
+        !tee_accounts_after_reshare
+            .iter()
+            .any(|uid| uid.account_id == stale_account.id().clone()),
+        "expired outsider attestation should have been evicted by the post-reshare sweep",
+    );
 
     Ok(())
 }

--- a/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
+++ b/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
@@ -106,6 +106,7 @@ async fn test_propose_update_config() {
         return_ck_and_clean_state_on_success_call_tera_gas: 77,
         fail_on_timeout_tera_gas: 88,
         clean_tee_status_tera_gas: 99,
+        clean_invalid_attestations_tera_gas: 101,
         cleanup_orphaned_node_migrations_tera_gas: 11,
         remove_non_participant_update_votes_tera_gas: 12,
         clean_foreign_chain_data_tera_gas: 13,

--- a/crates/contract/tests/sandbox/utils/consts.rs
+++ b/crates/contract/tests/sandbox/utils/consts.rs
@@ -17,7 +17,7 @@ pub const ALL_CURVES: &[Curve; 4] = &[
 /// gas attachment; in practice, nodes usually attach the maximum available gas. For testing,
 /// we use this constant to attach a fixed amount to each call and detect if gas usage
 /// increases unexpectedly in the future.
-pub const GAS_FOR_VOTE_RESHARED: Gas = Gas::from_tgas(34);
+pub const GAS_FOR_VOTE_RESHARED: Gas = Gas::from_tgas(44);
 pub const GAS_FOR_VOTE_PK: Gas = Gas::from_tgas(22);
 pub const GAS_FOR_VOTE_CANCEL_KEYGEN: Gas = Gas::from_tgas(5);
 pub const GAS_FOR_VOTE_CANCEL_RESHARING: Gas = Gas::from_tgas(5);

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -84,8 +84,34 @@ expression: abi
         }
       },
       {
+        "name": "clean_invalid_attestations",
+        "doc": " Prunes up to `max_scan` stored attestations that fail re-verification (expired or\n referencing stale whitelists). Returns the number of entries removed. Callable by\n anyone while the protocol is in `Running`.",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "max_scan",
+              "type_schema": {
+                "type": "integer",
+                "format": "uint32",
+                "minimum": 0.0
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "integer",
+            "format": "uint32",
+            "minimum": 0.0
+          }
+        }
+      },
+      {
         "name": "clean_tee_status",
-        "doc": " Private endpoint to clean up TEE information for non-participants after resharing.\n This can only be called by the contract itself via a promise.",
+        "doc": " Private endpoint to drop votes cast by non-participants after resharing.\n Attestation cleanup is handled separately by [`MpcContract::clean_invalid_attestations`].",
         "kind": "call",
         "modifiers": [
           "private"
@@ -624,6 +650,10 @@ expression: abi
                       ],
                       [
                         "clean_tee_status_tera_gas",
+                        "u64"
+                      ],
+                      [
+                        "clean_invalid_attestations_tera_gas",
                         "u64"
                       ],
                       [
@@ -1832,6 +1862,7 @@ expression: abi
           "required": [
             "ckd_call_gas_attachment_requirement_tera_gas",
             "clean_foreign_chain_data_tera_gas",
+            "clean_invalid_attestations_tera_gas",
             "clean_tee_status_tera_gas",
             "cleanup_orphaned_node_migrations_tera_gas",
             "contract_upgrade_deposit_tera_gas",
@@ -1852,6 +1883,12 @@ expression: abi
             },
             "clean_foreign_chain_data_tera_gas": {
               "description": "Prepaid gas for a `clean_foreign_chain_data` call.",
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "clean_invalid_attestations_tera_gas": {
+              "description": "Prepaid gas for the reshare-time `clean_invalid_attestations` promise.",
               "type": "integer",
               "format": "uint64",
               "minimum": 0.0
@@ -2415,6 +2452,15 @@ expression: abi
             },
             "clean_foreign_chain_data_tera_gas": {
               "description": "Prepaid gas for a `clean_foreign_chain_data` call.",
+              "type": [
+                "integer",
+                "null"
+              ],
+              "format": "uint64",
+              "minimum": 0.0
+            },
+            "clean_invalid_attestations_tera_gas": {
+              "description": "Prepaid gas for the reshare-time `clean_invalid_attestations` promise.",
               "type": [
                 "integer",
                 "null"

--- a/crates/near-mpc-contract-interface/src/method_names.rs
+++ b/crates/near-mpc-contract-interface/src/method_names.rs
@@ -50,6 +50,7 @@ pub const START_NODE_MIGRATION: &str = "start_node_migration";
 pub const REGISTER_BACKUP_SERVICE: &str = "register_backup_service";
 pub const CLEANUP_ORPHANED_NODE_MIGRATIONS: &str = "cleanup_orphaned_node_migrations";
 pub const CLEAN_TEE_STATUS: &str = "clean_tee_status";
+pub const CLEAN_INVALID_ATTESTATIONS: &str = "clean_invalid_attestations";
 pub const CLEAN_FOREIGN_CHAIN_DATA: &str = "clean_foreign_chain_data";
 
 // Callbacks (used in promise_yield_create and indexed by the node)

--- a/crates/near-mpc-contract-interface/src/types/config.rs
+++ b/crates/near-mpc-contract-interface/src/types/config.rs
@@ -39,6 +39,8 @@ pub struct InitConfig {
     pub fail_on_timeout_tera_gas: Option<u64>,
     /// Prepaid gas for a `clean_tee_status` call.
     pub clean_tee_status_tera_gas: Option<u64>,
+    /// Prepaid gas for the reshare-time `clean_invalid_attestations` promise.
+    pub clean_invalid_attestations_tera_gas: Option<u64>,
     /// Prepaid gas for a `cleanup_orphaned_node_migrations` call.
     pub cleanup_orphaned_node_migrations_tera_gas: Option<u64>,
     /// Prepaid gas for a `remove_non_participant_update_votes` call.
@@ -85,6 +87,8 @@ pub struct Config {
     pub fail_on_timeout_tera_gas: u64,
     /// Prepaid gas for a `clean_tee_status` call.
     pub clean_tee_status_tera_gas: u64,
+    /// Prepaid gas for the reshare-time `clean_invalid_attestations` promise.
+    pub clean_invalid_attestations_tera_gas: u64,
     /// Prepaid gas for a `cleanup_orphaned_node_migrations` call.
     pub cleanup_orphaned_node_migrations_tera_gas: u64,
     /// Prepaid gas for a `remove_non_participant_update_votes` call.
@@ -110,6 +114,7 @@ mod tests {
             return_ck_and_clean_state_on_success_call_tera_gas: Some(7),
             fail_on_timeout_tera_gas: Some(2),
             clean_tee_status_tera_gas: Some(10),
+            clean_invalid_attestations_tera_gas: Some(10),
             cleanup_orphaned_node_migrations_tera_gas: Some(3),
             remove_non_participant_update_votes_tera_gas: Some(5),
             clean_foreign_chain_data_tera_gas: Some(5),
@@ -158,6 +163,7 @@ mod tests {
             return_ck_and_clean_state_on_success_call_tera_gas: None,
             fail_on_timeout_tera_gas: None,
             clean_tee_status_tera_gas: None,
+            clean_invalid_attestations_tera_gas: None,
             cleanup_orphaned_node_migrations_tera_gas: None,
             remove_non_participant_update_votes_tera_gas: None,
             clean_foreign_chain_data_tera_gas: None,

--- a/crates/test-utils/src/contract_types.rs
+++ b/crates/test-utils/src/contract_types.rs
@@ -10,8 +10,9 @@ pub fn dummy_config(value: u64) -> near_mpc_contract_interface::types::Config {
         return_ck_and_clean_state_on_success_call_tera_gas: value + 6,
         fail_on_timeout_tera_gas: value + 7,
         clean_tee_status_tera_gas: value + 8,
-        cleanup_orphaned_node_migrations_tera_gas: value + 9,
-        remove_non_participant_update_votes_tera_gas: value + 10,
-        clean_foreign_chain_data_tera_gas: value + 11,
+        clean_invalid_attestations_tera_gas: value + 9,
+        cleanup_orphaned_node_migrations_tera_gas: value + 10,
+        remove_non_participant_update_votes_tera_gas: value + 11,
+        clean_foreign_chain_data_tera_gas: value + 12,
     }
 }


### PR DESCRIPTION
Use lazy struct to store attestations, and add a public cleanup function to eventually delete expired attestations