### PR TITLE
build(contract): switch reproducible build to wasm-opt -Os

### DIFF
--- a/.github/workflows/cargo-near-image.yml
+++ b/.github/workflows/cargo-near-image.yml
@@ -1,0 +1,58 @@
+name: Build cargo-near MPC image
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docker/cargo-near-mpc/Dockerfile'
+      - '.github/workflows/cargo-near-image.yml'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    name: "Build and push reproducible-build image"
+    runs-on: warp-ubuntu-2404-x64-2x
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push image
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/cargo-near-mpc
+          file: docker/cargo-near-mpc/Dockerfile
+          push: true
+          provenance: false
+          tags: |
+            nearone/cargo-near-mpc:${{ github.sha }}
+            nearone/cargo-near-mpc:latest
+          platforms: linux/amd64
+
+      - name: Print published digest
+        run: |
+          echo "Image: nearone/cargo-near-mpc@${{ steps.push.outputs.digest }}"
+          echo "Tag:   nearone/cargo-near-mpc:${{ github.sha }}"
+          echo
+          echo "Update crates/contract/Cargo.toml [package.metadata.near.reproducible_build]:"
+          echo "  image = \"nearone/cargo-near-mpc:${{ github.sha }}\""
+          echo "  image_digest = \"${{ steps.push.outputs.digest }}\""

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -8,29 +8,27 @@ repository = "https://github.com/near/mpc"
 # fields to configure build with WASM reproducibility, according to specs
 # in https://github.com/near/NEPs/blob/master/neps/nep-0330.md
 [package.metadata.near.reproducible_build]
-# docker image, descriptor of build environment
-image = "sourcescan/cargo-near:0.17.0-rust-1.86.0"
-# tag after colon above serves only descriptive purpose; image is identified by digest
-image_digest = "sha256:1784ca6310f3496f0048356ce420921c8f5fdf71ee8124d43a2e1ceb1f70db8a"
-# list of environment variables names, whose values, if set, will be used as external build parameters
-# in a reproducible manner
-# supported by `sourcescan/cargo-near:0.10.1-rust-1.82.0` image or later images
+# Custom image extending sourcescan/cargo-near:0.17.0-rust-1.86.0 with the
+# `binaryen` apt package so a standalone `wasm-opt` is available on PATH.
+# cargo-near's bundled wasm-opt is hard-coded to `-O`; we want `-Os` for size
+# (~64 KB savings on this contract). See docs/contract-build-size-optimization.md.
+# Built and published by .github/workflows/cargo-near-image.yml.
+image = "nearone/cargo-near-mpc:latest"
+# TODO: replace with the actual digest after the cargo-near-image workflow
+# publishes the first build. cargo-near verifies the image matches this digest
+# at reproducible-wasm time, so this PR is a draft until the digest is filled.
+image_digest = "sha256:0000000000000000000000000000000000000000000000000000000000000000"
 passed_env = []
-# build command inside of docker container
-# if docker image from default gallery is used https://hub.docker.com/r/sourcescan/cargo-near/tags,
-# the command may be any combination of flags of `cargo-near`,
-# supported by respective version of binary inside the container besides `--no-locked` flag
+# We replace cargo-near's bundled wasm-opt step (`-O`) with our own `wasm-opt
+# -Os --strip-*` invocation. The pipeline:
+#   1. cargo-near builds the wasm without optimization (--no-wasmopt)
+#   2. wasm-opt -Os shrinks code-size with no runtime cost vs `-O`
+#   3. --strip-debug --strip-producers --strip-target-features --vacuum
+#      drops sections that contribute size but nothing functional
 container_build_command = [
-    "cargo",
-    "near",
-    "build",
-    # this is counter intuitive, but it correctly follows the docs,
-    # the non-reproducible build inside a reproducible environment becomes reproducible
-    "non-reproducible-wasm",
-    "--locked",
-    "--profile=release-contract",
-    "--features",
-    "abi",
+    "bash",
+    "-c",
+    "cargo near build non-reproducible-wasm --locked --profile=release-contract --features abi --no-wasmopt && wasm-opt -Os --strip-debug --strip-producers --strip-target-features --vacuum target/near/mpc_contract/mpc_contract.wasm -o target/near/mpc_contract/mpc_contract.wasm",
 ]
 
 [lib]

--- a/docker/cargo-near-mpc/Dockerfile
+++ b/docker/cargo-near-mpc/Dockerfile
@@ -1,0 +1,17 @@
+# Reproducible-build image for the MPC contract.
+#
+# Extends the upstream sourcescan/cargo-near image with the standalone
+# `wasm-opt` binary (binaryen). cargo-near's bundled wasm-opt only exposes
+# a `--no-wasmopt` toggle and is hard-coded to `-O`; we want `-Oz` for
+# maximum size reduction, which requires invoking wasm-opt ourselves from
+# `container_build_command`. The base image has no wasm-opt on PATH, so we
+# install binaryen here and pin both the base digest and the apt version
+# so the image is deterministic.
+
+FROM sourcescan/cargo-near@sha256:1784ca6310f3496f0048356ce420921c8f5fdf71ee8124d43a2e1ceb1f70db8a
+
+USER root
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends binaryen=120-4 \
+ && rm -rf /var/lib/apt/lists/*
+USER near

--- a/docs/contract-build-size-optimization.md
+++ b/docs/contract-build-size-optimization.md
@@ -1,109 +1,135 @@
-# Contract build size optimization
+# Contract build size optimization — investigation log
 
-## Why this exists
+> **Status: superseded by measurement-driven conclusion. PR closed without
+> merging.** This document is the record of what we investigated and what
+> the corrected measurements showed. Kept here so future readers don't
+> repeat the same analysis from scratch. The current build pipeline is
+> unchanged; revisit if real size pressure appears.
 
-The `mpc-contract` WASM artifact is deployed to NEAR mainnet by passing the
-bytes through a `DeployContract` action. NEAR's protocol-level
-`max_transaction_size` is **1,572,864 bytes** (1.5 MiB), so the deploy
-transaction — which carries the wasm — must fit under that ceiling. The repo
-guards this in `scripts/check-contract-wasm-size.sh` with a tighter
-self-imposed limit of 1,490,000 bytes to keep some headroom.
+## Why this was opened
 
-The contract has been growing close to that limit. Before this change the
-artifact built by `cargo near build reproducible-wasm` was **1,499,976 bytes**
-— already over the safety margin. This change reduces it to
-**~1,435,586 bytes** (–64 KB / –4.3%) while keeping the reproducibility
-guarantee intact.
+The contract WASM was thought to be ~1,499,976 bytes — over the repo's
+self-imposed safety margin in `scripts/check-contract-wasm-size.sh`
+(`HARD_LIMIT=1490000`) and approaching NEAR's 1,572,864-byte
+`max_transaction_size` ceiling.
 
-## What changed
+The proposed remedy was to extend the pinned cargo-near reproducible-build
+image with `binaryen` so we could swap cargo-near's bundled `wasm-opt -O`
+for `-Os` (or `-Oz`) and apply `--strip-*` flags. The expected savings were
+~64 KB from the strip flags and an additional ~22 KB from `-Oz`.
 
-The reproducible build runs inside a digest-pinned docker image. The pinned
-upstream image (`sourcescan/cargo-near:0.17.0-rust-1.86.0`) only exposes
-`cargo-near`'s bundled wasm-opt at `-O`, with no flag to choose a different
-optimization level. To run wasm-opt at `-Os` we need a standalone `wasm-opt`
-binary on PATH inside the container — and the pinned image doesn't have one.
+## What measurement actually showed
 
-This PR adds a thin custom image (`nearone/cargo-near-mpc`) that extends the
-pinned base with `apt-get install binaryen`. The contract's
-`[package.metadata.near.reproducible_build]` then points at it, skips
-cargo-near's bundled wasm-opt (`--no-wasmopt`), and chains `wasm-opt -Os
---strip-*` as the optimization step.
+### The 1,499,976 baseline was wrong
 
-Reproducibility is preserved: everything still happens inside a digest-pinned
-image, with the same source and the same flags. Anyone running
-`cargo near build reproducible-wasm` produces byte-identical output. The
-sha256 published in GitHub release notes — and used by participants in
-`vote_update` — remains derivable from source.
+The "production" baseline came from a stale local-host build using
+`cargo-near 0.20.0`, not from a `cargo near build reproducible-wasm` run.
+The real reproducible-build output, produced inside the digest-pinned
+`sourcescan/cargo-near:0.17.0-rust-1.86.0` image, is **~1,436,167 bytes**
+— already 54 KB *under* the safety margin and 137 KB under the protocol
+ceiling. The headline urgency was based on a number that doesn't represent
+what actually ships.
 
-## Why `-Os` and not `-O` or `-Oz`
+### The strip flags save 0 bytes
 
-We measured all three on the same raw (un-optimized) wasm using wasm-opt 120
-inside the new image, with `--strip-debug --strip-producers
---strip-target-features --vacuum` applied to all variants:
+Measured inside the same docker image, on the identical raw (un-optimized)
+wasm, applying each strip flag in isolation:
 
-| Pipeline | Size (bytes) | Δ vs current production | Runtime tradeoff |
-|---|---|---|---|
-| Current production (cargo-near's bundled `-O`, no extra strip flags) | 1,499,976 | — | baseline |
-| Our pipeline `-O` + strip-flags | 1,435,586 | **−64,390 (−4.29%)** | none |
-| Our pipeline `-Os` + strip-flags | 1,435,586 | **−64,390 (−4.29%)** | none |
-| Our pipeline `-Oz` + strip-flags | 1,413,072 | −86,904 (−5.79%) | possibly slower runtime |
+| Pipeline | Size |
+|---|---|
+| Raw (no opt) | 1,755,836 |
+| `-O` (no flags) | 1,435,586 |
+| `-O --vacuum` | 1,435,586 |
+| `-O --strip-debug` | 1,435,586 |
+| `-O --strip-producers` | 1,435,586 |
+| `-O --strip-target-features` | 1,435,586 |
+| `-O` + all four strip-flags | 1,435,586 |
 
-Two takeaways:
+Every variant produces byte-identical output. The release profile already
+has `strip = true` in `[profile.release-contract]` so debug info is gone
+before wasm-opt sees the file, and the producer/target-features sections
+are either already absent or are dropped by `-O`'s default passes. The
+"~64 KB from strip flags" figure earlier in the investigation was actually
+the build-environment difference between cargo-near 0.20 (host) and
+cargo-near 0.17 (docker) — a baseline error, not a flag-attributable win.
 
-1. **Most of the win comes from the strip-flags**, not the optimization level.
-   Cargo-near's bundled wasm-opt doesn't strip the `producers` /
-   `target_features` sections by default, and those weigh ~64 KB on this
-   contract.
-2. **`-O` and `-Os` produce byte-identical output here.** wasm-opt 120's `-O`
-   pipeline already runs all the size-reducing passes that `-Os` enables;
-   there's nothing extra for `-Os` to do on this binary. `-Oz` runs additional
-   shrink-only passes (e.g. avoiding inlining that costs bytes) and saves a
-   further ~22 KB at the cost of potentially slower generated code.
+### `-O` and `-Os` are byte-identical on this contract
 
-We chose **`-Os`** for this PR because:
+| Pipeline | Size |
+|---|---|
+| `-O + strip-flags` | 1,435,586 |
+| `-Os + strip-flags` | 1,435,586 |
 
-- It captures the entire 64 KB win from the strip-flags with **zero runtime
-  risk** versus today's production binary (it is byte-identical to `-O` on
-  this contract — the instruction selection is unchanged).
-- The remaining 22 KB difference vs `-Oz` would require validating gas
-  parity on representative calls (e.g. `sign()`), which is an additional
-  step we would prefer not to bundle into a build-pipeline PR.
-- 64 KB of headroom is enough to bring the artifact comfortably under the
-  self-imposed 1,490,000-byte safety margin (54 KB headroom under the script
-  limit, 137 KB under the protocol ceiling).
+Same sha256 across the two outputs. wasm-opt 120's `-O` already runs the
+size-favoring passes that `-Os` enables; there's nothing extra to do on
+this binary.
 
-If size pressure returns later, switching to `-Oz` is a one-line change to
-`container_build_command`, gated on a quick gas-parity measurement.
+### Only `-Oz` saves real bytes
 
-## Reproducibility argument
+| Pipeline | Size | vs reproducible production |
+|---|---|---|
+| Reproducible production today | ~1,436,167 | — |
+| Any `-O` / `-Os` pipeline (with or without strip-flags) | ~1,435,586 | ~580 B (noise) |
+| `-Oz + strip-flags` | 1,413,072 | **−23,095 B (−1.6%)** |
 
-The full chain remains end-to-end deterministic:
+`-Oz` is the only variant that materially differs. It runs additional
+shrink-only passes (e.g. avoiding inlining decisions that would grow the
+binary) at the cost of potentially slower generated code.
 
-1. **Source** is fixed (the contract crate at a given commit).
-2. **Image** is fixed by digest (`image_digest` in `Cargo.toml` is the sha256
-   manifest digest of the published image; cargo-near refuses to run if the
-   pulled image doesn't match).
-3. **Compiler toolchain** is the rust toolchain bundled in the pinned image.
-4. **Optimizer** is `binaryen=120-4` from Debian trixie, installed at image
-   build time. The pinned image digest captures the exact `wasm-opt`
-   binary bytes; no rebuild can drift it without changing the digest.
-5. **Build command** is fixed in `container_build_command`.
+## Conclusion
 
-We verified empirically that two clean runs through this pipeline produce
-byte-identical output (sha256 stable across runs).
+The PR's premise was *"we're over the limit, this is urgent."* Real
+measurement shows we're not over any limit, and the proposed `-Os` change
+saves nothing on this contract. The `-Oz` path would save ~23 KB but
+introduces a new optimization level whose runtime cost would need to be
+validated with gas measurements on a representative call (e.g. `sign()`)
+before merging.
 
-## Operational notes
+Since there is no immediate size pressure, the PR was closed without
+merging. The build pipeline remains:
 
-- The image is published to `nearone/cargo-near-mpc` via
-  `.github/workflows/cargo-near-image.yml`. The workflow tags every build
-  with the source commit sha and `latest`, and prints the published manifest
-  digest in the workflow log.
-- After the first publish, update `image_digest` in
-  `crates/contract/Cargo.toml` to the published digest. Without this, the
-  reproducible build will fail.
-- When bumping the rust toolchain or cargo-near version, update the `FROM`
-  line in `docker/cargo-near-mpc/Dockerfile`, push a new image, and update
-  `image_digest` in lockstep.
-- The contract sha256 changes once on first release after this lands (the
-  release-notes hash will reflect the new value automatically; consumers
-  with hardcoded expectations of the prior hash need a heads-up).
+- `cargo near build reproducible-wasm` against the
+  `sourcescan/cargo-near:0.17.0-rust-1.86.0` image,
+- which runs cargo-near's bundled `wasm-opt -O` post-step,
+- producing ~1,436,167 bytes today, with ~54 KB headroom under the
+  self-imposed safety margin.
+
+## When to revisit
+
+Pivot to a `-Oz` pipeline if **either** of these becomes true:
+
+1. The contract grows past ~1.45 MB and headroom under the safety margin
+   shrinks below ~40 KB.
+2. A specific feature lands that pushes us past the script's
+   `HARD_LIMIT=1490000`.
+
+If revisited, the work is roughly:
+
+- Build a custom image extending the pinned `sourcescan/cargo-near` base
+  with `binaryen` (the Dockerfile from the closed PR is preserved at
+  `docker/cargo-near-mpc/Dockerfile` on branch
+  `experiment/wasm-opt-oz-reproducible-build` if useful).
+- Update `[package.metadata.near.reproducible_build]` in
+  `crates/contract/Cargo.toml` to point at the new image and chain
+  `bash -c "cargo near build … --no-wasmopt && wasm-opt -Oz --strip-* --vacuum …"`.
+- Gas-validate a representative `sign()` call on sandbox before merging.
+
+For larger headroom (multi-hundred-KB), structural options remain (in
+preference order):
+
+1. Move DCAP/TDX quote verification off the contract (sub-contract or
+   off-chain attestation oracle). Single call site at
+   `crates/attestation/src/attestation.rs`. Frees ~300–500 KB.
+2. Delete `crates/contract/src/v3_9_1_state.rs` once 3.9.1 has fully
+   rolled out (~20–50 KB).
+3. Collapse `crates/contract/src/dto_mapping.rs` (975 lines bridging two
+   parallel type universes).
+
+## Process lesson for next time
+
+The measurement design should isolate each variable from the start. The
+right setup is: same docker image, same source, vary one flag, measure.
+Comparing a host build to a docker build and calling the gap a "saving"
+mixed two effects (environment and flag) and produced misleading
+headline numbers. The corrected numbers above came from doing the
+isolation properly.

--- a/docs/contract-build-size-optimization.md
+++ b/docs/contract-build-size-optimization.md
@@ -1,0 +1,109 @@
+# Contract build size optimization
+
+## Why this exists
+
+The `mpc-contract` WASM artifact is deployed to NEAR mainnet by passing the
+bytes through a `DeployContract` action. NEAR's protocol-level
+`max_transaction_size` is **1,572,864 bytes** (1.5 MiB), so the deploy
+transaction — which carries the wasm — must fit under that ceiling. The repo
+guards this in `scripts/check-contract-wasm-size.sh` with a tighter
+self-imposed limit of 1,490,000 bytes to keep some headroom.
+
+The contract has been growing close to that limit. Before this change the
+artifact built by `cargo near build reproducible-wasm` was **1,499,976 bytes**
+— already over the safety margin. This change reduces it to
+**~1,435,586 bytes** (–64 KB / –4.3%) while keeping the reproducibility
+guarantee intact.
+
+## What changed
+
+The reproducible build runs inside a digest-pinned docker image. The pinned
+upstream image (`sourcescan/cargo-near:0.17.0-rust-1.86.0`) only exposes
+`cargo-near`'s bundled wasm-opt at `-O`, with no flag to choose a different
+optimization level. To run wasm-opt at `-Os` we need a standalone `wasm-opt`
+binary on PATH inside the container — and the pinned image doesn't have one.
+
+This PR adds a thin custom image (`nearone/cargo-near-mpc`) that extends the
+pinned base with `apt-get install binaryen`. The contract's
+`[package.metadata.near.reproducible_build]` then points at it, skips
+cargo-near's bundled wasm-opt (`--no-wasmopt`), and chains `wasm-opt -Os
+--strip-*` as the optimization step.
+
+Reproducibility is preserved: everything still happens inside a digest-pinned
+image, with the same source and the same flags. Anyone running
+`cargo near build reproducible-wasm` produces byte-identical output. The
+sha256 published in GitHub release notes — and used by participants in
+`vote_update` — remains derivable from source.
+
+## Why `-Os` and not `-O` or `-Oz`
+
+We measured all three on the same raw (un-optimized) wasm using wasm-opt 120
+inside the new image, with `--strip-debug --strip-producers
+--strip-target-features --vacuum` applied to all variants:
+
+| Pipeline | Size (bytes) | Δ vs current production | Runtime tradeoff |
+|---|---|---|---|
+| Current production (cargo-near's bundled `-O`, no extra strip flags) | 1,499,976 | — | baseline |
+| Our pipeline `-O` + strip-flags | 1,435,586 | **−64,390 (−4.29%)** | none |
+| Our pipeline `-Os` + strip-flags | 1,435,586 | **−64,390 (−4.29%)** | none |
+| Our pipeline `-Oz` + strip-flags | 1,413,072 | −86,904 (−5.79%) | possibly slower runtime |
+
+Two takeaways:
+
+1. **Most of the win comes from the strip-flags**, not the optimization level.
+   Cargo-near's bundled wasm-opt doesn't strip the `producers` /
+   `target_features` sections by default, and those weigh ~64 KB on this
+   contract.
+2. **`-O` and `-Os` produce byte-identical output here.** wasm-opt 120's `-O`
+   pipeline already runs all the size-reducing passes that `-Os` enables;
+   there's nothing extra for `-Os` to do on this binary. `-Oz` runs additional
+   shrink-only passes (e.g. avoiding inlining that costs bytes) and saves a
+   further ~22 KB at the cost of potentially slower generated code.
+
+We chose **`-Os`** for this PR because:
+
+- It captures the entire 64 KB win from the strip-flags with **zero runtime
+  risk** versus today's production binary (it is byte-identical to `-O` on
+  this contract — the instruction selection is unchanged).
+- The remaining 22 KB difference vs `-Oz` would require validating gas
+  parity on representative calls (e.g. `sign()`), which is an additional
+  step we would prefer not to bundle into a build-pipeline PR.
+- 64 KB of headroom is enough to bring the artifact comfortably under the
+  self-imposed 1,490,000-byte safety margin (54 KB headroom under the script
+  limit, 137 KB under the protocol ceiling).
+
+If size pressure returns later, switching to `-Oz` is a one-line change to
+`container_build_command`, gated on a quick gas-parity measurement.
+
+## Reproducibility argument
+
+The full chain remains end-to-end deterministic:
+
+1. **Source** is fixed (the contract crate at a given commit).
+2. **Image** is fixed by digest (`image_digest` in `Cargo.toml` is the sha256
+   manifest digest of the published image; cargo-near refuses to run if the
+   pulled image doesn't match).
+3. **Compiler toolchain** is the rust toolchain bundled in the pinned image.
+4. **Optimizer** is `binaryen=120-4` from Debian trixie, installed at image
+   build time. The pinned image digest captures the exact `wasm-opt`
+   binary bytes; no rebuild can drift it without changing the digest.
+5. **Build command** is fixed in `container_build_command`.
+
+We verified empirically that two clean runs through this pipeline produce
+byte-identical output (sha256 stable across runs).
+
+## Operational notes
+
+- The image is published to `nearone/cargo-near-mpc` via
+  `.github/workflows/cargo-near-image.yml`. The workflow tags every build
+  with the source commit sha and `latest`, and prints the published manifest
+  digest in the workflow log.
+- After the first publish, update `image_digest` in
+  `crates/contract/Cargo.toml` to the published digest. Without this, the
+  reproducible build will fail.
+- When bumping the rust toolchain or cargo-near version, update the `FROM`
+  line in `docker/cargo-near-mpc/Dockerfile`, push a new image, and update
+  `image_digest` in lockstep.
+- The contract sha256 changes once on first release after this lands (the
+  release-notes hash will reflect the new value automatically; consumers
+  with hardcoded expectations of the prior hash need a heads-up).


### PR DESCRIPTION
## Summary

Switches the contract's reproducible build to a custom image
(`nearone/cargo-near-mpc`) that has `binaryen` on PATH, then replaces
cargo-near's bundled `wasm-opt -O` with `wasm-opt -Os --strip-debug
--strip-producers --strip-target-features --vacuum`.

**Result:** contract WASM goes from **1,499,976 → 1,435,586 bytes**
(**−64 KB / −4.3%**), restoring headroom under the repo's 1,490,000-byte
safety margin (`scripts/check-contract-wasm-size.sh`) and the protocol's
1,572,864-byte `max_transaction_size`. No runtime tradeoff: `-O` and `-Os`
produce byte-identical output on this contract; the savings come from the
strip-flags. End-to-end reproducibility is preserved.

## What's in this PR

- `docker/cargo-near-mpc/Dockerfile` — extends the pinned
  `sourcescan/cargo-near:0.17.0-rust-1.86.0` base with `binaryen=120-4`.
- `.github/workflows/cargo-near-image.yml` — builds & pushes the image to
  `nearone/cargo-near-mpc:<sha>` + `:latest` on pushes to `main` that touch
  the Dockerfile or the workflow itself, plus `workflow_dispatch`. Prints
  the published manifest digest in the run log.
- `crates/contract/Cargo.toml` — `[package.metadata.near.reproducible_build]`
  now points at `nearone/cargo-near-mpc:latest` and chains
  `bash -c "cargo near build … --no-wasmopt && wasm-opt -Os …"` as the
  `container_build_command`.
- `docs/contract-build-size-optimization.md` — full rationale, measurements
  for `-O` / `-Os` / `-Oz`, reproducibility argument.

## Why `-Os` (and not `-O` or `-Oz`)

Measured on the same raw wasm with the same strip-flags, wasm-opt 120:

| Pipeline | Size | Δ vs production | Runtime tradeoff |
|---|---|---|---|
| Current production (`-O`, no extra strips) | 1,499,976 | — | baseline |
| Our pipeline `-O` + strip-flags | 1,435,586 | **−64 KB** | none |
| Our pipeline `-Os` + strip-flags | 1,435,586 | **−64 KB** | none |
| Our pipeline `-Oz` + strip-flags | 1,413,072 | −87 KB | possibly slower |

`-O` and `-Os` are byte-identical on this contract — wasm-opt's `-O` already
runs the size-favoring passes that `-Os` enables. Most of the win comes from
`--strip-producers` / `--strip-target-features`, sections cargo-near's
bundled wasm-opt does not strip. `-Oz` saves a further 22 KB but at the cost
of potentially slower generated code, which would require gas-parity
measurements before adopting.

## Verification done locally

- Built the custom image; `wasm-opt 120` available on PATH; cargo-near 0.17.0
  intact.
- Ran the new `container_build_command` inside the container twice — output
  is byte-identical (sha256 stable across runs).
- Final size: 1,435,586 bytes with `-Os`; 1,413,072 with `-Oz`.

## Why this is a draft

`image_digest` in `crates/contract/Cargo.toml` is a placeholder
(`sha256:0000…`). It needs to be updated to the real manifest digest after
the new `cargo-near-image` workflow publishes the first build. The workflow
log prints the digest for easy copy-paste into `Cargo.toml`.

Once the digest is filled in:
1. `cargo near build reproducible-wasm --manifest-path crates/contract/Cargo.toml`
   should produce a deterministic 1,435,586-byte artifact,
2. CI's `mpc-contract-reproducible-build` job should pass the
   `check-contract-wasm-size.sh` gate again.

## Test plan

- [ ] Merge order: this PR can land in two phases.
  - Phase 1 (after CI merges): the `cargo-near-image` workflow runs on
    `main` and publishes `nearone/cargo-near-mpc:<sha>` + `:latest`. Capture
    the digest from the workflow log.
  - Phase 2: a small follow-up PR (or amendment to this one) replaces the
    placeholder `image_digest` with the captured digest.
- [ ] Verify locally: `cargo near build reproducible-wasm --manifest-path crates/contract/Cargo.toml`,
      confirm sha256 stable across two clean runs.
- [ ] Verify size gate passes: `bash scripts/check-contract-wasm-size.sh`.
- [ ] Run `cargo make e2e-tests` against the optimized wasm to validate
      runtime correctness on the NEAR runtime (covers the small risk that
      stripping `target_features` or `producers` interacts with the
      runtime's wasm validator).
- [ ] Confirm the embedded ABI section is preserved through the
      `--strip-*` pass (`cargo near contract abi` against the new wasm, or
      equivalent extraction).
- [ ] Communicate to consumers that the contract sha256 changes on first
      release after this lands.