### PR TITLE
[testing] DSS fix via launcher TOML — tier3_public_addr + fallback threshold (#1734)

### DIFF
--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -108,6 +108,19 @@ pub struct NearInitConfig {
     /// Override the NEAR node network (indexer) listen address (e.g. "0.0.0.0:24568").
     /// Useful when running multiple nodes on the same machine.
     pub network_addr: Option<String>,
+    /// Override the public address advertised for Tier3 state-sync responses
+    /// (e.g. "203.0.113.5:24567"). Required on multi-IP hosts where outbound
+    /// source IP differs from the bound IP — auto-discovery picks the
+    /// outbound IP and DSS times out. Patches into nearcore's
+    /// `network.experimental.tier3_public_addr` config field.
+    pub tier3_public_addr: Option<String>,
+    /// Override how many P2P (DSS) state-sync attempts to make before falling
+    /// back to the external storage bucket. `0` (current default) means
+    /// "go straight to bucket, never use DSS." A moderate value enables
+    /// DSS-first with bucket as a safety net; a very large value effectively
+    /// disables the bucket fallback. Patches into nearcore's
+    /// `state_sync.sync.ExternalStorage.external_storage_fallback_threshold`.
+    pub external_storage_fallback_threshold: Option<u64>,
 }
 
 /// Encryption keys needed at startup.

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -201,6 +201,8 @@ impl InitConfigArgs {
             download_genesis_records_url: self.download_genesis_records_url,
             rpc_addr: None,
             network_addr: None,
+            tier3_public_addr: None,
+            external_storage_fallback_threshold: None,
         }
     }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -138,6 +138,25 @@ fn patch_near_config(
     let mut config: serde_json::Value =
         serde_json::from_str(&raw).context("failed to parse NEAR config.json")?;
 
+    let contract_id = node_config.indexer.mpc_contract_id.to_string();
+    apply_near_config_patches(&mut config, near_init, &contract_id);
+
+    let patched =
+        serde_json::to_string_pretty(&config).context("failed to re-serialize NEAR config.json")?;
+    std::fs::write(config_path, patched)
+        .with_context(|| format!("failed to write {}", config_path.display()))?;
+
+    tracing::info!("NEAR node config.json patched successfully");
+    Ok(())
+}
+
+/// Pure JSON-manipulation half of [`patch_near_config`], extracted so it can
+/// be unit-tested without filesystem I/O or constructing a full `ConfigFile`.
+fn apply_near_config_patches(
+    config: &mut serde_json::Value,
+    near_init: &NearInitConfig,
+    mpc_contract_id: &str,
+) {
     config["store"]["load_mem_tries_for_tracked_shards"] = serde_json::Value::Bool(true);
 
     let is_localnet = near_init.chain_id.is_localnet();
@@ -150,8 +169,7 @@ fn patch_near_config(
     }
 
     // Track the shard that hosts the MPC contract.
-    let contract_id = node_config.indexer.mpc_contract_id.to_string();
-    config["tracked_shards_config"] = serde_json::json!({ "Accounts": [contract_id] });
+    config["tracked_shards_config"] = serde_json::json!({ "Accounts": [mpc_contract_id] });
 
     // Override listen addresses when running multiple nodes on one machine.
     if let Some(rpc_addr) = &near_init.rpc_addr {
@@ -164,12 +182,167 @@ fn patch_near_config(
         config["network"]["experimental"]["tier3_public_addr"] =
             serde_json::Value::String(tier3.clone());
     }
+}
 
-    let patched =
-        serde_json::to_string_pretty(&config).context("failed to re-serialize NEAR config.json")?;
-    std::fs::write(config_path, patched)
-        .with_context(|| format!("failed to write {}", config_path.display()))?;
+#[cfg(test)]
+#[allow(non_snake_case)] // tests follow `<system_under_test>__should_<assertion>` convention
+mod tests {
+    use super::*;
+    use mpc_node_config::ChainId;
 
-    tracing::info!("NEAR node config.json patched successfully");
-    Ok(())
+    fn near_init(chain_id: ChainId) -> NearInitConfig {
+        NearInitConfig {
+            chain_id,
+            boot_nodes: None,
+            genesis_path: None,
+            download_config: None,
+            download_config_url: None,
+            download_genesis: false,
+            download_genesis_url: None,
+            download_genesis_records_url: None,
+            rpc_addr: None,
+            network_addr: None,
+            tier3_public_addr: None,
+            external_storage_fallback_threshold: None,
+        }
+    }
+
+    fn empty_config_json() -> serde_json::Value {
+        serde_json::json!({
+            "store": {},
+            "network": {},
+            "rpc": {},
+            "state_sync": { "sync": { "ExternalStorage": {} } }
+        })
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_tier3_public_addr_when_provided() {
+        // Given
+        let mut config = empty_config_json();
+        let mut init = near_init(ChainId::Testnet);
+        init.tier3_public_addr = Some("46.105.87.136:24567".to_string());
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["network"]["experimental"]["tier3_public_addr"],
+            serde_json::json!("46.105.87.136:24567")
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_omit_tier3_public_addr_when_unset() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert!(config["network"]["experimental"].get("tier3_public_addr").is_none());
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_default_fallback_threshold_to_zero() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then — preserves the historical bucket-only default when operator hasn't opted in
+        assert_eq!(
+            config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"],
+            serde_json::json!(0)
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_use_configured_fallback_threshold() {
+        // Given
+        let mut config = empty_config_json();
+        let mut init = near_init(ChainId::Testnet);
+        init.external_storage_fallback_threshold = Some(1000);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"],
+            serde_json::json!(1000)
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_disable_state_sync_for_localnet() {
+        // Given
+        let mut config = empty_config_json();
+        let mut init = near_init(ChainId::Localnet);
+        // Even if operator sets a threshold, localnet path should ignore it.
+        init.external_storage_fallback_threshold = Some(1000);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "mpc-contract.test.near");
+
+        // Then
+        assert_eq!(config["state_sync_enabled"], serde_json::json!(false));
+        // Threshold field should NOT have been set on localnet.
+        assert!(config["state_sync"]["sync"]["ExternalStorage"]
+            .get("external_storage_fallback_threshold")
+            .is_none());
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_tracked_shards_to_contract_account() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["tracked_shards_config"],
+            serde_json::json!({ "Accounts": ["v1.signer-prod.testnet"] })
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_network_and_rpc_addr_when_provided() {
+        // Given
+        let mut config = empty_config_json();
+        let mut init = near_init(ChainId::Testnet);
+        init.network_addr = Some("51.68.219.13:24567".to_string());
+        init.rpc_addr = Some("0.0.0.0:13030".to_string());
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(config["network"]["addr"], serde_json::json!("51.68.219.13:24567"));
+        assert_eq!(config["rpc"]["addr"], serde_json::json!("0.0.0.0:13030"));
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_load_mem_tries() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["store"]["load_mem_tries_for_tracked_shards"],
+            serde_json::json!(true)
+        );
+    }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -144,8 +144,9 @@ fn patch_near_config(
     if is_localnet {
         config["state_sync_enabled"] = serde_json::Value::Bool(false);
     } else {
+        let threshold = near_init.external_storage_fallback_threshold.unwrap_or(0);
         config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"] =
-            serde_json::json!(0);
+            serde_json::json!(threshold);
     }
 
     // Track the shard that hosts the MPC contract.
@@ -158,6 +159,10 @@ fn patch_near_config(
     }
     if let Some(network_addr) = &near_init.network_addr {
         config["network"]["addr"] = serde_json::Value::String(network_addr.clone());
+    }
+    if let Some(tier3) = &near_init.tier3_public_addr {
+        config["network"]["experimental"]["tier3_public_addr"] =
+            serde_json::Value::String(tier3.clone());
     }
 
     let patched =

--- a/deployment/testnet/dss-test.toml
+++ b/deployment/testnet/dss-test.toml
@@ -1,0 +1,84 @@
+# Minimal testnet TOML for DSS testing — see PR #3145 / issue #1734.
+# Goal: deploy a single TDX CVM that exercises DSS state-sync end-to-end.
+# Not a real MPC node: doesn't need contract registration, attestation, or signing.
+
+[launcher_config]
+image_reference = "nearone/mpc-node"   # replace with your custom-built image tag
+port_mappings = [
+    { host = 8080, container = 8080 },     # /metrics, debug
+    { host = 24567, container = 24567 },   # P2P (Tier2 + Tier3)
+]
+
+[mpc_node_config]
+home_dir = "/data"
+
+[mpc_node_config.log]
+format = "json"
+filter = "info,sync=debug,state_sync=debug,network=debug"   # extra verbose for state sync
+
+[mpc_node_config.near_init]
+chain_id = "testnet"
+download_genesis = true
+download_config = "rpc"
+
+# Populate from testnet RPC before deploying:
+#   curl -s -X POST https://rpc.testnet.near.org \
+#     -H "Content-Type: application/json" \
+#     -d '{"jsonrpc":"2.0","method":"network_info","params":[],"id":"x"}' \
+#     | jq -r '.result.active_peers[] | "\(.id)@\(.addr)"' \
+#     | awk -F'@' '!seen[$2]++ {print $0}' | paste -sd',' -
+boot_nodes = "PASTE_TESTNET_BOOT_NODES_HERE"
+
+# === The two fields under test (PR #3145) ===
+
+# Replace with the actual static IP that EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC
+# binds to in your dstack deploy script (NOT 0.0.0.0, NOT the dynamic outbound).
+tier3_public_addr = "51.68.219.13:24567"
+
+# Force DSS-first behavior. 0 = bucket only (current default), high = DSS only.
+# 1000 lets bucket act as safety net if state-parts is still up.
+external_storage_fallback_threshold = 1000
+
+# Bind only to the same static IP, mirroring Bob's setup so the bug reproduces
+# in the unfixed case (and we genuinely test the fix).
+network_addr = "51.68.219.13:24567"
+
+# === Dummy MPC config — DSS doesn't care, but the launcher TOML schema requires it ===
+
+[mpc_node_config.secrets]
+secret_store_key_hex = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+backup_encryption_key_hex = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[mpc_node_config.node]
+# Doesn't need to be a registered/funded testnet account for DSS testing.
+my_near_account_id = "dss-test.testnet"
+near_responder_account_id = "dss-test.testnet"
+number_of_responder_keys = 1
+web_ui = "0.0.0.0:8080"
+migration_web_ui = "0.0.0.0:8078"
+cores = 4
+
+[mpc_node_config.node.indexer]
+validate_genesis = false
+sync_mode = "Latest"
+concurrency = 1
+# Real testnet contract — we track its shard, which is what triggers state sync.
+mpc_contract_id = "v1.signer-prod.testnet"
+finality = "optimistic"
+
+[mpc_node_config.node.triple]
+concurrency = 2
+desired_triples_to_buffer = 128
+timeout_sec = 60
+parallel_triple_generation_stagger_time_sec = 1
+
+[mpc_node_config.node.presignature]
+concurrency = 4
+desired_presignatures_to_buffer = 64
+timeout_sec = 60
+
+[mpc_node_config.node.signature]
+timeout_sec = 60
+
+[mpc_node_config.node.ckd]
+timeout_sec = 60

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -276,24 +276,29 @@ INFO stats: node_status="State 8qYjL...[5: parts] (5 downloads, 0 computations)
                         11 peers ⬇ 319 kB/s ⬆ 28.9 kB/s ..."
 ```
 
-**Metrics observed during state sync (~13 min into run):**
+**Final metrics — state sync completed via DSS (~55 min total):**
 
 ```
 near_tier3_public_addr{addr="51.68.219.13:24567"} 1
-near_block_height_head 42376888                            ← state-sync still in progress
+near_block_height_head 249010656                           ← jumped from 42376888 to testnet tip ✅
 
-near_peer_connections{peer_type="Inbound",tier="T3"} 13    ← peers landing Tier3 inbound ✅
-near_peer_connections{peer_type="Outbound",tier="T2"} 11
+near_peer_connections{peer_type="Outbound",tier="T2"} 13
+# (Inbound,T3 = 0 between transfers — Tier3 is ephemeral by design)
 
 near_state_sync_download_result{result="success",
    shard_id="5", source="network", type="header"} 1
 near_state_sync_download_result{result="success",
-   shard_id="5", source="network", type="part"} 570        ← ~96% success rate
+   shard_id="5", source="network", type="part"} 1019       ← 96.3% success rate
 near_state_sync_download_result{result="timeout",
-   shard_id="5", source="network", type="part"} 23
+   shard_id="5", source="network", type="part"} 37
 near_state_sync_download_result{result="sender_dropped",
    shard_id="5", source="network", type="part"} 2
-near_sync_status 5                                          ← state sync phase
+# Total parts: 1058 — 1019 success, 39 transient failures (retried successfully)
+# Critically: ZERO source="external" entries — no bucket fallbacks
+
+near_sync_status 0                                         ← NoSync (caught up) ✅
+near_sync_requirements_current{state="AlreadyCaughtUp"} 1
+near_sync_requirements_total{state="AlreadyCaughtUp"} 18   ← multiple sync cycles all completed
 ```
 
 **Tier3 disconnect warnings** also observed in the log:
@@ -327,8 +332,10 @@ End-to-end fix works in TDX. Specifically validated:
    `0`, the node would have gone straight to bucket and we'd see no
    `near_state_sync_download_result{source="network"}` entries.
 3. **Real testnet peers reach the CVM through the full network stack.**
-   Verified: 13–29 Tier3 inbound connections at any given time, 570+
-   successful part downloads after ~13 min, ~96% success rate.
+   Verified: 13–29 Tier3 inbound connections at peak, 1019 successful
+   part downloads, ~96% success rate. State sync of shard 5 completed
+   entirely via DSS in ~55 min, with zero bucket fallbacks. Node is now
+   caught up at testnet tip and processing recent blocks normally.
 
 The TDX / dstack / QEMU / docker networking layers do **not** introduce
 additional failure modes beyond the host-level asymmetric-IP issue we

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -534,6 +534,10 @@ Auto-discovery records the right IP for each, gossip is correct,
 inbound Tier2 peers can connect.
 
 - **Type:** host network config + run-as-user. **No code changes.**
+- **Applies to:** native (non-CVM) deployments only.
+  **Does NOT apply to TEE/CVM deployments** — every dstack CVM on a host
+  is launched by the same `dstack-vmm` daemon under one UNIX user, so
+  a `uidrange` rule cannot distinguish CVMs from each other.
 - **Pros:**
   - Per-node, scales to as many nodes as you have static IPs.
   - Doesn't affect rest of host's outbound traffic.
@@ -545,25 +549,30 @@ inbound Tier2 peers can connect.
     `/etc/networkd-dispatcher` script).
   - Requires that each node actually run as its own UNIX user — adds
     a small operational requirement.
+  - Doesn't fit TEE/CVM (see "Applies to" above).
 - **Performance:** kernel does one extra rule lookup in the routing
   decision per outgoing packet. Negligible (sub-microsecond).
 
 **3b. Containers / CVMs — per-CVM SNAT on the host.**
 Each CVM has its own private IP on a docker / qemu bridge. SNAT on the
-host's POSTROUTING chain rewrites outbound source IP per CVM:
+host's POSTROUTING chain rewrites outbound source IP per CVM, identifying
+the CVM by its bridge-side address:
 
 ```bash
-sudo iptables -t nat -A POSTROUTING -s <cvm1_private_ip>/32 \
+sudo iptables -t nat -A POSTROUTING -s <cvm1_bridge_ip>/32 \
   -o ens49f0np0 -j SNAT --to-source 51.68.219.13
-sudo iptables -t nat -A POSTROUTING -s <cvm2_private_ip>/32 \
+sudo iptables -t nat -A POSTROUTING -s <cvm2_bridge_ip>/32 \
   -o ens49f0np0 -j SNAT --to-source 51.68.219.14
 ```
 
-Same correctness as 3a, but applied at the host's NAT layer rather than
-inside the CVMs. CVMs themselves don't need any networking changes.
+Same correctness as 3a, but matched at the host's NAT layer on the CVM's
+bridge IP rather than at policy-routing time on the UID. CVMs themselves
+don't need any networking changes.
 
 - **Type:** host iptables config. **No code changes** to neard, mpc-node,
   or the launcher. CVMs unchanged.
+- **Applies to:** TEE/CVM deployments (the case 3a does *not* cover) —
+  works identically for plain Docker containers.
 - **Pros:**
   - Native to container/CVM workflows — applies cleanly to dstack
     deployments.
@@ -571,7 +580,8 @@ inside the CVMs. CVMs themselves don't need any networking changes.
   - Doesn't affect host's other traffic.
   - Fixes both DSS and Tier2 inbound peers.
 - **Cons:**
-  - iptables rules need persistence (`iptables-persistent`, systemd unit).
+  - iptables rules need persistence (`iptables-persistent`, systemd unit,
+    or whatever the host uses).
   - Tied to the CVM bridge IPs being stable — which they generally are,
     but a re-deploy that changes the bridge layout breaks the rule.
   - SNAT relies on connection tracking — adds a small per-flow overhead.
@@ -579,6 +589,78 @@ inside the CVMs. CVMs themselves don't need any networking changes.
   For neard's traffic profile (a few hundred TCP connections, modest
   PPS), CPU overhead is in the noise. Becomes meaningful only at much
   higher throughput than neard generates.
+
+### Concrete recipe for Option 3b on Bob/Alice (multi-IP OVH host)
+
+Practical playbook for the only host topology where #1734 actually bites
+in our deployment (multiple public IPs on one NIC, default route picks
+the dynamic one). Same template applies to any analogous bare-metal host.
+
+**1. Identify each CVM's bridge IP.** The dstack/QEMU launcher attaches
+each CVM to a bridge interface (often `virbr0` for libvirt, or a
+docker-managed bridge). Each CVM gets a private IP on that bridge:
+
+```bash
+# Find the bridge the CVMs are attached to
+ip -4 addr show | grep -E "virbr|br-" | head -5
+
+# Inspect each running CVM's bridge IP — name varies by CVM tooling
+sudo ip -4 neigh show dev virbr0 2>/dev/null
+# or check the QEMU hostfwd / dnsmasq leases:
+sudo cat /var/lib/libvirt/dnsmasq/virbr0.status 2>/dev/null
+# or for docker-driven bridges:
+docker inspect <launcher-container> --format='{{.NetworkSettings.IPAddress}}'
+```
+
+**2. Pick the static public IP this CVM should be observed at.** Must be
+one already bound to the host's NIC (`ip -4 addr show ens49f0np0`) and
+configured as the `EXTERNAL_*` host of the deploy script's port-forward
+mappings. For the testnet TEE node on Bob: `46.105.87.136`.
+
+**3. Install the SNAT rule:**
+
+```bash
+# Replace <cvm_bridge_ip> with the CVM's private bridge IP from step 1,
+# and ens49f0np0 with the host's outbound NIC name.
+sudo iptables -t nat -A POSTROUTING \
+  -s <cvm_bridge_ip>/32 \
+  -o ens49f0np0 \
+  -j SNAT --to-source 46.105.87.136
+```
+
+**4. Persist across reboots.** The simplest:
+
+```bash
+sudo apt install iptables-persistent     # if not already
+sudo netfilter-persistent save
+```
+
+Or as a systemd unit / `if-up.d` hook keyed off the bridge interface
+coming up — cleaner if you want the rule re-applied automatically when
+the bridge is recreated by a re-deploy.
+
+**5. Verify the fix landed.** Without restarting the CVM:
+
+```bash
+# (a) Source IP that outbound traffic now egresses with — should match
+# the SNAT --to-source value (46.105.87.136), not the dynamic IP.
+# Run from inside the CVM (or check via tcpdump on the host's NIC):
+sudo tcpdump -n -i ens49f0np0 'tcp and dst port 24567' -c 3
+
+# (b) After restarting neard so auto-discovery re-runs, the metric
+# should show the corrected address:
+curl -s http://<host>:8080/metrics | grep near_tier3_public_addr
+# Expected: addr="46.105.87.136:24567" (NOT the previous "91.134.92.20:...")
+
+# (c) Inbound Tier2 peer count should climb from 0 over the next few minutes
+# as the network re-discovers our correct PeerInfo via gossip.
+curl -s http://<host>:8080/metrics | grep 'near_peer_connections{peer_type="Inbound"'
+```
+
+If (a) still shows the old IP, the rule isn't matching — usually means
+the wrong bridge IP in step 1, or another POSTROUTING rule is matching
+first (`sudo iptables -t nat -L POSTROUTING -n -v --line-numbers` shows
+ordering and hit counts).
 
 ### Option 4 — neard binds outbound source IP (upstream code change)
 
@@ -642,17 +724,31 @@ only egress as that IP. Strongest isolation.
 
 | Scenario | Use |
 |---|---|
-| **Today, immediate fix** | **Option 0** (`tier3_public_addr` per-node) |
-| One node per host, simplest setup | Option 1 (`0.0.0.0` bind) |
+| **Today, immediate DSS fix on Bob** | **Option 0** (`tier3_public_addr` per-node) — unblocks DSS without touching the host |
+| One node per host, simplest setup | Option 1 (`0.0.0.0` bind) — also fixes Tier2 inbound |
 | One node per host, can't bind on `0.0.0.0` for some reason | Option 2 (default-route override) |
-| Multiple native nodes per host | Option 3a (UID routing) — plus Option 0 as defense in depth |
-| Multiple CVMs per host | Option 3b (per-CVM SNAT) — plus Option 0 as defense in depth |
+| Multiple **CVMs/TEE** per host (Bob's case) | **Option 3b** (per-CVM SNAT) — plus Option 0 as defense in depth |
+| Multiple **native** nodes per host (no TEE) | Option 3a (UID routing) — plus Option 0 as defense in depth |
 | Long-term, future MPC release | Option 4 (upstream nearcore feature) |
 | Maximum isolation between nodes | Option 5 (netns) — plus Option 0 |
 
-**For the immediate testnet TEE node fix on Bob: just Option 0 is
-enough to unblock DSS.** The missing-inbound-peers issue is a follow-up,
-addressable later with Option 3b if/when needed.
+> **Note for TEE deployments**: Option 3a (UID-based) does **not** apply —
+> all CVMs on a host run under the same `dstack-vmm` UID, so per-UID rules
+> can't distinguish them. The TEE-correct host-level fix is **Option 3b**
+> (per-CVM SNAT keyed off bridge IP), or — if a single CVM per host is
+> acceptable — Option 1 / 2.
+
+**Concrete recommendation for Bob:**
+
+1. **Now:** apply Option 0 (`tier3_public_addr` in launcher TOML, via PR #3145)
+   — unblocks DSS without touching the host networking. Validated on Alice.
+2. **As a follow-up:** apply Option 3b (per-CVM SNAT) on Bob — also unblocks
+   the missing-Tier2-inbound symptom and is the architecturally cleaner
+   long-term answer for any new multi-IP host. See
+   [Concrete recipe for Option 3b](#concrete-recipe-for-option-3b-on-boballe-multi-ip-ovh-host)
+   above.
+3. **Eventually:** if upstream Option 4 lands in a future nearcore release,
+   we can drop Option 0 in favor of native outbound source-IP binding.
 
 ## Important nuances
 

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -1,0 +1,633 @@
+# Issue #1734 — DSS not working in TEE CVM mode: analysis
+
+Issue: https://github.com/near/mpc/issues/1734
+
+> **Status: root cause confirmed and fix validated end-to-end.**
+> Reproduced on bare-metal `neard` (no docker, no CVM) on Alice; the fix
+> (`network.experimental.tier3_public_addr`) was applied and DSS started
+> downloading state parts within seconds. The bug is **not CVM-specific**
+> — it's host-level, triggered by any host with multiple IPs where `:24567`
+> is bound to a non-default IP.
+
+## TL;DR
+
+- **Bug:** DSS state-sync times out on Bob's testnet TEE node. nearcore
+  advertises the wrong IP for peers to send Tier3 responses to. Caused by
+  Bob's multi-IP host topology — outbound traffic egresses on a different
+  IP than the one `:24567` is bound to, so auto-discovery picks the wrong
+  one.
+- **Scope:** only affects hosts with multiple public IPs on one NIC
+  (Bob, Alice — OVH bare-metal). **Mainnet GCP node is not affected**
+  (verified — single external IP, auto-discovery correct).
+- **Fix:** set `network.experimental.tier3_public_addr = "<bound_ip>:24567"`
+  in the neard config. Validated on Alice — DSS recovered within seconds.
+- **Also remove** the hardcoded `external_storage_fallback_threshold = 0`
+  in `deployment/start.sh:46`, which forced bucket-only sync and had been
+  masking this bug for every MPC node since launch.
+- **Action on Bob:** apply both via the dstack-vmm "Update VM Config" flow
+  (per the runbook in mpc-private PR #304), then Shutdown → Start.
+- **Optional follow-up:** the same multi-IP topology also blocks regular
+  Tier2 inbound peers (currently 0 on Bob). Fixing that needs a host-level
+  change — per-CVM SNAT in our case (Option 3b in the
+  [comparison table](#comparison-table)). Not blocking DSS; can be deferred.
+
+## Summary
+
+- **Symptom on Bob's testnet TEE node:** all DSS state-sync attempts time out.
+- **Root cause:** nearcore auto-discovers `my_public_addr` from the IP that
+  peers observe when *we* connect to them. On hosts with multiple public
+  IPs on one NIC (Bob, Alice), outbound traffic egresses with the dynamic
+  IP set by the default route, but `:24567` is bound to a different static
+  IP. Peers tell us "we see you at `<outbound_ip>:24567`", we believe them,
+  and we tell the network to deliver Tier3 state parts there — where
+  nothing is listening.
+- **Scope of impact:** only hosts with this multi-IP topology. The mainnet
+  GCP node is **not affected** (verified — `tier3_public_addr` correctly
+  set to its actual public IP, 9 inbound Tier2 peers, all healthy). See
+  [Scope of impact](#scope-of-impact) for the full breakdown.
+- **The bug had been masked** by `deployment/start.sh:46` hardcoding
+  `external_storage_fallback_threshold = 0`, which made every non-localnet
+  MPC node bucket-sync only. Bucket sync is being deprecated; once disabled,
+  this latent bug surfaced.
+- **Fix:** set `network.experimental.tier3_public_addr` in `config.json` to
+  `<bound_ip>:24567`. Validated on Alice — DSS recovered immediately.
+- **Caveat:** `tier3_public_addr` fixes Tier3 (state sync) only. The
+  separate "zero inbound peers" symptom — peers gossiping our wrong
+  `PeerInfo` and failing to connect — needs a different fix (binding on
+  `0.0.0.0` or per-process source-IP routing). Out of scope for this issue.
+
+## Reproduction and validation (run 2026-05-05 on Alice)
+
+### Test 1 — observe Bob's running testnet TEE node
+
+```bash
+curl -s http://46.105.87.136:8080/metrics | \
+  grep -E "near_tier3_public_addr|near_peer_connections|near_block_height_head"
+```
+
+| Probe | Result |
+|---|---|
+| `near_tier3_public_addr{addr="…"}` | `91.134.92.20:24567` |
+| Public IP for the CVM (where everything else binds) | `46.105.87.136` |
+| TCP `46.105.87.136:24567` from a remote host | OPEN |
+| TCP `91.134.92.20:24567` from a remote host | Connection refused |
+| `PeerManagerActor::handle tier3 request` count | 240 — Tier3 *outbound* fine |
+| `near_peer_connections{peer_type="Outbound",tier="T2"}` | 34 |
+| `near_peer_connections{peer_type="Inbound",…}` | (no line — i.e. 0) |
+
+Bob's network state confirmed the asymmetric-IP shape:
+
+```text
+ss -ltn | grep ':24567'
+LISTEN 0  1  46.105.87.136:24567   0.0.0.0:*   ← bound to one specific IP, not 0.0.0.0
+
+ip route get 8.8.8.8
+8.8.8.8 via 100.64.0.1 dev ens49f0np0 src 91.134.92.20   ← outbound exits as a different IP
+```
+
+### Test 2 — reproduce on Alice with bare `neard`, no CVM/docker
+
+Alice has the same multi-IP topology (`51.68.219.{1..14}` static + dynamic
+`57.129.140.254` as the default-route source). Steps:
+
+```bash
+HOME_DIR=/mnt/data/barak/testnet-dss
+mkdir -p $HOME_DIR
+neard --home $HOME_DIR init --chain-id testnet --download-genesis --download-config
+
+# Patch: bind P2P to one specific static IP, force DSS, track shard 5
+BOOT_NODES=$(curl -s -X POST https://rpc.testnet.near.org \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"network_info","params":[],"id":"x"}' \
+  | jq -r '.result.active_peers[] | "\(.id)@\(.addr)"' \
+  | awk -F'@' '!seen[$2]++ {print $0}' | paste -sd',' -)
+
+jq --arg bn "$BOOT_NODES" '
+  .network.addr = "51.68.219.13:24567"
+  | .rpc.addr = "0.0.0.0:13030"
+  | del(.state_sync)
+  | .state_sync_enabled = true
+  | .network.boot_nodes = $bn
+  | .tracked_shards_config = {"Accounts": ["v1.signer-prod.testnet"]}
+' $HOME_DIR/config.json > /tmp/c.json && mv /tmp/c.json $HOME_DIR/config.json
+
+nohup neard --home $HOME_DIR run > $HOME_DIR/neard.log 2>&1 &
+```
+
+Within ~1 minute, every Bob symptom reproduced:
+
+| Metric | Result on Alice (bare neard) |
+|---|---|
+| `near_tier3_public_addr{addr="…"}` | `57.129.140.254:24567` (the *outbound* IP, not the bound `51.68.219.13`) |
+| `near_peer_connections{peer_type="Outbound",tier="T2"}` | 18 |
+| `near_peer_connections{peer_type="Inbound",…}` | (none) |
+
+After ~5 minutes (when state sync started, tracking shard 5):
+
+| Metric | Result |
+|---|---|
+| `near_state_sync_download_result{result="timeout",shard_id="5",source="network",type="header"}` | climbing — 102 by ~25 min in |
+| `near_block_height_head` | stuck at `42376888` (state sync not progressing) |
+| `near_sync_status` | `5` (state sync) |
+
+And the explicit nearcore warning fired in the log:
+
+> "state sync header retrieval is failing repeatedly. This may indicate a
+> Tier3 connectivity issue - peers cannot connect back to deliver state
+> data. Check: (1) the node's listening port is open for inbound TCP,
+> (2) if behind NAT, set `network.experimental.tier3_public_addr` in
+> `config.json`."
+
+That's reproduction without docker, without dstack, without QEMU, without
+any CVM stack — just `neard` 2.11.0 on a multi-IP host.
+
+### Test 3 — apply the fix and verify DSS recovers
+
+```bash
+kill $(cat $HOME_DIR/neard.pid)
+jq '.network.experimental.tier3_public_addr = "51.68.219.13:24567"' \
+  $HOME_DIR/config.json > /tmp/c.json && mv /tmp/c.json $HOME_DIR/config.json
+nohup neard --home $HOME_DIR run > $HOME_DIR/neard.log 2>&1 &
+```
+
+Within ~15 seconds:
+
+| Metric | Before fix | After fix |
+|---|---|---|
+| `near_tier3_public_addr{addr="…"}` | `57.129.140.254:24567` | **`51.68.219.13:24567`** |
+| `near_state_sync_download_result{result="success",source="network",type="header"}` | 0 | 1 |
+| `near_state_sync_download_result{result="success",source="network",type="part"}` | 0 | 14 |
+| `near_peer_connections{peer_type="Inbound",tier="T3"}` | (none) | 12 |
+
+Fix confirmed — DSS state parts started flowing. T3 inbound connections
+landing as expected (responder peers connecting back to deliver state).
+
+Note: `near_peer_connections{peer_type="Inbound",tier="T2"}` remained
+absent. `tier3_public_addr` does not influence what peers gossip about us
+via `PeerInfo`, so regular Tier2 inbound from arbitrary peers continues to
+fail — peers still try the wrong IP they learned via gossip. **Separate
+problem; does not block DSS.**
+
+### Test 4 — confirm a healthy node on different topology (mainnet, GCP)
+
+Sanity check: does the bug actually require the multi-IP host topology, or
+does it affect any node? The mainnet MPC node runs on a GCP VM
+(`multichain-mainnet-0.nearone.org`, public IP `34.22.198.39`). Probed its
+metrics:
+
+| Probe | Result |
+|---|---|
+| `dig multichain-mainnet-0.nearone.org` | `34.22.198.39` |
+| `near_tier3_public_addr{addr="…"}` | **`34.22.198.39:24567`** ✅ matches |
+| TCP `34.22.198.39:24567` | OPEN ✅ |
+| `near_peer_connections{peer_type="Inbound",tier="T2"}` | **9** ✅ (none on Bob/Alice) |
+| `near_peer_connections{peer_type="Outbound",tier="T2"}` | 28 |
+| `near_sync_status` | 0 (caught up; no recent state sync to test against) |
+
+The mainnet node has the **correct** auto-discovered address and **9 real
+inbound Tier2 peers** — none of Bob's symptoms. This confirms the bug is
+specific to the multi-IP / asymmetric-routing host topology, not a defect
+in mpc-node, neard, or DSS itself.
+
+Why GCP works: a standard GCP VM has one internal IP on the NIC mapped via
+**1:1 NAT** to one external IP. Outbound source IP (as observed by peers)
+= inbound destination IP = the same external IP. Auto-discovery's
+"egress IP = ingress IP" assumption holds. The OVH bare-metal hosts
+Bob/Alice violate that assumption by exposing many IPs directly on one NIC
+and selecting outbound source via the default route.
+
+### Validation coverage — what's been tested vs. what hasn't
+
+Tests 1–4 cover the bug *mechanism* and *fix mechanism* end-to-end on bare
+neard, and confirm the mainnet GCP node is unaffected. But the production
+deployment shape adds layers we haven't exercised yet — specifically, the
+TDX/launcher chain on Bob, and the host-level fix options.
+
+**Tested ✅**
+
+- **Bug reproduces** on bare neard 2.11.0 with multi-IP host (Test 2).
+- **`tier3_public_addr` fixes DSS** on bare neard when set directly in
+  `config.json` (Test 3) — observed `near_tier3_public_addr` flip and
+  `near_state_sync_download_result{result="success",source="network"}`
+  start climbing within ~15 s.
+- **GCP single-IP topology is healthy** without any fix (Test 4) —
+  baseline that auto-discovery is correct in normal conditions.
+
+**Not yet tested ❌**
+
+- **`tier3_public_addr` through the TDX/launcher chain.** Bare-neard test
+  only validates the field on a freshly written `config.json`. The actual
+  TEE deployment path is launcher TOML → `deployment/start.sh` patches →
+  `config.json` inside the container → neard inside QEMU/dstack
+  networking. We haven't verified:
+  - There's a path to inject `tier3_public_addr` in this chain
+    (`start.sh` currently doesn't write it).
+  - The advertised address propagates correctly through the QEMU slirp
+    NAT layer (container's `network.addr` may be on the slirp internal
+    IP, while the value we'd inject is the host's public IP).
+  - Tier3 inbound from real testnet peers actually lands on the container
+    after going through host port-forward → QEMU slirp → docker bridge.
+- **Host-level routing fixes** (Options 2/3a/3b/5). All proposed but
+  none empirically validated. In particular Option 3b (per-CVM SNAT) is
+  the leading candidate for Bob's setup, but we haven't built the
+  iptables rules and watched whether `near_tier3_public_addr` becomes
+  correct via auto-discovery alone (no `tier3_public_addr` config).
+- **Whether the host fix alone is sufficient without `tier3_public_addr`.**
+  Theoretically yes (auto-discovery would pick the now-correct outbound
+  IP), but worth empirically confirming before we recommend the
+  defense-in-depth pattern in production.
+
+These gaps are the planned tests (1) and (2) of the validation work.
+
+## Scope of impact
+
+The bug only affects deployments where:
+
+- the host has **multiple public IPs on one NIC** (or asymmetric SNAT/DNAT
+  configurations where outbound source IP differs from inbound destination
+  IP), **and**
+- `:24567` is bound to a specific IP that's **not** the one Linux picks
+  for outbound traffic.
+
+Concretely:
+
+| Deployment | Topology | Affected? |
+|---|---|---|
+| GCP single-VM (mainnet today) | One ext IP via 1:1 NAT | No |
+| AWS single-VM | One ext IP via Elastic IP / public IP | No |
+| Plain VPS with one public IP | Single IP per NIC | No |
+| OVH bare-metal with additional IPs (Bob, Alice) | Many IPs on one NIC | **Yes** |
+| Hetzner / similar with floating IPs | Depends on routing config | Likely yes if floating IP is the bound one but not the default route source |
+| Container behind 1:1 host NAT | Same as host | Same as host |
+
+So the production fleet today is essentially: mainnet GCP (fine) + testnet
+TEE on Bob (broken) + future TEE deployments depending on the host they
+land on.
+
+## Mechanism — exactly why auto-discovery picks the wrong IP
+
+Four-step chain in `chain/network/src/peer/peer_actor.rs`:
+
+1. neard makes outbound connection to a peer. Linux picks the source IP
+   from the matching route (default route → dynamic IP `57.129.140.254` /
+   `91.134.92.20`).
+2. The peer observes the connection from `<outbound_ip>:<ephemeral>` and
+   reads `sender_listen_port = 24567` from neard's handshake.
+3. The peer constructs
+   `PeerInfo { addr: SocketAddr::new(observed_source_ip, sender_listen_port) }`
+   = `<outbound_ip>:24567`. It includes that in `PeersResponse` replies and
+   gossips it to other peers.
+4. Our neard reads `PeersResponse`, finds its own ID inside `direct_peers`,
+   and records `my_public_addr = <outbound_ip>:24567`. That value flows
+   into the `near_tier3_public_addr` metric and into every Tier3 state
+   request we send.
+
+The assumption: *"the IP we egress from is the IP others should connect
+to"* holds on a single-IP host. It breaks when the outbound source ≠
+inbound bind IP — exactly our case. There's no consensus check, no
+loopback verification — just trust what the first peer reports.
+
+## Why bucket sync had been masking this
+
+`deployment/start.sh:46` for any non-localnet env:
+
+```python
+config['state_sync']['sync']['ExternalStorage']['external_storage_fallback_threshold'] = 0
+```
+
+`= 0` means "never use P2P, always use external bucket." So **no MPC node
+in production has ever exercised DSS** — the bug existed all along, latent.
+fast-state-parts being decommissioned forced operators to consider DSS,
+and that's when the bug surfaced.
+
+## Recommended fix
+
+For the existing testnet TEE node and for the MPC deployment in general:
+
+1. **Set `tier3_public_addr` per-node** in `config.json`. Inject it via
+   `start.sh` (which already writes the neard config), or thread it through
+   the launcher TOML's `near_init` section. Value: the static IP that the
+   port-forward / `network.addr` uses, with port `24567`.
+
+2. **Stop hardcoding `external_storage_fallback_threshold = 0`** in
+   `start.sh` once (1) is in place. Let DSS actually run as nearcore
+   intends.
+
+3. *(Optional)* For multi-node-on-same-host setups, also add per-process
+   source-IP routing (UID-based `ip rule` for native processes, per-CVM
+   SNAT for containerized) so that gossiped `PeerInfo` is also correct
+   and inbound Tier2 peers can find each node. Without this, `tier3_public_addr`
+   alone is enough for DSS but each node will still have zero Tier2 inbound
+   peers from the wider network. For TEE that's likely acceptable; for
+   non-TEE deployments it depends on operational expectations.
+
+For Bob specifically: apply (1) and (2) to the testnet TEE node via the
+dstack-vmm "Update VM Config" flow + Shutdown → Start (per the on-call
+runbook in `mpc-private` PR #304). The deployed `user-config.toml` is the
+right place to inject the field; `start.sh` then writes it into
+`config.json`.
+
+## Network-level options for multi-node hosts
+
+`tier3_public_addr` fixes Tier3 (state sync) — sufficient for unblocking #1734.
+But it does **not** fix the gossip path: peers still learn our address as
+`<outbound_ip>:24567` via `PeerInfo` gossip, and `peer_type="Inbound",tier="T2"`
+stays at zero. If a deployment cares about regular Tier2 inbound peers
+landing (e.g., for general P2P network health, faster propagation, future
+features that depend on incoming Tier2), the outbound *source IP* itself
+needs to match the bound IP.
+
+Six options, ordered by how much we have to touch:
+
+### Option 0 — `tier3_public_addr` only (the validated fix)
+
+Add `network.experimental.tier3_public_addr = "<bound_ip>:24567"` to each
+node's `config.json`. Forces neard to advertise the right address, ignoring
+auto-discovery.
+
+- **Type:** node config change. **No code changes** to nearcore or
+  mpc-node. Field already exists in `config.json` schema (since nearcore
+  ≥ 2.10).
+- **Pros:**
+  - One-line config change per node.
+  - No host-level networking touched — works alongside docker, CVM, dstack.
+  - Survives reboots and DHCP renewals trivially (just file content).
+  - Independent per-node — multi-node-on-one-host friendly.
+- **Cons:**
+  - Fixes Tier3 only. Tier2 inbound peers (gossiped `PeerInfo` path) stay
+    broken; node remains "outbound-only" on T2.
+  - IP is hardcoded — if the bound IP ever changes, the config needs to
+    be updated.
+- **Performance:** none.
+
+### Option 1 — bind `network.addr = "0.0.0.0:24567"`
+
+Make `:24567` listen on every IP on the host. Auto-discovery's answer
+(whatever outbound IP it picks up) becomes valid because there's a listener
+on that IP too.
+
+- **Type:** node config change. **No code changes.**
+- **Pros:**
+  - Fixes both DSS *and* the Tier2 inbound-peers issue with one line.
+  - No host-level networking changes.
+  - Cheapest setup.
+- **Cons:**
+  - **Single-node only** — can't run two nodes on the same host (port
+    conflict on `:24567`).
+  - All host IPs become potential entry points to the node, which may
+    surprise security review or audit (vs. binding to one specific IP).
+- **Performance:** none.
+
+### Option 2 — host-wide default-route source override
+
+Change which IP outbound traffic exits as, host-wide:
+
+```bash
+sudo ip route replace default via 100.64.0.1 dev ens49f0np0 src 51.68.219.13
+```
+
+After this, `ip route get 8.8.8.8` reports `src 51.68.219.13`, and
+auto-discovery picks the right address for *every* process on the host.
+
+- **Type:** host network config. **No code changes.**
+- **Pros:**
+  - Fixes both DSS and the gossip / Tier2 inbound-peers issue.
+  - Single command, applies to anything on the host (not just neard).
+- **Cons:**
+  - Affects **all outbound traffic** on the host (Docker, SSH, monitoring,
+    package mirrors). Anything elsewhere whitelisted on the previous
+    outbound IP breaks.
+  - DHCP / `networkd` may re-install its own default route on lease
+    renewal — needs a persistent post-up hook (systemd unit,
+    `/etc/networkd-dispatcher`, etc.).
+  - Doesn't scale to multi-node — only one default-route source can
+    exist on a host.
+- **Performance:** none.
+
+### Option 3 — per-process / per-CVM source IP
+
+The right answer when you want different nodes on one host to advertise
+different IPs.
+
+**3a. Native processes — UID-based policy routing.**
+Run each node as its own user, then add per-UID routing tables:
+
+```bash
+# Run each node as a separate UNIX user
+sudo useradd -m mpc1   # UID 1001
+sudo useradd -m mpc2   # UID 1002
+
+# Per-node routing tables
+sudo ip route add default via 100.64.0.1 dev ens49f0np0 src 51.68.219.13 table 201
+sudo ip route add default via 100.64.0.1 dev ens49f0np0 src 51.68.219.14 table 202
+
+# Policy rules: bind each user to its table
+sudo ip rule add uidrange 1001-1001 lookup 201
+sudo ip rule add uidrange 1002-1002 lookup 202
+```
+
+Now `mpc1`'s outbound exits as `51.68.219.13`, `mpc2`'s as `51.68.219.14`.
+Auto-discovery records the right IP for each, gossip is correct,
+inbound Tier2 peers can connect.
+
+- **Type:** host network config + run-as-user. **No code changes.**
+- **Pros:**
+  - Per-node, scales to as many nodes as you have static IPs.
+  - Doesn't affect rest of host's outbound traffic.
+  - Fixes both DSS and Tier2 inbound peers.
+- **Cons:**
+  - Tied to UID — if a node is ever restarted under a different user,
+    the rule silently goes stale.
+  - Needs persistence across reboots (systemd `ip-rule` unit or
+    `/etc/networkd-dispatcher` script).
+  - Requires that each node actually run as its own UNIX user — adds
+    a small operational requirement.
+- **Performance:** kernel does one extra rule lookup in the routing
+  decision per outgoing packet. Negligible (sub-microsecond).
+
+**3b. Containers / CVMs — per-CVM SNAT on the host.**
+Each CVM has its own private IP on a docker / qemu bridge. SNAT on the
+host's POSTROUTING chain rewrites outbound source IP per CVM:
+
+```bash
+sudo iptables -t nat -A POSTROUTING -s <cvm1_private_ip>/32 \
+  -o ens49f0np0 -j SNAT --to-source 51.68.219.13
+sudo iptables -t nat -A POSTROUTING -s <cvm2_private_ip>/32 \
+  -o ens49f0np0 -j SNAT --to-source 51.68.219.14
+```
+
+Same correctness as 3a, but applied at the host's NAT layer rather than
+inside the CVMs. CVMs themselves don't need any networking changes.
+
+- **Type:** host iptables config. **No code changes** to neard, mpc-node,
+  or the launcher. CVMs unchanged.
+- **Pros:**
+  - Native to container/CVM workflows — applies cleanly to dstack
+    deployments.
+  - Each CVM gets its own outbound IP without any in-CVM config.
+  - Doesn't affect host's other traffic.
+  - Fixes both DSS and Tier2 inbound peers.
+- **Cons:**
+  - iptables rules need persistence (`iptables-persistent`, systemd unit).
+  - Tied to the CVM bridge IPs being stable — which they generally are,
+    but a re-deploy that changes the bridge layout breaks the rule.
+  - SNAT relies on connection tracking — adds a small per-flow overhead.
+- **Performance:** SNAT adds conntrack entry + rewrite per packet.
+  For neard's traffic profile (a few hundred TCP connections, modest
+  PPS), CPU overhead is in the noise. Becomes meaningful only at much
+  higher throughput than neard generates.
+
+### Option 4 — neard binds outbound source IP (upstream code change)
+
+Most "correct" solution architecturally: have neard bind its outbound
+TCP connections to a specific local source IP, instead of letting the
+kernel pick from the default route. Auto-discovery would then record
+the right IP without any host or environment hacks.
+
+- **Type:** **upstream nearcore code change.** Would need a new
+  `network.outbound_source_addr` (or similar) config field, plus a
+  `bind()` call before each `connect()` in `chain/network/src/peer/peer_actor.rs`
+  (or wherever the TCP connect happens).
+- **Pros:**
+  - Cleanest architectural fix — solves the asymmetric-IP problem at
+    the root.
+  - Pure config from operators' perspective (no host networking
+    knowledge needed).
+  - Per-node naturally — multi-node-friendly.
+  - Fixes both DSS and Tier2 inbound peers (because peers would observe
+    the correct source IP).
+- **Cons:**
+  - Requires upstream PR to nearcore + waiting for a release.
+  - Doesn't help us today; we'd still need Option 0 in the meantime.
+  - Possible interaction with IPv4/IPv6 dual-stack — implementation
+    needs to handle that explicitly.
+- **Performance:** none.
+
+### Option 5 — dedicated network namespace per node
+
+Run each node inside its own Linux network namespace with only the
+intended IP visible / routable. Outbound from inside the namespace can
+only egress as that IP. Strongest isolation.
+
+- **Type:** host networking + process isolation. **No code changes.**
+- **Pros:**
+  - Strongest isolation — node literally cannot see other IPs on the
+    host.
+  - Fixes both DSS and Tier2 inbound peers.
+  - Per-node, scales arbitrarily.
+- **Cons:**
+  - Heavyweight setup — netns + veth + routing per node.
+  - Affects every other network-touching detail (DNS, monitoring, debug
+    access — all need to be re-wired into the namespace).
+  - Operationally complex; harder to debug than UID routing or SNAT.
+- **Performance:** veth pair adds one extra hop per packet (memory copy
+  + interface dispatch). Tiny — comparable to docker bridge networking.
+
+### Comparison table
+
+| # | Solution | Type | Available today | Fixes DSS (Tier3) | Fixes Tier2 inbound | Multi-node on one host | Persistence | Perf impact |
+|---|---|---|---|---|---|---|---|---|
+| **0** | **`tier3_public_addr` per-node** | Node config | ✅ | ✅ | ❌ | ✅ | trivial (file) | none |
+| 1 | `network.addr = "0.0.0.0:24567"` | Node config | ✅ | ✅ | ✅ | ❌ (port conflict) | trivial (file) | none |
+| 2 | Host-wide default-route source | Host network config | ✅ | ✅ | ✅ | ❌ | needs systemd hook | none |
+| 3a | UID-based policy routing | Host network + run-as-user | ✅ | ✅ | ✅ | ✅ | needs systemd hook | negligible (one extra rule lookup per `connect()`) |
+| 3b | Per-CVM SNAT on host | Host iptables | ✅ | ✅ | ✅ | ✅ | needs `iptables-persistent` or systemd | low (conntrack + per-packet rewrite) |
+| 4 | neard binds outbound source IP | Upstream nearcore code change | ❌ (needs PR + release) | ✅ | ✅ | ✅ | trivial (file, once shipped) | none |
+| 5 | Network namespace per node | Host networking + process isolation | ✅ | ✅ | ✅ | ✅ | needs systemd hook | low (veth pair per packet) |
+
+### Picking between them
+
+| Scenario | Use |
+|---|---|
+| **Today, immediate fix** | **Option 0** (`tier3_public_addr` per-node) |
+| One node per host, simplest setup | Option 1 (`0.0.0.0` bind) |
+| One node per host, can't bind on `0.0.0.0` for some reason | Option 2 (default-route override) |
+| Multiple native nodes per host | Option 3a (UID routing) — plus Option 0 as defense in depth |
+| Multiple CVMs per host | Option 3b (per-CVM SNAT) — plus Option 0 as defense in depth |
+| Long-term, future MPC release | Option 4 (upstream nearcore feature) |
+| Maximum isolation between nodes | Option 5 (netns) — plus Option 0 |
+
+**For the immediate testnet TEE node fix on Bob: just Option 0 is
+enough to unblock DSS.** The missing-inbound-peers issue is a follow-up,
+addressable later with Option 3b if/when needed.
+
+## Important nuances
+
+- **Binding `network.addr = "0.0.0.0:24567"`** would also fix DSS *and*
+  the missing-inbound-peers symptom, by making `:24567` listen on every
+  IP including the outbound one. **But** it precludes running multiple
+  nodes on one host (port conflict). For deployments where that matters
+  (e.g., MPC localnet/testing, or future multi-tenant hosts), `0.0.0.0`
+  bind isn't an option — `tier3_public_addr` per-node is the
+  application-level fix that survives.
+
+- **The fix is forward-compatible with future nearcore changes.** The
+  `tier3_public_addr` field is supported by all current nearcore versions
+  (2.11.x and beyond) and is the path nearcore's own error message
+  recommends.
+
+- **Persistence:** `tier3_public_addr` lives in `config.json`, survives
+  reboots and DHCP renewals trivially. Network-level fixes (policy
+  routing, SNAT) need systemd / network-config persistence work.
+
+## Does the MPC node actually need inbound Tier2?
+
+Strictly: **no.** The MPC node functions correctly outbound-only.
+
+- The MPC signing protocol uses its own `mpc-tls` mesh on a different
+  port — *not* neard's Tier2. neard's network layer is purely for chain
+  consumption (indexer follows blocks, transactions get submitted, state
+  reads).
+- A Tier2 TCP socket is bidirectional once established — "outbound" only
+  describes who initiated. Routed messages can flow *to* us through our
+  outbound connections, which is why Bob's TEE node has still served 240
+  state-sync requests as a snapshot host despite 0 inbound.
+
+What outbound-only does cost:
+
+- **Less peer redundancy.** If our outbound peers go offline together, we
+  reconnect from scratch.
+- **Bad network citizenship.** We consume bandwidth (block propagation,
+  routed messages) without offering ourselves as an entry point.
+- **Slightly slower block propagation** in pathological peer sets — fewer
+  redundant gossip paths to us.
+- **Less useful as a relay** for other nodes' routed messages (peers don't
+  know about us, so our `RoutingTableActor` rarely shows up in their
+  paths).
+- *Not relevant for us:* validator Tier1 bootstrap depends on Tier2 peer
+  discovery. We're not validators.
+
+So fixing inbound Tier2 is **"should-do, not must-do."** Same root cause
+as DSS, no extra structural work if Option 3b is adopted on the host, but
+not blocking #1734.
+
+## Open questions / follow-ups
+
+- Should `start.sh` derive `tier3_public_addr` automatically (e.g., from
+  `EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC` env var stripped of `0.0.0.0`),
+  or should the launcher TOML's `near_init` section grow an explicit
+  field? Both work; explicit field is more discoverable.
+
+- Once `external_storage_fallback_threshold = 0` is removed from
+  `start.sh`, decide on a non-zero default — `1000`, "always try P2P
+  first," or remove the bucket entirely. Coordinate with the nearcore
+  team on the deprecation timeline for `state-parts`.
+
+## Key code references
+
+- `chain/network/src/tcp.rs` — `Tier` enum (T1/T2/T3) docs.
+- `chain/client/src/sync/state/network.rs` — Tier2 state request flow,
+  `MyPublicAddrNotKnown` short-circuit.
+- `chain/network/src/peer_manager/peer_manager_actor.rs` — where
+  `MyPublicAddrNotKnown` is returned (state header + part request handlers).
+- `chain/network/src/peer/peer_actor.rs` — `my_public_addr` auto-discovery
+  from `PeersResponse`; handshake → `PeerInfo { addr: source_ip + sender_listen_port }`.
+- `chain/network/src/peer_manager/network_state/mod.rs` —
+  `my_public_addr: Arc::new(RwLock::new(config.tier3_public_addr))` (config
+  pre-seeds it).
+- `chain/network/src/config_json.rs` — `tier3_public_addr: Option<SocketAddr>`
+  (format `"IP:port"`).
+- `chain/client/src/sync/state/downloader.rs` — the explicit "Tier3
+  connectivity issue" log message.
+- `deployment/start.sh:46` — hardcodes `external_storage_fallback_threshold = 0`
+  for non-localnet, disabling DSS in practice today.

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -28,10 +28,13 @@ Issue: https://github.com/near/mpc/issues/1734
   masking this bug for every MPC node since launch.
 - **Action on Bob:** apply both via the dstack-vmm "Update VM Config" flow
   (per the runbook in mpc-private PR #304), then Shutdown → Start.
-- **Optional follow-up:** the same multi-IP topology also blocks regular
-  Tier2 inbound peers (currently 0 on Bob). Fixing that needs a host-level
-  change — per-CVM SNAT in our case (Option 3b in the
-  [comparison table](#comparison-table)). Not blocking DSS; can be deferred.
+- **Tier2 inbound peers** (separate symptom, also caused by the same
+  topology) appear to need much longer than our test windows to recover
+  via gossip. Test 6 confirmed even fixing the gossiped `PeerInfo` (via
+  Option 3b) doesn't bring inbound peers within 30 min, and Option 0's
+  Test 5 ran 1.5+ days with the same result. The MPC node functions
+  fine without it (see "Does the MPC node actually need inbound Tier2?"
+  in the body), so this is hygiene/network-citizenship — not a blocker.
 
 ## Summary
 
@@ -211,17 +214,24 @@ and selecting outbound source via the default route.
   flow correctly from launcher TOML → `patch_near_config` → neard config
   inside the CVM, and DSS state sync works through the full QEMU /
   dstack / docker network stack.
+- **Option 3b (per-host SNAT) alone is sufficient for DSS** (Test 6).
+  No node config or code changes; iptables SNAT on `--dport 24567`.
+  State sync completed faster than Option 0 (~32 min vs ~55 min).
+  Caveat: SNAT rule must be in place before neard's first peer
+  connections, otherwise conntrack pins the pre-SNAT mapping and
+  auto-discovery latches onto the wrong IP.
 
 **Not yet tested ❌**
 
-- **Host-level routing fixes** (Options 2/3a/3b/5). All proposed but
-  none empirically validated. In particular Option 3b (per-CVM SNAT)
-  is the leading candidate for Bob's setup; we haven't run the iptables
-  rules and watched whether `near_tier3_public_addr` becomes correct via
-  auto-discovery alone (no `tier3_public_addr` config).
-- **Whether the host fix alone is sufficient without `tier3_public_addr`.**
-  Theoretically yes (auto-discovery would pick the now-correct outbound
-  IP), but worth empirically confirming.
+- **Options 2 / 3a / 5** of the host-level fix list. None empirically
+  validated. We have empirical confirmation only for the leading
+  candidate (Option 3b — see Test 6) and Option 0.
+- **Tier2 inbound recovery on long timescales.** Both Option 0
+  (Test 5, ran 1.5+ days) and Option 3b (Test 6, 32 min) ended with
+  zero Tier2 inbound peers. Either it takes much longer than these
+  windows, or it needs a separate fix entirely. The MPC node functions
+  fine without it (see "Does the MPC node actually need inbound
+  Tier2?"), so this is a hygiene follow-up.
 
 ### Test 5 — full TDX CVM with PR #3145 (run 2026-05-06 on Alice)
 
@@ -341,6 +351,94 @@ The TDX / dstack / QEMU / docker networking layers do **not** introduce
 additional failure modes beyond the host-level asymmetric-IP issue we
 already identified — once `tier3_public_addr` is set, the fix is the
 same on bare metal and in TDX.
+
+### Test 6 — Option 3b validated in TDX, isolated from Option 0 (run 2026-05-07 on Alice)
+
+Companion to Test 5: deliberately deploy *without* `tier3_public_addr`
+and rely **only** on a host-level iptables SNAT rule (Option 3b in this
+doc). Goal: prove the host-only fix works without any node config or
+code change.
+
+Setup:
+- Same custom mpc-node image as Test 5 (still PR #3145's image, but the
+  PR's fields are *unset* in the launcher TOML — so PR #3145 is a no-op
+  for this run).
+- `single-node-testnet.sh` invoked with `TIER3_PUBLIC_ADDR=""` (the
+  script omits the line from the rendered TOML when empty).
+- Single iptables rule on the host:
+  ```bash
+  sudo iptables -t nat -I POSTROUTING 1 \
+    -p tcp --dport 24567 -o ens49f0np0 \
+    -j SNAT --to-source 51.68.219.13
+  ```
+  Matched by destination port `:24567` because dstack uses QEMU
+  user-mode slirp (no host-visible CVM bridge IP to match on, the
+  recipe in [Concrete recipe for Option 3b](#concrete-recipe-for-option-3b-on-boballe-multi-ip-ovh-host)
+  notes this).
+- CVM was restarted *after* the SNAT rule was installed (initial deploy
+  raced — neard's first peer connections established before the rule
+  hit POSTROUTING, so conntrack pinned them with no SNAT and
+  auto-discovery latched onto the wrong IP). Restart resolved this.
+
+Final metrics after 32 min uptime:
+
+```
+near_tier3_public_addr{addr="51.68.219.13:24567"} 1   ← auto-discovered, no config field set ✅
+near_block_height_head 249137957                       ← jumped to testnet tip ✅
+near_sync_status 7                                     ← past state sync, in block sync now ✅
+
+near_state_sync_download_result{result="success",  type="header"} 1
+near_state_sync_download_result{result="success",  type="part"}   1019   ← full state sync ✅
+near_state_sync_download_result{result="timeout",  type="part"}   29
+near_state_sync_download_result{result="sender_dropped",..."part"} 20
+near_state_sync_download_result{result="route_not_found",..."part"} 16
+
+near_peer_connections{peer_type="Outbound",tier="T2"} 18
+near_peer_connections{peer_type="Inbound",tier="T2"}  (absent — 0)   ← still ❌
+```
+
+State sync of shard 5 completed in ~32 min (faster than Test 5's 55 min).
+SNAT rule packet counter climbed past 130, confirming the rule was
+matching outbound peer-port-24567 traffic.
+
+**Verdict:** Option 3b is sufficient by itself for DSS. It provides the
+same correctness as Option 0 with no node code/config changes, just one
+iptables rule. The rule must be in place *before* neard starts making
+peer connections, otherwise conntrack pins the pre-SNAT mapping and
+auto-discovery ends up wrong (mitigated by restart-after-rule).
+
+### Test 6 takeaway: Tier2 inbound recovery is unrelated to either fix
+
+A surprising finding from comparing Test 5 and Test 6 directly:
+
+|  | Option 0 (Test 5) | Option 3b (Test 6) |
+|---|---|---|
+| `near_tier3_public_addr` correct | ✅ via config | ✅ via SNAT auto-discovery |
+| State sync completed | ✅ in ~55 min | ✅ in ~32 min |
+| Successful state parts | 1019 | 1019 (same) |
+| Success rate | 96.3% | ~94% |
+| **`peer_connections{Inbound,T2}`** | **0 (after 1.5+ days)** | **0 (after 32 min)** |
+| Node config change required | yes (PR #3145) | no |
+| Host root required | no | yes (iptables) |
+| Persistence | trivial (file) | systemd / iptables-persistent |
+
+**Both options leave Tier2 inbound at zero**, despite Option 3b correcting
+the source IP that peers observe (so gossiped `PeerInfo` is correct from
+the moment of restart). This contradicts the working hypothesis that
+fixing the gossiped address would let other peers dial us inbound.
+
+What this means:
+- The "missing Tier2 inbound peers" symptom is **not** primarily caused
+  by the wrong gossiped `PeerInfo`. Peers don't actively dial random
+  gossiped addresses, so even a correct address may not produce inbound
+  connections quickly.
+- It's likely a function of network demand / convergence time, not of
+  the fix mechanism. Bob's mainnet GCP node has 9 inbound T2 because
+  it's been running long enough to be in many peers' active connection
+  set. Fresh nodes (us, Bob's TEE) won't catch up in minutes.
+- For our deployment, this means **Option 3b's purported "bonus benefit
+  of also fixing Tier2 inbound" is not real in practice** — at least not
+  on the timescale we tested. Both fixes deliver DSS equally well.
 
 ## Scope of impact
 
@@ -740,15 +838,37 @@ only egress as that IP. Strongest isolation.
 
 **Concrete recommendation for Bob:**
 
-1. **Now:** apply Option 0 (`tier3_public_addr` in launcher TOML, via PR #3145)
-   — unblocks DSS without touching the host networking. Validated on Alice.
-2. **As a follow-up:** apply Option 3b (per-CVM SNAT) on Bob — also unblocks
-   the missing-Tier2-inbound symptom and is the architecturally cleaner
-   long-term answer for any new multi-IP host. See
-   [Concrete recipe for Option 3b](#concrete-recipe-for-option-3b-on-boballe-multi-ip-ovh-host)
-   above.
-3. **Eventually:** if upstream Option 4 lands in a future nearcore release,
-   we can drop Option 0 in favor of native outbound source-IP binding.
+Both Option 0 and Option 3b are now empirically validated (Tests 5 and 6
+respectively). They deliver the same DSS correctness; **neither
+recovers Tier2 inbound** in the test windows. So the choice between them
+is operational, not functional.
+
+1. **Recommended: Option 0** (`tier3_public_addr` in launcher TOML, via
+   PR #3145).
+   - Operationally simpler — one TOML field, no host root, no iptables
+     persistence to maintain.
+   - The fix lives with the node config, so it travels with the
+     deployment automatically. No host-side state to forget on a
+     migration.
+   - Validated end-to-end on TDX (Test 5).
+2. **Alternative: Option 3b** (per-host iptables SNAT).
+   - Faster state sync in our test (~32 min vs ~55 min for Option 0),
+     possibly because the source IP is correct from the moment of the
+     first peer connection rather than only on the request payload.
+   - No node code/config changes — useful if you can't redeploy nodes
+     but can change the host.
+   - Cost: requires root on the host, an iptables rule that needs
+     persistence (systemd / `iptables-persistent`), and a SNAT rule
+     installed *before* neard starts (otherwise conntrack pins the
+     pre-SNAT mapping and the fix is wasted).
+3. **Eventually:** if upstream Option 4 lands in a future nearcore
+   release, we can drop both Option 0 and Option 3b in favor of native
+   outbound source-IP binding.
+
+We initially expected Option 3b's bonus over Option 0 to be "also
+recovers Tier2 inbound peers" — that turned out **not** to materialize
+empirically (see Test 6 takeaway above). So there's no functional
+reason to prefer 3b over 0; the choice is purely operational.
 
 ## Important nuances
 

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -860,28 +860,52 @@ process-launch.
 - **Performance:** veth pair adds one memory copy + interface dispatch
   per packet. Tiny — comparable to docker bridge networking.
 
-### Option 6 — cgroup-based SNAT (fits dstack-slirp)
+### Option 6 — cgroup-based SNAT (fits dstack-slirp via "one dstack-vmm per CVM")
 
-dstack-vmm spawns one qemu process per CVM, and on systemd-managed hosts
-each qemu lands in its own cgroup (e.g. `/system.slice/dstack-vm-<id>.slice`,
-or a child `cgroup.procs` of dstack-vmm itself). iptables can match
-packets by the source process's cgroup, which gives us **per-CVM
-matching even in slirp where no bridge IP is exposed**:
+iptables can match packets by the source process's cgroup
+(`-m cgroup --path /...`), which gives us per-CVM matching even in slirp
+where no host-visible bridge IP is exposed. The challenge is making sure
+each CVM's qemu actually lands in a distinct cgroup.
+
+**Empirical finding on dstack 0.5.8 (Alice, 2026-05-07):** when **one**
+`dstack-vmm` instance spawns multiple CVMs, all the qemu processes
+inherit the **same** cgroup (`session-N.scope` of whichever shell started
+dstack-vmm). Children of one process share its cgroup. So Option 6 with
+one dstack-vmm doesn't work — verified:
+
+```text
+qemu A (Node A) PID 1416319 → /user.slice/user-1000.slice/session-24531.scope
+qemu B (Node B) PID 1763647 → /user.slice/user-1000.slice/session-24531.scope    ← same cgroup
+dstack-vmm     PID 2137301 → /user.slice/user-1000.slice/session-24531.scope    ← parent
+```
+
+The fix is to run **one `dstack-vmm` instance per CVM**, each in its own
+cgroup. Each instance's qemu child then inherits a distinct cgroup, and
+iptables can SNAT each correctly.
 
 ```bash
-# Match each qemu's outbound by cgroup, SNAT to the right public IP.
+# 1. Start each dstack-vmm in its own systemd scope.
+sudo systemd-run --scope --unit=dstack-vmm-A.scope \
+  --working-directory=/path/to/vmm-A-config \
+  /path/to/dstack-vmm -c vmm-A.toml
+
+sudo systemd-run --scope --unit=dstack-vmm-B.scope \
+  --working-directory=/path/to/vmm-B-config \
+  /path/to/dstack-vmm -c vmm-B.toml
+
+# 2. SNAT each scope's outbound to its assigned public IP.
 sudo iptables -t nat -A POSTROUTING \
-  -m cgroup --path /system.slice/<dstack-vm-A>.slice \
-  -p tcp --dport 24567 -o ens49f0np0 \
+  -m cgroup --path /system.slice/dstack-vmm-A.scope \
+  -o ens49f0np0 -p tcp --dport 24567 \
   -j SNAT --to-source 51.68.219.13
 
 sudo iptables -t nat -A POSTROUTING \
-  -m cgroup --path /system.slice/<dstack-vm-B>.slice \
-  -p tcp --dport 24567 -o ens49f0np0 \
+  -m cgroup --path /system.slice/dstack-vmm-B.scope \
+  -o ens49f0np0 -p tcp --dport 24567 \
   -j SNAT --to-source 51.68.219.14
 ```
 
-Or via `net_cls` cgroup classid (older kernels):
+Or via `net_cls` cgroup classid (older kernels with cgroup v1):
 
 ```bash
 echo 0x100001 | sudo tee /sys/fs/cgroup/<vm-A>/net_cls.classid
@@ -889,28 +913,34 @@ sudo iptables -t nat -A POSTROUTING -m cgroup --cgroup 0x100001 \
   -j SNAT --to-source 51.68.219.13
 ```
 
-- **Type:** host iptables config. **No code changes** to neard, mpc-node,
-  or the launcher.
-- **Applies to:** any setup where each CVM/process is in a distinct
-  cgroup. **Likely fits dstack** (each qemu runs as a subprocess of
-  dstack-vmm, typically under its own cgroup) — needs verification.
+- **Type:** host iptables config + per-CVM dstack-vmm instance.
+  **No code changes** to neard, mpc-node, the launcher, or dstack-vmm
+  itself.
+- **Applies to:** any host with cgroup v2 + iptables `-m cgroup`
+  (verified on Alice). Works on dstack-slirp specifically.
 - **Pros:**
   - Per-CVM in slirp setups (the case Option 3b couldn't handle).
   - No netns/veth re-wiring.
-  - Fixes both DSS and Tier2 inbound peers.
+  - Fixes both DSS and Tier2 inbound peers (in principle).
+  - No code change needed in dstack-vmm.
 - **Cons:**
-  - Depends on dstack-vmm placing each qemu in a distinct cgroup, which
-    is implementation-specific. **Needs empirical verification on
-    dstack 0.5.8.**
-  - cgroup paths change if dstack restarts the VM; rule install needs
-    to be coordinated with VM lifecycle (or use stable label/classid).
-  - iptables rules need persistence.
-  - cgroup match has been empirically less performant than other matches
-    in some kernel versions — usually not material for neard's
-    traffic.
+  - **Operational overhead: each CVM needs its own dstack-vmm process,
+    config file, working directory, RPC port.** ~doubles the dstack
+    management surface for each additional CVM.
+  - Memory: each dstack-vmm process is ~50 MB resident.
+  - Cgroup path is tied to the systemd scope name; if dstack-vmm is
+    restarted (crash → revive), the iptables rule should still match
+    because systemd reuses the unit name, but worth wiring an
+    integrity check.
+  - iptables rules need persistence (`iptables-persistent`, systemd
+    unit, or whatever the host uses).
+  - Hasn't been end-to-end validated yet on dstack 0.5.8 — kernel +
+    iptables support is confirmed, but a real "2 dstack-vmm + 2 SNAT
+    rules + observe per-CVM `near_tier3_public_addr`" experiment hasn't
+    been run.
 - **Performance:** per-packet cgroup lookup; negligible.
-- **Status:** **proposed but not yet validated on dstack.** See
-  "Open questions / follow-ups."
+- **Status:** **proposed; cgroup mechanism verified, end-to-end test
+  not yet run.**
 
 ### Comparison table
 
@@ -924,17 +954,17 @@ sudo iptables -t nat -A POSTROUTING -m cgroup --cgroup 0x100001 \
 > hardcoded line. The "Available today" column reflects what's needed
 > *beyond* that.
 
-| # | Solution | Type | Needs (besides DSS-enable) | Fixes DSS (Tier3) | Fixes Tier2 inbound | Multi-node on dstack-slirp | Persistence | Perf impact |
-|---|---|---|---|---|---|---|---|---|
-| **0** | **`tier3_public_addr` per-node** | Node config | PR #3145 (the field itself) | ✅ | ❌ (empirical, Test 5) | ✅ for DSS, ❌ for T2 inbound | trivial (file) | none |
-| 1 | `network.addr = "0.0.0.0:24567"` | Node config | nothing extra | n/a inside CVM | n/a inside CVM | n/a (CVM-internal) | trivial (file) | none |
-| 2 | Host-wide default-route source | Host network config | nothing extra | ✅ for one IP | partial | ❌ (only one src possible) | needs systemd hook | none |
-| 3a | UID-based policy routing | Host network + run-as-user | nothing extra | ✅ | ✅ (likely, untested) | ❌ (all dstack qemus share `dstack-vmm` UID) | needs systemd hook | negligible |
-| **3b (bridge-IP)** | Per-CVM SNAT keyed by CVM bridge IP | Host iptables | nothing extra | ✅ | ✅ | ❌ (no bridge IP in slirp) | needs persistence | low |
-| **3b (dport, deployed)** | Per-host SNAT keyed by `--dport 24567` | Host iptables | nothing extra | ✅ (Test 6) | ❌ (empirical, Test 6) | ❌ (single CVM only — see "Multi-node trap") | needs persistence | low |
-| 4 | neard binds outbound source IP | Upstream nearcore code change | upstream PR + release | ✅ in non-slirp; ❌ in slirp | ✅ in non-slirp; ❌ in slirp | ❌ in slirp (neard can't bind to host IP from inside CVM) | trivial once shipped | none |
-| 5 | Network namespace per qemu | Host networking + process isolation | dstack-vmm cooperation | ✅ | ✅ | ✅ but needs dstack-vmm patch | needs systemd hook | low |
-| **6** | **cgroup-based SNAT** | Host iptables | dstack-vmm puts each qemu in distinct cgroup | ✅ (proposed) | ✅ (proposed) | ✅ likely (needs verification) | needs persistence | negligible |
+| # | Solution | Type | Needs (besides DSS-enable) | Fixes DSS (Tier3) | Fixes Tier2 inbound | Multi-node on dstack-slirp | Persistence | Perf impact | Tested? |
+|---|---|---|---|---|---|---|---|---|---|
+| **0** | **`tier3_public_addr` per-node** | Node config | PR #3145 (the field itself) | ✅ | ❌ (empirical, Test 5) | ✅ for DSS, ❌ for T2 inbound | trivial (file) | none | ✅ Test 5 (TDX, single CVM) |
+| 1 | `network.addr = "0.0.0.0:24567"` | Node config | nothing extra | n/a inside CVM | n/a inside CVM | n/a (CVM-internal) | trivial (file) | none | ❌ not applicable in CVM |
+| 2 | Host-wide default-route source | Host network config | nothing extra | ✅ for one IP | partial | ❌ (only one src possible) | needs systemd hook | none | ❌ not tested |
+| 3a | UID-based policy routing | Host network + run-as-user | nothing extra | ✅ | ✅ (likely, untested) | ❌ (all dstack qemus share `dstack-vmm` UID) | needs systemd hook | negligible | ❌ not tested |
+| **3b (bridge-IP)** | Per-CVM SNAT keyed by CVM bridge IP | Host iptables | nothing extra | ✅ | ✅ | ❌ (no bridge IP in slirp) | needs persistence | low | ❌ not applicable in slirp |
+| **3b (dport, deployed)** | Per-host SNAT keyed by `--dport 24567` | Host iptables | nothing extra | ✅ (Test 6) | ❌ (empirical, Test 6) | ❌ (single CVM only — see "Multi-node trap") | needs persistence | low | ✅ Test 6 (TDX, single CVM) |
+| 4 | neard binds outbound source IP | Upstream nearcore code change | upstream PR + release | ✅ in non-slirp; ❌ in slirp | ✅ in non-slirp; ❌ in slirp | ❌ in slirp (neard can't bind to host IP from inside CVM) | trivial once shipped | none | ❌ doesn't exist yet |
+| 5 | Network namespace per qemu | Host networking + process isolation | dstack-vmm cooperation | ✅ | ✅ | ✅ but needs dstack-vmm patch | needs systemd hook | low | ❌ not tested |
+| **6** | **cgroup-based SNAT (one dstack-vmm per CVM)** | Host iptables + per-CVM dstack-vmm | nothing in dstack-vmm, but one instance per CVM | ✅ (proposed) | ✅ (proposed) | ✅ (mechanism verified, end-to-end not run) | needs persistence | negligible | ⚠️ partial: cgroup mechanism verified on Alice, full deploy not run |
 
 ### Picking between them
 

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -2,12 +2,11 @@
 
 Issue: https://github.com/near/mpc/issues/1734
 
-> **Status: root cause confirmed and fix validated end-to-end.**
-> Reproduced on bare-metal `neard` (no docker, no CVM) on Alice; the fix
-> (`network.experimental.tier3_public_addr`) was applied and DSS started
-> downloading state parts within seconds. The bug is **not CVM-specific**
-> — it's host-level, triggered by any host with multiple IPs where `:24567`
-> is bound to a non-default IP.
+> **Status: root cause confirmed and fix validated end-to-end on bare neard
+> AND through a full TDX CVM** (PR #3145 — launcher TOML plumbing for
+> `tier3_public_addr` and `external_storage_fallback_threshold`). The bug is
+> **not CVM-specific** — it's host-level, triggered by any host with
+> multiple IPs where `:24567` is bound to a non-default IP.
 
 ## TL;DR
 
@@ -20,7 +19,10 @@ Issue: https://github.com/near/mpc/issues/1734
   (Bob, Alice — OVH bare-metal). **Mainnet GCP node is not affected**
   (verified — single external IP, auto-discovery correct).
 - **Fix:** set `network.experimental.tier3_public_addr = "<bound_ip>:24567"`
-  in the neard config. Validated on Alice — DSS recovered within seconds.
+  in the neard config. Validated on Alice end-to-end — both on bare neard
+  (DSS recovered within seconds) and through a full TDX CVM with
+  PR #3145's launcher TOML plumbing (96% DSS success rate, 13–29 Tier3
+  inbound connections from real testnet peers).
 - **Also remove** the hardcoded `external_storage_fallback_threshold = 0`
   in `deployment/start.sh:46`, which forced bucket-only sync and had been
   masking this bug for every MPC node since launch.
@@ -198,46 +200,140 @@ and selecting outbound source via the default route.
 
 ### Validation coverage — what's been tested vs. what hasn't
 
-Tests 1–4 cover the bug *mechanism* and *fix mechanism* end-to-end on bare
-neard, and confirm the mainnet GCP node is unaffected. But the production
-deployment shape adds layers we haven't exercised yet — specifically, the
-TDX/launcher chain on Bob, and the host-level fix options.
-
 **Tested ✅**
 
 - **Bug reproduces** on bare neard 2.11.0 with multi-IP host (Test 2).
 - **`tier3_public_addr` fixes DSS** on bare neard when set directly in
-  `config.json` (Test 3) — observed `near_tier3_public_addr` flip and
-  `near_state_sync_download_result{result="success",source="network"}`
-  start climbing within ~15 s.
-- **GCP single-IP topology is healthy** without any fix (Test 4) —
-  baseline that auto-discovery is correct in normal conditions.
+  `config.json` (Test 3).
+- **GCP single-IP topology is healthy** without any fix (Test 4).
+- **End-to-end through the TDX/launcher chain** (Test 5). PR #3145's
+  `tier3_public_addr` and `external_storage_fallback_threshold` fields
+  flow correctly from launcher TOML → `patch_near_config` → neard config
+  inside the CVM, and DSS state sync works through the full QEMU /
+  dstack / docker network stack.
 
 **Not yet tested ❌**
 
-- **`tier3_public_addr` through the TDX/launcher chain.** Bare-neard test
-  only validates the field on a freshly written `config.json`. The actual
-  TEE deployment path is launcher TOML → `deployment/start.sh` patches →
-  `config.json` inside the container → neard inside QEMU/dstack
-  networking. We haven't verified:
-  - There's a path to inject `tier3_public_addr` in this chain
-    (`start.sh` currently doesn't write it).
-  - The advertised address propagates correctly through the QEMU slirp
-    NAT layer (container's `network.addr` may be on the slirp internal
-    IP, while the value we'd inject is the host's public IP).
-  - Tier3 inbound from real testnet peers actually lands on the container
-    after going through host port-forward → QEMU slirp → docker bridge.
 - **Host-level routing fixes** (Options 2/3a/3b/5). All proposed but
-  none empirically validated. In particular Option 3b (per-CVM SNAT) is
-  the leading candidate for Bob's setup, but we haven't built the
-  iptables rules and watched whether `near_tier3_public_addr` becomes
-  correct via auto-discovery alone (no `tier3_public_addr` config).
+  none empirically validated. In particular Option 3b (per-CVM SNAT)
+  is the leading candidate for Bob's setup; we haven't run the iptables
+  rules and watched whether `near_tier3_public_addr` becomes correct via
+  auto-discovery alone (no `tier3_public_addr` config).
 - **Whether the host fix alone is sufficient without `tier3_public_addr`.**
   Theoretically yes (auto-discovery would pick the now-correct outbound
-  IP), but worth empirically confirming before we recommend the
-  defense-in-depth pattern in production.
+  IP), but worth empirically confirming.
 
-These gaps are the planned tests (1) and (2) of the validation work.
+### Test 5 — full TDX CVM with PR #3145 (run 2026-05-06 on Alice)
+
+Validates the entire fix pipeline against a real testnet TDX CVM:
+
+```
+launcher TOML (tier3_public_addr, external_storage_fallback_threshold)
+  ↓
+launcher's intercept_node_config → mpc-config.toml on shared volume
+  ↓
+mpc-node's StartConfig::from_toml_file → patch_near_config (PR #3145)
+  ↓
+neard config.json
+  (network.experimental.tier3_public_addr +
+   state_sync.sync.ExternalStorage.external_storage_fallback_threshold)
+  ↓
+neard at runtime → near_tier3_public_addr metric
+  ↓
+peers send Tier3 state-sync responses → host port-forward → QEMU slirp
+                                      → docker bridge → neard inside CVM
+```
+
+Setup:
+- Custom mpc-node image built from PR #3145 branch (CI), tag
+  `barak-testing-dss-tier3-public-addr-c371677`,
+  manifest `sha256:7210432270b0d05f62cae03074feb51575d4b28feeceae525fe068935020f206`.
+- Launcher image `nearone/mpc-launcher:main-c0778dc` (latest main, supports
+  the current TOML schema with `image_reference`).
+- Testnet TDX CVM on Alice, dstack-dev-0.5.8, SGX local key provider.
+- TOML fields under test:
+  ```toml
+  [mpc_node_config.near_init]
+  tier3_public_addr = "51.68.219.13:24567"
+  external_storage_fallback_threshold = 1000
+  ```
+- Bound to a single static IP (`51.68.219.13:24567`), mirroring Bob's
+  setup so the bug would reproduce in the unfixed case.
+- Script: `localnet/tee/scripts/rust-launcher/single-node-testnet.sh`.
+
+**mpc-node startup logs** (all timestamps from the same boot):
+
+```
+INFO mpc_node::run: mpc-node 3.9.0 (release 3.9.0) (commit c371677)   ← PR #3145 branch
+INFO mpc_node::run: starting MPC node account_id=dss-test.testnet
+                    contract_id=v1.signer-prod.testnet home_dir=/data
+INFO mpc_node::run: TEE config tee_authority=dstack
+                    image_hash=sha256:7210432...020f206
+INFO mpc_node::run: NEAR init config chain_id=testnet download_genesis=true
+INFO mpc_node::run: TEE attestation generated successfully
+...
+INFO stats: node_status="State 8qYjL...[5: parts] (5 downloads, 0 computations)
+                        11 peers ⬇ 319 kB/s ⬆ 28.9 kB/s ..."
+```
+
+**Metrics observed during state sync (~13 min into run):**
+
+```
+near_tier3_public_addr{addr="51.68.219.13:24567"} 1
+near_block_height_head 42376888                            ← state-sync still in progress
+
+near_peer_connections{peer_type="Inbound",tier="T3"} 13    ← peers landing Tier3 inbound ✅
+near_peer_connections{peer_type="Outbound",tier="T2"} 11
+
+near_state_sync_download_result{result="success",
+   shard_id="5", source="network", type="header"} 1
+near_state_sync_download_result{result="success",
+   shard_id="5", source="network", type="part"} 570        ← ~96% success rate
+near_state_sync_download_result{result="timeout",
+   shard_id="5", source="network", type="part"} 23
+near_state_sync_download_result{result="sender_dropped",
+   shard_id="5", source="network", type="part"} 2
+near_sync_status 5                                          ← state sync phase
+```
+
+**Tier3 disconnect warnings** also observed in the log:
+
+```
+WARN network: received message on connection, disconnecting
+              msg_variant=Disconnect tier=T3
+```
+
+These look concerning at first read but are normal Tier3 lifecycle —
+nearcore explicitly designs Tier3 connections as ephemeral: peer opens
+TCP, sends one state part, sends Disconnect, both sides close (from
+`chain/network/src/tcp.rs`'s `Tier::T3` doc: *"Tier3 connections are
+created ad hoc to directly transfer large messages... we avoid delaying
+other messages and we minimize network bandwidth usage."*). Each
+Disconnect = one successful state-part transfer completing. Repeated
+Disconnects = repeated successful transfers, which is the *desired*
+path.
+
+**Verdict**
+
+End-to-end fix works in TDX. Specifically validated:
+
+1. **Launcher reads `tier3_public_addr`** from the TOML and propagates
+   it into the neard config inside the CVM. Verified: the
+   `near_tier3_public_addr` metric shows the exact configured value
+   (`51.68.219.13:24567`), not the auto-discovered outbound IP that the
+   unfixed case would produce.
+2. **`external_storage_fallback_threshold = 1000` was applied.**
+   Verified: DSS attempts happen at all — with the previous hardcoded
+   `0`, the node would have gone straight to bucket and we'd see no
+   `near_state_sync_download_result{source="network"}` entries.
+3. **Real testnet peers reach the CVM through the full network stack.**
+   Verified: 13–29 Tier3 inbound connections at any given time, 570+
+   successful part downloads after ~13 min, ~96% success rate.
+
+The TDX / dstack / QEMU / docker networking layers do **not** introduce
+additional failure modes beyond the host-level asymmetric-IP issue we
+already identified — once `tier3_public_addr` is set, the fix is the
+same on bare metal and in TDX.
 
 ## Scope of impact
 

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -401,10 +401,24 @@ State sync of shard 5 completed in ~32 min (faster than Test 5's 55 min).
 SNAT rule packet counter climbed past 130, confirming the rule was
 matching outbound peer-port-24567 traffic.
 
-**Verdict:** Option 3b is sufficient by itself for DSS. It provides the
-same correctness as Option 0 with no node code/config changes, just one
-iptables rule. The rule must be in place *before* neard starts making
-peer connections, otherwise conntrack pins the pre-SNAT mapping and
+**Verdict:** Option 3b correctly fixes the source-IP discovery — once
+in place, `near_tier3_public_addr` auto-discovers `51.68.219.13:24567`
+and DSS proceeds normally.
+
+**Important caveat about "no code changes":** Test 6 ran *with* PR #3145's
+binary AND with `external_storage_fallback_threshold = 1000` set in the
+launcher TOML. Without PR #3145, `patch_near_config` hardcodes the
+threshold to `0` (bucket-only) — DSS is never *attempted* in the first
+place, so Option 3b's source-IP correction has nothing to act on. So
+Option 3b is **not** a code-free alternative to Option 0; it's an
+alternative to Option 0's `tier3_public_addr` field while still relying
+on Option 0's `external_storage_fallback_threshold` field. The smallest
+"truly code-free" Option 3b would require us to also remove the
+hardcoded `= 0` line in `patch_near_config` (a one-line code change,
+smaller than the rest of PR #3145).
+
+The SNAT rule must be in place *before* neard starts making peer
+connections — otherwise conntrack pins the pre-SNAT mapping and
 auto-discovery ends up wrong (mitigated by restart-after-rule).
 
 ### Test 6 takeaway: Tier2 inbound recovery is unrelated to either fix
@@ -418,7 +432,8 @@ A surprising finding from comparing Test 5 and Test 6 directly:
 | Successful state parts | 1019 | 1019 (same) |
 | Success rate | 96.3% | ~94% |
 | **`peer_connections{Inbound,T2}`** | **0 (after 1.5+ days)** | **0 (after 32 min)** |
-| Node config change required | yes (PR #3145) | no |
+| Requires PR #3145 | yes (both new fields) | yes (`external_storage_fallback_threshold` only) |
+| Hardcoded IP in node config | yes (`tier3_public_addr`) | no |
 | Host root required | no | yes (iptables) |
 | Persistence | trivial (file) | systemd / iptables-persistent |
 
@@ -808,15 +823,25 @@ only egress as that IP. Strongest isolation.
 
 ### Comparison table
 
-| # | Solution | Type | Available today | Fixes DSS (Tier3) | Fixes Tier2 inbound | Multi-node on one host | Persistence | Perf impact |
+> **Note about "Available today":** stock MPC `main` hardcodes
+> `external_storage_fallback_threshold = 0` in `patch_near_config`
+> (`crates/node/src/config/start.rs`), which forces bucket-only and
+> means **DSS is never attempted at all**. So none of the options below
+> actually enable DSS on stock main — they all require *some* code
+> change to lift that hardcoded threshold. PR #3145 adds it as a
+> launcher TOML field; the smallest possible fix is to just remove the
+> hardcoded line. The "Available today" column reflects what's needed
+> *beyond* that.
+
+| # | Solution | Type | Needs (besides DSS-enable) | Fixes DSS (Tier3) | Fixes Tier2 inbound | Multi-node on one host | Persistence | Perf impact |
 |---|---|---|---|---|---|---|---|---|
-| **0** | **`tier3_public_addr` per-node** | Node config | ✅ | ✅ | ❌ | ✅ | trivial (file) | none |
-| 1 | `network.addr = "0.0.0.0:24567"` | Node config | ✅ | ✅ | ✅ | ❌ (port conflict) | trivial (file) | none |
-| 2 | Host-wide default-route source | Host network config | ✅ | ✅ | ✅ | ❌ | needs systemd hook | none |
-| 3a | UID-based policy routing | Host network + run-as-user | ✅ | ✅ | ✅ | ✅ | needs systemd hook | negligible (one extra rule lookup per `connect()`) |
-| 3b | Per-CVM SNAT on host | Host iptables | ✅ | ✅ | ✅ | ✅ | needs `iptables-persistent` or systemd | low (conntrack + per-packet rewrite) |
-| 4 | neard binds outbound source IP | Upstream nearcore code change | ❌ (needs PR + release) | ✅ | ✅ | ✅ | trivial (file, once shipped) | none |
-| 5 | Network namespace per node | Host networking + process isolation | ✅ | ✅ | ✅ | ✅ | needs systemd hook | low (veth pair per packet) |
+| **0** | **`tier3_public_addr` per-node** | Node config | PR #3145 (the field itself) | ✅ | ❌ (empirical, Test 5) | ✅ | trivial (file) | none |
+| 1 | `network.addr = "0.0.0.0:24567"` | Node config | nothing extra | ✅ | likely ✅ (untested) | ❌ (port conflict) | trivial (file) | none |
+| 2 | Host-wide default-route source | Host network config | nothing extra | ✅ | likely ✅ (untested) | ❌ | needs systemd hook | none |
+| 3a | UID-based policy routing | Host network + run-as-user | nothing extra | ✅ | likely ✅ (untested) | ✅ | needs systemd hook | negligible |
+| **3b** | **Per-CVM SNAT on host** | Host iptables | nothing extra | ✅ (Test 6) | ❌ (empirical, Test 6) | ✅ | needs `iptables-persistent` or systemd | low (conntrack + per-packet rewrite) |
+| 4 | neard binds outbound source IP | Upstream nearcore code change | upstream PR + release | ✅ | likely ✅ (untested) | ✅ | trivial (file, once shipped) | none |
+| 5 | Network namespace per node | Host networking + process isolation | nothing extra | ✅ | likely ✅ (untested) | ✅ | needs systemd hook | low (veth pair per packet) |
 
 ### Picking between them
 

--- a/docs/analysis/issue-1734-dss.md
+++ b/docs/analysis/issue-1734-dss.md
@@ -684,11 +684,18 @@ don't need any networking changes.
 
 - **Type:** host iptables config. **No code changes** to neard, mpc-node,
   or the launcher. CVMs unchanged.
-- **Applies to:** TEE/CVM deployments (the case 3a does *not* cover) —
-  works identically for plain Docker containers.
+- **Applies to:** container/CVM stacks where each guest has a host-visible
+  bridge IP — Docker bridge, libvirt `virbr0`, QEMU `-netdev tap`, etc.
+- **Critical: does NOT work on dstack 0.5.8 with QEMU user-mode slirp.**
+  dstack uses `-netdev user` (slirp), which keeps the CVM's network
+  entirely *inside* the qemu process — no per-CVM IP is visible on any
+  host bridge. The matching key (`-s <cvm_bridge_ip>/32`) doesn't exist.
+  The fallback we deployed in Test 6 (matching by `--dport 24567` only)
+  works for one CVM but cannot distinguish two — see "**Multi-node
+  trap** for slirp setups" below.
 - **Pros:**
-  - Native to container/CVM workflows — applies cleanly to dstack
-    deployments.
+  - Native to container/CVM workflows — applies cleanly when bridge IP
+    is exposed.
   - Each CVM gets its own outbound IP without any in-CVM config.
   - Doesn't affect host's other traffic.
   - Fixes both DSS and Tier2 inbound peers.
@@ -698,10 +705,24 @@ don't need any networking changes.
   - Tied to the CVM bridge IPs being stable — which they generally are,
     but a re-deploy that changes the bridge layout breaks the rule.
   - SNAT relies on connection tracking — adds a small per-flow overhead.
+  - **Doesn't fit dstack-slirp at all** (see above).
 - **Performance:** SNAT adds conntrack entry + rewrite per packet.
   For neard's traffic profile (a few hundred TCP connections, modest
   PPS), CPU overhead is in the noise. Becomes meaningful only at much
   higher throughput than neard generates.
+
+> **Multi-node trap for slirp setups** (the case we hit in Test 6 on
+> Alice). When CVMs use `-netdev user` (slirp), there is no host-visible
+> per-CVM IP to use as the SNAT match. The fallback rule we deployed —
+> `iptables -t nat -A POSTROUTING -p tcp --dport 24567 -o <NIC> -j
+> SNAT --to-source <bound_ip>` — uses only the destination port to
+> match, which is identical for every CVM. **A second CVM on the same
+> host would have its outbound rewritten to the same source IP, causing
+> a collision in peers' peer_stores (same `SocketAddr`, different
+> `peer_id`).** Only one CVM "wins" each peer's store slot, leaving the
+> other partially invisible. So the dport-keyed fallback is **single-CVM
+> only by construction.** For multi-CVM on slirp, see Options 5 / 6
+> below.
 
 ### Concrete recipe for Option 3b on Bob/Alice (multi-IP OVH host)
 
@@ -801,25 +822,95 @@ the right IP without any host or environment hacks.
     needs to handle that explicitly.
 - **Performance:** none.
 
-### Option 5 — dedicated network namespace per node
+### Option 5 — dedicated network namespace per QEMU process
 
-Run each node inside its own Linux network namespace with only the
-intended IP visible / routable. Outbound from inside the namespace can
-only egress as that IP. Strongest isolation.
+Wrap each qemu process in its own Linux network namespace. The host
+exposes only one outbound IP into the namespace via a veth pair, so the
+qemu's outbound source IP is forced to be the right one for that CVM.
 
-- **Type:** host networking + process isolation. **No code changes.**
+```bash
+# Sketch (for one CVM):
+sudo ip netns add cvm-A
+sudo ip link add veth-A type veth peer name veth-A-host
+sudo ip link set veth-A netns cvm-A
+sudo ip netns exec cvm-A ip addr add <netns-internal-ip>/30 dev veth-A
+sudo ip addr add <peer-of-internal-ip>/30 dev veth-A-host
+# ... NAT/routing so the netns's outbound exits with src=51.68.219.13
+sudo ip netns exec cvm-A /usr/bin/qemu-system-x86_64 ...   # launch qemu inside
+```
+
+For dstack, this means **wrapping each `qemu-system-x86_64` invocation
+in `ip netns exec`** — which `dstack-vmm` doesn't natively do.
+Operationally requires patching dstack-vmm or interposing on its
+process-launch.
+
+- **Type:** host networking + process isolation. **No code changes** to
+  neard, mpc-node, or the launcher — but **does require dstack-vmm to
+  cooperate** (or be wrapped).
+- **Applies to:** any host setup, including dstack-slirp.
 - **Pros:**
-  - Strongest isolation — node literally cannot see other IPs on the
-    host.
+  - Strongest isolation — qemu literally cannot see other host IPs.
   - Fixes both DSS and Tier2 inbound peers.
-  - Per-node, scales arbitrarily.
+  - Per-CVM, scales arbitrarily.
 - **Cons:**
-  - Heavyweight setup — netns + veth + routing per node.
-  - Affects every other network-touching detail (DNS, monitoring, debug
-    access — all need to be re-wired into the namespace).
-  - Operationally complex; harder to debug than UID routing or SNAT.
-- **Performance:** veth pair adds one extra hop per packet (memory copy
-  + interface dispatch). Tiny — comparable to docker bridge networking.
+  - Requires changes to dstack-vmm's qemu launch sequence (insert
+    `ip netns exec` per CVM).
+  - Each netns needs its own routing / DNS / monitoring re-wired in.
+  - Heavyweight to debug.
+- **Performance:** veth pair adds one memory copy + interface dispatch
+  per packet. Tiny — comparable to docker bridge networking.
+
+### Option 6 — cgroup-based SNAT (fits dstack-slirp)
+
+dstack-vmm spawns one qemu process per CVM, and on systemd-managed hosts
+each qemu lands in its own cgroup (e.g. `/system.slice/dstack-vm-<id>.slice`,
+or a child `cgroup.procs` of dstack-vmm itself). iptables can match
+packets by the source process's cgroup, which gives us **per-CVM
+matching even in slirp where no bridge IP is exposed**:
+
+```bash
+# Match each qemu's outbound by cgroup, SNAT to the right public IP.
+sudo iptables -t nat -A POSTROUTING \
+  -m cgroup --path /system.slice/<dstack-vm-A>.slice \
+  -p tcp --dport 24567 -o ens49f0np0 \
+  -j SNAT --to-source 51.68.219.13
+
+sudo iptables -t nat -A POSTROUTING \
+  -m cgroup --path /system.slice/<dstack-vm-B>.slice \
+  -p tcp --dport 24567 -o ens49f0np0 \
+  -j SNAT --to-source 51.68.219.14
+```
+
+Or via `net_cls` cgroup classid (older kernels):
+
+```bash
+echo 0x100001 | sudo tee /sys/fs/cgroup/<vm-A>/net_cls.classid
+sudo iptables -t nat -A POSTROUTING -m cgroup --cgroup 0x100001 \
+  -j SNAT --to-source 51.68.219.13
+```
+
+- **Type:** host iptables config. **No code changes** to neard, mpc-node,
+  or the launcher.
+- **Applies to:** any setup where each CVM/process is in a distinct
+  cgroup. **Likely fits dstack** (each qemu runs as a subprocess of
+  dstack-vmm, typically under its own cgroup) — needs verification.
+- **Pros:**
+  - Per-CVM in slirp setups (the case Option 3b couldn't handle).
+  - No netns/veth re-wiring.
+  - Fixes both DSS and Tier2 inbound peers.
+- **Cons:**
+  - Depends on dstack-vmm placing each qemu in a distinct cgroup, which
+    is implementation-specific. **Needs empirical verification on
+    dstack 0.5.8.**
+  - cgroup paths change if dstack restarts the VM; rule install needs
+    to be coordinated with VM lifecycle (or use stable label/classid).
+  - iptables rules need persistence.
+  - cgroup match has been empirically less performant than other matches
+    in some kernel versions — usually not material for neard's
+    traffic.
+- **Performance:** per-packet cgroup lookup; negligible.
+- **Status:** **proposed but not yet validated on dstack.** See
+  "Open questions / follow-ups."
 
 ### Comparison table
 
@@ -833,15 +924,17 @@ only egress as that IP. Strongest isolation.
 > hardcoded line. The "Available today" column reflects what's needed
 > *beyond* that.
 
-| # | Solution | Type | Needs (besides DSS-enable) | Fixes DSS (Tier3) | Fixes Tier2 inbound | Multi-node on one host | Persistence | Perf impact |
+| # | Solution | Type | Needs (besides DSS-enable) | Fixes DSS (Tier3) | Fixes Tier2 inbound | Multi-node on dstack-slirp | Persistence | Perf impact |
 |---|---|---|---|---|---|---|---|---|
-| **0** | **`tier3_public_addr` per-node** | Node config | PR #3145 (the field itself) | ✅ | ❌ (empirical, Test 5) | ✅ | trivial (file) | none |
-| 1 | `network.addr = "0.0.0.0:24567"` | Node config | nothing extra | ✅ | likely ✅ (untested) | ❌ (port conflict) | trivial (file) | none |
-| 2 | Host-wide default-route source | Host network config | nothing extra | ✅ | likely ✅ (untested) | ❌ | needs systemd hook | none |
-| 3a | UID-based policy routing | Host network + run-as-user | nothing extra | ✅ | likely ✅ (untested) | ✅ | needs systemd hook | negligible |
-| **3b** | **Per-CVM SNAT on host** | Host iptables | nothing extra | ✅ (Test 6) | ❌ (empirical, Test 6) | ✅ | needs `iptables-persistent` or systemd | low (conntrack + per-packet rewrite) |
-| 4 | neard binds outbound source IP | Upstream nearcore code change | upstream PR + release | ✅ | likely ✅ (untested) | ✅ | trivial (file, once shipped) | none |
-| 5 | Network namespace per node | Host networking + process isolation | nothing extra | ✅ | likely ✅ (untested) | ✅ | needs systemd hook | low (veth pair per packet) |
+| **0** | **`tier3_public_addr` per-node** | Node config | PR #3145 (the field itself) | ✅ | ❌ (empirical, Test 5) | ✅ for DSS, ❌ for T2 inbound | trivial (file) | none |
+| 1 | `network.addr = "0.0.0.0:24567"` | Node config | nothing extra | n/a inside CVM | n/a inside CVM | n/a (CVM-internal) | trivial (file) | none |
+| 2 | Host-wide default-route source | Host network config | nothing extra | ✅ for one IP | partial | ❌ (only one src possible) | needs systemd hook | none |
+| 3a | UID-based policy routing | Host network + run-as-user | nothing extra | ✅ | ✅ (likely, untested) | ❌ (all dstack qemus share `dstack-vmm` UID) | needs systemd hook | negligible |
+| **3b (bridge-IP)** | Per-CVM SNAT keyed by CVM bridge IP | Host iptables | nothing extra | ✅ | ✅ | ❌ (no bridge IP in slirp) | needs persistence | low |
+| **3b (dport, deployed)** | Per-host SNAT keyed by `--dport 24567` | Host iptables | nothing extra | ✅ (Test 6) | ❌ (empirical, Test 6) | ❌ (single CVM only — see "Multi-node trap") | needs persistence | low |
+| 4 | neard binds outbound source IP | Upstream nearcore code change | upstream PR + release | ✅ in non-slirp; ❌ in slirp | ✅ in non-slirp; ❌ in slirp | ❌ in slirp (neard can't bind to host IP from inside CVM) | trivial once shipped | none |
+| 5 | Network namespace per qemu | Host networking + process isolation | dstack-vmm cooperation | ✅ | ✅ | ✅ but needs dstack-vmm patch | needs systemd hook | low |
+| **6** | **cgroup-based SNAT** | Host iptables | dstack-vmm puts each qemu in distinct cgroup | ✅ (proposed) | ✅ (proposed) | ✅ likely (needs verification) | needs persistence | negligible |
 
 ### Picking between them
 

--- a/docs/dss-multi-ip-host-fix.md
+++ b/docs/dss-multi-ip-host-fix.md
@@ -1,0 +1,223 @@
+# Fixing DSS state-sync timeouts on multi-IP hosts
+
+Operator guide for the bug tracked in
+[#1734](https://github.com/near/mpc/issues/1734). For the underlying
+root-cause analysis, see
+[`docs/analysis/issue-1734-dss.md`](./analysis/issue-1734-dss.md).
+
+## When you need this
+
+You are affected if **all** of these are true:
+
+1. Your MPC node runs on a host with **multiple public IPs on one NIC**
+   (typical of OVH / Hetzner bare-metal — `ip -4 addr show <nic>` shows
+   several `inet` lines).
+2. `:24567` is bound to **one specific** static IP on the host (e.g. via
+   `EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC=51.68.219.13:24567`), not
+   `0.0.0.0`.
+3. Outbound traffic egresses with a **different** IP from that bound
+   one. Check:
+   ```bash
+   ip route get 8.8.8.8
+   # 8.8.8.8 via 100.64.0.1 dev <nic> src <outbound_ip>
+   ```
+   If `<outbound_ip>` differs from your bound `:24567` IP — you're
+   affected.
+
+You are **not** affected on a single-IP host (most cloud VMs — GCP, AWS
+single-VM, etc.). The bug only manifests when outbound source IP differs
+from inbound bind IP.
+
+## Symptoms
+
+DSS state sync times out continuously. Visible in metrics
+(`http://<node>:<metrics-port>/metrics`):
+
+- `near_tier3_public_addr{addr="..."}` reports the **outbound** IP, not
+  the bound IP — that's the canary.
+- `near_state_sync_download_result{result="timeout",source="network"}`
+  climbs while `result="success"` stays at 0.
+- nearcore log warns:
+  > "state sync header retrieval is failing repeatedly. This may
+  > indicate a Tier3 connectivity issue - peers cannot connect back to
+  > deliver state data. Check: ... if behind NAT, set
+  > `network.experimental.tier3_public_addr` in `config.json`."
+
+## Quick diagnostic
+
+```bash
+# 1. What does the node advertise?
+curl -s http://<your-node>:<metrics-port>/metrics | grep near_tier3_public_addr
+
+# 2. What IP does the host outbound exit as?
+ip route get 8.8.8.8 | awk '/src/ {print $7}'
+
+# 3. What IP is :24567 bound on (host)?
+sudo ss -ltn | grep ':24567'
+```
+
+If (1) matches (2) but **not** (3) → you have this bug.
+
+---
+
+## Option A (recommended): set `tier3_public_addr` in the launcher TOML
+
+Lives in node config; no host root or iptables work; survives reboots
+trivially. **This is what we ship in PR #3145.**
+
+In the launcher's user-config TOML, add to the `[mpc_node_config.near_init]`
+section:
+
+```toml
+[mpc_node_config.near_init]
+chain_id = "testnet"            # existing
+boot_nodes = "..."              # existing
+download_genesis = true         # existing
+download_config = "rpc"         # existing
+
+# NEW — set to the same IP:port your dstack port-forward uses for :24567
+tier3_public_addr = "51.68.219.13:24567"
+
+# NEW (optional) — enable DSS-first behavior. 0 (current default) =
+# bucket-only and DSS never runs. 1000 = try DSS up to 1000 times before
+# falling back to bucket as a safety net. Required if you want DSS to
+# actually be exercised once bucket sync is decommissioned.
+external_storage_fallback_threshold = 1000
+```
+
+For the dstack TEE deployment specifically: edit the user-config file
+through the dstack-vmm "Update VM Config" modal (per
+[`mpc-private` PR #304's runbook](https://github.com/near/mpc-private/pull/304)),
+then **Shutdown → Start** the CVM to apply.
+
+### Verify
+
+After restart, hit the metrics endpoint. Expect:
+
+```bash
+curl -s http://<node>:<metrics-port>/metrics | grep near_tier3_public_addr
+# near_tier3_public_addr{addr="51.68.219.13:24567"} 1
+```
+
+If the address matches what you configured (and **not** the dynamic
+outbound IP), the fix is live.
+
+DSS attempts should start succeeding within a minute:
+
+```bash
+curl -s http://<node>:<metrics-port>/metrics | grep near_state_sync_download_result
+# expect near_state_sync_download_result{result="success",source="network",type="part"} climbing
+```
+
+---
+
+## Option B (alternative): host-level iptables SNAT
+
+For hosts where you can't easily change the launcher TOML, or you'd
+rather fix it once at the host level. Equivalent correctness; somewhat
+harder to operate.
+
+```bash
+# Replace 51.68.219.13 with your bound IP and ens49f0np0 with your NIC.
+sudo iptables -t nat -I POSTROUTING 1 \
+  -p tcp --dport 24567 -o ens49f0np0 \
+  -j SNAT --to-source 51.68.219.13
+```
+
+Persist across reboots:
+
+```bash
+sudo apt install iptables-persistent
+sudo netfilter-persistent save
+```
+
+Or via a systemd unit / `if-up.d` hook keyed off the bridge interface
+coming up.
+
+### Critical: timing matters
+
+The SNAT rule must be in place **before** neard starts making peer
+connections. Otherwise conntrack pins the existing connections with no
+SNAT, neard's auto-discovery latches onto the wrong IP, and the rule
+applies only to *new* connections. The fix won't take effect until you
+restart the node.
+
+For a freshly-deployed node, install the rule, then deploy.
+For an already-running node, install the rule, then restart neard (or
+the whole CVM).
+
+### Verify
+
+Same metric check as Option A:
+
+```bash
+curl -s http://<node>:<metrics-port>/metrics | grep near_tier3_public_addr
+# near_tier3_public_addr{addr="51.68.219.13:24567"} 1   ← right IP via auto-discovery
+```
+
+Also confirm the SNAT rule is matching packets:
+
+```bash
+sudo iptables -t nat -L POSTROUTING -n -v --line-numbers | head -3
+#       pkts  bytes  target  ...
+# 1     <N>   <B>    SNAT    ... tcp dpt:24567 to:51.68.219.13
+```
+
+The `pkts` column should be non-zero and climbing — those are your
+node's outbound connections to peers being SNAT'd.
+
+---
+
+## Picking between the two options
+
+| | Option A (`tier3_public_addr`) | Option B (iptables SNAT) |
+|---|---|---|
+| Lives in | node config (TOML) | host firewall |
+| Requires root on host | no | yes |
+| Persistence | trivial (file) | needs systemd / `iptables-persistent` |
+| Survives node redeploy | yes | yes |
+| Survives host migration | depends on whether new host has the same IP setup | no — host config doesn't travel |
+| Minimum nearcore version | 2.10+ | any |
+| Restart required to apply | yes (once) | yes (once, *after* rule install) |
+
+**Recommendation: Option A**, unless you specifically need a host-level
+fix (e.g., you can't redeploy the node, or you're standardizing on
+host-level network policy across many nodes).
+
+Both options are validated end-to-end on a TDX CVM (Tests 5 and 6 in
+the [analysis doc](./analysis/issue-1734-dss.md)). They deliver the same
+DSS correctness; neither recovers `peer_connections{Inbound,T2}` in
+test windows up to 1.5 days, so don't pick Option B expecting that as a
+bonus.
+
+## Common pitfalls
+
+- **The bound IP changed.** If your dstack port-forward target changes
+  (e.g., you migrate from `51.68.219.13` to `51.68.219.14`), update
+  `tier3_public_addr` (Option A) or the SNAT `--to-source` (Option B)
+  to match. They must agree with the IP that's actually port-forwarded.
+- **`external_storage_fallback_threshold = 0`** (the default in
+  `start.sh` historically) means **DSS never runs**, regardless of
+  whether `tier3_public_addr` is set. If you want to actually exercise
+  DSS, set the threshold to a non-zero value (1000 is a safe
+  DSS-first-with-bucket-fallback choice).
+- **Forgetting to restart neard** after a config change. Both options
+  only take effect after a fresh process startup so peer-connection
+  state and `my_public_addr` are re-derived.
+- **iptables rule installed too late** (Option B). If neard already
+  established connections before the rule was installed, conntrack
+  pinned them without SNAT — those connections are useless for the
+  fix. Restart neard to drop the conntrack entries and force fresh
+  connections.
+
+## What this fix does NOT change
+
+- **Existing peer connections aren't retroactively SNAT'd / re-discovered.**
+  Both fixes only take effect on neard restarts.
+- **Tier2 inbound peers** (`peer_connections{Inbound,T2}`) — neither
+  fix produces these in our test windows. The MPC node functions fine
+  outbound-only; this is a separate hygiene issue.
+- **Bucket sync configuration** — both fixes are about DSS only. If
+  you're still relying on the external bucket for state sync, leave the
+  threshold at 0 and the bucket settings as-is; this fix doesn't change
+  bucket behavior.

--- a/docs/dss-multi-ip-host-fix.md
+++ b/docs/dss-multi-ip-host-fix.md
@@ -113,9 +113,31 @@ curl -s http://<node>:<metrics-port>/metrics | grep near_state_sync_download_res
 
 ## Option B (alternative): host-level iptables SNAT
 
-For hosts where you can't easily change the launcher TOML, or you'd
-rather fix it once at the host level. Equivalent correctness; somewhat
-harder to operate.
+For hosts where you don't want to put a specific IP in the launcher
+TOML, or you'd rather fix it once at the host's network layer.
+Equivalent DSS correctness once everything's wired up.
+
+> **You still need PR #3145** to even get DSS running. `start.sh` /
+> `patch_near_config` hardcodes `external_storage_fallback_threshold = 0`
+> for any non-localnet chain — i.e., bucket-only, DSS never attempted.
+> Without PR #3145's `external_storage_fallback_threshold` field set
+> to a non-zero value in the TOML, your iptables rule has nothing to
+> SNAT (no DSS traffic), and state sync stays stuck on the broken
+> bucket path. So Option B is *not* a code-free alternative to Option A
+> — it just lets you skip the `tier3_public_addr` field while keeping
+> the `external_storage_fallback_threshold` field.
+
+In the launcher TOML, set the threshold but leave `tier3_public_addr`
+unset:
+
+```toml
+[mpc_node_config.near_init]
+# (existing fields ...)
+external_storage_fallback_threshold = 1000
+# tier3_public_addr deliberately omitted — host SNAT will correct it
+```
+
+Then on the host:
 
 ```bash
 # Replace 51.68.219.13 with your bound IP and ens49f0np0 with your NIC.
@@ -172,16 +194,16 @@ node's outbound connections to peers being SNAT'd.
 
 | | Option A (`tier3_public_addr`) | Option B (iptables SNAT) |
 |---|---|---|
-| Lives in | node config (TOML) | host firewall |
+| Requires PR #3145 | yes (for both fields) | yes (for `external_storage_fallback_threshold`) |
+| Hardcoded IP in node config | yes (`tier3_public_addr`) | no |
 | Requires root on host | no | yes |
 | Persistence | trivial (file) | needs systemd / `iptables-persistent` |
 | Survives node redeploy | yes | yes |
-| Survives host migration | depends on whether new host has the same IP setup | no — host config doesn't travel |
-| Minimum nearcore version | 2.10+ | any |
+| Survives host migration | depends on whether new host has the same IP setup | no — host iptables doesn't travel with the node |
 | Restart required to apply | yes (once) | yes (once, *after* rule install) |
 
-**Recommendation: Option A**, unless you specifically need a host-level
-fix (e.g., you can't redeploy the node, or you're standardizing on
+**Recommendation: Option A**, unless you specifically need to avoid
+hardcoding an IP in the node config (e.g., you're standardizing on
 host-level network policy across many nodes).
 
 Both options are validated end-to-end on a TDX CVM (Tests 5 and 6 in

--- a/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
@@ -815,6 +815,12 @@ render_node_files_range() {
     export EXTERNAL_MPC_LOCAL_DEBUG_PORT="127.0.0.1:${local_dbg_port}"
     export EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC="${ip}:${STATE_SYNC_PORT}"
     export EXTERNAL_MPC_MAIN_PORT="${ip}:${MAIN_PORT}"
+
+    # PR #3145 (DSS fix for multi-IP hosts): each node advertises its own
+    # bound IP for Tier3 state-sync responses. On testnet, also enable
+    # DSS-first behavior with bucket fallback as safety net.
+    export TIER3_PUBLIC_ADDR="${ip}:${STATE_SYNC_PORT}"
+    export FALLBACK_THRESHOLD="${FALLBACK_THRESHOLD:-1000}"
         local future_port
     future_port="$(future_port_for_i "$i")"
 

--- a/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
@@ -18,6 +18,9 @@ chain_id = "testnet"
 boot_nodes = "${NEAR_BOOT_NODES}"
 download_genesis = true
 download_config = "rpc"
+# Two new fields under test (PR #3145):
+tier3_public_addr = "${TIER3_PUBLIC_ADDR}"
+external_storage_fallback_threshold = ${FALLBACK_THRESHOLD}
 
 [mpc_node_config.secrets]
 secret_store_key_hex = "${MPC_SECRET_STORE_KEY}"

--- a/localnet/tee/scripts/rust-launcher/single-node-testnet.sh
+++ b/localnet/tee/scripts/rust-launcher/single-node-testnet.sh
@@ -104,7 +104,10 @@ AGENT_PORT="${AGENT_PORT:-$(find_free_port)}"
 LOCAL_DEBUG_PORT="${LOCAL_DEBUG_PORT:-$(find_free_port)}"
 
 # --- PR #3145 fields under test ---
-TIER3_PUBLIC_ADDR="${TIER3_PUBLIC_ADDR:-${MACHINE_IP}:${STATE_SYNC_PORT}}"
+# TIER3_PUBLIC_ADDR: explicitly empty/unset = omit from TOML (test Option 3b
+# without the application-level fix). Default = MACHINE_IP:STATE_SYNC_PORT
+# (matches Bob's setup, exercises PR #3145).
+TIER3_PUBLIC_ADDR="${TIER3_PUBLIC_ADDR-${MACHINE_IP}:${STATE_SYNC_PORT}}"
 FALLBACK_THRESHOLD="${FALLBACK_THRESHOLD:-1000}"
 
 # dstack
@@ -191,8 +194,15 @@ render_env_and_conf() {
   envsubst <"$ENV_TPL" >"$ENV_OUT"
   envsubst <"$CONF_TPL" >"$CONF_OUT"
 
+  # If TIER3_PUBLIC_ADDR is empty (i.e. operator opted out so we can test
+  # host-level fixes like Option 3b in isolation), drop the rendered line —
+  # neard rejects an empty SocketAddr.
+  if [ -z "$TIER3_PUBLIC_ADDR" ]; then
+    sed -i '/^tier3_public_addr = ""/d' "$CONF_OUT"
+  fi
+
   log "Rendered env/conf in $WORKDIR"
-  log "tier3_public_addr: $TIER3_PUBLIC_ADDR"
+  log "tier3_public_addr: ${TIER3_PUBLIC_ADDR:-<unset — host-level fix expected>}"
   log "external_storage_fallback_threshold: $FALLBACK_THRESHOLD"
   log "Image tag: $MPC_IMAGE_TAG"
 }

--- a/localnet/tee/scripts/rust-launcher/single-node-testnet.sh
+++ b/localnet/tee/scripts/rust-launcher/single-node-testnet.sh
@@ -1,0 +1,278 @@
+#!/usr/bin/env bash
+# Adaptation of single-node.sh for testnet — for testing PR #3145 (DSS fix).
+#
+# Differences from single-node.sh:
+#  - chain_id = testnet (not localnet)
+#  - No NEAR account creation (uses dummy account ID — DSS doesn't care)
+#  - Boot nodes fetched from testnet RPC, not localnet validator
+#  - Threads tier3_public_addr + external_storage_fallback_threshold from
+#    PR #3145 into the launcher TOML
+#  - Genesis is downloaded from testnet (no embedded local genesis)
+#
+# Required env:
+#   BASE_PATH       — dstack base path (e.g. /mnt/data/barak/dstack_latest/meta-dstack/dstack)
+#   MACHINE_IP      — host IP reachable from the CVM (one of the static IPs)
+#   MPC_IMAGE_TAG   — custom mpc-node image tag built from PR #3145
+#                     (e.g. "barak-testing-dss-tier3-public-addr-c371677")
+#
+# Optional env:
+#   TIER3_PUBLIC_ADDR     — defaults to ${MACHINE_IP}:${STATE_SYNC_PORT}
+#   FALLBACK_THRESHOLD    — defaults to 1000 (DSS-first with bucket safety net)
+#   FORCE_BIND_TO_IP      — if "1", bind network.addr to the same specific IP
+#                           (mirrors Bob's setup for true reproduction)
+#
+set -euo pipefail
+export NEAR_CLI_DISABLE_SPINNER=1
+
+log(){ echo -e "\033[1;34m[INFO]\033[0m $*"; }
+err(){ echo -e "\033[1;31m[ERROR]\033[0m $*"; }
+
+find_free_port() {
+  python3 -c '
+import socket, random
+while True:
+    port = random.randint(12000, 24000)
+    try:
+        s = socket.socket()
+        s.bind(("", port))
+        s.close()
+        print(port)
+        break
+    except OSError:
+        continue
+'
+}
+
+remove_cvm_app() {
+  local name_file="$1"
+  if [ ! -f "$name_file" ]; then
+    err "No app name file found at $name_file"
+    return 1
+  fi
+  local name
+  name="$(cat "$name_file")"
+  log "Looking up VM ID for $name ..."
+  local vm_id
+  vm_id="$(python3 "$BASE_PATH/vmm/src/vmm-cli.py" --url "$VMM_RPC" lsvm 2>/dev/null \
+    | grep "$name" | awk -F'│' '{gsub(/ /,"",$2); print $2}' | head -1)"
+  if [ -n "$vm_id" ]; then
+    log "Stopping CVM app: $name (vm_id=$vm_id)"
+    python3 "$BASE_PATH/vmm/src/vmm-cli.py" --url "$VMM_RPC" stop "$vm_id" 2>/dev/null || true
+    log "Waiting for VM to stop ..."
+    for (( i=1; i<=30; i++ )); do
+      if python3 "$BASE_PATH/vmm/src/vmm-cli.py" --url "$VMM_RPC" lsvm 2>/dev/null \
+          | grep "$vm_id" | grep -q "stopped"; then
+        break
+      fi
+      sleep 2
+    done
+    log "Removing CVM app: $name (vm_id=$vm_id)"
+    python3 "$BASE_PATH/vmm/src/vmm-cli.py" --url "$VMM_RPC" remove "$vm_id"
+  else
+    err "No VM found for $name"
+    return 1
+  fi
+}
+
+# --- Cleanup mode (only needs BASE_PATH) ---
+if [ "${1:-}" = "--cleanup" ]; then
+  : "${BASE_PATH:?Set BASE_PATH (dstack base path)}"
+  VMM_RPC="${VMM_RPC:-http://127.0.0.1:10000}"
+  workdir="${2:?Usage: $0 --cleanup <WORKDIR>}"
+  remove_cvm_app "$workdir/app_name"
+  exit $?
+fi
+
+# --- Required ---
+: "${BASE_PATH:?Set BASE_PATH (dstack base path)}"
+: "${MACHINE_IP:?Set MACHINE_IP (one of the static host IPs)}"
+: "${MPC_IMAGE_TAG:?Set MPC_IMAGE_TAG (custom image built from PR #3145, e.g. barak-testing-...)}"
+
+NODE_IP="${NODE_IP:-$MACHINE_IP}"
+
+# --- Defaults ---
+NODE_ACCOUNT="${NODE_ACCOUNT:-dss-test.testnet}"        # dummy — DSS doesn't care
+CONTRACT_ACCOUNT="${CONTRACT_ACCOUNT:-v1.signer-prod.testnet}"  # real testnet contract — drives shard tracking
+
+# Ports — auto-pick free ports.
+PUBLIC_DATA_PORT="${PUBLIC_DATA_PORT:-$(find_free_port)}"
+STATE_SYNC_PORT="${STATE_SYNC_PORT:-24567}"             # nearcore default; needs to match peers' expectations
+MAIN_PORT="${MAIN_PORT:-$(find_free_port)}"
+FUTURE_PORT="${FUTURE_PORT:-$(find_free_port)}"
+SSH_PORT="${SSH_PORT:-$(find_free_port)}"
+AGENT_PORT="${AGENT_PORT:-$(find_free_port)}"
+LOCAL_DEBUG_PORT="${LOCAL_DEBUG_PORT:-$(find_free_port)}"
+
+# --- PR #3145 fields under test ---
+TIER3_PUBLIC_ADDR="${TIER3_PUBLIC_ADDR:-${MACHINE_IP}:${STATE_SYNC_PORT}}"
+FALLBACK_THRESHOLD="${FALLBACK_THRESHOLD:-1000}"
+
+# dstack
+VMM_RPC="${VMM_RPC:-http://127.0.0.1:10000}"
+OS_IMAGE="${OS_IMAGE:-dstack-dev-0.5.8}"
+SEALING_KEY_TYPE="${SEALING_KEY_TYPE:-KMS}"
+DISK="${DISK:-500G}"
+
+# Paths
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+TEE_LAUNCHER_DIR="$REPO_ROOT/deployment/cvm-deployment"
+ENV_TPL="${ENV_TPL:-$REPO_ROOT/localnet/tee/scripts/node.env.tpl}"
+CONF_TPL="${CONF_TPL:-$REPO_ROOT/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl}"
+
+ports_to_toml() {
+  local ports="$1" result=""
+  IFS=',' read -ra pairs <<< "$ports"
+  for pair in "${pairs[@]}"; do
+    local host_port="${pair%%:*}"
+    local container_port="${pair##*:}"
+    result+="    { host =$host_port, container =$container_port },
+"
+  done
+  echo -n "$result"
+}
+
+WORKDIR="${WORKDIR:-$(mktemp -d /tmp/mpc_testnet_dss.XXXXXX)}"
+mkdir -p "$WORKDIR"
+log "Work directory: $WORKDIR"
+ENV_OUT="$WORKDIR/node.env"
+CONF_OUT="$WORKDIR/node.toml"
+PUBLIC_DATA_JSON_OUT="${PUBLIC_DATA_JSON_OUT:-$WORKDIR/public_data.json}"
+
+fetch_testnet_bootnodes() {
+  curl -s -X POST https://rpc.testnet.near.org \
+    -H "Content-Type: application/json" \
+    -d '{"jsonrpc":"2.0","method":"network_info","params":[],"id":"x"}' \
+  | jq -r '.result.active_peers[] | "\(.id)@\(.addr)"' \
+  | awk -F'@' '!seen[$2]++ {print $0}' \
+  | paste -sd',' -
+}
+
+render_env_and_conf() {
+  log "Fetching testnet boot nodes ..."
+  export NEAR_BOOT_NODES="${NEAR_BOOT_NODES:-$(fetch_testnet_bootnodes)}"
+  log "Got $(echo "$NEAR_BOOT_NODES" | tr ',' '\n' | wc -l) boot nodes"
+
+  export APP_NAME="${APP_NAME:-mpc-testnet-dss-$(date +%s)}"
+  export VMM_RPC OS_IMAGE SEALING_KEY_TYPE DISK
+  export DOCKER_COMPOSE_FILE_PATH="launcher_docker_compose.yaml"
+  export USER_CONFIG_FILE_PATH="$CONF_OUT"
+
+  export EXTERNAL_SSH_PORT="127.0.0.1:${SSH_PORT}"
+  export EXTERNAL_DSTACK_AGENT_PORT="127.0.0.1:${AGENT_PORT}"
+  export EXTERNAL_MPC_LOCAL_DEBUG_PORT="127.0.0.1:${LOCAL_DEBUG_PORT}"
+
+  export INTERNAL_SSH_PORT="${INTERNAL_SSH_PORT:-22}"
+  export INTERNAL_DSTACK_AGENT_PORT="${INTERNAL_DSTACK_AGENT_PORT:-8090}"
+  export INTERNAL_MPC_LOCAL_DEBUG_PORT="${INTERNAL_MPC_LOCAL_DEBUG_PORT:-3030}"
+
+  export EXTERNAL_MPC_PUBLIC_DEBUG_PORT="${NODE_IP}:${PUBLIC_DATA_PORT}"
+  # CRITICAL: bind state sync port to the specific NODE_IP (not 0.0.0.0) so we
+  # genuinely test the multi-IP-host scenario from #1734.
+  export EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC="${NODE_IP}:${STATE_SYNC_PORT}"
+  export EXTERNAL_MPC_MAIN_PORT="${NODE_IP}:${MAIN_PORT}"
+  export EXTERNAL_MPC_FUTURE_PORT="${NODE_IP}:${FUTURE_PORT}"
+
+  export INTERNAL_MPC_PUBLIC_DEBUG_PORT="${INTERNAL_PUBLIC_DEBUG_PORT:-8080}"
+  export INTERNAL_MPC_DECENTRALIZED_STATE_SYNC="${INTERNAL_STATE_SYNC_PORT:-24567}"
+  export INTERNAL_MPC_MAIN_PORT="${INTERNAL_MAIN_PORT:-80}"
+  export INTERNAL_MPC_FUTURE_PORT="${INTERNAL_FUTURE_PORT:-13001}"
+
+  export MPC_IMAGE="nearone/mpc-node"
+  export MPC_ACCOUNT_ID="$NODE_ACCOUNT"
+  export MPC_CONTRACT_ID="$CONTRACT_ACCOUNT"
+  export MPC_SECRET_STORE_KEY="${MPC_SECRET_STORE_KEY:-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA}"
+
+  export TIER3_PUBLIC_ADDR FALLBACK_THRESHOLD
+
+  export PORTS="${PORTS:-8080:8080,${STATE_SYNC_PORT}:${STATE_SYNC_PORT}}"
+  export PORTS_TOML
+  PORTS_TOML="$(ports_to_toml "$PORTS")"
+
+  envsubst <"$ENV_TPL" >"$ENV_OUT"
+  envsubst <"$CONF_TPL" >"$CONF_OUT"
+
+  log "Rendered env/conf in $WORKDIR"
+  log "tier3_public_addr: $TIER3_PUBLIC_ADDR"
+  log "external_storage_fallback_threshold: $FALLBACK_THRESHOLD"
+  log "Image tag: $MPC_IMAGE_TAG"
+}
+
+deploy_one_node() {
+  local deploy_log="$WORKDIR/deploy.log"
+  log "Deploying dstack CVM app: $APP_NAME (log: $deploy_log)"
+  if ! ( cd "$TEE_LAUNCHER_DIR" && ./deploy-launcher.sh --yes --env-file "$ENV_OUT" --base-path "$BASE_PATH" --python-exec python ) > "$deploy_log" 2>&1; then
+    err "deploy-launcher.sh failed. Output:"
+    cat "$deploy_log" >&2
+    return 1
+  fi
+}
+
+wait_for_launcher() {
+  local agent_url="http://127.0.0.1:${AGENT_PORT}"
+  local logs_url="${agent_url}/logs/launcher?text&bare&timestamps&tail=20"
+
+  log "Waiting for dstack agent to become reachable at ${agent_url} ..."
+  if ! curl -fsS --retry 60 --retry-delay 2 --retry-all-errors "${agent_url}/" >/dev/null 2>&1; then
+    err "dstack agent never became reachable at ${agent_url}"
+    return 1
+  fi
+
+  log "Agent is up. Checking launcher logs for MPC container startup ..."
+  local max_attempts=60
+  for (( i=1; i<=max_attempts; i++ )); do
+    local logs
+    logs="$(curl -fsS "${logs_url}" 2>/dev/null || true)"
+
+    if echo "$logs" | grep -qi "MPC launched successfully"; then
+      log "Launcher started the MPC container successfully."
+      return 0
+    fi
+
+    if echo "$logs" | grep -qi "no such image\|pull.*error\|fatal\|exited with code"; then
+      err "Launcher failed to start the MPC container. Last launcher logs:"
+      echo "$logs" >&2
+      return 1
+    fi
+
+    sleep 5
+  done
+
+  log "Launcher hasn't confirmed MPC container after $((max_attempts * 5))s. Launcher logs:"
+  curl -fsS "${logs_url}" 2>/dev/null || true
+  log "Continuing anyway — node may still be starting (testnet genesis is large) ..."
+}
+
+watch_dss_metrics() {
+  local metrics_url="http://${NODE_IP}:${PUBLIC_DATA_PORT}/metrics"
+  log "Watching DSS metrics at ${metrics_url} (Ctrl+C to stop) ..."
+  while true; do
+    echo "=== $(date +%T) ==="
+    curl -sf --max-time 5 "$metrics_url" 2>/dev/null | grep -E "^near_block_height_head |^near_tier3_public_addr|^near_peer_connections|^near_state_sync_download_result|^near_sync_status" || echo "(metrics not yet reachable)"
+    sleep 30
+  done
+}
+
+# --- Main ---
+render_env_and_conf
+
+log "Rendered TOML config (relevant fields):"
+grep -E "tier3_public_addr|external_storage_fallback_threshold|chain_id|boot_nodes|network_addr|mpc_contract_id" "$CONF_OUT" || true
+
+deploy_one_node
+echo "$APP_NAME" > "$WORKDIR/app_name"
+log "Saved app name to $WORKDIR/app_name"
+
+wait_for_launcher
+
+log ""
+log "=== Deployment complete ==="
+log "Public metrics: http://${NODE_IP}:${PUBLIC_DATA_PORT}/metrics"
+log "Launcher logs:  curl http://127.0.0.1:${AGENT_PORT}/logs/launcher?text&bare&timestamps&tail=40"
+log "MPC node logs:  curl http://127.0.0.1:${AGENT_PORT}/logs/mpc-node?text&bare&timestamps&tail=40"
+log ""
+log "Run with WATCH_METRICS=1 to tail DSS metrics, or:"
+log "  bash $0 --cleanup $WORKDIR"
+
+if [ "${WATCH_METRICS:-0}" = "1" ]; then
+  watch_dss_metrics
+fi

--- a/localnet/tee/scripts/rust-launcher/single-node-testnet.sh
+++ b/localnet/tee/scripts/rust-launcher/single-node-testnet.sh
@@ -110,7 +110,7 @@ FALLBACK_THRESHOLD="${FALLBACK_THRESHOLD:-1000}"
 # dstack
 VMM_RPC="${VMM_RPC:-http://127.0.0.1:10000}"
 OS_IMAGE="${OS_IMAGE:-dstack-dev-0.5.8}"
-SEALING_KEY_TYPE="${SEALING_KEY_TYPE:-KMS}"
+SEALING_KEY_TYPE="${SEALING_KEY_TYPE:-SGX}"   # SGX = local key provider, no external KMS dep
 DISK="${DISK:-500G}"
 
 # Paths


### PR DESCRIPTION
## Summary

Adds two optional fields to the launcher TOML's `[mpc_node_config.near_init]`
section to address #1734 (DSS state-sync timing out on multi-IP hosts):

- **`tier3_public_addr`** → patches `network.experimental.tier3_public_addr`
  in neard's `config.json`. Required on hosts where outbound source IP
  differs from the bound IP (Bob, Alice — OVH bare-metal).
- **`external_storage_fallback_threshold`** → overrides the hardcoded `0`
  (bucket-only) default in `patch_near_config`. Setting a non-zero value
  enables DSS-first behavior.

Default behavior unchanged when neither field is set.

## Status: testing branch, validated end-to-end

Currently a **draft testing branch** for empirical validation of the
#1734 fix. The plan is to do a full testnet E2E (multi-node MPC contract
+ key generation + signing) before this lands cleanly against `main`.

### Already validated

- [x] **Code compiles cleanly** (`cargo check -p mpc-node-config -p mpc-node`)
- [x] **8 unit tests** for `apply_near_config_patches` cover field presence,
      defaults, localnet behavior, and existing field interactions
- [x] **End-to-end TDX CVM run on Alice** with custom mpc-node image
      from this branch:
  - `near_tier3_public_addr{addr="51.68.219.13:24567"}` matches the
    configured value (proves launcher TOML chain works)
  - State sync of testnet shard 5 completed via DSS in ~55 min
  - **1019 successful part downloads, 96.3% success rate**, zero bucket
    fallbacks
  - Node now caught up at testnet tip (gap = 1 block)
- [x] **Diagnostic analysis** documenting bug mechanism, scope, fix
      options, and validation history (`docs/analysis/issue-1734-dss.md`)

### Pending

- [ ] **Full testnet E2E with MPC**: 2-node cluster on testnet doing
      contract registration, key generation, and signing — uses launcher
      TOML chain end-to-end with the new fields populated
- [ ] **Host-level fix validation** (Option 3b — per-CVM SNAT): confirm
      DSS works *without* `tier3_public_addr` when host outbound source
      IP is corrected via SNAT rules

## Files

- `crates/node-config/src/start.rs` — adds `tier3_public_addr` and
  `external_storage_fallback_threshold` to `NearInitConfig`
- `crates/node/src/config/start.rs` — extracts pure
  `apply_near_config_patches` for testability, wires the two fields,
  adds 8 unit tests
- `crates/node/src/cli.rs` — initializes new fields to `None` for the
  legacy CLI-flags init path
- `localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl` —
  testnet launcher TOML template with new fields
- `localnet/tee/scripts/rust-launcher/single-node-testnet.sh` —
  testnet adaptation of `single-node.sh`
- `deployment/testnet/dss-test.toml` — example testnet TOML with
  the new fields
- `docs/analysis/issue-1734-dss.md` — full analysis doc with bug
  mechanism, scope of impact, all 6 mitigation options, and
  validation history (Tests 1–5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)