### PR TITLE
chore: add status badges, skip contract-history tests in PR's

### DIFF
--- a/.github/workflows/external-services-tests.yml
+++ b/.github/workflows/external-services-tests.yml
@@ -42,7 +42,7 @@ jobs:
           tool: nextest@0.9.126
 
       - name: Run contract-history tests
-        if: always()
+        if: always() && github.event_name == 'schedule'
         run: cargo nextest run -p contract-history --features external-services-tests --cargo-profile test-release --locked
 
       - name: Run tee-launcher registry tests

--- a/README.md
+++ b/README.md
@@ -1,5 +1,12 @@
 # MPC
 
+[![CI](https://github.com/near/mpc/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/near/mpc/actions/workflows/ci.yml?query=branch%3Amain)
+[![External Services Tests](https://github.com/near/mpc/actions/workflows/external-services-tests.yml/badge.svg?branch=main)](https://github.com/near/mpc/actions/workflows/external-services-tests.yml?query=branch%3Amain)
+[![nearcore](https://img.shields.io/badge/nearcore-2.11.1-blue)](https://github.com/near/nearcore/releases/tag/2.11.1)
+[![rust](https://img.shields.io/badge/dynamic/toml?url=https%3A%2F%2Fraw.githubusercontent.com%2Fnear%2Fmpc%2Fmain%2Frust-toolchain.toml&query=%24.toolchain.channel&label=rust&color=orange&logo=rust)](./rust-toolchain.toml)
+[![mainnet contract](https://img.shields.io/badge/mainnet-v1.signer-brightgreen)](https://nearblocks.io/address/v1.signer)
+[![testnet contract](https://img.shields.io/badge/testnet-v1.signer--prod.testnet-yellow)](https://testnet.nearblocks.io/address/v1.signer-prod.testnet)
+
 This repository contains the code for the NEAR MPC node that powers [Chain Signatures](https://docs.near.org/chain-abstraction/chain-signatures).
 
 ## How it works


### PR DESCRIPTION
sample of how badges will look:
<img width="1195" height="279" alt="image" src="https://github.com/user-attachments/assets/23284e57-6f17-4a94-9b24-00c12331fbe2" />


Why skip contract-history in PR's: before it's updated it fails CI and we have pages of red CI which can mask real issues. 