### PR TITLE
chore(localnet): finish Python-launcher removal on localnet path

### DIFF
--- a/deployment/cvm-deployment/deploy-launcher.sh
+++ b/deployment/cvm-deployment/deploy-launcher.sh
@@ -132,6 +132,8 @@ required_env_vars=(
   "DISK"
   "USER_CONFIG_FILE_PATH"
   "DOCKER_COMPOSE_FILE_PATH"
+  "APP_NAME"
+  "OS_IMAGE"
 )
 
 echo $VMM_RPC

--- a/deployment/cvm-deployment/deploy-launcher.sh
+++ b/deployment/cvm-deployment/deploy-launcher.sh
@@ -130,6 +130,8 @@ required_env_vars=(
   "INTERNAL_AGENT_ADDR"
   "SEALING_KEY_TYPE"
   "DISK"
+  "USER_CONFIG_FILE_PATH"
+  "DOCKER_COMPOSE_FILE_PATH"
 )
 
 echo $VMM_RPC
@@ -138,6 +140,18 @@ for var in "${required_env_vars[@]}"; do
   if [ -z "${!var}" ]; then
     echo "Error: Required environment variable $var is not set."
     echo "Please edit the .env file and set a value for $var, then run this script again."
+    exit 1
+  fi
+done
+
+required_files=(
+  "USER_CONFIG_FILE_PATH"
+  "DOCKER_COMPOSE_FILE_PATH"
+)
+
+for var in "${required_files[@]}"; do
+  if [ ! -f "${!var}" ]; then
+    echo "Error: $var points to a non-existent file: ${!var}"
     exit 1
   fi
 done

--- a/deployment/localnet/tee/frodo.env
+++ b/deployment/localnet/tee/frodo.env
@@ -40,7 +40,7 @@ OS_IMAGE=dstack-dev-0.5.8
 # Path of the launcher docker_compose_file
 DOCKER_COMPOSE_FILE_PATH=launcher_docker_compose.yaml
 # Path of the user_config file
-USER_CONFIG_FILE_PATH=/tmp/$USER/frodo.conf
+USER_CONFIG_FILE_PATH=/tmp/$USER/frodo.toml
 
 # for testing use a smaller disk size 128G
 DISK=128G

--- a/deployment/localnet/tee/frodo.toml
+++ b/deployment/localnet/tee/frodo.toml
@@ -15,7 +15,10 @@ filter = "info"
 
 [mpc_node_config.near_init]
 chain_id = "mpc-localnet"
-boot_nodes = ""
+# 10.0.2.2 is the QEMU slirp gateway inside the CVM — routes to the host's
+# loopback so the CVM reaches `neard` regardless of whether it binds to
+# 0.0.0.0 or 127.0.0.1 (see #2949).
+boot_nodes = "ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
 genesis_path = "/app/localnet-genesis.json"
 download_genesis = false
 

--- a/deployment/localnet/tee/sam.env
+++ b/deployment/localnet/tee/sam.env
@@ -41,7 +41,7 @@ OS_IMAGE=dstack-dev-0.5.8
 # Path of the launcher docker_compose_file
 DOCKER_COMPOSE_FILE_PATH=launcher_docker_compose.yaml
 # Path of the user_config file
-USER_CONFIG_FILE_PATH=/tmp/$USER/sam.conf
+USER_CONFIG_FILE_PATH=/tmp/$USER/sam.toml
 
 # for testing use a smaller disk size 128G
 DISK=128G

--- a/deployment/localnet/tee/sam.toml
+++ b/deployment/localnet/tee/sam.toml
@@ -15,7 +15,10 @@ filter = "info"
 
 [mpc_node_config.near_init]
 chain_id = "mpc-localnet"
-boot_nodes = ""
+# 10.0.2.2 is the QEMU slirp gateway inside the CVM — routes to the host's
+# loopback so the CVM reaches `neard` regardless of whether it binds to
+# 0.0.0.0 or 127.0.0.1 (see #2949).
+boot_nodes = "ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
 genesis_path = "/app/localnet-genesis.json"
 download_genesis = false
 

--- a/docs/localnet/tee-localnet.md
+++ b/docs/localnet/tee-localnet.md
@@ -72,7 +72,7 @@ There are additional ports defined in frodo/sam.env, but you may change those to
 Those are the recommended configuration settings:
 you will need the following files:
 
-* [docker-compose.yml](../../deployment/cvm-deployment/launcher_docker_compose.yaml)
+* [launcher_docker_compose.yaml](../../deployment/cvm-deployment/launcher_docker_compose.yaml)
 * [frodo.toml](../../deployment/localnet/tee/frodo.toml) / [sam.toml](../../deployment/localnet/tee/sam.toml) 
 * [frodo.env](../../deployment/localnet/tee/frodo.env)/ [sam.env](../../deployment/localnet/tee/sam.env)    - if you use the deployment script
 
@@ -84,7 +84,7 @@ mkdir -p "/tmp/$USER"
 ```
 
 
-Concfiguratoin fields in `docker-compose.yml`
+Configuration fields in `launcher_docker_compose.yaml`
 
 Update to use the correct launcher image: (note - this must match the launcher template defined in the MPC contract)
 
@@ -228,10 +228,10 @@ near account add-key sam.test.near grant-function-call-access --allowance unlimi
 
 ### Initialize the MPC Contract
 
-Move to MPC root folder:
+Move back to the MPC repo root (we are currently in `deployment/cvm-deployment/`):
 
 ```bash
-cd ..
+cd ../..
 ```
 
 Initialize the MPC contract with the two participants (using the `P2P_KEY` values retrieved earlier).
@@ -259,7 +259,7 @@ near contract call-function as-read-only mpc-contract.test.near state json-args 
 ## Voting for a New MPC Docker Image Hash
 
 Before voting, the contract’s list of valid MPC image hashes is empty.  
-Therefor, node attestation submissions will fail.
+Therefore, node attestation submissions will fail.
 
 **Sample Error Log (Expected Before Voting):**
 
@@ -270,7 +270,7 @@ mpc_node::indexer::tx_sender: sending tx 381yxJCV5ByYo27oD8fX3BsGwnFpfGSzNCgDpfQ
 ERROR mpc_node::tee::remote_attestation: failed to submit attestation cause=attestation submission was not executed
 ```
 
-You can view the trasaction details by calling:
+You can view the transaction details by calling:
 
 ```bash
 near transaction view-status <transaction_Id> network-config mpc-localnet
@@ -404,7 +404,7 @@ In the MPC node's logs you should see something like this:
 
 ```bash
 near contract call-function as-transaction mpc-contract.test.near sign \
-  file-args docs/localnet/args/sign.json \
+  file-args docs/localnet/args/sign_ecdsa.json \
   prepaid-gas '300.0 Tgas' attached-deposit '100 yoctoNEAR' \
   sign-as frodo.test.near network-config mpc-localnet sign-with-keychain send
 ```
@@ -433,7 +433,7 @@ near contract call-function as-transaction mpc-contract.test.near sign \
 
 ## Troubleshooting
 
-You can view trascation using:
+You can view a transaction using:
 ```bash
 near transaction view-status <transaction_Id>  network-config mpc-localnet
 ```

--- a/docs/localnet/tee-localnet.md
+++ b/docs/localnet/tee-localnet.md
@@ -156,14 +156,16 @@ Example:
 export BASE_PATH="dstask base path"
 ```
 
-#### 4. Replace ${MACHINE_IP} inside the config files
-```bash
-envsubst '${MACHINE_IP}' < deployment/localnet/tee/frodo.toml > "/tmp/$USER/frodo.toml"
-```
+#### 4. Copy the TOML config files into place
+
+The `.env` files reference `/tmp/$USER/frodo.toml` and `/tmp/$USER/sam.toml` via `USER_CONFIG_FILE_PATH`, so the checked-in templates need to land there before deployment:
 
 ```bash
-envsubst '${MACHINE_IP}' < deployment/localnet/tee/sam.toml > "/tmp/$USER/sam.toml"
+cp deployment/localnet/tee/frodo.toml "/tmp/$USER/frodo.toml"
+cp deployment/localnet/tee/sam.toml   "/tmp/$USER/sam.toml"
 ```
+
+The TOML files already contain a working `boot_nodes` entry pointing at `10.0.2.2:24566` — the QEMU slirp gateway inside the CVM, which routes to the host's loopback and works regardless of whether `neard` binds to `0.0.0.0` or `127.0.0.1` on the host (see #2949). `MACHINE_IP` is still needed for externally-reachable endpoints (public-data, telemetry) and should remain set.
 
 #### 5. Start the Frodo MPC Node
 

--- a/docs/localnet/tee-localnet.md
+++ b/docs/localnet/tee-localnet.md
@@ -134,29 +134,9 @@ You can start the nodes **manually** as described in the Operator Guide, or you 
 
 Once all paths and configuration files (`*.env` and `*.toml`) are prepared, you can launch each MPC node (Frodo and Sam) using the `deploy-launcher.sh` helper script.
 
-#### 1. Move into the `deployment/cvm-deployment` Directory
+All commands below are run from the **repo root** unless noted otherwise.
 
-```bash
-cd deployment/cvm-deployment
-```
-
-#### 2. Ensure the Script Is Executable
-
-```bash
-chmod +x deploy-launcher.sh
-```
-#### 3. Set your env variables 
-
-Set your `BASE_PATH` to the DStack directory that contains the `vmm` folder.
-
-Example:  
-`$BASE_PATH/vmm/src/vmm-cli.py` should exist.
-
-```bash
-export BASE_PATH="dstask base path"
-```
-
-#### 4. Copy the TOML config files into place
+#### 1. Copy the TOML config files into place
 
 The `.env` files reference `/tmp/$USER/frodo.toml` and `/tmp/$USER/sam.toml` via `USER_CONFIG_FILE_PATH`, so the checked-in templates need to land there before deployment:
 
@@ -167,20 +147,43 @@ cp deployment/localnet/tee/sam.toml   "/tmp/$USER/sam.toml"
 
 The TOML files already contain a working `boot_nodes` entry pointing at `10.0.2.2:24566` — the QEMU slirp gateway inside the CVM, which routes to the host's loopback and works regardless of whether `neard` binds to `0.0.0.0` or `127.0.0.1` on the host (see #2949). `MACHINE_IP` is still needed for externally-reachable endpoints (public-data, telemetry) and should remain set.
 
+#### 2. Move into the `deployment/cvm-deployment` Directory
+
+```bash
+cd deployment/cvm-deployment
+```
+
+#### 3. Ensure the Script Is Executable
+
+```bash
+chmod +x deploy-launcher.sh
+```
+
+#### 4. Set your env variables
+
+Set your `BASE_PATH` to the DStack directory that contains the `vmm` folder.
+
+Example:
+`$BASE_PATH/vmm/src/vmm-cli.py` should exist.
+
+```bash
+export BASE_PATH="dstask base path"
+```
+
 #### 5. Start the Frodo MPC Node
 
 ```bash
 ./deploy-launcher.sh \
-  --env-file ../deployment/localnet/tee/frodo.env \
+  --env-file ../localnet/tee/frodo.env \
   --base-path $BASE_PATH \
   --python-exec python
 ```
 
-#### 5. Start the Sam MPC Node
+#### 6. Start the Sam MPC Node
 
 ```bash
 ./deploy-launcher.sh \
-  --env-file ../deployment/localnet/tee/sam.env \
+  --env-file ../localnet/tee/sam.env \
   --base-path $BASE_PATH \
   --python-exec python
 ```


### PR DESCRIPTION
Closes #2971.

## Summary

Localnet-side follow-ups that #2951 (Python-launcher removal) missed. 
plus some extra sanity checks. 

## Changes

- **Env files**: `deployment/localnet/tee/frodo.env`, `sam.env` — `USER_CONFIG_FILE_PATH` now points at `/tmp/\$USER/frodo.toml` (was `.conf`, which is deleted).
- **Boot nodes**: `deployment/localnet/tee/frodo.toml`, `sam.toml` — `boot_nodes` filled in with the slirp-gateway default (`10.0.2.2:24566`, matches the rust-launcher scripts after #2949). Was empty placeholder.
- **Guide**: `docs/localnet/tee-localnet.md` step 4 — `envsubst '\${MACHINE_IP}'` was a no-op (nothing to substitute in the `.toml`) and implicitly depended on a `.conf` file that no longer exists. Replaced with a plain `cp`, added a short note about the slirp-gateway bootnode choice.
- **deploy-launcher.sh validation**: validate that \`USER_CONFIG_FILE_PATH\` and \`DOCKER_COMPOSE_FILE_PATH\` are set and that the files actually exist. Without this, missing files (e.g. operator forgot to \`cp\` the \`.toml\` into place) would propagate to \`vmm-cli.py\` with an unclear error. Fail early with a clear message instead.

## Not in scope (tracked separately)

Testnet side is in #2952 — separate PR because it needs a new \`node.conf.testnet.toml.tpl\` template and testnet-infra testing.

## Test plan

- [ ] Fresh walk-through of \`docs/localnet/tee-localnet.md\` from step 1 produces a working 2-node cluster without any \`.conf\` intermediate files.
- [ ] Manual deploy via \`./deploy-launcher.sh --env-file …/frodo.env …\` now reads the \`.toml\` as its user config (no "file not found" on the old \`.conf\` path).
- [ ] Running \`deploy-launcher.sh\` without the \`.toml\` file in place fails early with a clear error message.