### PR TITLE
ci: bump cache-nix action to latest commit to be reviewed

### DIFF
--- a/.github/actions/restore-nix-cache/action.yml
+++ b/.github/actions/restore-nix-cache/action.yml
@@ -16,13 +16,13 @@ runs:
         backend: warpbuild
         primary-key: nix-${{ runner.os }}-ci-${{ hashFiles('flake.nix', 'flake.lock', 'nix/**', 'rust-toolchain.toml', 'Cargo.lock') }}
         restore-prefixes-first-match: nix-${{ runner.os }}-ci-
-        save: true
+        save: ${{ inputs.save }}
         # Target store size of 0 means always run garbage collection.
         # Note that pinning step below prevents the usable cache to be cleaned.
         gc-max-store-size: 0
 
     - name: Pin dev-shell closure as GC root
-      # if: inputs.save == 'true'
+      if: inputs.save == 'true'
       shell: bash
       # `--profile` registers the dev-shell closure as an indirect GC root,
       # so the pre-upload garbage collection keeps it (and its dependencies)

--- a/.github/actions/restore-nix-cache/action.yml
+++ b/.github/actions/restore-nix-cache/action.yml
@@ -11,7 +11,7 @@ runs:
   using: composite
   steps:
     - name: Restore /nix from cache
-      uses: near/cache-nix-action@3e2c4eea4e825e74575cbc8e25d38173df7686c2 # enable-warpbuild-cache
+      uses: near/cache-nix-action@5949a19eab9787f4744a08c1b93917404819d424 # enable-warpbuild-cache
       with:
         backend: warpbuild
         primary-key: nix-${{ runner.os }}-ci-${{ hashFiles('flake.nix', 'flake.lock', 'nix/**', 'rust-toolchain.toml', 'Cargo.lock') }}

--- a/.github/actions/restore-nix-cache/action.yml
+++ b/.github/actions/restore-nix-cache/action.yml
@@ -16,13 +16,13 @@ runs:
         backend: warpbuild
         primary-key: nix-${{ runner.os }}-ci-${{ hashFiles('flake.nix', 'flake.lock', 'nix/**', 'rust-toolchain.toml', 'Cargo.lock') }}
         restore-prefixes-first-match: nix-${{ runner.os }}-ci-
-        save: ${{ inputs.save }}
+        save: true
         # Target store size of 0 means always run garbage collection.
         # Note that pinning step below prevents the usable cache to be cleaned.
         gc-max-store-size: 0
 
     - name: Pin dev-shell closure as GC root
-      if: inputs.save == 'true'
+      # if: inputs.save == 'true'
       shell: bash
       # `--profile` registers the dev-shell closure as an indirect GC root,
       # so the pre-upload garbage collection keeps it (and its dependencies)

--- a/.github/workflows/nix-build-mpc-node.yml
+++ b/.github/workflows/nix-build-mpc-node.yml
@@ -29,7 +29,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@21a544727d0c62386e78b4befe52d19ad12692e3 # v17
 
       - name: Restore /nix from cache
-        uses: near/cache-nix-action@3e2c4eea4e825e74575cbc8e25d38173df7686c2 # enable-warpbuild-cache
+        uses: near/cache-nix-action@5949a19eab9787f4744a08c1b93917404819d424 # enable-warpbuild-cache
         with:
           backend: warpbuild
           primary-key: nix-${{ runner.os }}-mpc-node-${{ hashFiles('flake.nix', 'flake.lock', 'nix/**', 'rust-toolchain.toml', 'Cargo.lock') }}


### PR DESCRIPTION
The fork branch we are using was updated as part of the PR on https://github.com/nix-community/cache-nix-action/pull/334