### PR TITLE
perf(contract): enable dcap-qvl `json-core` feature to slim wasm

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,7 +1934,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2597,7 +2597,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "dcap-qvl"
 version = "0.4.0"
-source = "git+https://github.com/pbeza/dcap-qvl?rev=a51048ca6f63b5080be8f3cc335ff9024fc353ac#a51048ca6f63b5080be8f3cc335ff9024fc353ac"
+source = "git+https://github.com/Phala-Network/dcap-qvl?rev=9c21fa520feb5585281554f962a93a384baa2d0e#9c21fa520feb5585281554f962a93a384baa2d0e"
 dependencies = [
  "anyhow",
  "asn1_der",
@@ -2919,7 +2919,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3334,7 +3334,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4514,7 +4514,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4865,7 +4865,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7929,7 +7929,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9077,7 +9077,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -9115,9 +9115,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -9974,7 +9974,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10072,7 +10072,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11241,7 +11241,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -12823,7 +12823,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2597,8 +2597,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 [[package]]
 name = "dcap-qvl"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cd80641b0f720cfa2dccadba84c80f11873b98f4d32fbb6f78c230b4a35f3a4"
+source = "git+https://github.com/pbeza/dcap-qvl?rev=a51048ca6f63b5080be8f3cc335ff9024fc353ac#a51048ca6f63b5080be8f3cc335ff9024fc353ac"
 dependencies = [
  "anyhow",
  "asn1_der",
@@ -2622,6 +2621,7 @@ dependencies = [
  "scale-info",
  "serde",
  "serde-human-bytes",
+ "serde-json-core",
  "serde_json",
  "tracing",
  "urlencoding",
@@ -10381,6 +10381,16 @@ checksum = "6a091af6294712930d01e375cce513e4ac416f823e033e8991ec4e5d6e6ef4c0"
 dependencies = [
  "base64 0.13.1",
  "hex",
+ "serde",
+]
+
+[[package]]
+name = "serde-json-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b81787e655bd59cecadc91f7b6b8651330b2be6c33246039a65e5cd6f4e0828"
+dependencies = [
+ "ryu",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,12 +94,12 @@ curve25519-dalek = { version = "4.1.3", features = [
     "group",
     "serde",
 ], default-features = false }
-# Temporarily pinned to the `pbeza/dcap-qvl` fork's `perf/json-core-feature`
-# branch for the `json-core` opt-in feature. Tracks
-# <https://github.com/Phala-Network/dcap-qvl/pull/153>; once that PR merges
-# and a new `dcap-qvl` release is cut, swap the git pin back to a crates.io
-# `version = "X.Y.Z"` and drop the matching `deny.toml` allow-git entry.
-dcap-qvl = { git = "https://github.com/pbeza/dcap-qvl", rev = "a51048ca6f63b5080be8f3cc335ff9024fc353ac", default-features = false, features = [
+# TODO(#3008): swap this git pin for a crates.io `version = "X.Y.Z"` and
+# drop the matching `deny.toml` allow-git entry once upstream cuts a release
+# containing <https://github.com/Phala-Network/dcap-qvl/pull/153> (merged as
+# commit 9c21fa52 on 2026-04-24). Until then, we pin to upstream master at
+# that merge commit so that we can enable the `json-core` opt-in feature.
+dcap-qvl = { git = "https://github.com/Phala-Network/dcap-qvl", rev = "9c21fa520feb5585281554f962a93a384baa2d0e", default-features = false, features = [
     "contract",
     "borsh",
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -94,12 +94,18 @@ curve25519-dalek = { version = "4.1.3", features = [
     "group",
     "serde",
 ], default-features = false }
-dcap-qvl = { version = "0.4.0", default-features = false, features = [
+# Temporarily pinned to the `pbeza/dcap-qvl` fork's `perf/json-core-feature`
+# branch for the `json-core` opt-in feature. Tracks
+# <https://github.com/Phala-Network/dcap-qvl/pull/153>; once that PR merges
+# and a new `dcap-qvl` release is cut, swap the git pin back to a crates.io
+# `version = "X.Y.Z"` and drop the matching `deny.toml` allow-git entry.
+dcap-qvl = { git = "https://github.com/pbeza/dcap-qvl", rev = "a51048ca6f63b5080be8f3cc335ff9024fc353ac", default-features = false, features = [
     "contract",
     "borsh",
     "std",
     "ring",
     "default-x509",
+    "json-core",
 ] }
 derive_more = { version = "2.1.1", features = [
     "as_ref",

--- a/deny.toml
+++ b/deny.toml
@@ -48,4 +48,8 @@ unknown-git = "deny"
 allow-git = [
   "https://github.com/near/nearcore",
   "https://github.com/near/reddsa",
+  # Temporary: pinned at a fork of dcap-qvl while
+  # <https://github.com/Phala-Network/dcap-qvl/pull/153> is in review.
+  # Drop this entry when swapping back to crates.io.
+  "https://github.com/pbeza/dcap-qvl",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -48,8 +48,7 @@ unknown-git = "deny"
 allow-git = [
   "https://github.com/near/nearcore",
   "https://github.com/near/reddsa",
-  # Temporary: pinned at a fork of dcap-qvl while
-  # <https://github.com/Phala-Network/dcap-qvl/pull/153> is in review.
-  # Drop this entry when swapping back to crates.io.
-  "https://github.com/pbeza/dcap-qvl",
+  # TODO(#3008): drop this entry when swapping back to a crates.io `dcap-qvl`
+  # release containing <https://github.com/Phala-Network/dcap-qvl/pull/153>.
+  "https://github.com/Phala-Network/dcap-qvl",
 ]


### PR DESCRIPTION
## Summary

Opt into the new `json-core` Cargo feature in `dcap-qvl` ([Phala-Network/dcap-qvl#153](https://github.com/Phala-Network/dcap-qvl/pull/153)), which swaps TCB Info / QE Identity JSON parsing from `serde_json` to `serde-json-core` inside dcap-qvl's `verify.rs`. Saves ~8 KiB of `release-contract` wasm for free — no behaviour or API change, the feature is a pure internal parser swap in dcap-qvl's verify path.

## Measurement

`cargo near build non-reproducible-wasm --features abi --profile=release-contract --manifest-path crates/contract/Cargo.toml --locked` → `wasm-opt -O -Oz`:

| Build | bytes | KiB |
| --- | --- | --- |
| `origin/main` (vanilla `dcap-qvl = "0.4.0"`) | 1,470,904 | 1,436.43 |
| this branch (`json-core` feature on) | 1,462,268 | 1,427.99 |
| **delta** | **−8,636** | **−8.43** |

Also measured via the direct `cargo build -p mpc-contract --target wasm32-unknown-unknown --profile=release-contract` + `wasm-opt`: **−7,925 B (−7.74 KiB)**. Both paths give a consistent sub-10 KiB saving.

Byte-reproducible on a second build.

## How the feature works

[dcap-qvl PR #153](https://github.com/Phala-Network/dcap-qvl/pull/153) adds an opt-in `json-core` Cargo feature that routes the two `verify.rs` JSON parse sites through `serde_json_core::from_str` instead of `serde_json::from_str`. The feature is strictly opt-in; default `dcap-qvl` builds are unaffected. Trailing-non-whitespace rejection was added in a follow-up commit to match `serde_json`'s strictness exactly, so the feature is behaviour-equivalent for well-formed Intel collateral.

`serde-json-core` does not support `deserialize_any` or `deserialize_bytes`, but neither is exercised by `TcbInfo` / `QeIdentity` (no `#[serde(untagged)]` / `flatten` / `serde_json::Value` fields; `#[serde(with = "serde_bytes")]` fields route via `serde-human-bytes` through `deserialize_str` on human-readable JSON). The dcap-qvl test suite (40 tests across `verify::tests`, `tests/verify_quote.rs`, `tests/config_conformance.rs`) passes under both feature variants — I ran both matrices locally.

## Temporary git pin

Upstream `Phala-Network/dcap-qvl#153` merged into `master` on 2026-04-24 as commit [`9c21fa52`](https://github.com/Phala-Network/dcap-qvl/commit/9c21fa520feb5585281554f962a93a384baa2d0e). No upstream release has been cut yet (latest crates.io release is `v0.4.0`, pre-#153), so this PR temporarily pins the workspace dependency to `Phala-Network/dcap-qvl` at that merge commit, with a matching `allow-git` entry in `deny.toml`. A `TODO(#3008)` comment is left next to both.

**Follow-up tracked in #3008** — swap the git pin back to a crates.io version and drop the `deny.toml` allow-git entry once upstream cuts a release containing #153.

## Test plan

- [x] `cargo build -p mpc-contract --target wasm32-unknown-unknown --profile=release-contract` — clean.
- [x] `cargo near build non-reproducible-wasm ...` — produces a smaller wasm than the `origin/main` baseline.
- [x] `cargo test -p attestation -p mpc-attestation` — passes.
- [x] `cargo deny check` — clean (license/advisories/bans/sources).
- [x] Local two-rebuild byte-reproducibility check — wasm is byte-identical on rebuild.
- [ ] CI green.