### PR TITLE
docs(tdx-guide): pin apt sources for reproducible key-provider build

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -540,9 +540,9 @@ For more information, see [local-key-provider-from-phala](https://github.com/Dst
       && rm -rf /var/lib/apt/lists/*
      ```
 
-     The date `20260423T000000Z` matches the canonical-build host. Do not
-     change it — every operator must use the same date so all enclaves
-     produce the same `mr_enclave` the contract expects.
+     Paste this block exactly as shown — the snapshot date
+     `20260423T000000Z` is the specific value that produces the canonical
+     `mr_enclave`. Any change will produce a different one.
 
    - On the `rustup` line, change `--default-toolchain 1.85` to
      `--default-toolchain 1.85.1`. (`1.85` resolves to whatever 1.85.x is

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -524,8 +524,8 @@ For more information, see [local-key-provider-from-phala](https://github.com/Dst
          && rm -rf /var/lib/apt/lists/*
      ```
 
-     with this snapshot-pinned version (also overrides
-     `/etc/apt/sources.list` to point at a fixed Ubuntu archive date):
+     with this snapshot-pinned version, which points apt at a fixed
+     Ubuntu archive date by rewriting `/etc/apt/sources.list`:
 
      ```dockerfile
      RUN { \

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -505,7 +505,59 @@ For more information, see [local-key-provider-from-phala](https://github.com/Dst
 
 1. Follow the [canonical/tdx setup](#1-tdx-bare-metal-server-setup) if not already completed — especially step 9.1–2 (establishing an SGX PCCS: Provisioning Certification Caching Service).
 
-2. Deploy an instance of `gramine-sealing-key-provider` on the host machine.
+2. **Patch `Dockerfile.key-provider` to pin transitive deps.** This is a
+   temporary build-reproducibility patch; the structural fix is tracked in
+   [#3153](https://github.com/near/mpc/issues/3153). The upstream
+   Dockerfile leaves apt dependencies and the Rust toolchain version
+   under-pinned, so a fresh build on a different date produces a different
+   `mr_enclave` and your CVM fails attestation. After completing the
+   v0.5.8 dstack checkout from
+   [§2 *Dstack Setup and Configuration*](#2-dstack-setup-and-configuration),
+   edit `/opt/mpc/dstack/key-provider-build/Dockerfile.key-provider`:
+
+   - Replace the original apt block, which reads:
+
+     ```dockerfile
+     RUN apt-get update && apt-get install -y \
+         git=1:2.34.1-1ubuntu1.17 \
+         build-essential=12.9ubuntu3 \
+         && rm -rf /var/lib/apt/lists/*
+     ```
+
+     with this snapshot-pinned version (also overrides
+     `/etc/apt/sources.list` to point at a fixed Ubuntu archive date):
+
+     ```dockerfile
+     RUN { \
+           echo 'deb https://snapshot.ubuntu.com/ubuntu/20260423T000000Z jammy main universe restricted multiverse'; \
+           echo 'deb https://snapshot.ubuntu.com/ubuntu/20260423T000000Z jammy-updates main universe restricted multiverse'; \
+           echo 'deb https://snapshot.ubuntu.com/ubuntu/20260423T000000Z jammy-security main universe restricted multiverse'; \
+         } > /etc/apt/sources.list \
+      && rm -rf /etc/apt/sources.list.d/* \
+      && apt-get update && apt-get install -y \
+           git=1:2.34.1-1ubuntu1.17 \
+           build-essential=12.9ubuntu3 \
+      && rm -rf /var/lib/apt/lists/*
+     ```
+
+     The date `20260423T000000Z` matches the canonical-build host. Do not
+     change it — every operator must use the same date so all enclaves
+     produce the same `mr_enclave` the contract expects.
+
+   - On the `rustup` line, change `--default-toolchain 1.85` to
+     `--default-toolchain 1.85.1`. (`1.85` resolves to whatever 1.85.x is
+     current when rustup runs; pinning the exact patch version makes the
+     build deterministic.)
+
+   After running `./run.sh` in the next step, the `mr_enclave` you see in
+   step 4 should match `6b5ed02e…`. If it doesn't, the patch wasn't
+   applied correctly — re-check both edits.
+
+   <!-- TODO(#3153): remove this manual patch once the structural fix lands. -->
+   <!-- Requires snapshot.ubuntu.com to be reachable from the build host. -->
+
+
+3. Deploy an instance of `gramine-sealing-key-provider` on the host machine.
    * On the TDX server, run the script [run.sh](https://github.com/Dstack-TEE/dstack/blob/master/key-provider-build/run.sh)
    > **Prerequisite:** Docker must be installed.
 
@@ -513,7 +565,7 @@ For more information, see [local-key-provider-from-phala](https://github.com/Dst
     cd /opt/mpc/dstack/key-provider-build
     ./run.sh
     ```
-3. To find the `mr_enclave` value of the SGX key provider, run:
+4. To find the `mr_enclave` value of the SGX key provider, run:
 
    ```bash
    docker logs gramine-sealing-key-provider 2>&1 | grep mr_enclave | head -n 1


### PR DESCRIPTION
Closes #3191. Long-term structural fix tracked in #3153.

## Summary

Updates the TDX operator guide to instruct operators to patch `Dockerfile.key-provider` before running `./run.sh`:
- Apt sources pinned to `snapshot.ubuntu.com/ubuntu/20260423T000000Z` (`jammy` + `jammy-updates` + `jammy-security`).
- Rust toolchain pinned to `1.85.1` instead of `1.85`.

Without these pins, transitive apt deps like `libcurl3-gnutls` drift between operators' build dates → different bytes in the Gramine manifest → different `mr_enclave` → CVM fails mutual attestation. Hit in practice (operator produced `98f735d1…` instead of `6b5ed02e…`).

The Dockerfile we're patching lives upstream in `Dstack-TEE/dstack`; once #3153 lands the structural fix, these temporary instructions can be removed.

## Verified

Patched build reproduces the canonical `mr_enclave` on multiple independent hosts:
```
6b5ed02e549a1c30aaa8e3171a045f1f449b0017353ef595e78e39c348c98d01
```

## Test plan

- [ ] A new operator follows the updated guide and produces `mr_enclave = 6b5ed02e…`.