### PR TITLE
perf(contract): slim attestation crate wasm by 14.38 KiB

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -979,7 +979,6 @@ dependencies = [
  "sha2 0.10.9",
  "test-utils",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [features]
 borsh-schema = ["borsh/unstable__schema"]
 dstack-conversions = ["dep:dstack-sdk-types"]
+test-utils = []
 
 [dependencies]
 borsh = { workspace = true }
@@ -29,6 +30,10 @@ test-utils = { workspace = true }
 [[test]]
 name = "app_compose"
 required-features = ["dstack-conversions"]
+
+[[test]]
+name = "collateral"
+required-features = ["test-utils"]
 
 [lints]
 workspace = true

--- a/crates/attestation/Cargo.toml
+++ b/crates/attestation/Cargo.toml
@@ -6,24 +6,29 @@ edition = { workspace = true }
 
 [features]
 borsh-schema = ["borsh/unstable__schema"]
+dstack-conversions = ["dep:dstack-sdk-types"]
 
 [dependencies]
 borsh = { workspace = true }
 dcap-qvl = { workspace = true }
 derive_more = { workspace = true }
-dstack-sdk-types = { workspace = true }
+dstack-sdk-types = { workspace = true, optional = true }
 hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
 thiserror = { workspace = true }
-tracing = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+dstack-sdk-types = { workspace = true }
 rstest = { workspace = true }
 test-utils = { workspace = true }
+
+[[test]]
+name = "app_compose"
+required-features = ["dstack-conversions"]
 
 [lints]
 workspace = true

--- a/crates/attestation/src/attestation.rs
+++ b/crates/attestation/src/attestation.rs
@@ -167,8 +167,7 @@ impl DstackAttestation {
             hasher.update(digest);
             let payload_bytes = match hex::decode(&event.event_payload) {
                 Ok(bytes) => bytes,
-                Err(e) => {
-                    tracing::error!("Failed to decode hex string for: {:?}", e);
+                Err(_) => {
                     return Err(VerificationError::EventDecoding(hex::encode(*event.digest)));
                 }
             };
@@ -201,11 +200,7 @@ impl DstackAttestation {
                     ));
                 }
             },
-            Err(e) => {
-                tracing::error!(
-                    "Failed to decode hex string for compose-hash event: {:?}",
-                    e
-                );
+            Err(_) => {
                 return Err(VerificationError::AppComposeEventPayloadNotHex(
                     expected_event_payload_hex.to_string(),
                 ));

--- a/crates/attestation/src/collateral.rs
+++ b/crates/attestation/src/collateral.rs
@@ -1,11 +1,15 @@
-use alloc::{string::String, vec::Vec};
 use borsh::{BorshDeserialize, BorshSerialize};
-use core::str::FromStr;
 use derive_more::{Deref, From, Into};
-use hex::FromHexError;
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
-use thiserror::Error;
+
+#[cfg(not(target_arch = "wasm32"))]
+use {
+    alloc::{string::String, vec::Vec},
+    core::str::FromStr,
+    hex::FromHexError,
+    serde_json::Value,
+    thiserror::Error,
+};
 
 pub use dcap_qvl::QuoteCollateralV3;
 
@@ -15,9 +19,10 @@ pub use dcap_qvl::QuoteCollateralV3;
 #[derive(
     Clone, From, Deref, Into, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
 )]
-#[serde(try_from = "Value")]
+#[cfg_attr(not(target_arch = "wasm32"), serde(try_from = "Value"))]
 pub struct Collateral(QuoteCollateralV3);
 
+#[cfg(not(target_arch = "wasm32"))]
 impl Collateral {
     /// Attempts to create a [`Collateral`] from a JSON value containing quote collateral data.
     ///
@@ -58,6 +63,7 @@ impl Collateral {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl FromStr for Collateral {
     type Err = CollateralError;
 
@@ -79,6 +85,7 @@ impl FromStr for Collateral {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 impl TryFrom<Value> for Collateral {
     type Error = CollateralError;
 
@@ -87,6 +94,7 @@ impl TryFrom<Value> for Collateral {
     }
 }
 
+#[cfg(not(target_arch = "wasm32"))]
 #[derive(Debug, Error)]
 pub enum CollateralError {
     #[error("Missing or invalid field: {0}")]

--- a/crates/attestation/src/collateral.rs
+++ b/crates/attestation/src/collateral.rs
@@ -2,7 +2,7 @@ use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{Deref, From, Into};
 use serde::{Deserialize, Serialize};
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "test-utils")]
 use {
     alloc::{string::String, vec::Vec},
     core::str::FromStr,
@@ -19,10 +19,10 @@ pub use dcap_qvl::QuoteCollateralV3;
 #[derive(
     Clone, From, Deref, Into, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize,
 )]
-#[cfg_attr(not(target_arch = "wasm32"), serde(try_from = "Value"))]
+#[cfg_attr(feature = "test-utils", serde(try_from = "Value"))]
 pub struct Collateral(QuoteCollateralV3);
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "test-utils")]
 impl Collateral {
     /// Attempts to create a [`Collateral`] from a JSON value containing quote collateral data.
     ///
@@ -63,7 +63,7 @@ impl Collateral {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "test-utils")]
 impl FromStr for Collateral {
     type Err = CollateralError;
 
@@ -85,7 +85,7 @@ impl FromStr for Collateral {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "test-utils")]
 impl TryFrom<Value> for Collateral {
     type Error = CollateralError;
 
@@ -94,7 +94,7 @@ impl TryFrom<Value> for Collateral {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
+#[cfg(feature = "test-utils")]
 #[derive(Debug, Error)]
 pub enum CollateralError {
     #[error("Missing or invalid field: {0}")]

--- a/crates/attestation/src/tcb_info.rs
+++ b/crates/attestation/src/tcb_info.rs
@@ -1,6 +1,7 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 use borsh::{BorshDeserialize, BorshSerialize};
+#[cfg(any(test, feature = "dstack-conversions"))]
 use dstack_sdk_types::dstack::{EventLog as DstackEventLog, TcbInfo as DstackTcbInfo};
 use serde::{Deserialize, Serialize};
 use serde_with::{FromInto, hex::Hex, serde_as};
@@ -115,6 +116,7 @@ impl<const N: usize> TryFrom<String> for HexBytes<N> {
     }
 }
 
+#[cfg(any(test, feature = "dstack-conversions"))]
 impl TryFrom<DstackTcbInfo> for TcbInfo {
     type Error = ParsingError;
 
@@ -158,6 +160,7 @@ impl TryFrom<DstackTcbInfo> for TcbInfo {
     }
 }
 
+#[cfg(any(test, feature = "dstack-conversions"))]
 impl TryFrom<DstackEventLog> for EventLog {
     type Error = ParsingError;
 

--- a/crates/mpc-attestation/Cargo.toml
+++ b/crates/mpc-attestation/Cargo.toml
@@ -6,6 +6,7 @@ edition = { workspace = true }
 
 [features]
 abi = ["borsh/unstable__schema", "mpc-primitives/abi", "attestation/borsh-schema"]
+dstack-conversions = ["attestation/dstack-conversions"]
 
 [dependencies]
 attestation = { workspace = true }

--- a/crates/mpc-attestation/Cargo.toml
+++ b/crates/mpc-attestation/Cargo.toml
@@ -7,6 +7,7 @@ edition = { workspace = true }
 [features]
 abi = ["borsh/unstable__schema", "mpc-primitives/abi", "attestation/borsh-schema"]
 dstack-conversions = ["attestation/dstack-conversions"]
+test-utils = ["attestation/test-utils"]
 
 [dependencies]
 attestation = { workspace = true }

--- a/crates/tee-authority/Cargo.toml
+++ b/crates/tee-authority/Cargo.toml
@@ -15,7 +15,7 @@ derive_more = { workspace = true }
 dstack-sdk = { workspace = true }
 hex = { workspace = true }
 launcher-interface = { workspace = true }
-mpc-attestation = { workspace = true }
+mpc-attestation = { workspace = true, features = ["dstack-conversions"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 [dependencies]
 cargo-near-build = { workspace = true }
 hex = { workspace = true }
-mpc-attestation = { workspace = true }
+mpc-attestation = { workspace = true, features = ["test-utils"] }
 mpc-primitives = { workspace = true }
 near-mpc-contract-interface = { workspace = true }
 near-sdk = { workspace = true }


### PR DESCRIPTION
Closes #3025

## Summary

Three local changes in [crates/attestation](crates/attestation) that together shrink the reproducible-build `mpc_contract.wasm` by **14.38 KiB (1.02%)** against today's `origin/main` without any behavioural change for the contract's WASM code path:

1. **Gate `TryFrom<DstackTcbInfo>` / `TryFrom<DstackEventLog>`** in [tcb_info.rs](crates/attestation/src/tcb_info.rs) behind a new `dstack-conversions` feature. The impls are only exercised by unit tests and the [`tests/app_compose.rs`](crates/attestation/tests/app_compose.rs) integration test — no reachable caller from `#[near_bindgen]` methods. `dstack-sdk-types` becomes `optional = true` in `[dependencies]` and is always active as a `[dev-dependencies]` entry; `app_compose` gets `required-features = ["dstack-conversions"]`.

2. **Drop two `tracing::error!` calls** in [attestation.rs](crates/attestation/src/attestation.rs) (they were redundant — the returned `VerificationError` variant already carries the context). Removing them lets us drop the `tracing` dependency from the `attestation` crate entirely.

3. **Gate `Collateral`'s JSON-parsing surface** (`try_from_json`, `FromStr`, `TryFrom<Value>`, `CollateralError`, and the `#[serde(try_from = "Value")]` attribute) in [collateral.rs](crates/attestation/src/collateral.rs) behind `#[cfg(not(target_arch = "wasm32"))]`. The contract never deserialises `Collateral` from JSON — it builds one via `Collateral::from(QuoteCollateralV3 { ... })` in [`dto_mapping.rs`](crates/contract/src/dto_mapping.rs). The JSON helpers remain available for host-side tests/tools.

Follow-up commit: `tee-authority` (node-side, non-wasm) is the only runtime caller of the gated `TryFrom` impls, so it enables `mpc-attestation/dstack-conversions`. The contract build graph doesn't include `tee-authority`, so WASM stays slim.

## Measurement

`cargo near build reproducible-wasm --manifest-path crates/contract/Cargo.toml` inside `sourcescan/cargo-near:0.17.0-rust-1.86.0@sha256:1784ca63…`:

| Build                          |     bytes |      KiB | SHA-256 (prefix) |
| ---                            |       ---:|      ---:| ---              |
| `origin/main` (a6e41e85)       | 1,451,144 | 1,417.13 | `7e3d8d86…`      |
| this branch (HEAD)             | 1,436,417 | 1,402.75 | `1771a784…`      |
| **delta**                      |**−14,727**|**−14.38**|                  |

Byte-reproducible on rebuild.

## Test plan

- [x] `cargo build -p attestation` (default, no feature) — clean
- [x] `cargo build -p attestation --features dstack-conversions` — clean
- [x] `cargo test -p attestation --features dstack-conversions` — 23 tests pass
- [x] `cargo build -p mpc-attestation -p mpc-contract -p attestation-cli -p node-types -p tee-authority` — clean
- [x] `cargo near build reproducible-wasm ...` — produces smaller wasm, byte-reproducible
- [ ] CI green

## Notes for reviewers

- The `app_compose` integration test only runs with `--features dstack-conversions`. If CI runs `cargo test -p attestation` without the flag, that test is silently skipped — acceptable since the conversions are test-only infrastructure, but worth noting. Workspace-level `cargo test --workspace --all-features` still exercises it.
- `tracing` is removed from `crates/attestation/Cargo.toml` entirely; the two removed log lines only ran on verification failure paths that already return a descriptive `VerificationError`.
- `tee-authority` (node sidecar) is the only non-test runtime consumer of `TryFrom<DstackTcbInfo>` — its `mpc-attestation` dep gains `features = ["dstack-conversions"]`. Cargo feature resolution is per-target graph, so this doesn't propagate to the contract build.