### PR TITLE
test: update allowance to unlimited in all scrips

### DIFF
--- a/deployment/testnet/scripts/scale-testnet-tee.sh
+++ b/deployment/testnet/scripts/scale-testnet-tee.sh
@@ -295,7 +295,7 @@ near_add_key_skip_if_exists() {
   # The key can only call node-facing methods on the MPC contract.
   local node_methods="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
   local cmd=(near account add-key "$acct" grant-function-call-access
-             --allowance '1 NEAR'
+             --allowance unlimited
              --contract-account-id "$MPC_CONTRACT_ACCOUNT"
              --function-names "$node_methods"
              use-manually-provided-public-key "$pk"

--- a/docs/localnet/localnet.md
+++ b/docs/localnet/localnet.md
@@ -243,11 +243,11 @@ Now we can add these keys to the appropriate NEAR accounts with the NEAR CLI.
 ```shell
 NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
 
-near account add-key frodo.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_PUBKEY" network-config mpc-localnet sign-with-keychain send
-near account add-key frodo.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
+near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_PUBKEY" network-config mpc-localnet sign-with-keychain send
+near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
 
-near account add-key sam.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_PUBKEY" network-config mpc-localnet sign-with-keychain send
-near account add-key sam.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
+near account add-key sam.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_PUBKEY" network-config mpc-localnet sign-with-keychain send
+near account add-key sam.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
 ```
 
 ## 4. Initialize the MPC contract

--- a/docs/localnet/tee-localnet.md
+++ b/docs/localnet/tee-localnet.md
@@ -214,11 +214,11 @@ Now, add these keys to the appropriate NEAR accounts using the NEAR CLI:
 ```bash
 NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
 
-near account add-key frodo.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_PUBKEY" network-config mpc-localnet sign-with-keychain send
-near account add-key frodo.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
+near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_PUBKEY" network-config mpc-localnet sign-with-keychain send
+near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
 
-near account add-key sam.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_PUBKEY" network-config mpc-localnet sign-with-keychain send
-near account add-key sam.test.near grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
+near account add-key sam.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_PUBKEY" network-config mpc-localnet sign-with-keychain send
+near account add-key sam.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$SAM_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send
 ```
 
 ### Initialize the MPC Contract

--- a/docs/testnet/setup-guide-for-testnet-with-tee-support.md
+++ b/docs/testnet/setup-guide-for-testnet-with-tee-support.md
@@ -237,19 +237,19 @@ Add keys to each NEAR account:
 NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
 
 near account add-key $FRODO_ACCOUNT grant-function-call-access \
-  --allowance '1 NEAR' --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
+  --allowance unlimited --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
   use-manually-provided-public-key "$FRODO_PUBKEY" network-config testnet sign-with-keychain send
 
 near account add-key $FRODO_ACCOUNT grant-function-call-access \
-  --allowance '1 NEAR' --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
+  --allowance unlimited --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
   use-manually-provided-public-key "$FRODO_RESPONDER_KEY" network-config testnet sign-with-keychain send
 
 near account add-key $SAM_ACCOUNT grant-function-call-access \
-  --allowance '1 NEAR' --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
+  --allowance unlimited --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
   use-manually-provided-public-key "$SAM_PUBKEY" network-config testnet sign-with-keychain send
 
 near account add-key $SAM_ACCOUNT grant-function-call-access \
-  --allowance '1 NEAR' --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
+  --allowance unlimited --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \
   use-manually-provided-public-key "$SAM_RESPONDER_KEY" network-config testnet sign-with-keychain send
 ```
 

--- a/localnet/tee/scripts/rust-launcher/deploy-tee-localnet.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-localnet.sh
@@ -395,7 +395,7 @@ near_add_key_skip_if_exists() {
   # The key can only call node-facing methods on the MPC contract.
   local node_methods="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
   local cmd=(near account add-key "$acct" grant-function-call-access
-             --allowance '1 NEAR'
+             --allowance unlimited
              --contract-account-id "$MPC_CONTRACT_ACCOUNT"
              --function-names "$node_methods"
              use-manually-provided-public-key "$pk"

--- a/scripts/launch-localnet.sh
+++ b/scripts/launch-localnet.sh
@@ -175,8 +175,8 @@ EOF
     NODE_RESPONDER_KEY=$(curl -s localhost:$((BASE_WEB_UI_PORT + i))/public_data | jq -r ".near_responder_public_keys[0]")
 
     NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
-    run_quiet_on_success "near account add-key $node_name grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names \"$NODE_METHODS\" use-manually-provided-public-key \"$NODE_PUBKEY\" network-config mpc-localnet sign-with-keychain send" && \
-    run_quiet_on_success "near account add-key $node_name grant-function-call-access --allowance '1 NEAR' --contract-account-id mpc-contract.test.near --function-names \"$NODE_METHODS\" use-manually-provided-public-key \"$NODE_RESPONDER_KEY\" network-config mpc-localnet sign-with-keychain send" &
+    run_quiet_on_success "near account add-key $node_name grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names \"$NODE_METHODS\" use-manually-provided-public-key \"$NODE_PUBKEY\" network-config mpc-localnet sign-with-keychain send" && \
+    run_quiet_on_success "near account add-key $node_name grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names \"$NODE_METHODS\" use-manually-provided-public-key \"$NODE_RESPONDER_KEY\" network-config mpc-localnet sign-with-keychain send" &
     pids_adding_keys+=($!)
   done
 


### PR DESCRIPTION
Mechanical follow-up to #3029 (operator guide). The same `'1 NEAR'` allowance value that triggered the 2026-04-26 testnet signing-failure incident is also hardcoded in five other doc/script paths that are used for testing.
This PR sweeps them all to `unlimited`.

Related:
- Issue: [#3028](https://github.com/near/mpc/issues/3028)
- Operator-guide PR (already open): [#3029](https://github.com/near/mpc/pull/3029)
- Post-mortem (private): [near/mpc-private#307](https://github.com/near/mpc-private/pull/307)
