### PR TITLE
refactor: recent blocks tracker relies on internal block height

### DIFF
--- a/crates/node/src/requests/queue.rs
+++ b/crates/node/src/requests/queue.rs
@@ -467,7 +467,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                     request_type = %RequestType::get_type(),
                     request_id = %request.request.get_id(),
                     block_height = request.block_height,
-                    "disarding expired request"
+                    "discarding expired request"
                 );
                 // Increment metric for timeout (only for signature requests)
                 if matches!(RequestType::get_type(), types::RequestType::Signature) {
@@ -479,14 +479,9 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                 requests_to_remove.push(*id);
                 continue;
             }
-
-            match self
-                .recent_blocks
-                .classify_block(request.block_hash, request.block_height)
-            {
-                CheckBlockResult::RecentAndFinal
-                | CheckBlockResult::OptimisticAndCanonical
-                | CheckBlockResult::Unknown => {
+            let block_classification = self.recent_blocks.classify_block(request.block_hash);
+            match block_classification {
+                CheckBlockResult::RecentAndFinal | CheckBlockResult::OptimisticAndCanonical => {
                     if let Some(leader) = request.current_leader(&eligible_leaders) {
                         tracing::debug!(
                             target: "request",
@@ -555,15 +550,21 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                         "ignoring non-canonical request",
                     );
                 }
-                CheckBlockResult::NotIncluded | CheckBlockResult::OlderThanRecentWindow => {
+                CheckBlockResult::NotIncluded
+                | CheckBlockResult::OlderThanRecentWindow
+                | CheckBlockResult::Unknown => {
                     // note: We will not receive "OlderThanRecentWindow" if the `RecentBlocksTracker`
                     // has the same recencly window as the queue.
+                    // Since we add signature requests to the queue after adding the block to the
+                    // tracker, receiving `Unknown` means that the tracker removed the block, most
+                    // likely due to the block being expired.
                     tracing::debug!(
                         target: "request",
                         request_type = %RequestType::get_type(),
                         request_id = %request.request.get_id(),
                         block_height = request.block_height,
-                        "disarding request because it was not included or expired"
+                        reason = ?block_classification,
+                        "discarding request because it was not included, expired, or the tracker removed the block"
                     );
                     // Increment metric for timeout (only for signature requests)
                     if matches!(RequestType::get_type(), types::RequestType::Signature) {

--- a/crates/node/src/requests/queue.rs
+++ b/crates/node/src/requests/queue.rs
@@ -554,7 +554,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                 | CheckBlockResult::OlderThanRecentWindow
                 | CheckBlockResult::Unknown => {
                     // note: We will not receive "OlderThanRecentWindow" if the `RecentBlocksTracker`
-                    // has the same recencly window as the queue.
+                    // has the same recency window as the queue.
                     // Since we add signature requests to the queue after adding the block to the
                     // tracker, receiving `Unknown` means that the tracker removed the block, most
                     // likely due to the block being expired.

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -409,22 +409,26 @@ impl<T: Clone> RecentBlocksTracker<T> {
     }
 
     /// Classifies a block into one of the categories in `CheckBlockResult`.
-    pub fn classify_block(&self, block_hash: CryptoHash, block_height: u64) -> CheckBlockResult {
-        if self
-            .maximum_height_available
-            .saturating_sub(self.window_size)
-            .add(1)
-            > block_height
-        {
-            return CheckBlockResult::OlderThanRecentWindow;
-        }
+    pub fn classify_block(&self, block_hash: CryptoHash) -> CheckBlockResult {
         match self.hash_to_node.get(&block_hash) {
             Some(node) => {
+                if self
+                    .maximum_height_available
+                    .saturating_sub(self.window_size)
+                    .add(1)
+                    > node.height
+                {
+                    // this can happen if the block in question is expired, but has not yet been
+                    // removed because it is the last final block
+                    return CheckBlockResult::OlderThanRecentWindow;
+                }
                 if node.is_final.load(Ordering::Relaxed) {
                     return CheckBlockResult::RecentAndFinal;
                 }
                 if let Some(final_head) = &self.final_head {
-                    if block_height <= final_head.height {
+                    // The block is not final, yet, we have a final head of greater height.
+                    // That means, the block was not included.
+                    if node.height <= final_head.height {
                         return CheckBlockResult::NotIncluded;
                     }
                 }
@@ -648,7 +652,7 @@ pub mod tests {
         }
 
         pub fn check(&self, block: &Arc<TestBlock>) -> CheckBlockResult {
-            self.tracker.classify_block(block.hash, block.height)
+            self.tracker.classify_block(block.hash)
         }
 
         pub fn add(&mut self, block: &Arc<TestBlock>, name: &str) -> String {
@@ -700,8 +704,8 @@ pub mod tests {
         tester.print();
 
         // At this point, the tracker should keep blocks 12, 13, 14, 15.
-        assert_eq!(tester.check(&b10), CheckBlockResult::OlderThanRecentWindow);
-        assert_eq!(tester.check(&b11), CheckBlockResult::OlderThanRecentWindow);
+        assert_eq!(tester.check(&b10), CheckBlockResult::Unknown);
+        assert_eq!(tester.check(&b11), CheckBlockResult::Unknown);
         assert_eq!(tester.check(&b12), CheckBlockResult::RecentAndFinal);
         assert_eq!(tester.check(&b13), CheckBlockResult::RecentAndFinal);
         assert_eq!(tester.check(&b14), CheckBlockResult::OptimisticAndCanonical);
@@ -741,7 +745,8 @@ pub mod tests {
         // CH   └─[16] C   81v6keTjdkVp8RgTdWQE2vx7E7nof7NxtZNaYFh3oVpG "16"
         t.print();
 
-        assert_eq!(t.check(&b10), CheckBlockResult::OlderThanRecentWindow);
+        // This block has been removed by the tracker
+        assert_eq!(t.check(&b10), CheckBlockResult::Unknown);
         // The tracker kept the block internally as it is the last final block, but it is still
         // outside of the window.
         assert_eq!(t.check(&b11), CheckBlockResult::OlderThanRecentWindow);
@@ -781,8 +786,9 @@ pub mod tests {
         //    └─[16]     81v6keTjdkVp8RgTdWQE2vx7E7nof7NxtZNaYFh3oVpG "16"
         t.print();
 
-        assert_eq!(t.check(&b14), CheckBlockResult::OlderThanRecentWindow);
-        assert_eq!(t.check(&b15), CheckBlockResult::OlderThanRecentWindow);
+        // b14 and b15 were removed, they are too old and we have newer, final blocks
+        assert_eq!(t.check(&b14), CheckBlockResult::Unknown);
+        assert_eq!(t.check(&b15), CheckBlockResult::Unknown);
         assert_eq!(t.check(&b16), CheckBlockResult::NotIncluded);
         assert_eq!(t.check(&b17), CheckBlockResult::Unknown);
         assert_eq!(t.check(&b18), CheckBlockResult::RecentAndFinal);
@@ -878,7 +884,8 @@ pub mod tests {
         // Note above: the canonical head is not a descendant of final head. This can't happen in
         // the real blockchain, but here we fed in a pathological scenario.
         t.print();
-        assert_eq!(t.check(&b0), CheckBlockResult::OlderThanRecentWindow);
+        // b0 was removed, becasue it was not included and is older than recent window
+        assert_eq!(t.check(&b0), CheckBlockResult::Unknown);
         assert_eq!(t.check(&b00), CheckBlockResult::NotIncluded);
         // Note: b000 has no chance of being included in the canonical chain due to b10 being final.
         // However, checking that case is not worth the complexity. In practice, the check we use of
@@ -887,7 +894,8 @@ pub mod tests {
         assert_eq!(t.check(&b01), CheckBlockResult::OptimisticAndCanonical);
         assert_eq!(t.check(&b010), CheckBlockResult::OptimisticButNotCanonical);
         assert_eq!(t.check(&b011), CheckBlockResult::OptimisticAndCanonical);
-        assert_eq!(t.check(&b1), CheckBlockResult::OlderThanRecentWindow);
+        // b1 was removed, because it is too old and we have newer final blocks
+        assert_eq!(t.check(&b1), CheckBlockResult::Unknown);
         assert_eq!(t.check(&b10), CheckBlockResult::RecentAndFinal);
         assert_eq!(t.check(&b100), CheckBlockResult::OptimisticButNotCanonical);
         assert_eq!(t.check(&b11), CheckBlockResult::OptimisticButNotCanonical);

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -86,7 +86,7 @@ pub enum CheckBlockResult {
     /// The block is optimistically included in the chain, but it is not on the canonical chain.
     /// It is also recent enough.
     OptimisticButNotCanonical,
-    /// We have not seen the block yet, but it appears recent, judging from the height.
+    /// We may have not seen the block and removed it, or we may never have seen it.
     Unknown,
 }
 
@@ -438,9 +438,8 @@ impl<T: Clone> RecentBlocksTracker<T> {
                 CheckBlockResult::OptimisticButNotCanonical
             }
             None => {
-                // At this point, the block is recent enough but we have not seen it yet.
-                // We could do a few more checks to narrow down the case, but it's not really
-                // worth the complexity. So just return Unknown.
+                // We don't know this block: either it is too old and we removed it, or we have
+                // geninely never seen it.
                 CheckBlockResult::Unknown
             }
         }

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -439,7 +439,7 @@ impl<T: Clone> RecentBlocksTracker<T> {
             }
             None => {
                 // We don't know this block: either it is too old and we removed it, or we have
-                // geninely never seen it.
+                // genuinely never seen it.
                 CheckBlockResult::Unknown
             }
         }


### PR DESCRIPTION
resolves #3061

With this PR, we treat treat `Unknown` the same as `OlderThanRecentWindow`.

With our current code, the queue contains a request from block `B`, only if block `B` has been added to the tracker (c.f. [notify_new_block](https://github.com/near/mpc/blob/22249473f051a572b377f2afa840bf200b0967dd/crates/node/src/requests/queue.rs#L282)).

That means, if we have a request from block `B` in the queue, but block `B` is unknown to the tracker, then the tracker removed it. That happens only if the block is outside of the trackers recency window.