### PR TITLE
ci: concurrency group in nix-build-mpc-node.yml

### DIFF
--- a/.github/workflows/nix-build-mpc-node.yml
+++ b/.github/workflows/nix-build-mpc-node.yml
@@ -1,7 +1,10 @@
 name: Nix build mpc-node
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Hardcoded group name (not `${{ github.workflow }}`) because when invoked via
+  # `workflow_call`, `github.workflow` resolves to the *caller's* workflow name,
+  # which causes a concurrency-group collision with the caller and a deadlock.
+  group: nix-build-mpc-node-${{ github.ref }}
   cancel-in-progress: true
 
 on:


### PR DESCRIPTION
Followup on: https://github.com/near/mpc/issues/3054

Hardcode concurrency group, otherwise we get deadlock when it's invoked from ci.yml

https://github.com/near/mpc/actions/runs/25100642705: 
```
Canceling since a deadlock was detected for concurrency group: 'CI-refs/heads/main' between a top level workflow and 'Nix build mpc-node'
```