### PR TITLE
docs: recommend unlimited function-call allowance for the MPC operator account

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -918,6 +918,23 @@ This section shows how to add the MPC node's public key (from the previous secti
 
   > **Note:** This must be a single comma-separated string with no spaces or newlines.
 
+* **`ALLOWANCE`** → The total NEAR budget the function-call key can spend on
+  gas across all calls signed with it. **Recommended: `unlimited`** (or a very
+  large value, e.g. `'1000 NEAR'`).
+
+  > **Why unlimited?** The per-key allowance is *not* a meaningful safety
+  > boundary here — the key is already restricted to specific methods on
+  > `$MPC_CONTRACT_ID` via `--contract-account-id` + `--function-names`, so
+  > it cannot burn NEAR for anything else. A small finite allowance only
+  > creates a slow-burn failure mode: once the budget runs out, the RPC's
+  > pre-validation silently rejects every `respond*` transaction, and
+  > because the node uses `broadcast_tx_async` (fire-and-forget), the
+  > rejection is invisible in node logs — the node will keep reporting
+  > "succeeded" rounds while every response is dropped before reaching a
+  > validator. **Whatever value you pick, monitor and alert on remaining
+  > allowance** (e.g. via Grafana on `view_access_key`) so you don't
+  > rediscover this the same way we did.
+
 ---
 
 #### Example Command
@@ -925,7 +942,7 @@ This section shows how to add the MPC node's public key (from the previous secti
 ```bash
 ./target/release/near account add-key $ACCOUNT_ID \
   grant-function-call-access \
-  --allowance '1 NEAR' \
+  --allowance unlimited \
   --contract-account-id $MPC_CONTRACT_ID \
   --function-names $METHOD_NAMES \
   use-manually-provided-public-key $MPC_NODE_PUBLIC_KEY \
@@ -945,7 +962,7 @@ This section shows how to add the MPC node's public key (from the previous secti
 ACCOUNT_ID="your-node-account.testnet"
 MPC_CONTRACT_ID="v1.signer-prod.testnet"    # use "v1.signer" for mainnet
 MPC_NODE_PUBLIC_KEY="ed25519:YOUR_PUBLIC_KEY_HERE"
-ALLOWANCE="1 NEAR"
+ALLOWANCE="unlimited"   # see the Parameters section above for why
 NETWORK="testnet"   # or "mainnet"
 
 # Methods the MPC node is allowed to call

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -918,22 +918,9 @@ This section shows how to add the MPC node's public key (from the previous secti
 
   > **Note:** This must be a single comma-separated string with no spaces or newlines.
 
-* **`ALLOWANCE`** → The total NEAR budget the function-call key can spend on
-  gas across all calls signed with it. **Recommended: `unlimited`** (or a very
-  large value, e.g. `'1000 NEAR'`).
-
-  > **Why unlimited?** The per-key allowance is *not* a meaningful safety
-  > boundary here — the key is already restricted to specific methods on
-  > `$MPC_CONTRACT_ID` via `--contract-account-id` + `--function-names`, so
-  > it cannot burn NEAR for anything else. A small finite allowance only
-  > creates a slow-burn failure mode: once the budget runs out, the RPC's
-  > pre-validation silently rejects every `respond*` transaction, and
-  > because the node uses `broadcast_tx_async` (fire-and-forget), the
-  > rejection is invisible in node logs — the node will keep reporting
-  > "succeeded" rounds while every response is dropped before reaching a
-  > validator. **Whatever value you pick, monitor and alert on remaining
-  > allowance** (e.g. via Grafana on `view_access_key`) so you don't
-  > rediscover this the same way we did.
+* **`ALLOWANCE`** → Use `unlimited`. A finite allowance just means the node
+  will eventually stop being able to submit `respond*` transactions once the
+  budget runs out, with no error visible in node logs.
 
 ---
 
@@ -962,7 +949,7 @@ This section shows how to add the MPC node's public key (from the previous secti
 ACCOUNT_ID="your-node-account.testnet"
 MPC_CONTRACT_ID="v1.signer-prod.testnet"    # use "v1.signer" for mainnet
 MPC_NODE_PUBLIC_KEY="ed25519:YOUR_PUBLIC_KEY_HERE"
-ALLOWANCE="unlimited"   # see the Parameters section above for why
+ALLOWANCE="unlimited"
 NETWORK="testnet"   # or "mainnet"
 
 # Methods the MPC node is allowed to call


### PR DESCRIPTION
Closes #3028.

## Why

A 2026-04-26 testnet signing-failure incident (post-mortem in [near/mpc-private#307](https://github.com/near/mpc-private/pull/307), private) traced back to the function-call access key on the operator account running out of NEAR allowance and being unable to submit `Respond` transactions. With sustained signing load, the `1 NEAR` budget that this guide previously recommended drains in roughly two days, after which the RPC silently rejects every `respond*` tx — and because the node uses `broadcast_tx_async` (fire-and-forget), the rejection is invisible in node logs. The node keeps reporting "succeeded" rounds while every response is rejected before reaching a validator.

The per-key allowance is *not* a meaningful safety boundary in this configuration: the key is already restricted to a fixed set of methods on the MPC contract via `--contract-account-id` + `--function-names`, so it cannot burn NEAR for anything else. Capping the allowance just creates a slow-burn outage that's hard to detect.

## Changes

- Adds an explicit `ALLOWANCE` row to the *Parameters* section, recommending `unlimited` (or a very large value) and explaining why per-key capping doesn't help here, plus a reminder to monitor remaining allowance via Grafana since the failure mode is silent at the node level today.
- Updates the *Example Command* literal from `--allowance '1 NEAR'` to `--allowance unlimited`.
- Updates the *Sample Bash Script* default from `ALLOWANCE="1 NEAR"` to `ALLOWANCE="unlimited"`, with an inline comment pointing back at the new Parameters explanation.

## Verification

The same change is being made in the corresponding internal docs in `near/mpc-private` (companion follow-up [near/mpc-private#309](https://github.com/near/mpc-private/issues/309)) so the migration playbook + on-call runbook stay aligned with this guide.

## Out of scope

- Adding the actual Grafana alert on remaining allowance — separate follow-up.
- Surfacing on-chain `Respond` transaction status inside the node, which would have made this incident loud at the node level instead of silent — tracked in [#2890](https://github.com/near/mpc/issues/2890).