### PR TITLE
chore: Prepare for 3.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 
 This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## [3.9.1] - 2026-04-21
+
+### 🐛 Bug Fixes
+
+- : Cleanup of stored attestations (#2956)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- : Bump nearcore to 2.11.1 (#2978)
+
+
 ## [3.9.0] - 2026-04-16
 
 ### 🚀 Features
@@ -161,6 +173,8 @@ This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conv
 - [#2869](https://github.com/near/mpc/pull/2869)(@pbeza): Reduce contract WASM size and add CI size check (#2869)
 
 - [#2911](https://github.com/near/mpc/pull/2911)(@netrome): Make llm agents better at following our testing conventions (#2911)
+
+- [#2920](https://github.com/near/mpc/pull/2920)(@gilcu3): Prepare for 3.9.0 release  (#2920)
 
 
 ## [3.8.1] - 2026-04-07

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -964,7 +964,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -984,7 +984,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-cli"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "attestation",
@@ -1193,7 +1193,7 @@ dependencies = [
 
 [[package]]
 name = "backup-cli"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -1742,7 +1742,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chain-gateway"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",
@@ -1775,7 +1775,7 @@ dependencies = [
 
 [[package]]
 name = "chain-gateway-test-contract"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "borsh",
  "derive_more 2.1.1",
@@ -1836,7 +1836,7 @@ dependencies = [
 
 [[package]]
 name = "ckd-example-cli"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "blstrs",
@@ -2043,7 +2043,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "contract-history"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "bs58 0.5.1",
  "clap",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "backon",
@@ -3588,7 +3588,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-chain-inspector"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "derive_more 2.1.1",
@@ -3608,7 +3608,7 @@ dependencies = [
 
 [[package]]
 name = "foreign-chain-rpc-interfaces"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "derive_more 2.1.1",
  "ethereum-types",
@@ -4720,7 +4720,7 @@ dependencies = [
 
 [[package]]
 name = "include-measurements"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "attestation",
@@ -5165,7 +5165,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-interface"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "derive_more 2.1.1",
@@ -5595,7 +5595,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mpc-attestation"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "attestation",
@@ -5615,7 +5615,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5664,7 +5664,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-devnet"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "borsh",
@@ -5696,7 +5696,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5779,7 +5779,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node-config"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -5815,7 +5815,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-tls"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -7688,7 +7688,7 @@ dependencies = [
 
 [[package]]
 name = "node-types"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "mpc-attestation",
  "near-mpc-crypto-types",
@@ -10958,7 +10958,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tee-authority"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "anyhow",
  "backon",
@@ -10979,7 +10979,7 @@ dependencies = [
 
 [[package]]
 name = "tee-context"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "chain-gateway",
@@ -10996,7 +10996,7 @@ dependencies = [
 
 [[package]]
 name = "tee-launcher"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "backon",
@@ -11067,7 +11067,7 @@ dependencies = [
 
 [[package]]
 name = "test-migration-contract"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "borsh",
  "near-sdk",
@@ -11075,7 +11075,7 @@ dependencies = [
 
 [[package]]
 name = "test-parallel-contract"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "assert_matches",
  "blstrs",
@@ -11090,7 +11090,7 @@ dependencies = [
 
 [[package]]
 name = "test-port-allocator"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "named-lock",
  "rand 0.8.5",
@@ -11098,7 +11098,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "cargo-near-build",
  "hex",
@@ -11950,7 +11950,7 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "utilities"
-version = "3.9.0"
+version = "3.9.1"
 dependencies = [
  "near-account-id 1.1.4",
  "near-account-id 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.9.0"
+version = "3.9.1"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/near/mpc"

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -6,7 +6,7 @@ expression: abi
   "schema_version": "0.4.0",
   "metadata": {
     "name": "mpc-contract",
-    "version": "3.9.0",
+    "version": "3.9.1",
     "build": {
       "compiler": "rustc 1.86.0",
       "builder": "[CARGO_NEAR_BUILD_VERSION]"

--- a/third-party-licenses/licenses.html
+++ b/third-party-licenses/licenses.html
@@ -45,10 +45,10 @@
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
             <li><a href="#Apache-2.0">Apache License 2.0</a> (694)</li>
-            <li><a href="#MIT">MIT License</a> (213)</li>
+            <li><a href="#MIT">MIT License</a> (212)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
             <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (11)</li>
-            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (8)</li>
+            <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (7)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (7)</li>
             <li><a href="#ISC">ISC License</a> (7)</li>
             <li><a href="#Zlib">zlib License</a> (4)</li>
@@ -3933,33 +3933,33 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-async-derive 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-async 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-cache 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chain-primitives 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chunks-primitives 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-client-primitives 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-dyn-configs 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-external-storage 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-fmt 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-indexer-primitives 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-o11y 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-parameters 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-pool 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-stdx 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-store 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-time 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">node-runtime 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-async-derive 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-async 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-cache 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chain-primitives 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chunks-primitives 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-client-primitives 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-crypto 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-dyn-configs 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-external-storage 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-fmt 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-indexer-primitives 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-o11y 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-parameters 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-pool 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-stdx 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-store 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-time 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">node-runtime 2.11.1</a></li>
                     <li><a href=" https://github.com/near/near-account-id ">near-account-id 1.1.4</a></li>
                     <li><a href=" https://github.com/near/near-account-id ">near-account-id 2.6.0</a></li>
                     <li><a href=" https://github.com/near/nearcore ">near-chain-configs 0.28.0</a></li>
@@ -12296,22 +12296,22 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">nearcore 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chunks 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-client 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-epoch-manager 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-indexer 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-client-internal 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-mainnet-res 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-network 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-rosetta-rpc 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-telemetry 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-engine 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-types 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-vm 2.11.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-wallet-contract 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">nearcore 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chunks 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-client 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-epoch-manager 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-indexer 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-client-internal 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-mainnet-res 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-network 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-rosetta-rpc 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-telemetry 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-engine 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-types 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-vm 2.11.1</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-wallet-contract 2.11.1</a></li>
                     <li><a href=" https://github.com/ZcashFoundation/reddsa ">reddsa 0.5.1</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-consensus-any 1.0.42</a></li>
@@ -13180,7 +13180,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                 <h3 id="BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto-ed25519-batch 2.11.0</a></li>
                     <li><a href=" https://github.com/dalek-cryptography/curve25519-dalek/tree/main/ed25519-dalek ">ed25519-dalek 2.2.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017-2019 isis agora lovecruft. All rights reserved.
@@ -15581,35 +15580,6 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/zkcrypto/merlin ">merlin 3.0.0</a></li>
-                </ul>
-                <pre class="license-text">MIT License
-
-Copyright (c) 2018 Henry de Valence.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/bitvecto-rs/bitvec ">bitvec 1.0.1</a></li>
                     <li><a href=" https://github.com/myrrlyn/wyz ">wyz 0.5.1</a></li>
                 </ul>
@@ -15848,7 +15818,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler-singlepass 2.11.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler-singlepass 2.11.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -16260,39 +16230,39 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/attestation ">attestation 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/attestation-cli ">attestation-cli 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/backup-cli ">backup-cli 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/chain-gateway ">chain-gateway 3.9.0</a></li>
-                    <li><a href=" https://github.com/near/mpc ">chain-gateway-test-contract 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/ckd-example-cli ">ckd-example-cli 3.9.0</a></li>
-                    <li><a href=" https://github.com/near/mpc ">mpc-contract 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/contract-history ">contract-history 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-devnet ">mpc-devnet 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/e2e-tests ">e2e-tests 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/foreign-chain-inspector ">foreign-chain-inspector 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/foreign-chain-rpc-interfaces ">foreign-chain-rpc-interfaces 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/include-measurements ">include-measurements 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/launcher-interface ">launcher-interface 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-attestation ">mpc-attestation 3.9.0</a></li>
+                    <li><a href=" https://crates.io/crates/attestation ">attestation 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/attestation-cli ">attestation-cli 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/backup-cli ">backup-cli 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/chain-gateway ">chain-gateway 3.9.1</a></li>
+                    <li><a href=" https://github.com/near/mpc ">chain-gateway-test-contract 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/ckd-example-cli ">ckd-example-cli 3.9.1</a></li>
+                    <li><a href=" https://github.com/near/mpc ">mpc-contract 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/contract-history ">contract-history 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-devnet ">mpc-devnet 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/e2e-tests ">e2e-tests 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/foreign-chain-inspector ">foreign-chain-inspector 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/foreign-chain-rpc-interfaces ">foreign-chain-rpc-interfaces 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/include-measurements ">include-measurements 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/launcher-interface ">launcher-interface 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-attestation ">mpc-attestation 3.9.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-bounded-collections 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-contract-interface 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-crypto-types 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-sdk 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-signature-verifier 0.0.1</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-node ">mpc-node 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-node-config ">mpc-node-config 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/node-types ">node-types 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-primitives ">mpc-primitives 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/tee-authority ">tee-authority 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/tee-context ">tee-context 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/tee-launcher ">tee-launcher 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-migration-contract ">test-migration-contract 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-parallel-contract ">test-parallel-contract 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-port-allocator ">test-port-allocator 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-utils ">test-utils 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-tls ">mpc-tls 3.9.0</a></li>
-                    <li><a href=" https://crates.io/crates/utilities ">utilities 3.9.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-node ">mpc-node 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-node-config ">mpc-node-config 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/node-types ">node-types 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-primitives ">mpc-primitives 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/tee-authority ">tee-authority 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/tee-context ">tee-context 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/tee-launcher ">tee-launcher 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/test-migration-contract ">test-migration-contract 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/test-parallel-contract ">test-parallel-contract 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/test-port-allocator ">test-port-allocator 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/test-utils ">test-utils 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-tls ">mpc-tls 3.9.1</a></li>
+                    <li><a href=" https://crates.io/crates/utilities ">utilities 3.9.1</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">aws-creds 0.30.0</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">aws-region 0.25.5</a></li>
                     <li><a href=" https://github.com/oconnor663/blake2_simd ">blake2b_simd 1.0.4</a></li>


### PR DESCRIPTION
I'll release directly from `release/v3.9.1` - just putting this PR up to show the diff.