### PR TITLE
ci: make Claude reviews more thorough, similar to Copilot

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,9 +1,11 @@
-Analyze this pull request focusing on CRITICAL issues only. Be concise and actionable.
+You are reviewing a Rust pull request. Produce a thorough, actionable review using the structure below.
 
 **IMPORTANT - CONTEXT AWARENESS:**
 - Review any existing PR comments and discussions provided alongside this prompt before giving feedback
 - Do not duplicate points already raised in existing discussions
 - If a resolved thread addressed an issue, do not re-raise it
+- You have read access to the checked-out repository — use `Read`, `Grep`, and `Glob` to verify how changes interact with surrounding code, look up referenced types/functions/tests, and consult [CLAUDE.md], [AGENTS.md], [CONTRIBUTING.md], and [engineering-standards.md] for project conventions
+- Use `gh pr diff` for the full diff and `gh pr view` for PR metadata
 
 PRIORITY CHECKS (report only if found):
 
@@ -53,11 +55,52 @@ REVIEW STYLE:
 - If no critical issues found: approve with a one-line summary
 - Sign off with: ✅ (approved) or ⚠️ (issues found)
 
+REQUIRED OUTPUT STRUCTURE:
+
+The review body must follow this layout:
+
+```
+## Pull request overview
+
+<2–4 sentence narrative summary of what this PR does and why.>
+
+**Changes:**
+- <bullet list of substantive changes — group related edits>
+
+### Reviewed changes
+
+<details>
+<summary>Per-file summary</summary>
+
+| File | Description |
+| ---- | ----------- |
+| path/to/file.rs | What changed in this file |
+| ... | ... |
+
+</details>
+
+### Findings
+
+**Blocking** (must fix before merge):
+- `path/to/file.rs:LINE` — <description and concrete suggested fix>
+
+**Non-blocking** (nits, follow-ups, suggestions):
+- `path/to/file.rs:LINE` — <description>
+
+<Omit a category if empty.>
+
+<End with one of:>
+✅ Approved
+⚠️ Issues found
+```
+
+Anchor every finding with a `file:line` reference so reviewers can jump to the location.
+
 Consult the repository's [CLAUDE.md], [CONTRIBUTING.md], and [AGENTS.md] for project-specific conventions.
-Don't try to use `gh pr review` you don't have permissions for that and it will fail. 
+Don't try to use `gh pr review` you don't have permissions for that and it will fail.
 Please always use `gh pr comment` to post your review instead.
 
 [CLAUDE.md]: ../../CLAUDE.md
-[CONTRIBUTING.md]: ../../CONTRIBUTING.md
 [AGENTS.md]: ../../AGENTS.md
+[CONTRIBUTING.md]: ../../CONTRIBUTING.md
 [engineering-standards.md]: ../../docs/engineering-standards.md

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -66,4 +66,7 @@ jobs:
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API }}
           prompt: ${{ env.REVIEW_PROMPT }}
-          claude_args: '--model claude-opus-4-6 --allowed-tools "Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"'
+          claude_args: >-
+            --model claude-opus-4-7
+            --effort xhigh
+            --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"


### PR DESCRIPTION
Closes #3116 

I tried to get also inline comments, but that requires too broad permissions with `gh api` that are not easy to scope properly.

As we know this change can only be tested after merge, as the review does not work when the workflow is modified