### PR TITLE
docs: tell agents to verify docs stay aligned with code changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,3 +124,7 @@ Do not suggest using `checked_add`, `checked_mul`, `checked_sub`, `saturating_ad
 - **Integration test**: Rust test in `/tests` folder
 - **System test**: pytest in `/pytest` folder
 
+## Documentation alignment
+
+When authoring or reviewing a change that renames, removes, or reshapes code (types, methods, contract entry points, config fields, protocol state, architecture), verify that the surrounding documentation still describes the new behavior. This covers Markdown under `docs/` and any referenced templates, as well as Rust doc comments (`///`, `//!`) on and near the changed items — names, parameters, invariants, and examples in doc comments drift just as easily as prose docs. Design documents (`docs/design/`, `docs/*-design.md`) that describe a superseded design must be either updated, removed, or prominently marked as outdated (e.g. a "Status: superseded by #NNNN" banner at the top) — never left silently stale. If you find stale passages, flag them with `file:line` and, when authoring, fix them in the same PR. Doc drift is a review-blocking issue, not a follow-up.
+


### PR DESCRIPTION
## Summary

- Adds a "Documentation alignment" section to `AGENTS.md` (aliased as `CLAUDE.md`) so code agents authoring or reviewing a PR verify that the surrounding documentation still describes the new behavior when code is renamed, removed, or reshaped.
- Scope covers Markdown under `docs/` and any referenced templates, Rust doc comments (`///`, `//!`) on and near the changed items, and design documents — with the explicit rule that superseded design docs must be updated, removed, or prominently marked outdated rather than silently left stale.
- Motivated by a reviewer note on #3001 (https://github.com/near/mpc/pull/3001#pullrequestreview-4164373999) where `docs/foreign-chain-transactions.md` still described the removed unanimous-voting mechanism and deleted types.

Closes #3012

## Test plan

- Docs-only change; no build or test impact.
- Visually confirm that `AGENTS.md` / `CLAUDE.md` ends with the new "Documentation alignment" section at the same heading level as the surrounding sections.