### PR TITLE
feat(launcher): add restart policy for MPC node container when started by the launcher

### DIFF
--- a/crates/tee-launcher/assets/mpc-node-docker-compose.tee.template.yml
+++ b/crates/tee-launcher/assets/mpc-node-docker-compose.tee.template.yml
@@ -2,6 +2,7 @@ services:
   mpc-node:
     image: "{{IMAGE_NAME}}@{{MANIFEST_DIGEST}}"
     container_name: "{{CONTAINER_NAME}}"
+    restart: on-failure
     security_opt:
       - no-new-privileges:true
     ports: {{PORTS}}

--- a/crates/tee-launcher/assets/mpc-node-docker-compose.template.yml
+++ b/crates/tee-launcher/assets/mpc-node-docker-compose.template.yml
@@ -2,6 +2,7 @@ services:
   mpc-node:
     image: "{{IMAGE_NAME}}@{{MANIFEST_DIGEST}}"
     container_name: "{{CONTAINER_NAME}}"
+    restart: on-failure
     security_opt:
       - no-new-privileges:true
     ports: {{PORTS}}

--- a/crates/tee-launcher/src/compose.rs
+++ b/crates/tee-launcher/src/compose.rs
@@ -175,6 +175,32 @@ mod tests {
     }
 
     #[test]
+    fn tee_mode_includes_restart_on_failure() {
+        // given
+        let port_mappings = empty_port_mappings();
+        let digest = sample_digest();
+
+        // when
+        let rendered = render(Platform::Tee, &port_mappings, &digest);
+
+        // then
+        assert!(rendered.contains("restart: on-failure"));
+    }
+
+    #[test]
+    fn nontee_mode_includes_restart_on_failure() {
+        // given
+        let port_mappings = empty_port_mappings();
+        let digest = sample_digest();
+
+        // when
+        let rendered = render(Platform::NonTee, &port_mappings, &digest);
+
+        // then
+        assert!(rendered.contains("restart: on-failure"));
+    }
+
+    #[test]
     fn mounts_config_file_read_only() {
         // given
         let port_mappings = empty_port_mappings();


### PR DESCRIPTION
## Summary

When the MPC node crashes inside a TEE/dstack deployment, nothing restarts it — the container exits and stays down until manual intervention or CVM redeployment.

Non-TEE production uses systemd to restart the Docker container on failure (configured by @amustuc). TEE deployments had no equivalent — this PR adds \`restart: on-failure\` to the MPC node compose templates rendered by the Rust launcher.

## Changes

- \`crates/tee-launcher/assets/mpc-node-docker-compose.tee.template.yml\`: add \`restart: on-failure\`
- \`crates/tee-launcher/assets/mpc-node-docker-compose.template.yml\`: same for non-TEE template
- \`crates/tee-launcher/src/compose.rs\`: 2 new tests verifying the rendered compose contains the restart policy

## Follow-up

Restart observability (metrics + structured logs to detect when restarts occur) is tracked separately in #3044.

Closes #2764

## Test plan

- [x] \`cargo test -p tee-launcher\` — 65 tests pass (added 2)
- [ ] CI