### PR TITLE
chore: remove image hashes, manifest digest is enough to guarantee repro

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -81,11 +81,8 @@ jobs:
 
     outputs:
       mpc_node_manifest_digest: ${{ steps.digests.outputs.mpc_node_manifest_digest }}
-      mpc_node_image_id: ${{ steps.digests.outputs.mpc_node_image_id }}
       mpc_node_gcp_manifest_digest: ${{ steps.digests.outputs.mpc_node_gcp_manifest_digest }}
-      mpc_node_gcp_image_id: ${{ steps.digests.outputs.mpc_node_gcp_image_id }}
       mpc_launcher_manifest_digest: ${{ steps.digests.outputs.mpc_launcher_manifest_digest }}
-      mpc_launcher_image_id: ${{ steps.digests.outputs.mpc_launcher_image_id }}
 
     steps:
       - name: Install skopeo
@@ -102,13 +99,11 @@ jobs:
           for REPO in mpc-launcher mpc-node-gcp mpc-node; do
             SAFE_NAME="${REPO//-/_}"
             MANIFEST_DIGEST=$(skopeo inspect docker://nearone/$REPO:$RELEASE_TAG | jq -r '.Digest')
-            IMAGE_ID=$(skopeo inspect --raw --override-os linux --override-arch amd64 docker://nearone/$REPO:$RELEASE_TAG | jq -r '.config.digest')
-            if [[ -z "$MANIFEST_DIGEST" || -z "$IMAGE_ID" ]]; then
-              echo "::error::Failed to get digests for nearone/$REPO:$RELEASE_TAG"
+            if [[ -z "$MANIFEST_DIGEST" ]]; then
+              echo "::error::Failed to get manifest digest for nearone/$REPO:$RELEASE_TAG"
               exit 1
             fi
             echo "${SAFE_NAME}_manifest_digest=$MANIFEST_DIGEST" >> "$GITHUB_OUTPUT"
-            echo "${SAFE_NAME}_image_id=$IMAGE_ID" >> "$GITHUB_OUTPUT"
           done
 
   build-contract:
@@ -200,11 +195,8 @@ jobs:
         env:
           VERSION: ${{ needs.release-info.outputs.version }}
           NODE_MANIFEST: ${{ needs.collect-digests.outputs.mpc_node_manifest_digest }}
-          NODE_IMAGE_ID: ${{ needs.collect-digests.outputs.mpc_node_image_id }}
           NODE_GCP_MANIFEST: ${{ needs.collect-digests.outputs.mpc_node_gcp_manifest_digest }}
-          NODE_GCP_IMAGE_ID: ${{ needs.collect-digests.outputs.mpc_node_gcp_image_id }}
           LAUNCHER_MANIFEST: ${{ needs.collect-digests.outputs.mpc_launcher_manifest_digest }}
-          LAUNCHER_IMAGE_ID: ${{ needs.collect-digests.outputs.mpc_launcher_image_id }}
           CONTRACT_HASH: ${{ needs.build-contract.outputs.contract-hash }}
         run: |
           cp release-notes-raw.md release-notes.md
@@ -214,15 +206,12 @@ jobs:
 
           - [nearone/mpc-node:${VERSION}](https://hub.docker.com/layers/nearone/mpc-node/${VERSION}/)
             Manifest digest: \`${NODE_MANIFEST}\`
-            Image ID: \`${NODE_IMAGE_ID}\`
 
           - [nearone/mpc-node-gcp:${VERSION}](https://hub.docker.com/layers/nearone/mpc-node-gcp/${VERSION}/)
             Manifest digest: \`${NODE_GCP_MANIFEST}\`
-            Image ID: \`${NODE_GCP_IMAGE_ID}\`
 
           - [nearone/mpc-launcher:${VERSION}](https://hub.docker.com/layers/nearone/mpc-launcher/${VERSION}/)
             Manifest digest: \`${LAUNCHER_MANIFEST}\`
-            Image ID: \`${LAUNCHER_IMAGE_ID}\`
 
           ## MPC contract
 

--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -1,7 +1,7 @@
 #! /usr/bin/env bash
 # Script to reproducibly build the docker images for the node and launcher
 #
-# Requirements: docker, docker-buildx, jq, git, find, touch, skopeo
+# Requirements: docker, docker-buildx, git, find, touch, skopeo
 # Extra requirements if using --node or --rust-launcher: repro-env, podman
 # Extra requirements if using --push: docker must be logged in to registry
 #
@@ -60,7 +60,7 @@ require_cmds() {
   [[ "${missing}" -eq 0 ]] || die "Please install the missing dependencies above."
 }
 
-require_cmds docker jq git find touch skopeo
+require_cmds docker git find touch skopeo
 
 if $USE_NODE || $USE_RUST_LAUNCHER; then
     require_cmds repro-env podman
@@ -106,15 +106,10 @@ fi
 build_reproducible_image() {
   local image_name=$1
   local dockerfile_path=$2
-  docker buildx build --builder ${buildkit_image_name} --no-cache \
+  docker buildx build --builder "${buildkit_image_name}" --no-cache \
     --build-arg SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
-    --output type=docker,name=$image_name,rewrite-timestamp=true \
+    --output "type=docker,name=$image_name,rewrite-timestamp=true" \
     --progress plain -f "$dockerfile_path" .
-}
-
-get_image_hash() {
-    local image_name=$1
-    docker inspect $image_name | jq -r .[0].Id
 }
 
 # Compress a locally built image via skopeo to a temp directory.
@@ -138,8 +133,7 @@ if $USE_RUST_LAUNCHER; then
     SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH repro-env build --env SOURCE_DATE_EPOCH -- cargo build -p tee-launcher --profile reproducible --locked
     rust_launcher_binary_hash=$(sha256sum target/reproducible/tee-launcher | cut -d' ' -f1)
 
-    build_reproducible_image $RUST_LAUNCHER_IMAGE_NAME $DOCKERFILE_RUST_LAUNCHER
-    rust_launcher_image_hash=$(get_image_hash $RUST_LAUNCHER_IMAGE_NAME)
+    build_reproducible_image "$RUST_LAUNCHER_IMAGE_NAME" "$DOCKERFILE_RUST_LAUNCHER"
     rust_launcher_skopeo_dir="$(skopeo_compress "$RUST_LAUNCHER_IMAGE_NAME")"
     rust_launcher_manifest_digest="$(manifest_digest_from_dir "$rust_launcher_skopeo_dir")"
 fi
@@ -150,15 +144,13 @@ if $USE_NODE || $USE_NODE_GCP; then
 fi
 
 if $USE_NODE; then
-    build_reproducible_image $NODE_IMAGE_NAME $DOCKERFILE_NODE
-    node_image_hash=$(get_image_hash $NODE_IMAGE_NAME)
+    build_reproducible_image "$NODE_IMAGE_NAME" "$DOCKERFILE_NODE"
     node_skopeo_dir="$(skopeo_compress "$NODE_IMAGE_NAME")"
     node_manifest_digest="$(manifest_digest_from_dir "$node_skopeo_dir")"
 fi
 
 if $USE_NODE_GCP; then
-    build_reproducible_image $NODE_GCP_IMAGE_NAME $DOCKERFILE_NODE_GCP
-    node_gcp_image_hash=$(get_image_hash $NODE_GCP_IMAGE_NAME)
+    build_reproducible_image "$NODE_GCP_IMAGE_NAME" "$DOCKERFILE_NODE_GCP"
     node_gcp_skopeo_dir="$(skopeo_compress "$NODE_GCP_IMAGE_NAME")"
     node_gcp_manifest_digest="$(manifest_digest_from_dir "$node_gcp_skopeo_dir")"
 fi
@@ -196,15 +188,12 @@ if $USE_NODE || $USE_NODE_GCP; then
     echo "node binary hash: $node_binary_hash"
 fi
 if $USE_NODE; then
-    echo "node docker image hash: $node_image_hash"
     echo "node manifest digest: $node_manifest_digest"
 fi
 if $USE_NODE_GCP; then
-    echo "node gcp docker image hash: $node_gcp_image_hash"
     echo "node gcp manifest digest: $node_gcp_manifest_digest"
 fi
 if $USE_RUST_LAUNCHER; then
     echo "rust launcher binary hash: $rust_launcher_binary_hash"
-    echo "rust launcher docker image hash: $rust_launcher_image_hash"
     echo "rust launcher manifest digest: $rust_launcher_manifest_digest"
 fi

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1211,7 +1211,6 @@ $ ./deployment/build-images.sh --node
 commit hash: 828f816be36aed6f0d2438e0131b3e9d7d0931ad
 SOURCE_DATE_EPOCH used: 0
 node binary hash: 86c8f7d8913d6fe37a6992bba165d15a3a1d88fbf6cdff605e4827d5183721bc
-node docker image hash: sha256:0e48003c0ac6ec01e79ce47aa094379e7a8fac428512dfeb18d49d558e100a53
 node manifest digest: sha256:331cfec941671ac343c52847e255eb36a280da65535d2a1e4d002c4c64686e19
 ```
 
@@ -1293,7 +1292,6 @@ git checkout <commit-hash>
 $ ./deployment/build-images.sh --rust-launcher
 ...
 rust launcher binary hash: <hex>
-rust launcher docker image hash: sha256:<hex>
 rust launcher manifest digest: sha256:<hex>
 ```
 


### PR DESCRIPTION
Closes #3045

I took the easiest solution of simply removing the image hash values, as having a reproducible manifest digest is enough, so we no longer need the former.

Our releases should be a little bit less confusing now