### PR TITLE
refactor(tee-authority): add typed PCCS endpoint errors and fallback logging

### DIFF
--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -130,10 +130,6 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
                 .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
                 .inc();
-            // %e (Display): renders the multi-line per-endpoint summary.
-            // ?e (Debug) would print the derived `AllPccsEndpointsFailed { .. }`
-            // shape and lose the per-failure breakdown the typed error exists
-            // to surface.
             tracing::error!(
                 error = %e,
                 "TEE attestation failed. Node will continue without attestation and retry periodically",

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -130,8 +130,12 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
             crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
                 .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
                 .inc();
+            // %e (Display): renders the multi-line per-endpoint summary.
+            // ?e (Debug) would print the derived `AllPccsEndpointsFailed { .. }`
+            // shape and lose the per-failure breakdown the typed error exists
+            // to surface.
             tracing::error!(
-                error = ?e,
+                error = %e,
                 "TEE attestation failed. Node will continue without attestation and retry periodically",
             );
             None

--- a/crates/node/src/tee/remote_attestation.rs
+++ b/crates/node/src/tee/remote_attestation.rs
@@ -166,8 +166,6 @@ pub async fn periodic_attestation_submission<T: TransactionSender + Clone, I: Ti
                 crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
                     .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
                     .inc();
-                // %e (Display) renders the multi-line per-endpoint summary;
-                // ?e (Debug) would lose it.
                 tracing::warn!(error = %e, "TEE attestation failed, will retry next interval");
                 continue;
             }
@@ -267,8 +265,6 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
                     crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
                         .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
                         .inc();
-                    // %e (Display) renders the multi-line per-endpoint
-                    // summary; ?e (Debug) would lose it.
                     tracing::warn!(
                         error = %e,
                         "TEE attestation failed, periodic attestation task will retry",

--- a/crates/node/src/tee/remote_attestation.rs
+++ b/crates/node/src/tee/remote_attestation.rs
@@ -166,7 +166,9 @@ pub async fn periodic_attestation_submission<T: TransactionSender + Clone, I: Ti
                 crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
                     .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
                     .inc();
-                tracing::warn!(error = ?e, "TEE attestation failed, will retry next interval");
+                // %e (Display) renders the multi-line per-endpoint summary;
+                // ?e (Debug) would lose it.
+                tracing::warn!(error = %e, "TEE attestation failed, will retry next interval");
                 continue;
             }
             Err(e) => {
@@ -265,8 +267,10 @@ pub async fn monitor_attestation_removal<T: TransactionSender + Clone>(
                     crate::metrics::MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL
                         .with_label_values(&[crate::metrics::MPC_TEE_ATTESTATION_OUTCOME_FAILURE])
                         .inc();
+                    // %e (Display) renders the multi-line per-endpoint
+                    // summary; ?e (Debug) would lose it.
                     tracing::warn!(
-                        error = ?e,
+                        error = %e,
                         "TEE attestation failed, periodic attestation task will retry",
                     );
                     was_available = is_available;

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -69,11 +69,18 @@ impl PccsEndpointError {
 }
 
 /// Returned when every configured PCCS endpoint failed. Owns the full list
-/// of per-endpoint failures in the order they were tried.
+/// of per-endpoint failures in the order they were tried. The collection is
+/// non-empty by construction: this error only ever fires after a loop over a
+/// `NonEmptyVec<Url>`, so the type-level invariant matches the value-level
+/// one and rules out nonsense renderings like "all 0 PCCS endpoints failed".
 #[derive(Debug, Error)]
-#[error("all {} PCCS endpoints failed:\n{}", failures.len(), format_pccs_failures(failures))]
+#[error(
+    "all {} PCCS endpoints failed:\n{}",
+    failures.len(),
+    format_pccs_failures(failures.as_slice())
+)]
 pub struct AllPccsEndpointsFailed {
-    pub failures: Vec<PccsEndpointError>,
+    pub failures: NonEmptyVec<PccsEndpointError>,
 }
 
 fn format_pccs_failures(failures: &[PccsEndpointError]) -> String {
@@ -290,6 +297,11 @@ where
             }
         }
     }
+    // Sound by construction: the loop iterates `pccs_urls`, which is itself a
+    // `NonEmptyVec<Url>`, so any path that exits the loop without an early
+    // `Ok(...)` return must have pushed at least one failure.
+    let failures = NonEmptyVec::try_from(failures)
+        .expect("loop over NonEmptyVec<Url> guarantees at least one failure");
     Err(AllPccsEndpointsFailed { failures })
 }
 
@@ -653,12 +665,15 @@ mod tests {
 
     /// `Display` for the aggregate error renders one line per failure, so the
     /// reviewer's example shape ("all 3 PCCS endpoints failed: …") shows up
-    /// intact in `tracing::error!(?e)` and support-ticket pastes.
+    /// intact in `tracing::error!(error = %e, …)` (Display) and
+    /// support-ticket pastes. Note: `?e` (Debug) prints the derived
+    /// `AllPccsEndpointsFailed { failures: [...] }` shape instead, so call
+    /// sites that want the multi-line summary must format with `%e`.
     #[tokio::test]
     async fn all_pccs_endpoints_failed__should_render_each_failure_on_its_own_line() {
         // Given
         let err = AllPccsEndpointsFailed {
-            failures: vec![
+            failures: NonEmptyVec::try_from(vec![
                 PccsEndpointError::Timeout {
                     url: "https://first.example/".parse().unwrap(),
                     timeout: Duration::from_secs(10),
@@ -667,7 +682,8 @@ mod tests {
                     url: "https://second.example/".parse().unwrap(),
                     source: anyhow::anyhow!("503 Service Unavailable"),
                 },
-            ],
+            ])
+            .expect("two-element vec is non-empty"),
         };
 
         // When

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -634,6 +634,28 @@ mod tests {
     /// attempt.
     #[tokio::test]
     async fn try_each_pccs_endpoint__should_collect_every_endpoint_failure_in_order() {
+        // PccsEndpointError can't derive PartialEq (anyhow::Error: !PartialEq),
+        // so we project to a comparable shape that drops the source field but
+        // keeps the variant + URL — the only properties this test asserts.
+        #[derive(Debug, PartialEq)]
+        enum FailureShape {
+            Fetch(Url),
+            Timeout(Url),
+            ClientConstruction(Url),
+        }
+
+        impl From<&PccsEndpointError> for FailureShape {
+            fn from(err: &PccsEndpointError) -> Self {
+                match err {
+                    PccsEndpointError::Fetch { url, .. } => Self::Fetch(url.clone()),
+                    PccsEndpointError::Timeout { url, .. } => Self::Timeout(url.clone()),
+                    PccsEndpointError::ClientConstruction { url, .. } => {
+                        Self::ClientConstruction(url.clone())
+                    }
+                }
+            }
+        }
+
         // Given
         let pccs_urls = urls(&[
             "https://first.example/",
@@ -652,14 +674,12 @@ mod tests {
         .unwrap_err();
 
         // Then
-        let failed_urls: Vec<&Url> = err.failures.iter().map(PccsEndpointError::url).collect();
-        let expected_urls: Vec<&Url> = pccs_urls.iter().collect();
-        assert_eq!(failed_urls, expected_urls);
-        assert!(
-            err.failures
-                .iter()
-                .all(|e| matches!(e, PccsEndpointError::Fetch { .. }))
-        );
+        let actual: Vec<FailureShape> = err.failures.iter().map(FailureShape::from).collect();
+        let expected: Vec<FailureShape> = pccs_urls
+            .iter()
+            .map(|url| FailureShape::Fetch(url.clone()))
+            .collect();
+        assert_eq!(actual, expected);
     }
 
     /// `Display` for the aggregate error renders one line per failure, so the

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -10,7 +10,7 @@ use mpc_attestation::{
 use near_mpc_bounded_collections::NonEmptyVec;
 use std::path::PathBuf;
 use thiserror::Error;
-use tracing::{error, warn};
+use tracing::{error, info, warn};
 use url::Url;
 
 /// Errors that can occur during TEE attestation generation.
@@ -250,7 +250,8 @@ impl TeeAuthority {
 /// endpoint fails, an [`AllPccsEndpointsFailed`] aggregating each per-endpoint
 /// failure is returned. `fetcher(url) -> Future` is called once per URL in the
 /// order the caller listed them; intermediate failures are logged at `warn`
-/// level and do not short-circuit.
+/// level and do not short-circuit. A success on attempt 2+ emits a single
+/// `info!` so silent primary degradation is visible to log-based alerting.
 async fn try_each_pccs_endpoint<Fetcher, Fut>(
     pccs_urls: &NonEmptyVec<Url>,
     fetcher: Fetcher,
@@ -265,7 +266,17 @@ where
         let attempt = index + 1;
         let is_last_endpoint = attempt == total_endpoints;
         match fetcher(url.clone()).await {
-            Ok(collateral) => return Ok(collateral),
+            Ok(collateral) => {
+                if attempt > 1 {
+                    info!(
+                        %url,
+                        attempt,
+                        total_endpoints,
+                        "fetched collateral via PCCS fallback"
+                    );
+                }
+                return Ok(collateral);
+            }
             Err(err) => {
                 warn!(
                     ?err,

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -682,12 +682,7 @@ mod tests {
         assert_eq!(actual, expected);
     }
 
-    /// `Display` for the aggregate error renders one line per failure, so the
-    /// reviewer's example shape ("all 3 PCCS endpoints failed: …") shows up
-    /// intact in `tracing::error!(error = %e, …)` (Display) and
-    /// support-ticket pastes. Note: `?e` (Debug) prints the derived
-    /// `AllPccsEndpointsFailed { failures: [...] }` shape instead, so call
-    /// sites that want the multi-line summary must format with `%e`.
+    /// `Display` renders one line per failure for log/ticket pastes.
     #[tokio::test]
     async fn all_pccs_endpoints_failed__should_render_each_failure_on_its_own_line() {
         // Given

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -676,15 +676,20 @@ mod tests {
     #[tokio::test]
     async fn all_pccs_endpoints_failed__should_render_each_failure_on_its_own_line() {
         // Given
+        const FIRST_URL: &str = "https://first.example/";
+        const SECOND_URL: &str = "https://second.example/";
+        const TIMEOUT: Duration = Duration::from_secs(10);
+        const FETCH_ERROR: &str = "503 Service Unavailable";
+
         let err = AllPccsEndpointsFailed {
             failures: NonEmptyVec::try_from(vec![
                 PccsEndpointError::Timeout {
-                    url: "https://first.example/".parse().unwrap(),
-                    timeout: Duration::from_secs(10),
+                    url: FIRST_URL.parse().unwrap(),
+                    timeout: TIMEOUT,
                 },
                 PccsEndpointError::Fetch {
-                    url: "https://second.example/".parse().unwrap(),
-                    source: anyhow::anyhow!("503 Service Unavailable"),
+                    url: SECOND_URL.parse().unwrap(),
+                    source: anyhow::anyhow!(FETCH_ERROR),
                 },
             ])
             .expect("two-element vec is non-empty"),
@@ -696,9 +701,11 @@ mod tests {
         // Then
         assert_eq!(
             rendered,
-            "all 2 PCCS endpoints failed:\n\
-             \x20 - timed out fetching collateral from https://first.example/ after 10s\n\
-             \x20 - collateral fetch failed for https://second.example/: 503 Service Unavailable"
+            format!(
+                "all 2 PCCS endpoints failed:\n\
+                 \x20 - timed out fetching collateral from {FIRST_URL} after {TIMEOUT:?}\n\
+                 \x20 - collateral fetch failed for {SECOND_URL}: {FETCH_ERROR}"
+            )
         );
     }
 

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -254,11 +254,10 @@ impl TeeAuthority {
 }
 
 /// Try each PCCS endpoint in order, returning the first success. If every
-/// endpoint fails, an [`AllPccsEndpointsFailed`] aggregating each per-endpoint
-/// failure is returned. `fetcher(url) -> Future` is called once per URL in the
-/// order the caller listed them; intermediate failures are logged at `warn`
-/// level and do not short-circuit. A success on attempt 2+ emits a single
-/// `info!` so silent primary degradation is visible to log-based alerting.
+/// endpoint fails, returns [`AllPccsEndpointsFailed`] listing each
+/// per-endpoint failure in attempt order. Failed attempts log at `warn`;
+/// a fallback success (attempt > 1) logs at `info` so an always-failing
+/// primary masked by a healthy fallback isn't invisible.
 async fn try_each_pccs_endpoint<Fetcher, Fut>(
     pccs_urls: &NonEmptyVec<Url>,
     fetcher: Fetcher,

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -28,11 +28,60 @@ pub enum AttestationError {
     #[error("TDX quote decoding failed: {0:#}")]
     QuoteDecode(#[source] anyhow::Error),
 
-    #[error("collateral fetch failed: {0:#}")]
-    CollateralFetch(#[source] anyhow::Error),
+    #[error("collateral fetch failed: {0}")]
+    CollateralFetch(#[source] AllPccsEndpointsFailed),
 
     #[error("dstack_endpoint path is not valid UTF-8")]
     InvalidEndpoint,
+}
+
+/// One PCCS endpoint's failure. Carries the URL it was tried against and
+/// the underlying cause. The cause stays as `anyhow::Error` because the
+/// upstream `dcap_qvl::CollateralClient` itself returns `anyhow::Result`.
+#[derive(Debug, Error)]
+pub enum PccsEndpointError {
+    #[error("invalid PCCS client construction for {url}: {source:#}")]
+    ClientConstruction {
+        url: Url,
+        #[source]
+        source: anyhow::Error,
+    },
+
+    #[error("timed out fetching collateral from {url} after {timeout:?}")]
+    Timeout { url: Url, timeout: Duration },
+
+    #[error("collateral fetch failed for {url}: {source:#}")]
+    Fetch {
+        url: Url,
+        #[source]
+        source: anyhow::Error,
+    },
+}
+
+impl PccsEndpointError {
+    pub fn url(&self) -> &Url {
+        match self {
+            Self::ClientConstruction { url, .. }
+            | Self::Timeout { url, .. }
+            | Self::Fetch { url, .. } => url,
+        }
+    }
+}
+
+/// Returned when every configured PCCS endpoint failed. Owns the full list
+/// of per-endpoint failures in the order they were tried.
+#[derive(Debug, Error)]
+#[error("all {} PCCS endpoints failed:\n{}", failures.len(), format_pccs_failures(failures))]
+pub struct AllPccsEndpointsFailed {
+    pub failures: Vec<PccsEndpointError>,
+}
+
+fn format_pccs_failures(failures: &[PccsEndpointError]) -> String {
+    failures
+        .iter()
+        .map(|e| format!("  - {e}"))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// The maximum duration to wait for retrying requests.
@@ -156,11 +205,12 @@ impl TeeAuthority {
     /// Fetches attestation collateral from a list of PCCS servers, tried in
     /// order. The first URL to return success wins; later URLs act as
     /// fallbacks and are only contacted when earlier ones fail (after their
-    /// own per-URL backoff). Returns the last error if every URL fails.
+    /// own per-URL backoff). When every URL fails, returns an
+    /// [`AllPccsEndpointsFailed`] aggregating each endpoint's failure.
     async fn fetch_collateral(
         pccs_urls: &NonEmptyVec<Url>,
         quote: &[u8],
-    ) -> anyhow::Result<Collateral> {
+    ) -> Result<Collateral, AllPccsEndpointsFailed> {
         try_each_pccs_endpoint(pccs_urls, async |url: Url| {
             Self::fetch_collateral_from(&url, quote).await
         })
@@ -169,15 +219,27 @@ impl TeeAuthority {
 
     /// Fetches attestation collateral from a single PCCS endpoint, with the
     /// usual per-request timeout and a single retry via exponential backoff.
-    async fn fetch_collateral_from(pccs_url: &Url, quote: &[u8]) -> anyhow::Result<Collateral> {
+    async fn fetch_collateral_from(
+        pccs_url: &Url,
+        quote: &[u8],
+    ) -> Result<Collateral, PccsEndpointError> {
         let client = dcap_qvl::collateral::CollateralClient::with_default_http(pccs_url.as_str())
-            .map_err(|e| anyhow::anyhow!(e))?;
+            .map_err(|e| PccsEndpointError::ClientConstruction {
+            url: pccs_url.clone(),
+            source: anyhow::anyhow!(e),
+        })?;
         let fetch = async || {
             tokio::time::timeout(PCCS_REQUEST_TIMEOUT, client.fetch(quote))
                 .await
-                .map_err(|_| anyhow::anyhow!("timed out fetching collateral from PCCS"))?
+                .map_err(|_| PccsEndpointError::Timeout {
+                    url: pccs_url.clone(),
+                    timeout: PCCS_REQUEST_TIMEOUT,
+                })?
                 .map(Collateral::from)
-                .map_err(|e| anyhow::anyhow!(e))
+                .map_err(|e| PccsEndpointError::Fetch {
+                    url: pccs_url.clone(),
+                    source: anyhow::anyhow!(e),
+                })
         };
 
         get_with_backoff(fetch, "fetch collateral from PCCS", Some(1)).await
@@ -185,18 +247,19 @@ impl TeeAuthority {
 }
 
 /// Try each PCCS endpoint in order, returning the first success. If every
-/// endpoint fails, the last error is returned. `fetcher(url) -> Future` is
-/// called once per URL in the order the caller listed them; intermediate
-/// failures are logged at `warn` level and do not short-circuit.
+/// endpoint fails, an [`AllPccsEndpointsFailed`] aggregating each per-endpoint
+/// failure is returned. `fetcher(url) -> Future` is called once per URL in the
+/// order the caller listed them; intermediate failures are logged at `warn`
+/// level and do not short-circuit.
 async fn try_each_pccs_endpoint<Fetcher, Fut>(
     pccs_urls: &NonEmptyVec<Url>,
     fetcher: Fetcher,
-) -> anyhow::Result<Collateral>
+) -> Result<Collateral, AllPccsEndpointsFailed>
 where
     Fetcher: Fn(Url) -> Fut,
-    Fut: Future<Output = anyhow::Result<Collateral>>,
+    Fut: Future<Output = Result<Collateral, PccsEndpointError>>,
 {
-    let mut last_err: Option<anyhow::Error> = None;
+    let mut failures: Vec<PccsEndpointError> = Vec::new();
     let total_endpoints = pccs_urls.len();
     for (index, url) in pccs_urls.iter().enumerate() {
         let attempt = index + 1;
@@ -212,13 +275,11 @@ where
                     "failed to fetch collateral from PCCS; {}",
                     if is_last_endpoint { "no more endpoints remain" } else { "trying next endpoint" }
                 );
-                last_err = Some(err);
+                failures.push(err);
             }
         }
     }
-    // NonEmptyVec guarantees at least one iteration above, which either
-    // returns Ok(...) or populates last_err.
-    Err(last_err.expect("NonEmptyVec guarantees at least one URL"))
+    Err(AllPccsEndpointsFailed { failures })
 }
 
 async fn get_with_backoff<Operation, OperationFuture, Value, Error>(
@@ -519,9 +580,12 @@ mod tests {
                 let seen_urls = seen_urls.clone();
                 async move {
                     let is_primary = url.as_str().contains("primary");
-                    seen_urls.borrow_mut().push(url);
+                    seen_urls.borrow_mut().push(url.clone());
                     if is_primary {
-                        Err(anyhow::anyhow!("simulated primary outage"))
+                        Err(PccsEndpointError::Fetch {
+                            url,
+                            source: anyhow::anyhow!("simulated primary outage"),
+                        })
                     } else {
                         Ok(dummy_collateral("fallback"))
                     }
@@ -542,23 +606,69 @@ mod tests {
         assert_eq!(result.pck_crl_issuer_chain, "fallback");
     }
 
-    /// If every URL fails, the error returned is the last one (ordering-wise)
-    /// so operators can see the most recently attempted endpoint's message.
+    /// When every URL fails, the loop captures every per-endpoint failure in
+    /// the order the URLs were tried — so structured consumers (alerting,
+    /// support tickets, tests) see the full picture, not just the last
+    /// attempt.
     #[tokio::test]
-    async fn try_each_pccs_endpoint__all_fail_returns_last_error() {
-        let err = try_each_pccs_endpoint(
-            &urls(&[
-                "https://first.example/",
-                "https://second.example/",
-                "https://third.example/",
-            ]),
-            |url: Url| async move { Err::<Collateral, _>(anyhow::anyhow!("{url} is down")) },
-        )
-        .await
-        .unwrap_err()
-        .to_string();
+    async fn try_each_pccs_endpoint__should_collect_every_endpoint_failure_in_order() {
+        // Given
+        let pccs_urls = urls(&[
+            "https://first.example/",
+            "https://second.example/",
+            "https://third.example/",
+        ]);
 
-        assert_eq!(err, "https://third.example/ is down");
+        // When
+        let err = try_each_pccs_endpoint(&pccs_urls, |url: Url| async move {
+            Err::<Collateral, _>(PccsEndpointError::Fetch {
+                url: url.clone(),
+                source: anyhow::anyhow!("{url} is down"),
+            })
+        })
+        .await
+        .unwrap_err();
+
+        // Then
+        let failed_urls: Vec<&Url> = err.failures.iter().map(PccsEndpointError::url).collect();
+        let expected_urls: Vec<&Url> = pccs_urls.iter().collect();
+        assert_eq!(failed_urls, expected_urls);
+        assert!(
+            err.failures
+                .iter()
+                .all(|e| matches!(e, PccsEndpointError::Fetch { .. }))
+        );
+    }
+
+    /// `Display` for the aggregate error renders one line per failure, so the
+    /// reviewer's example shape ("all 3 PCCS endpoints failed: …") shows up
+    /// intact in `tracing::error!(?e)` and support-ticket pastes.
+    #[tokio::test]
+    async fn all_pccs_endpoints_failed__should_render_each_failure_on_its_own_line() {
+        // Given
+        let err = AllPccsEndpointsFailed {
+            failures: vec![
+                PccsEndpointError::Timeout {
+                    url: "https://first.example/".parse().unwrap(),
+                    timeout: Duration::from_secs(10),
+                },
+                PccsEndpointError::Fetch {
+                    url: "https://second.example/".parse().unwrap(),
+                    source: anyhow::anyhow!("503 Service Unavailable"),
+                },
+            ],
+        };
+
+        // When
+        let rendered = err.to_string();
+
+        // Then
+        assert_eq!(
+            rendered,
+            "all 2 PCCS endpoints failed:\n\
+             \x20 - timed out fetching collateral from https://first.example/ after 10s\n\
+             \x20 - collateral fetch failed for https://second.example/: 503 Service Unavailable"
+        );
     }
 
     #[tokio::test]

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -58,16 +58,6 @@ pub enum PccsEndpointError {
     },
 }
 
-impl PccsEndpointError {
-    pub fn url(&self) -> &Url {
-        match self {
-            Self::ClientConstruction { url, .. }
-            | Self::Timeout { url, .. }
-            | Self::Fetch { url, .. } => url,
-        }
-    }
-}
-
 /// Returned when every configured PCCS endpoint failed. Owns the full list
 /// of per-endpoint failures in the order they were tried. The collection is
 /// non-empty by construction: this error only ever fires after a loop over a


### PR DESCRIPTION
Closes #3046.

Two non-blocking follow-ups from #3010, addressed in a separate PR per https://github.com/near/mpc/pull/3010#discussion_r3152749328:

- **Typed aggregate error for PCCS-fallback failures.** `try_each_pccs_endpoint` now returns `Result<Collateral, AllPccsEndpointsFailed>` listing every endpoint's failure in attempt order, instead of dropping all but the last. Addresses https://github.com/near/mpc/pull/3010#discussion_r3151863673.
- **`info!` log on successful fallback.** A success on attempt 2+ now emits one structured log line so silent primary degradation is visible to alerting; common path (attempt == 1) stays silent. Addresses https://github.com/near/mpc/pull/3010#discussion_r3151864848.

See #3046 for the full scope and acceptance criteria.