### PR TITLE
chore: deprecate ForeignChainPolicyVotes storage key

### DIFF
--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -17,7 +17,7 @@ pub enum StorageKey {
     _DeprecatedPendingCKDRequests,
     BackupServicesInfo,
     NodeMigrations,
-    ForeignChainPolicyVotes,
+    _ForeignChainPolicyVotes,
     PendingVerifyForeignTxRequests,
     PendingCKDRequestsV2,
     SupportedForeignChainsVotes,


### PR DESCRIPTION
closes #2712

#2712 was already mostly completed, but we frogot to deprecate the storage key as well by prefixing with underscore