### PR TITLE
ci: workaround for claude-code bug

### DIFF
--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -30,6 +30,12 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: symlink fix workaround
+        run: |
+          # see https://github.com/anthropics/claude-code-action/issues/1205#issuecomment-4248704481
+          rm CLAUDE.md
+          cp AGENTS.md CLAUDE.md
+
       - name: Fetch PR Comments Context
         id: fetch-comments
         env:


### PR DESCRIPTION
Follow up to #3125 due to failure in https://github.com/near/mpc/actions/runs/25367259655/job/74381223964

Applying potential solution from https://github.com/anthropics/claude-code-action/issues/1205#issuecomment-4248704481

Alternative is to do https://github.com/shenghaoc/hdb-resale-visualizer/commit/1b93d17fd8283e6a10faec95ad52da1e9c52584e but we would lose opus 4.7