### PR TITLE
feat: add ReconstructionThreshold to DomainConfig

### DIFF
--- a/crates/backup-cli/assets/contract_state.json
+++ b/crates/backup-cli/assets/contract_state.json
@@ -6,12 +6,14 @@
           "id": 0,
           "curve": "Secp256k1",
           "protocol": "CaitSith",
+          "reconstruction_threshold": 7,
           "purpose": "Sign"
         },
         {
           "id": 1,
           "curve": "Edwards25519",
           "protocol": "Frost",
+          "reconstruction_threshold": 7,
           "purpose": "Sign"
         }
       ],

--- a/crates/contract/README.md
+++ b/crates/contract/README.md
@@ -228,7 +228,7 @@ To generate a new threshold signature key, all participants must vote for it to 
 }
 ```
 
-`reconstruction_threshold` is the per-domain `t` in t-of-n key reconstruction; it must satisfy `2 <= t <= n` against the current participant count.
+`reconstruction_threshold` is the per-domain `t` in t-of-n key reconstruction; it must satisfy `2 <= t <= n` against the current participant count. `DamgardEtAl` domains additionally require the honest-majority bound `2t - 1 <= n`.
 
 ### Deployment
 

--- a/crates/contract/README.md
+++ b/crates/contract/README.md
@@ -207,23 +207,28 @@ To generate a new threshold signature key, all participants must vote for it to 
       "id":2,
       "curve":"Secp256k1",
       "protocol":"CaitSith",
+      "reconstruction_threshold":2,
       "purpose":"Sign"
     },
     {
       "id":3,
       "curve":"Edwards25519",
       "protocol":"Frost",
+      "reconstruction_threshold":2,
       "purpose":"Sign"
     },
     {
       "id":4,
       "curve":"Bls12381",
       "protocol":"ConfidentialKeyDerivation",
+      "reconstruction_threshold":2,
       "purpose":"CKD"
     }
   ]
 }
 ```
+
+`reconstruction_threshold` is the per-domain `t` in t-of-n key reconstruction; it must satisfy `2 <= t <= n` against the current participant count.
 
 ### Deployment
 
@@ -289,7 +294,7 @@ These functions require the caller to be a participant or candidate.
 | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------- | --------------- | ------------------ |
 | `respond(request: SignatureRequest, response: SignatureResponse)`                   | Processes a response to a signature request, verifying its validity and ensuring proper state cleanup.                                                                                                                                  | `Result<(), Error>`       | 10Tgas          | ~6Tgas             |
 | `respond_ckd(request: CKDRequest, response: CKDResponse)`                           | Processes a response to a ckd request, ensuring proper state cleanup.                                                                                                                                                                   | `Result<(), Error>`       | 10Tgas          | ~6Tgas             |
-| `vote_add_domains(domains: Vec<DomainConfig>)`                                      | Votes to add new domains (new keys) to the MPC network; newly proposed domain IDs must start from next_domain_id and be contiguous.                                                                                                     | `Result<(), Error>`       | TBD             | TBD                |
+| `vote_add_domains(domains: Vec<DomainConfig>)`                                      | Votes to add new domains (new keys) to the MPC network; newly proposed domain IDs must start from next_domain_id and be contiguous, and each domain must specify a `reconstruction_threshold` with `2 <= t <= n`.                       | `Result<(), Error>`       | TBD             | TBD                |
 | `vote_new_parameters(prospective_epoch_id: EpochId, proposal: ThresholdParameters)` | Votes to change the set of participants as well as the new threshold for the network. (Prospective epoch ID must be 1 plus current)                                                                                                     | `Result<(), Error>`       | TBD             | TBD                |
 | `vote_code_hash(code_hash: CodeHash)`                                               | Votes to add new whitelisted TEE Docker image code hashes.                                                                                                                                                                              | `Result<(), Error>`       | TBD             | TBD                |
 | `vote_add_launcher_hash(launcher_hash: LauncherImageHash)`                          | Votes to add a launcher image hash to the allowed set. Requires threshold votes.                                                                                                                                                        | `Result<(), Error>`       | TBD             | TBD                |

--- a/crates/contract/src/errors.rs
+++ b/crates/contract/src/errors.rs
@@ -1,4 +1,5 @@
 use crate::crypto_shared::kdf::TweakNotOnCurve;
+use crate::primitives::domain::MIN_RECONSTRUCTION_THRESHOLD;
 use crate::primitives::key_state::{EpochId, Keyset};
 use near_account_id::AccountId;
 use near_mpc_contract_interface::types as dtos;
@@ -204,7 +205,10 @@ pub enum DomainError {
         protocol: Protocol,
         purpose: DomainPurpose,
     },
-    #[error("Reconstruction threshold must be at least 2.")]
+    #[error(
+        "Reconstruction threshold must be at least {}.",
+        MIN_RECONSTRUCTION_THRESHOLD
+    )]
     ReconstructionThresholdTooLow,
     #[error("Reconstruction threshold {threshold} exceeds participant count {participants}.")]
     ReconstructionThresholdExceedsParticipants { threshold: u64, participants: u64 },
@@ -216,6 +220,10 @@ pub enum DomainError {
         required: u64,
         participants: u64,
     },
+    #[error(
+        "Reconstruction threshold {threshold} overflowed when computing the DamgardEtAl bound."
+    )]
+    ReconstructionThresholdOverflow { threshold: u64 },
 }
 
 /// A list specifying general categories of MPC Contract errors.

--- a/crates/contract/src/errors.rs
+++ b/crates/contract/src/errors.rs
@@ -204,6 +204,18 @@ pub enum DomainError {
         protocol: Protocol,
         purpose: DomainPurpose,
     },
+    #[error("Reconstruction threshold must be at least 2.")]
+    ReconstructionThresholdTooLow,
+    #[error("Reconstruction threshold {threshold} exceeds participant count {participants}.")]
+    ReconstructionThresholdExceedsParticipants { threshold: u64, participants: u64 },
+    #[error(
+        "Protocol {protocol:?} requires at least {required} participants, found {participants}."
+    )]
+    InsufficientParticipantsForProtocol {
+        protocol: Protocol,
+        required: u64,
+        participants: u64,
+    },
 }
 
 /// A list specifying general categories of MPC Contract errors.

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1740,6 +1740,10 @@ impl MpcContract {
         );
         parameters.validate()?;
         let domains = DomainRegistry::from_raw_validated(domains, next_domain_id)?;
+        let num_participants = parameters.participants().len() as u64;
+        for domain in domains.domains() {
+            crate::primitives::domain::validate_domain_threshold(domain, num_participants)?;
+        }
 
         // Check that the domains match exactly those in the keyset.
         let domain_ids_from_domains = domains.domains().iter().map(|d| d.id).collect::<Vec<_>>();
@@ -2323,7 +2327,7 @@ mod tests {
     use crate::tee::tee_state::NodeId;
     use assert_matches::assert_matches;
     use dtos::{Attestation, Ed25519PublicKey, ForeignTxSignPayload, MockAttestation};
-    use dtos::{Curve, DomainConfig, DomainId, Payload, Protocol, Tweak};
+    use dtos::{Curve, DomainConfig, DomainId, Payload, Protocol, ReconstructionThreshold, Tweak};
     use elliptic_curve::Field as _;
     use elliptic_curve::Group;
     use k256::{self, ecdsa::SigningKey, elliptic_curve, Secp256k1};
@@ -2488,10 +2492,16 @@ mod tests {
             .build();
         testing_env!(context.clone());
         let domain_id = DomainId::default();
+        // DamgardEtAl requires 2t - 1 <= n; with n=4, the max valid t is 2.
+        let reconstruction_threshold = match protocol {
+            Protocol::DamgardEtAl => ReconstructionThreshold::new(2),
+            _ => ReconstructionThreshold::new(3),
+        };
         let domains = vec![DomainConfig {
             id: domain_id,
             curve,
             protocol,
+            reconstruction_threshold,
             purpose,
         }];
         let epoch_id = EpochId::new(0);
@@ -4575,6 +4585,7 @@ mod tests {
             id: domain_id,
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose: DomainPurpose::Sign,
         }];
         let (pk, _) = make_public_key_for_curve(Curve::Secp256k1, &mut OsRng);

--- a/crates/contract/src/primitives/domain.rs
+++ b/crates/contract/src/primitives/domain.rs
@@ -1,11 +1,14 @@
 use super::key_state::AuthenticatedParticipantId;
 use crate::errors::{DomainError, Error};
 use crate::primitives::participants::Participants;
-use near_mpc_contract_interface::types::{
-    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
-};
+use near_mpc_contract_interface::types::{Curve, DomainConfig, DomainId, DomainPurpose, Protocol};
 use near_sdk::{log, near};
 use std::collections::BTreeMap;
+
+/// Lower bound on a domain's reconstruction threshold. `t = 1` would mean a
+/// single share is sufficient to reconstruct the secret, defeating the point
+/// of threshold cryptography.
+pub const MIN_RECONSTRUCTION_THRESHOLD: u64 = 2;
 
 /// Returns whether the given protocol is valid for the given purpose.
 pub fn is_valid_protocol_for_purpose(purpose: DomainPurpose, protocol: Protocol) -> bool {
@@ -50,7 +53,7 @@ pub fn validate_domain_threshold(
     num_participants: u64,
 ) -> Result<(), Error> {
     let t = domain.reconstruction_threshold.inner();
-    if t < 2 {
+    if t < MIN_RECONSTRUCTION_THRESHOLD {
         return Err(DomainError::ReconstructionThresholdTooLow.into());
     }
     if t > num_participants {
@@ -64,7 +67,7 @@ pub fn validate_domain_threshold(
         let required = t
             .checked_mul(2)
             .and_then(|x| x.checked_sub(1))
-            .unwrap_or(u64::MAX);
+            .ok_or(DomainError::ReconstructionThresholdOverflow { threshold: t })?;
         if required > num_participants {
             return Err(DomainError::InsufficientParticipantsForProtocol {
                 protocol: domain.protocol,
@@ -92,26 +95,19 @@ impl DomainRegistry {
         &self.domains
     }
 
-    /// Append a domain at `next_domain_id`, returning its DomainId. The caller is
-    /// responsible for any validation (curve/protocol consistency, etc.); this
-    /// helper does no checks.
-    fn add_domain(
-        &mut self,
-        curve: Curve,
-        protocol: Protocol,
-        reconstruction_threshold: ReconstructionThreshold,
-        purpose: DomainPurpose,
-    ) -> DomainId {
-        let domain = DomainConfig {
+    /// Append `domain` at `next_domain_id`, returning its assigned DomainId.
+    /// The caller's `domain.id` is ignored; the registry assigns the id
+    /// monotonically. The caller is responsible for any validation
+    /// (curve/protocol consistency, etc.); this helper does no checks.
+    fn add_domain(&mut self, domain: DomainConfig) -> DomainId {
+        let assigned = DomainConfig {
             id: DomainId(self.next_domain_id),
-            curve,
-            protocol,
-            reconstruction_threshold,
-            purpose,
+            ..domain
         };
         self.next_domain_id += 1;
-        self.domains.push(domain.clone());
-        domain.id
+        let id = assigned.id;
+        self.domains.push(assigned);
+        id
     }
 
     /// Processes the addition of the given domains, returning a new DomainRegistry.
@@ -121,13 +117,9 @@ impl DomainRegistry {
         let mut new_registry = self.clone();
         for domain in domains {
             validate_domain_consistency(&domain)?;
-            let new_domain_id = new_registry.add_domain(
-                domain.curve,
-                domain.protocol,
-                domain.reconstruction_threshold,
-                domain.purpose,
-            );
-            if new_domain_id != domain.id {
+            let expected_id = domain.id;
+            let new_domain_id = new_registry.add_domain(domain);
+            if new_domain_id != expected_id {
                 return Err(DomainError::NewDomainIdsNotContiguous {
                     expected_id: new_domain_id,
                 }
@@ -250,12 +242,12 @@ pub mod tests {
     use super::{
         is_valid_protocol_for_purpose, validate_domain_consistency, AddDomainsVotes, Curve,
         DomainConfig, DomainId, DomainPurpose, DomainRegistry, Participants, Protocol,
-        ReconstructionThreshold,
     };
     use crate::primitives::key_state::AuthenticatedParticipantId;
     use crate::primitives::test_utils::{
         gen_participant, gen_participants, infer_purpose_from_curve,
     };
+    use near_mpc_contract_interface::types::ReconstructionThreshold;
     use near_sdk::test_utils::VMContextBuilder;
     use near_sdk::testing_env;
     use rstest::rstest;

--- a/crates/contract/src/primitives/domain.rs
+++ b/crates/contract/src/primitives/domain.rs
@@ -1,7 +1,9 @@
 use super::key_state::AuthenticatedParticipantId;
 use crate::errors::{DomainError, Error};
 use crate::primitives::participants::Participants;
-use near_mpc_contract_interface::types::{Curve, DomainConfig, DomainId, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_sdk::{log, near};
 use std::collections::BTreeMap;
 
@@ -40,6 +42,41 @@ pub fn validate_domain_consistency(domain: &DomainConfig) -> Result<(), Error> {
     Ok(())
 }
 
+/// Validates the per-domain reconstruction threshold against the participant
+/// count. Universal bound `2 <= t <= n` plus, for `DamgardEtAl`, the
+/// honest-majority bound `2t - 1 <= n`.
+pub fn validate_domain_threshold(
+    domain: &DomainConfig,
+    num_participants: u64,
+) -> Result<(), Error> {
+    let t = domain.reconstruction_threshold.inner();
+    if t < 2 {
+        return Err(DomainError::ReconstructionThresholdTooLow.into());
+    }
+    if t > num_participants {
+        return Err(DomainError::ReconstructionThresholdExceedsParticipants {
+            threshold: t,
+            participants: num_participants,
+        }
+        .into());
+    }
+    if domain.protocol == Protocol::DamgardEtAl {
+        let required = t
+            .checked_mul(2)
+            .and_then(|x| x.checked_sub(1))
+            .unwrap_or(u64::MAX);
+        if required > num_participants {
+            return Err(DomainError::InsufficientParticipantsForProtocol {
+                protocol: domain.protocol,
+                required,
+                participants: num_participants,
+            }
+            .into());
+        }
+    }
+    Ok(())
+}
+
 /// All the domains present in the contract, as well as the next domain ID which is kept to ensure
 /// that we never reuse domain IDs. (Domains may be deleted in only one case: when we decided to
 /// add domains but ultimately canceled that process.)
@@ -55,21 +92,21 @@ impl DomainRegistry {
         &self.domains
     }
 
-    /// Migration from legacy: creates a DomainRegistry with a single ecdsa key.
-    pub fn new_single_ecdsa_key_from_legacy() -> Self {
-        let mut registry = Self::default();
-        registry.add_domain(Curve::Secp256k1, Protocol::CaitSith, DomainPurpose::Sign);
-        registry
-    }
-
     /// Append a domain at `next_domain_id`, returning its DomainId. The caller is
     /// responsible for any validation (curve/protocol consistency, etc.); this
     /// helper does no checks.
-    fn add_domain(&mut self, curve: Curve, protocol: Protocol, purpose: DomainPurpose) -> DomainId {
+    fn add_domain(
+        &mut self,
+        curve: Curve,
+        protocol: Protocol,
+        reconstruction_threshold: ReconstructionThreshold,
+        purpose: DomainPurpose,
+    ) -> DomainId {
         let domain = DomainConfig {
             id: DomainId(self.next_domain_id),
             curve,
             protocol,
+            reconstruction_threshold,
             purpose,
         };
         self.next_domain_id += 1;
@@ -84,8 +121,12 @@ impl DomainRegistry {
         let mut new_registry = self.clone();
         for domain in domains {
             validate_domain_consistency(&domain)?;
-            let new_domain_id =
-                new_registry.add_domain(domain.curve, domain.protocol, domain.purpose);
+            let new_domain_id = new_registry.add_domain(
+                domain.curve,
+                domain.protocol,
+                domain.reconstruction_threshold,
+                domain.purpose,
+            );
             if new_domain_id != domain.id {
                 return Err(DomainError::NewDomainIdsNotContiguous {
                     expected_id: new_domain_id,
@@ -209,6 +250,7 @@ pub mod tests {
     use super::{
         is_valid_protocol_for_purpose, validate_domain_consistency, AddDomainsVotes, Curve,
         DomainConfig, DomainId, DomainPurpose, DomainRegistry, Participants, Protocol,
+        ReconstructionThreshold,
     };
     use crate::primitives::key_state::AuthenticatedParticipantId;
     use crate::primitives::test_utils::{
@@ -226,12 +268,14 @@ pub mod tests {
                 id: DomainId(0),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             DomainConfig {
                 id: DomainId(1),
                 curve: Curve::Edwards25519,
                 protocol: Protocol::Frost,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
         ];
@@ -243,12 +287,14 @@ pub mod tests {
                 id: DomainId(2),
                 curve: Curve::Bls12381,
                 protocol: Protocol::ConfidentialKeyDerivation,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::CKD,
             },
             DomainConfig {
                 id: DomainId(3),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::DamgardEtAl,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
         ];
@@ -261,6 +307,7 @@ pub mod tests {
             id: DomainId(5),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose: DomainPurpose::Sign,
         }];
         let _ = new_registry.add_domains(domains3).unwrap_err();
@@ -271,12 +318,14 @@ pub mod tests {
                 id: DomainId(5),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             DomainConfig {
                 id: DomainId(4),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
         ];
@@ -290,24 +339,28 @@ pub mod tests {
                 id: DomainId(0),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             DomainConfig {
                 id: DomainId(2),
                 curve: Curve::Edwards25519,
                 protocol: Protocol::Frost,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             DomainConfig {
                 id: DomainId(3),
                 curve: Curve::Bls12381,
                 protocol: Protocol::ConfidentialKeyDerivation,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::CKD,
             },
             DomainConfig {
                 id: DomainId(4),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::DamgardEtAl,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
         ];
@@ -333,18 +386,21 @@ pub mod tests {
                     id: DomainId(0),
                     curve: Curve::Secp256k1,
                     protocol: Protocol::CaitSith,
+                    reconstruction_threshold: ReconstructionThreshold::new(2),
                     purpose: DomainPurpose::Sign,
                 },
                 DomainConfig {
                     id: DomainId(2),
                     curve: Curve::Edwards25519,
                     protocol: Protocol::Frost,
+                    reconstruction_threshold: ReconstructionThreshold::new(2),
                     purpose: DomainPurpose::Sign,
                 },
                 DomainConfig {
                     id: DomainId(3),
                     curve: Curve::Secp256k1,
                     protocol: Protocol::CaitSith,
+                    reconstruction_threshold: ReconstructionThreshold::new(2),
                     purpose: DomainPurpose::Sign,
                 },
             ],
@@ -363,17 +419,17 @@ pub mod tests {
 
     #[rstest]
     #[case(
-        r#"{"id":3,"curve":"Secp256k1","purpose":"Sign"}"#,
+        r#"{"id":3,"curve":"Secp256k1","reconstruction_threshold":2,"purpose":"Sign"}"#,
         Curve::Secp256k1,
         DomainPurpose::Sign
     )]
     #[case(
-        r#"{"id":1,"curve":"Bls12381","purpose":"CKD"}"#,
+        r#"{"id":1,"curve":"Bls12381","reconstruction_threshold":2,"purpose":"CKD"}"#,
         Curve::Bls12381,
         DomainPurpose::CKD
     )]
     #[case(
-        r#"{"id":1,"curve":"Edwards25519","purpose":"Sign"}"#,
+        r#"{"id":1,"curve":"Edwards25519","reconstruction_threshold":2,"purpose":"Sign"}"#,
         Curve::Edwards25519,
         DomainPurpose::Sign
     )]
@@ -457,6 +513,7 @@ pub mod tests {
             id: DomainId(0),
             curve,
             protocol,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose,
         };
         assert_eq!(validate_domain_consistency(&domain).is_ok(), expected_ok);
@@ -485,6 +542,7 @@ pub mod tests {
             id: DomainId(0),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose: DomainPurpose::Sign,
         }]
     }
@@ -564,12 +622,14 @@ pub mod tests {
             id: DomainId(0),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose: DomainPurpose::Sign,
         }];
         let proposal_b = vec![DomainConfig {
             id: DomainId(0),
             curve: Curve::Edwards25519,
             protocol: Protocol::Frost,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose: DomainPurpose::Sign,
         }];
         let mut votes = AddDomainsVotes::default();

--- a/crates/contract/src/primitives/test_utils.rs
+++ b/crates/contract/src/primitives/test_utils.rs
@@ -8,7 +8,9 @@ use crate::{
 };
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use near_account_id::AccountId;
-use near_mpc_contract_interface::types::{Curve, DomainConfig, DomainId, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use rand::{distributions::Uniform, Rng};
 use std::collections::BTreeMap;
 // Re-export for convenience
@@ -21,6 +23,14 @@ const ALL_PROTOCOLS: [Protocol; 4] = [
 ];
 pub const NUM_PROTOCOLS: usize = ALL_PROTOCOLS.len();
 
+/// Default per-domain reconstruction threshold used by test fixtures. `2` is
+/// the minimum valid value (`validate_domain_threshold` requires `t >= 2`).
+/// Works for participant counts `>= 3`, which is what `gen_threshold_params`
+/// produces — needed because fixtures may include `DamgardEtAl` domains,
+/// whose `2t - 1 <= n` bound becomes `n >= 3` at `t = 2`.
+pub const DEFAULT_TEST_RECONSTRUCTION_THRESHOLD: ReconstructionThreshold =
+    ReconstructionThreshold::new(2);
+
 /// Generates a valid DomainRegistry covering all protocols, with num_domains total.
 pub fn gen_domain_registry(num_domains: usize) -> DomainRegistry {
     let mut domains = Vec::new();
@@ -31,6 +41,7 @@ pub fn gen_domain_registry(num_domains: usize) -> DomainRegistry {
             id: DomainId(i as u64 * 2),
             curve,
             protocol,
+            reconstruction_threshold: DEFAULT_TEST_RECONSTRUCTION_THRESHOLD,
             purpose: infer_purpose_from_curve(curve),
         });
     }
@@ -47,6 +58,7 @@ pub fn gen_domains_to_add(registry: &DomainRegistry, num_domains: usize) -> Vec<
             id: DomainId(registry.next_domain_id() + i as u64),
             curve,
             protocol,
+            reconstruction_threshold: DEFAULT_TEST_RECONSTRUCTION_THRESHOLD,
             purpose: infer_purpose_from_curve(curve),
         });
     }
@@ -146,7 +158,10 @@ pub fn gen_seed() -> [u8; 32] {
 }
 
 pub fn gen_threshold_params(max_n: usize) -> ThresholdParameters {
-    let n: usize = rand::thread_rng().gen_range(2..max_n + 1);
+    // Lower bound is 3 (not 2) so the produced parameters are compatible with
+    // every protocol — `DamgardEtAl` requires `n >= 2t - 1`, which forces
+    // `n >= 3` even at the minimum `t = 2`.
+    let n: usize = rand::thread_rng().gen_range(3..max_n + 1);
     let k_min = min_thrershold(n);
     let k = rand::thread_rng().gen_range(k_min..n + 1);
     ThresholdParameters::new(gen_participants(n), Threshold::new(k as u64)).unwrap()

--- a/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
+++ b/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
@@ -324,6 +324,10 @@ BorshSchemaContainer {
                         "Protocol",
                     ),
                     (
+                        "reconstruction_threshold",
+                        "ReconstructionThreshold",
+                    ),
+                    (
                         "purpose",
                         "DomainPurpose",
                     ),
@@ -996,6 +1000,13 @@ BorshSchemaContainer {
                         "near_public_key",
                         "PublicKey",
                     ),
+                ],
+            ),
+        },
+        "ReconstructionThreshold": Struct {
+            fields: UnnamedFields(
+                [
+                    "u64",
                 ],
             ),
         },

--- a/crates/contract/src/state/running.rs
+++ b/crates/contract/src/state/running.rs
@@ -213,13 +213,12 @@ impl RunningContractState {
 pub mod running_tests {
     use rstest::rstest;
 
+    use super::RunningContractState;
     use crate::primitives::domain::AddDomainsVotes;
     use crate::primitives::test_utils::{gen_threshold_params, NUM_PROTOCOLS};
+    use crate::primitives::threshold_votes::ThresholdParametersVotes;
     use crate::state::key_event::tests::Environment;
-    use crate::state::test_utils::gen_valid_params_proposal;
-    use crate::{
-        primitives::threshold_votes::ThresholdParametersVotes, state::test_utils::gen_running_state,
-    };
+    use crate::state::test_utils::{gen_running_state, gen_valid_params_proposal};
     use near_mpc_contract_interface::types::{
         Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
     };
@@ -385,10 +384,7 @@ pub mod running_tests {
         );
     }
 
-    fn proposal_with_threshold(
-        state: &super::RunningContractState,
-        threshold: u64,
-    ) -> Vec<DomainConfig> {
+    fn proposal_with_threshold(state: &RunningContractState, threshold: u64) -> Vec<DomainConfig> {
         let next_id = state.domains.next_domain_id();
         vec![DomainConfig {
             id: DomainId(next_id),

--- a/crates/contract/src/state/running.rs
+++ b/crates/contract/src/state/running.rs
@@ -137,6 +137,15 @@ impl RunningContractState {
         // ensure the proposal is valid against the current parameters
         self.parameters.validate_incoming_proposal(proposal)?;
 
+        // TODO(#3169): re-enable once resharing votes carry per-domain `t`
+        // and the node honors per-domain reconstruction thresholds (#3164).
+        // Until both are in place this check would block legitimate
+        // resharings that the node currently signs at the cluster threshold.
+        // let new_num_participants = proposal.participants().len() as u64;
+        // for domain in self.domains.domains() {
+        //     crate::primitives::domain::validate_domain_threshold(domain, new_num_participants)?;
+        // }
+
         // ensure the signer is a proposed participant
         let candidate = AuthenticatedAccountId::new(proposal.participants())?;
 
@@ -167,8 +176,10 @@ impl RunningContractState {
         if domains.is_empty() {
             return Err(DomainError::AddDomainsMustAddAtLeastOneDomain.into());
         }
+        let num_participants = self.parameters.participants().len() as u64;
         for domain in &domains {
             crate::primitives::domain::validate_domain_consistency(domain)?;
+            crate::primitives::domain::validate_domain_threshold(domain, num_participants)?;
         }
         let participant = AuthenticatedParticipantId::new(self.parameters.participants())?;
         let n_votes = self.add_domains_votes.vote(domains.clone(), &participant);
@@ -210,7 +221,7 @@ pub mod running_tests {
         primitives::threshold_votes::ThresholdParametersVotes, state::test_utils::gen_running_state,
     };
     use near_mpc_contract_interface::types::{
-        Curve, DomainConfig, DomainId, DomainPurpose, Protocol,
+        Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
     };
 
     fn test_running_for(num_domains: usize) {
@@ -359,6 +370,7 @@ pub mod running_tests {
             id: DomainId(next_id),
             curve: Curve::from(protocol),
             protocol,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose,
         }];
 
@@ -370,6 +382,102 @@ pub mod running_tests {
             err.to_string()
                 .contains("Invalid protocol-purpose combination"),
             "Expected InvalidProtocolPurposeCombination, got: {err}"
+        );
+    }
+
+    fn proposal_with_threshold(
+        state: &super::RunningContractState,
+        threshold: u64,
+    ) -> Vec<DomainConfig> {
+        let next_id = state.domains.next_domain_id();
+        vec![DomainConfig {
+            id: DomainId(next_id),
+            curve: Curve::Secp256k1,
+            protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(threshold),
+            purpose: DomainPurpose::Sign,
+        }]
+    }
+
+    #[test]
+    fn vote_add_domains__should_reject_threshold_below_two() {
+        // Given a running state and a proposal carrying t = 1
+        let mut state = gen_running_state(1);
+        let mut env = Environment::new(None, None, None);
+        env.set_signer(&state.parameters.participants().participants()[0].0);
+        let proposal = proposal_with_threshold(&state, 1);
+
+        // When voting to add the domain
+        let err = state.vote_add_domains(proposal).unwrap_err();
+
+        // Then the universal lower bound is enforced
+        assert!(
+            err.to_string()
+                .contains("Reconstruction threshold must be at least 2"),
+            "Expected ReconstructionThresholdTooLow, got: {err}"
+        );
+    }
+
+    #[test]
+    fn vote_add_domains__should_reject_threshold_exceeding_participants() {
+        // Given a running state and a proposal whose threshold > n
+        let mut state = gen_running_state(1);
+        let mut env = Environment::new(None, None, None);
+        env.set_signer(&state.parameters.participants().participants()[0].0);
+        let n = state.parameters.participants().len() as u64;
+        let proposal = proposal_with_threshold(&state, n + 1);
+
+        // When voting to add the domain
+        let err = state.vote_add_domains(proposal).unwrap_err();
+
+        // Then the upper bound is enforced
+        assert!(
+            err.to_string().contains("exceeds participant count"),
+            "Expected ReconstructionThresholdExceedsParticipants, got: {err}"
+        );
+    }
+
+    #[test]
+    fn vote_add_domains__should_accept_threshold_equal_to_participant_count() {
+        // Given a running state and a proposal where t == n (boundary case)
+        let mut state = gen_running_state(1);
+        let mut env = Environment::new(None, None, None);
+        env.set_signer(&state.parameters.participants().participants()[0].0);
+        let n = state.parameters.participants().len() as u64;
+        let proposal = proposal_with_threshold(&state, n);
+
+        // When voting to add the domain — vote is recorded without error
+        let res = state.vote_add_domains(proposal);
+
+        // Then the call succeeds (single voter is below quorum, so no transition)
+        assert!(res.is_ok(), "Expected success at boundary t == n: {res:?}");
+    }
+
+    #[test]
+    fn vote_add_domains__should_reject_damgard_etal_threshold_violating_honest_majority() {
+        // Given a running state and a DamgardEtAl proposal with `2t - 1 > n`.
+        // gen_threshold_params produces n in [3, 30]; pick t = n so that
+        // 2t - 1 > n holds (universally true for n >= 2).
+        let mut state = gen_running_state(1);
+        let mut env = Environment::new(None, None, None);
+        env.set_signer(&state.parameters.participants().participants()[0].0);
+        let n = state.parameters.participants().len() as u64;
+        let next_id = state.domains.next_domain_id();
+        let proposal = vec![DomainConfig {
+            id: DomainId(next_id),
+            curve: Curve::Secp256k1,
+            protocol: Protocol::DamgardEtAl,
+            reconstruction_threshold: ReconstructionThreshold::new(n),
+            purpose: DomainPurpose::Sign,
+        }];
+
+        // When voting to add the domain
+        let err = state.vote_add_domains(proposal).unwrap_err();
+
+        // Then the DamgardEtAl-specific bound is enforced
+        assert!(
+            err.to_string().contains("requires at least"),
+            "Expected InsufficientParticipantsForProtocol, got: {err}"
         );
     }
 }

--- a/crates/contract/src/v3_9_1_state.rs
+++ b/crates/contract/src/v3_9_1_state.rs
@@ -10,7 +10,7 @@
 use borsh::{BorshDeserialize, BorshSerialize};
 use dtos::{
     Curve, DomainConfig, DomainId, DomainPurpose, Ed25519PublicKey, ParticipantId, Protocol,
-    Threshold,
+    ReconstructionThreshold, Threshold,
 };
 use mpc_attestation::attestation::VerifiedAttestation;
 use near_account_id::AccountId;
@@ -36,13 +36,7 @@ use crate::{
         threshold_votes::ThresholdParametersVotes,
         thresholds::ThresholdParameters,
     },
-    state::{
-        initializing::InitializingContractState,
-        key_event::{KeyEvent, KeyEventInstance},
-        resharing::ResharingContractState,
-        running::RunningContractState,
-        ProtocolContractState,
-    },
+    state::{key_event::KeyEventInstance, running::RunningContractState, ProtocolContractState},
     storage_keys::StorageKey,
     tee::{
         measurements::{AllowedMeasurements, MeasurementVotes},
@@ -84,52 +78,50 @@ struct OldDomainRegistry {
 }
 
 /// Previous `AddDomainsVotes` Borsh layout — stored old `DomainConfig`s.
+/// Deserialize-only: kept solely to preserve the on-chain Borsh layout of
+/// `OldRunningContractState`. The migration discards the contents (see the
+/// `From<OldRunningContractState> for RunningContractState` impl below).
 #[derive(Debug, BorshSerialize, BorshDeserialize)]
 struct OldAddDomainsVotes {
     proposal_by_account: BTreeMap<AuthenticatedParticipantId, Vec<OldDomainConfig>>,
 }
 
-impl From<OldDomainConfig> for DomainConfig {
-    fn from(old: OldDomainConfig) -> Self {
-        let (curve, protocol) = match old.curve {
-            OldCurve::Secp256k1 => (Curve::Secp256k1, Protocol::CaitSith),
-            OldCurve::Edwards25519 => (Curve::Edwards25519, Protocol::Frost),
-            OldCurve::Bls12381 => (Curve::Bls12381, Protocol::ConfidentialKeyDerivation),
-            OldCurve::V2Secp256k1 => (Curve::Secp256k1, Protocol::DamgardEtAl),
-        };
-        DomainConfig {
-            id: old.id,
-            curve,
-            protocol,
-            purpose: old.purpose,
-        }
+/// Caller supplies the global threshold; legacy state had no per-domain value.
+/// V2Secp256k1 (DamgardEtAl) was never deployed to production, so no
+/// protocol-specific adjustment is required here — every legacy domain
+/// inherits the global threshold uniformly.
+fn migrate_domain_config(
+    old: OldDomainConfig,
+    reconstruction_threshold: ReconstructionThreshold,
+) -> DomainConfig {
+    let (curve, protocol) = match old.curve {
+        OldCurve::Secp256k1 => (Curve::Secp256k1, Protocol::CaitSith),
+        OldCurve::Edwards25519 => (Curve::Edwards25519, Protocol::Frost),
+        OldCurve::Bls12381 => (Curve::Bls12381, Protocol::ConfidentialKeyDerivation),
+        OldCurve::V2Secp256k1 => (Curve::Secp256k1, Protocol::DamgardEtAl),
+    };
+    DomainConfig {
+        id: old.id,
+        curve,
+        protocol,
+        reconstruction_threshold,
+        purpose: old.purpose,
     }
 }
 
-impl From<OldDomainRegistry> for DomainRegistry {
-    fn from(old: OldDomainRegistry) -> Self {
-        let domains: Vec<DomainConfig> = old.domains.into_iter().map(Into::into).collect();
-        // The on-chain DomainRegistry was previously valid by construction;
-        // its invariants (id contiguity, monotonic next_domain_id) carry over.
-        DomainRegistry::from_raw_validated(domains, old.next_domain_id)
-            .expect("on-chain DomainRegistry should be valid")
-    }
-}
-
-impl From<OldAddDomainsVotes> for AddDomainsVotes {
-    fn from(old: OldAddDomainsVotes) -> Self {
-        let proposal_by_account = old
-            .proposal_by_account
-            .into_iter()
-            .map(|(account, proposal)| {
-                let proposal: Vec<DomainConfig> = proposal.into_iter().map(Into::into).collect();
-                (account, proposal)
-            })
-            .collect();
-        AddDomainsVotes {
-            proposal_by_account,
-        }
-    }
+fn migrate_domain_registry(
+    old: OldDomainRegistry,
+    reconstruction_threshold: ReconstructionThreshold,
+) -> DomainRegistry {
+    let domains: Vec<DomainConfig> = old
+        .domains
+        .into_iter()
+        .map(|d| migrate_domain_config(d, reconstruction_threshold))
+        .collect();
+    // The on-chain DomainRegistry was previously valid by construction;
+    // its invariants (id contiguity, monotonic next_domain_id) carry over.
+    DomainRegistry::from_raw_validated(domains, old.next_domain_id)
+        .expect("on-chain DomainRegistry should be valid")
 }
 
 /// Previous `ParticipantInfo` layout — the TLS key was stored as a tagged
@@ -313,81 +305,35 @@ impl From<OldThresholdParametersVotes> for ThresholdParametersVotes {
     }
 }
 
-impl From<OldKeyEvent> for KeyEvent {
-    fn from(old: OldKeyEvent) -> Self {
-        KeyEvent::from_raw(
-            old.epoch_id,
-            old.domain.into(),
-            old.parameters.into(),
-            old.instance,
-            old.next_attempt_id,
-        )
-    }
-}
-
 impl From<OldRunningContractState> for RunningContractState {
     fn from(old: OldRunningContractState) -> Self {
+        let reconstruction_threshold = ReconstructionThreshold::from(old.parameters.threshold);
         RunningContractState {
-            domains: old.domains.into(),
+            domains: migrate_domain_registry(old.domains, reconstruction_threshold),
             keyset: old.keyset,
             parameters: old.parameters.into(),
             parameters_votes: old.parameters_votes.into(),
-            add_domains_votes: old.add_domains_votes.into(),
+            // Pending `add_domains_votes` are dropped: legacy entries didn't
+            // carry a per-domain `reconstruction_threshold`, and stamping
+            // them with the global threshold would cause post-migration
+            // voters that recast with a different threshold to fail to
+            // match — voters re-cast on a clean slate after the upgrade.
+            add_domains_votes: AddDomainsVotes::default(),
             previously_cancelled_resharing_epoch_id: old.previously_cancelled_resharing_epoch_id,
-        }
-    }
-}
-
-impl From<OldInitializingContractState> for InitializingContractState {
-    fn from(old: OldInitializingContractState) -> Self {
-        InitializingContractState {
-            domains: old.domains.into(),
-            epoch_id: old.epoch_id,
-            generated_keys: old.generated_keys,
-            generating_key: old.generating_key.into(),
-            cancel_votes: old.cancel_votes,
-        }
-    }
-}
-
-impl From<OldResharingContractState> for ResharingContractState {
-    fn from(old: OldResharingContractState) -> Self {
-        ResharingContractState {
-            previous_running_state: old.previous_running_state.into(),
-            reshared_keys: old.reshared_keys,
-            resharing_key: old.resharing_key.into(),
-            cancellation_requests: old.cancellation_requests,
-        }
-    }
-}
-
-impl From<OldProtocolContractState> for ProtocolContractState {
-    fn from(old: OldProtocolContractState) -> Self {
-        match old {
-            OldProtocolContractState::NotInitialized => ProtocolContractState::NotInitialized,
-            OldProtocolContractState::Initializing(state) => {
-                ProtocolContractState::Initializing(state.into())
-            }
-            OldProtocolContractState::Running(state) => {
-                ProtocolContractState::Running(state.into())
-            }
-            OldProtocolContractState::Resharing(state) => {
-                ProtocolContractState::Resharing(state.into())
-            }
         }
     }
 }
 
 impl From<MpcContract> for crate::MpcContract {
     fn from(mut value: MpcContract) -> Self {
-        if !matches!(value.protocol_state, OldProtocolContractState::Running(_)) {
+        let OldProtocolContractState::Running(running) = value.protocol_state else {
             env::panic_str("Contract must be in running state when migrating.");
-        }
+        };
 
         value.foreign_chain_policy_votes.proposal_by_account.clear();
 
         Self {
-            protocol_state: value.protocol_state.into(),
+            protocol_state: ProtocolContractState::Running(running.into()),
             pending_signature_requests: value.pending_signature_requests,
             pending_ckd_requests: value.pending_ckd_requests,
             pending_verify_foreign_tx_requests: value.pending_verify_foreign_tx_requests,
@@ -716,18 +662,14 @@ mod tests {
         // Given a minimal Running state with one participant in the old layout
         let participants = old_participants(1, vec![("alice.near", 0, old_ed25519_near_pk(2))]);
         let running = old_running_state(participants, 2);
-        let old_state = OldProtocolContractState::Running(running);
-        let bytes = borsh::to_vec(&old_state).unwrap();
+        let bytes = borsh::to_vec(&running).unwrap();
 
         // When borsh-decoding and migrating to the new layout
-        let decoded: OldProtocolContractState = borsh::from_slice(&bytes).unwrap();
-        let migrated: ProtocolContractState = decoded.into();
+        let decoded: OldRunningContractState = borsh::from_slice(&bytes).unwrap();
+        let migrated: RunningContractState = decoded.into();
 
         // Then the migrated participant exposes tls_public_key with the Ed25519 bytes
-        let ProtocolContractState::Running(state) = migrated else {
-            panic!("expected Running state");
-        };
-        let participants = state.parameters.participants().participants();
+        let participants = migrated.parameters.participants().participants();
         assert_eq!(participants.len(), 1);
         assert_eq!(
             participants[0].2.tls_public_key,
@@ -850,7 +792,7 @@ mod tests {
         assert!(new.foreign_chain_support_by_node.is_empty());
     }
     #[test]
-    fn domain_config_migration__should_derive_protocol_from_curve_for_each_variant() {
+    fn domain_config_migration__should_derive_protocol_from_curve_and_inherit_threshold() {
         // Given OldDomainConfigs covering every legacy curve, including V2Secp256k1
         let cases = [
             (OldCurve::Secp256k1, Curve::Secp256k1, Protocol::CaitSith),
@@ -867,6 +809,7 @@ mod tests {
             ),
         ];
 
+        let global_threshold = ReconstructionThreshold::new(7);
         for (i, (old_curve, expected_curve, expected_protocol)) in cases.into_iter().enumerate() {
             let purpose = match expected_curve {
                 Curve::Bls12381 => DomainPurpose::CKD,
@@ -881,12 +824,46 @@ mod tests {
 
             // When borsh-decoding the old layout and converting to the new DomainConfig
             let decoded: OldDomainConfig = borsh::from_slice(&bytes).unwrap();
-            let migrated: DomainConfig = decoded.into();
+            let migrated = migrate_domain_config(decoded, global_threshold);
 
-            // Then curve and protocol match the expected post-migration pair
+            // Then curve, protocol, and per-domain reconstruction threshold are set
             assert_eq!(migrated.curve, expected_curve);
             assert_eq!(migrated.protocol, expected_protocol);
             assert_eq!(migrated.id, DomainId(i as u64));
+            assert_eq!(migrated.reconstruction_threshold, global_threshold);
+        }
+    }
+
+    #[test]
+    fn running_state_migration__should_copy_global_threshold_into_each_domain() {
+        // Given a legacy running state with two domains and a global threshold
+        testing_env!(VMContextBuilder::new().build());
+        let participants = old_participants(1, vec![("alice.near", 0, old_ed25519_near_pk(2))]);
+        let mut running = old_running_state(participants, 5);
+        running.domains = OldDomainRegistry {
+            domains: vec![
+                OldDomainConfig {
+                    id: DomainId(0),
+                    curve: OldCurve::Secp256k1,
+                    purpose: DomainPurpose::Sign,
+                },
+                OldDomainConfig {
+                    id: DomainId(1),
+                    curve: OldCurve::Edwards25519,
+                    purpose: DomainPurpose::Sign,
+                },
+            ],
+            next_domain_id: 2,
+        };
+
+        // When migrating
+        let migrated: RunningContractState = running.into();
+
+        // Then every migrated domain inherits the legacy global threshold
+        let expected = ReconstructionThreshold::new(5);
+        assert_eq!(migrated.domains.domains().len(), 2);
+        for domain in migrated.domains.domains() {
+            assert_eq!(domain.reconstruction_threshold, expected);
         }
     }
 }

--- a/crates/contract/tests/inprocess/attestation_submission.rs
+++ b/crates/contract/tests/inprocess/attestation_submission.rs
@@ -13,6 +13,7 @@ use mpc_contract::{
 };
 use near_mpc_contract_interface::types::{
     Attestation, InitConfig, MockAttestation, Protocol, ProtocolContractState,
+    ReconstructionThreshold,
 };
 use near_mpc_contract_interface::types::{Curve, DomainConfig, DomainId, DomainPurpose};
 
@@ -107,6 +108,7 @@ impl TestSetupBuilder {
             id: DomainId::default(),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose: DomainPurpose::Sign,
         }];
 
@@ -160,6 +162,7 @@ impl TestSetupBuilder {
                             id: DomainId(1),
                             curve: Curve::Edwards25519,
                             protocol: Protocol::Frost,
+                            reconstruction_threshold: ReconstructionThreshold::new(2),
                             purpose: DomainPurpose::Sign,
                         }])
                         .unwrap();

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -22,7 +22,8 @@ use mpc_contract::{
 };
 use near_account_id::AccountId;
 use near_mpc_contract_interface::types::{
-    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, SupportedForeignChains,
+    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+    SupportedForeignChains,
 };
 use near_mpc_contract_interface::{
     method_names,
@@ -215,18 +216,30 @@ impl SandboxTestSetupBuilder {
         let mut domain_configs = Vec::new();
         let mut key_for_domains = Vec::new();
 
-        // Sign-purpose domains from protocols
+        // Match the per-domain reconstruction threshold to the cluster
+        // threshold by default. DamgardEtAl additionally requires
+        // `2t - 1 <= n`, so cap t at `n.div_ceil(2)`.
+        let n = self.number_of_participants as u64;
+        let cluster_threshold = threshold_parameters.threshold().value();
+
         for protocol in &self.protocols {
             let curve = Curve::from(*protocol);
             let (pk, sk) = make_key_for_domain(curve);
             let purpose = infer_purpose_from_curve(curve);
             let domain_id = DomainId(domain_configs.len() as u64);
 
+            let reconstruction_threshold = match *protocol {
+                Protocol::DamgardEtAl => {
+                    ReconstructionThreshold::new(cluster_threshold.min(n.div_ceil(2)))
+                }
+                _ => ReconstructionThreshold::new(cluster_threshold),
+            };
             let key: PublicKeyExtended = pk.try_into().unwrap();
             let config = DomainConfig {
                 id: domain_id,
                 curve,
                 protocol: *protocol,
+                reconstruction_threshold,
                 purpose,
             };
             keys.push(DomainKey {
@@ -252,6 +265,7 @@ impl SandboxTestSetupBuilder {
                 id: domain_id,
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(cluster_threshold),
                 purpose: DomainPurpose::ForeignTx,
             };
             keys.push(DomainKey {
@@ -574,18 +588,21 @@ pub async fn execute_key_generation_and_add_random_state(
             id: 0.into(),
             curve: Curve::Edwards25519,
             protocol: Protocol::Frost,
+            reconstruction_threshold: ReconstructionThreshold::new(6),
             purpose: DomainPurpose::Sign,
         },
         DomainConfig {
             id: 1.into(),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(6),
             purpose: DomainPurpose::Sign,
         },
         DomainConfig {
             id: 2.into(),
             curve: Curve::Edwards25519,
             protocol: Protocol::Frost,
+            reconstruction_threshold: ReconstructionThreshold::new(6),
             purpose: DomainPurpose::Sign,
         },
     ];

--- a/crates/contract/tests/sandbox/participants_gas.rs
+++ b/crates/contract/tests/sandbox/participants_gas.rs
@@ -19,7 +19,9 @@ use mpc_contract::{
     primitives::key_state::{AttemptId, EpochId, KeyForDomain, Keyset},
 };
 use near_account_id::AccountId;
-use near_mpc_contract_interface::types::{Curve, DomainConfig, DomainId, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_sdk::Gas;
 use near_workspaces::{Account, Contract};
 use rstest::rstest;
@@ -273,6 +275,7 @@ async fn setup_test_env_with_state(n_participants: usize, running_state: bool) -
             id: domain_id,
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(2),
             purpose: DomainPurpose::Sign,
         };
         let (dto_pk, _) = new_secp256k1();

--- a/crates/contract/tests/sandbox/update_votes_cleanup_after_resharing.rs
+++ b/crates/contract/tests/sandbox/update_votes_cleanup_after_resharing.rs
@@ -17,7 +17,9 @@ use mpc_contract::{
 use near_account_id::AccountId;
 use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types as dtos;
-use near_mpc_contract_interface::types::{Curve, DomainConfig, DomainId, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_workspaces::Account;
 use serde_json::json;
 use sha2::Digest;
@@ -169,6 +171,7 @@ async fn add_domain_votes_from_kicked_out_participants_are_cleared_after_reshari
         id: DomainId(next_domain_id),
         curve: Curve::Edwards25519,
         protocol: Protocol::Frost,
+        reconstruction_threshold: ReconstructionThreshold::new(6),
         purpose: DomainPurpose::Sign,
     }];
     execute_async_transactions(

--- a/crates/contract/tests/sandbox/upgrade_to_current_contract.rs
+++ b/crates/contract/tests/sandbox/upgrade_to_current_contract.rs
@@ -22,7 +22,7 @@ use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types as dtos;
 use near_mpc_contract_interface::types::ProtocolContractState;
 use near_mpc_contract_interface::types::{
-    CKDResponse, Curve, DomainConfig, DomainPurpose, Protocol,
+    CKDResponse, Curve, DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
 };
 use near_mpc_sdk::sign::SignatureRequestResponse;
 use near_workspaces::{network::Sandbox, Account, Contract, Worker};
@@ -368,12 +368,14 @@ async fn upgrade_allows_new_request_types(
             id: first_available_domain_id.into(),
             curve: Curve::Bls12381,
             protocol: Protocol::ConfidentialKeyDerivation,
+            reconstruction_threshold: ReconstructionThreshold::new(6),
             purpose: DomainPurpose::CKD,
         },
         DomainConfig {
             id: (first_available_domain_id + 1).into(),
             curve: Curve::Edwards25519,
             protocol: Protocol::Frost,
+            reconstruction_threshold: ReconstructionThreshold::new(6),
             purpose: DomainPurpose::Sign,
         },
     ];

--- a/crates/contract/tests/sandbox/vote.rs
+++ b/crates/contract/tests/sandbox/vote.rs
@@ -22,6 +22,7 @@ use mpc_contract::primitives::{
     test_utils::infer_purpose_from_curve,
     thresholds::{Threshold, ThresholdParameters},
 };
+use near_mpc_contract_interface::types::ReconstructionThreshold;
 use near_mpc_contract_interface::{method_names, types as dtos};
 use near_workspaces::{network::Sandbox, Account, Contract, Worker};
 use rstest::rstest;
@@ -54,6 +55,7 @@ async fn test_keygen() -> anyhow::Result<()> {
             id: domain_id.into(),
             curve,
             protocol,
+            reconstruction_threshold: ReconstructionThreshold::new(6),
             purpose: DomainPurpose::Sign,
         }],
     )
@@ -68,6 +70,7 @@ async fn test_keygen() -> anyhow::Result<()> {
         id: dtos::DomainId(domain_id),
         curve,
         protocol,
+        reconstruction_threshold: ReconstructionThreshold::new(6),
         purpose: dtos::DomainPurpose::Sign,
     };
     let found = init
@@ -154,6 +157,13 @@ async fn test_cancel_keygen() -> anyhow::Result<()> {
         let curve = Curve::from(*protocol);
         let threshold = init_running.parameters.threshold.0 as usize;
 
+        // DamgardEtAl requires `2t - 1 <= n` (n=10 => t <= 5); other
+        // protocols use the cluster threshold (= 6 for n=10).
+        let reconstruction_threshold = match *protocol {
+            Protocol::DamgardEtAl => ReconstructionThreshold::new(5),
+            _ => ReconstructionThreshold::new(6),
+        };
+
         // vote to start key generation
         vote_add_domains(
             &contract,
@@ -162,6 +172,7 @@ async fn test_cancel_keygen() -> anyhow::Result<()> {
                 id: next_domain_id.into(),
                 curve,
                 protocol: *protocol,
+                reconstruction_threshold,
                 purpose: infer_purpose_from_curve(curve),
             }],
         )
@@ -181,6 +192,7 @@ async fn test_cancel_keygen() -> anyhow::Result<()> {
             id: dtos::DomainId(next_domain_id),
             curve,
             protocol: *protocol,
+            reconstruction_threshold,
             purpose: expected_purpose,
         };
         let found = init

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -1991,7 +1991,8 @@ expression: abi
             "curve",
             "id",
             "protocol",
-            "purpose"
+            "purpose",
+            "reconstruction_threshold"
           ],
           "properties": {
             "curve": {
@@ -2005,6 +2006,11 @@ expression: abi
             },
             "purpose": {
               "$ref": "#/definitions/DomainPurpose"
+            },
+            "reconstruction_threshold": {
+              "type": "integer",
+              "format": "uint64",
+              "minimum": 0.0
             }
           }
         },

--- a/crates/devnet/src/mpc.rs
+++ b/crates/devnet/src/mpc.rs
@@ -25,7 +25,8 @@ use near_jsonrpc_primitives::types::query::QueryResponseKind;
 use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types::{
     protocol_state_to_string, DomainConfig, DomainPurpose, EpochId, NodeImageHash, ParticipantId,
-    ParticipantInfo, Participants, Protocol, ProtocolContractState, Threshold, ThresholdParameters,
+    ParticipantInfo, Participants, Protocol, ProtocolContractState, ReconstructionThreshold,
+    Threshold, ThresholdParameters,
 };
 use near_primitives::types::{BlockReference, Finality, FunctionArgs};
 use near_primitives::views::QueryRequest;
@@ -616,6 +617,7 @@ impl MpcVoteAddDomainsCmd {
                 id: DomainId(next_domain),
                 curve: Curve::from(*protocol),
                 protocol: *protocol,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose,
             });
             next_domain += 1;

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -10,7 +10,7 @@ use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types::{
     AccountId as ContractAccountId, CKDAppPublicKey, Curve, DomainConfig, DomainId, DomainPurpose,
     Ed25519PublicKey, EpochId, ParticipantId, ParticipantInfo, Participants, Protocol,
-    ProtocolContractState, Threshold, ThresholdParameters,
+    ProtocolContractState, ReconstructionThreshold, Threshold, ThresholdParameters,
 };
 use rand::SeedableRng;
 use rand::rngs::StdRng;
@@ -153,18 +153,21 @@ impl MpcClusterConfig {
                     id: DomainId(0),
                     curve: Curve::Secp256k1,
                     protocol: Protocol::CaitSith,
+                    reconstruction_threshold: ReconstructionThreshold::new(2),
                     purpose: DomainPurpose::Sign,
                 },
                 DomainConfig {
                     id: DomainId(1),
                     curve: Curve::Edwards25519,
                     protocol: Protocol::Frost,
+                    reconstruction_threshold: ReconstructionThreshold::new(2),
                     purpose: DomainPurpose::Sign,
                 },
                 DomainConfig {
                     id: DomainId(2),
                     curve: Curve::Bls12381,
                     protocol: Protocol::ConfidentialKeyDerivation,
+                    reconstruction_threshold: ReconstructionThreshold::new(2),
                     purpose: DomainPurpose::CKD,
                 },
             ],

--- a/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
+++ b/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
@@ -12,8 +12,9 @@ use near_mpc_bounded_collections::NonEmptyBTreeMap;
 use near_mpc_contract_interface::types::{
     BitcoinExtractor, BitcoinRpcRequest, BitcoinTxId, BlockConfirmations, Curve, DomainConfig,
     DomainId, DomainPurpose, EvmExtractor, EvmFinality, EvmRpcRequest, EvmTxId, ForeignChain,
-    ForeignChainRpcRequest, ForeignTxPayloadVersion, Protocol, StarknetExtractor, StarknetFelt,
-    StarknetFinality, StarknetRpcRequest, StarknetTxId, VerifyForeignTransactionRequestArgs,
+    ForeignChainRpcRequest, ForeignTxPayloadVersion, Protocol, ReconstructionThreshold,
+    StarknetExtractor, StarknetFelt, StarknetFinality, StarknetRpcRequest, StarknetTxId,
+    VerifyForeignTransactionRequestArgs,
 };
 
 struct ForeignTxTestEnv {
@@ -178,6 +179,7 @@ async fn setup_foreign_tx_cluster() -> anyhow::Result<ForeignTxTestEnv> {
                 id: DomainId(0),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::ForeignTx,
             }];
             c.node_foreign_chains_configs = vec![fc_config.clone(), fc_config];

--- a/crates/e2e-tests/tests/key_resharing.rs
+++ b/crates/e2e-tests/tests/key_resharing.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, bail};
 use e2e_tests::CLUSTER_WAIT_TIMEOUT;
 use mpc_primitives::domain::{Curve, DomainId};
 use near_mpc_contract_interface::types::{
-    DomainConfig, DomainPurpose, Protocol, ProtocolContractState,
+    DomainConfig, DomainPurpose, Protocol, ProtocolContractState, ReconstructionThreshold,
 };
 use rand::SeedableRng;
 
@@ -137,24 +137,28 @@ async fn test_multi_domain() {
                 id: DomainId(3),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             DomainConfig {
                 id: DomainId(4),
                 curve: Curve::Edwards25519,
                 protocol: Protocol::Frost,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             DomainConfig {
                 id: DomainId(5),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             DomainConfig {
                 id: DomainId(6),
                 curve: Curve::Edwards25519,
                 protocol: Protocol::Frost,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
         ])
@@ -178,6 +182,7 @@ async fn test_multi_domain() {
             id: DomainId(7),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::Sign,
         }])
         .await

--- a/crates/e2e-tests/tests/parallel_sign_calls.rs
+++ b/crates/e2e-tests/tests/parallel_sign_calls.rs
@@ -2,7 +2,9 @@ use crate::common;
 
 use e2e_tests::{CLUSTER_WAIT_TIMEOUT, metrics};
 use mpc_primitives::domain::{Curve, DomainId};
-use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use serde_json::json;
 
 /// 9 parallel calls (3 robust ECDSA + 2 ECDSA + 2 EdDSA + 2 CKD) via the test parallel
@@ -27,24 +29,28 @@ async fn mpc_cluster_should_successfully_process_parallel_requests() {
                     id: DomainId(0),
                     curve: Curve::Secp256k1,
                     protocol: Protocol::DamgardEtAl,
+                    reconstruction_threshold: ReconstructionThreshold::new(3),
                     purpose: DomainPurpose::Sign,
                 },
                 DomainConfig {
                     id: DomainId(1),
                     curve: Curve::Secp256k1,
                     protocol: Protocol::CaitSith,
+                    reconstruction_threshold: ReconstructionThreshold::new(5),
                     purpose: DomainPurpose::Sign,
                 },
                 DomainConfig {
                     id: DomainId(2),
                     curve: Curve::Edwards25519,
                     protocol: Protocol::Frost,
+                    reconstruction_threshold: ReconstructionThreshold::new(5),
                     purpose: DomainPurpose::Sign,
                 },
                 DomainConfig {
                     id: DomainId(3),
                     curve: Curve::Bls12381,
                     protocol: Protocol::ConfidentialKeyDerivation,
+                    reconstruction_threshold: ReconstructionThreshold::new(5),
                     purpose: DomainPurpose::CKD,
                 },
             ];

--- a/crates/e2e-tests/tests/request_during_resharing.rs
+++ b/crates/e2e-tests/tests/request_during_resharing.rs
@@ -2,7 +2,7 @@ use crate::common;
 
 use mpc_primitives::domain::{Curve, DomainId};
 use near_mpc_contract_interface::types::{
-    DomainConfig, DomainPurpose, Protocol, ProtocolContractState,
+    DomainConfig, DomainPurpose, Protocol, ProtocolContractState, ReconstructionThreshold,
 };
 use rand::SeedableRng;
 
@@ -30,6 +30,7 @@ async fn test_request_during_resharing() {
                 id: DomainId(c.domains.len() as u64),
                 curve: Curve::Secp256k1,
                 protocol: Protocol::DamgardEtAl,
+                reconstruction_threshold: ReconstructionThreshold::new(3),
                 purpose: DomainPurpose::Sign,
             });
         })

--- a/crates/e2e-tests/tests/request_lifecycle.rs
+++ b/crates/e2e-tests/tests/request_lifecycle.rs
@@ -1,7 +1,8 @@
 use crate::common;
 
 use near_mpc_contract_interface::types::{
-    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, SignatureResponse,
+    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+    SignatureResponse,
 };
 use rand::SeedableRng;
 
@@ -92,6 +93,7 @@ async fn mpc_cluster__should_successfully_process_robust_ecdsa_requests() {
             id: DomainId(0),
             curve: Curve::Secp256k1,
             protocol: Protocol::DamgardEtAl,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::Sign,
         }];
         c.triples_to_buffer = 0;

--- a/crates/near-mpc-contract-interface/src/lib.rs
+++ b/crates/near-mpc-contract-interface/src/lib.rs
@@ -23,8 +23,8 @@ pub mod types {
         AddDomainsVotes, AttemptId, AuthenticatedAccountId, AuthenticatedParticipantId, Curve,
         DomainConfig, DomainPurpose, DomainRegistry, EpochId, InitializingContractState, KeyEvent,
         KeyEventId, KeyEventInstance, KeyForDomain, Keyset, Protocol, ProtocolContractState,
-        ResharingContractState, RunningContractState, Threshold, ThresholdParameters,
-        ThresholdParametersVotes, protocol_state_to_string,
+        ReconstructionThreshold, ResharingContractState, RunningContractState, Threshold,
+        ThresholdParameters, ThresholdParametersVotes, protocol_state_to_string,
     };
     pub use tee::NodeId;
     pub use updates::{ProposedUpdates, UpdateHash};

--- a/crates/near-mpc-contract-interface/src/types/state.rs
+++ b/crates/near-mpc-contract-interface/src/types/state.rs
@@ -600,8 +600,8 @@ mod tests {
     /// would emit. Both `Running` and `Initializing` shapes need to keep
     /// deserializing with the field back-filled from the surrounding
     /// `parameters.threshold`.
-    fn legacy_running_state_json() -> &'static str {
-        r#"{
+    fn legacy_running_state_json() -> serde_json::Value {
+        serde_json::json!({
             "domains": {
                 "domains": [
                     {"id": 0, "curve": "Secp256k1", "purpose": "Sign"},
@@ -616,8 +616,8 @@ mod tests {
             },
             "parameters_votes": { "proposal_by_account": {} },
             "add_domains_votes": { "proposal_by_account": {} },
-            "previously_cancelled_resharing_epoch_id": null
-        }"#
+            "previously_cancelled_resharing_epoch_id": null,
+        })
     }
 
     #[test]
@@ -627,7 +627,7 @@ mod tests {
         let json = legacy_running_state_json();
 
         // When deserializing into the new RunningContractState DTO
-        let state: RunningContractState = serde_json::from_str(json).unwrap();
+        let state: RunningContractState = serde_json::from_value(json).unwrap();
 
         // Then each domain inherits the global threshold (5)
         let expected = ReconstructionThreshold::new(5);

--- a/crates/near-mpc-contract-interface/src/types/state.rs
+++ b/crates/near-mpc-contract-interface/src/types/state.rs
@@ -16,7 +16,7 @@ use super::primitives::DomainId;
 // Simple Wrapper Types (newtypes)
 // =============================================================================
 
-pub use mpc_primitives::{AttemptId, EpochId, Threshold};
+pub use mpc_primitives::{AttemptId, EpochId, ReconstructionThreshold, Threshold};
 
 /// A participant ID that has been authenticated (i.e., the caller is this participant).
 #[derive(
@@ -106,35 +106,73 @@ pub struct DomainConfig {
     pub id: DomainId,
     pub curve: Curve,
     pub protocol: Protocol,
+    pub reconstruction_threshold: ReconstructionThreshold,
     pub purpose: DomainPurpose,
 }
 
-// `Deserialize` is implemented manually via this compat struct so that JSON
-// emitted by older contracts (pre-`protocol` field) still deserializes:
-// the missing `protocol` is inferred from `curve`.
+// TODO(#3166): once every deployment has run the v3.9.1 migration, the
+// legacy-JSON compat below can be removed entirely. After that point `state()`
+// always emits `protocol` and `reconstruction_threshold`, so the
+// `DomainConfig` struct can derive `Deserialize` directly and the following
+// items become dead code:
+//   - `DomainConfigCompat` and its `From<DomainConfigCompat>` impl
+//   - `infer_protocol`
+//   - `RawDomainConfig`, `RawDomainRegistry`, `RawAddDomainsVotes`
+//   - `RunningContractStateCompat`, `KeyEventCompat`,
+//     `InitializingContractStateCompat` (and their `serde(from = …)` attrs)
+/// Standalone-deserialization compat: `protocol` is optional (inferred from
+/// `curve` for legacy JSON); `reconstruction_threshold` is required.
+/// Legacy `state()` reads back-fill the threshold one level up via
+/// `RawDomainConfig`, not here.
 #[derive(Deserialize)]
 struct DomainConfigCompat {
     id: DomainId,
     curve: Curve,
     protocol: Option<Protocol>,
+    reconstruction_threshold: ReconstructionThreshold,
     purpose: DomainPurpose,
 }
 
 impl From<DomainConfigCompat> for DomainConfig {
     fn from(c: DomainConfigCompat) -> Self {
-        // Pre-`protocol` JSON: infer the canonical protocol from the curve.
-        // Old contracts only ever emitted CaitSith/Frost/CKD via this path —
-        // DamgardEtAl never existed in old JSON, so this fallback is total.
-        let protocol = c.protocol.unwrap_or(match c.curve {
-            Curve::Secp256k1 => Protocol::CaitSith,
-            Curve::Edwards25519 => Protocol::Frost,
-            Curve::Bls12381 => Protocol::ConfidentialKeyDerivation,
-        });
         Self {
             id: c.id,
             curve: c.curve,
-            protocol,
+            protocol: c.protocol.unwrap_or_else(|| infer_protocol(c.curve)),
+            reconstruction_threshold: c.reconstruction_threshold,
             purpose: c.purpose,
+        }
+    }
+}
+
+/// Legacy curves map 1:1 to protocols (DamgardEtAl never appeared in old JSON).
+fn infer_protocol(curve: Curve) -> Protocol {
+    match curve {
+        Curve::Secp256k1 => Protocol::CaitSith,
+        Curve::Edwards25519 => Protocol::Frost,
+        Curve::Bls12381 => Protocol::ConfidentialKeyDerivation,
+    }
+}
+
+/// Intermediate for legacy `state()` reads where `reconstruction_threshold`
+/// may be absent and is filled from the surrounding `parameters.threshold`.
+#[derive(Deserialize)]
+struct RawDomainConfig {
+    id: DomainId,
+    curve: Curve,
+    protocol: Option<Protocol>,
+    reconstruction_threshold: Option<ReconstructionThreshold>,
+    purpose: DomainPurpose,
+}
+
+impl RawDomainConfig {
+    fn into_domain_config(self, fallback: ReconstructionThreshold) -> DomainConfig {
+        DomainConfig {
+            id: self.id,
+            curve: self.curve,
+            protocol: self.protocol.unwrap_or_else(|| infer_protocol(self.curve)),
+            reconstruction_threshold: self.reconstruction_threshold.unwrap_or(fallback),
+            purpose: self.purpose,
         }
     }
 }
@@ -220,12 +258,37 @@ pub struct KeyEventInstance {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[serde(from = "KeyEventCompat")]
 pub struct KeyEvent {
     pub epoch_id: EpochId,
     pub domain: DomainConfig,
     pub parameters: ThresholdParameters,
     pub instance: Option<KeyEventInstance>,
     pub next_attempt_id: AttemptId,
+}
+
+/// Legacy compat: back-fill the embedded domain's `reconstruction_threshold`
+/// from the event's own `parameters.threshold`.
+#[derive(Deserialize)]
+struct KeyEventCompat {
+    epoch_id: EpochId,
+    domain: RawDomainConfig,
+    parameters: ThresholdParameters,
+    instance: Option<KeyEventInstance>,
+    next_attempt_id: AttemptId,
+}
+
+impl From<KeyEventCompat> for KeyEvent {
+    fn from(c: KeyEventCompat) -> Self {
+        let fallback = ReconstructionThreshold::from(c.parameters.threshold);
+        Self {
+            epoch_id: c.epoch_id,
+            domain: c.domain.into_domain_config(fallback),
+            parameters: c.parameters,
+            instance: c.instance,
+            next_attempt_id: c.next_attempt_id,
+        }
+    }
 }
 
 // =============================================================================
@@ -238,6 +301,7 @@ pub struct KeyEvent {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[serde(from = "InitializingContractStateCompat")]
 pub struct InitializingContractState {
     pub domains: DomainRegistry,
     pub epoch_id: EpochId,
@@ -246,12 +310,46 @@ pub struct InitializingContractState {
     pub cancel_votes: BTreeSet<AuthenticatedParticipantId>,
 }
 
+/// Legacy compat: back-fill registry thresholds from
+/// `generating_key.parameters.threshold` (the global threshold under which
+/// keygen was started, shared by every domain in the legacy registry).
+#[derive(Deserialize)]
+struct InitializingContractStateCompat {
+    domains: RawDomainRegistry,
+    epoch_id: EpochId,
+    generated_keys: Vec<KeyForDomain>,
+    generating_key: KeyEvent,
+    cancel_votes: BTreeSet<AuthenticatedParticipantId>,
+}
+
+impl From<InitializingContractStateCompat> for InitializingContractState {
+    fn from(c: InitializingContractStateCompat) -> Self {
+        let fallback = ReconstructionThreshold::from(c.generating_key.parameters.threshold);
+        Self {
+            domains: DomainRegistry {
+                domains: c
+                    .domains
+                    .domains
+                    .into_iter()
+                    .map(|d| d.into_domain_config(fallback))
+                    .collect(),
+                next_domain_id: c.domains.next_domain_id,
+            },
+            epoch_id: c.epoch_id,
+            generated_keys: c.generated_keys,
+            generating_key: c.generating_key,
+            cancel_votes: c.cancel_votes,
+        }
+    }
+}
+
 /// State when the contract is ready for signature operations.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
 )]
+#[serde(from = "RunningContractStateCompat")]
 pub struct RunningContractState {
     pub domains: DomainRegistry,
     pub keyset: Keyset,
@@ -259,6 +357,66 @@ pub struct RunningContractState {
     pub parameters_votes: ThresholdParametersVotes,
     pub add_domains_votes: AddDomainsVotes,
     pub previously_cancelled_resharing_epoch_id: Option<EpochId>,
+}
+
+/// Legacy compat: back-fill per-domain `reconstruction_threshold` from the
+/// global `parameters.threshold`. Also covers proposals nested in
+/// `add_domains_votes`.
+#[derive(Deserialize)]
+struct RunningContractStateCompat {
+    domains: RawDomainRegistry,
+    keyset: Keyset,
+    parameters: ThresholdParameters,
+    parameters_votes: ThresholdParametersVotes,
+    add_domains_votes: RawAddDomainsVotes,
+    previously_cancelled_resharing_epoch_id: Option<EpochId>,
+}
+
+#[derive(Deserialize)]
+struct RawDomainRegistry {
+    domains: Vec<RawDomainConfig>,
+    next_domain_id: u64,
+}
+
+#[derive(Deserialize)]
+struct RawAddDomainsVotes {
+    proposal_by_account: BTreeMap<AuthenticatedParticipantId, Vec<RawDomainConfig>>,
+}
+
+impl From<RunningContractStateCompat> for RunningContractState {
+    fn from(c: RunningContractStateCompat) -> Self {
+        let fallback = ReconstructionThreshold::from(c.parameters.threshold);
+        Self {
+            domains: DomainRegistry {
+                domains: c
+                    .domains
+                    .domains
+                    .into_iter()
+                    .map(|d| d.into_domain_config(fallback))
+                    .collect(),
+                next_domain_id: c.domains.next_domain_id,
+            },
+            keyset: c.keyset,
+            parameters: c.parameters,
+            parameters_votes: c.parameters_votes,
+            add_domains_votes: AddDomainsVotes {
+                proposal_by_account: c
+                    .add_domains_votes
+                    .proposal_by_account
+                    .into_iter()
+                    .map(|(k, v)| {
+                        (
+                            k,
+                            v.into_iter()
+                                .map(|d| d.into_domain_config(fallback))
+                                .collect(),
+                        )
+                    })
+                    .collect(),
+            },
+            previously_cancelled_resharing_epoch_id: c.previously_cancelled_resharing_epoch_id,
+        }
+    }
 }
 
 /// State when the contract is resharing keys to new participants.
@@ -435,5 +593,64 @@ mod tests {
 
         // Then
         assert_eq!(output, "Contract is not initialized\n");
+    }
+
+    /// Bare-bones legacy `state()` JSON without per-domain
+    /// `reconstruction_threshold`. Mirrors what a not-yet-upgraded contract
+    /// would emit. Both `Running` and `Initializing` shapes need to keep
+    /// deserializing with the field back-filled from the surrounding
+    /// `parameters.threshold`.
+    fn legacy_running_state_json() -> &'static str {
+        r#"{
+            "domains": {
+                "domains": [
+                    {"id": 0, "curve": "Secp256k1", "purpose": "Sign"},
+                    {"id": 1, "curve": "Edwards25519", "purpose": "Sign"}
+                ],
+                "next_domain_id": 2
+            },
+            "keyset": { "epoch_id": 0, "domains": [] },
+            "parameters": {
+                "participants": { "next_id": 0, "participants": [] },
+                "threshold": 5
+            },
+            "parameters_votes": { "proposal_by_account": {} },
+            "add_domains_votes": { "proposal_by_account": {} },
+            "previously_cancelled_resharing_epoch_id": null
+        }"#
+    }
+
+    #[test]
+    #[expect(non_snake_case)]
+    fn running_state_compat__should_backfill_missing_reconstruction_threshold() {
+        // Given legacy `state()` JSON with no per-domain reconstruction_threshold
+        let json = legacy_running_state_json();
+
+        // When deserializing into the new RunningContractState DTO
+        let state: RunningContractState = serde_json::from_str(json).unwrap();
+
+        // Then each domain inherits the global threshold (5)
+        let expected = ReconstructionThreshold::new(5);
+        assert_eq!(state.parameters.threshold, Threshold::new(5));
+        assert_eq!(state.domains.domains.len(), 2);
+        for domain in &state.domains.domains {
+            assert_eq!(domain.reconstruction_threshold, expected);
+        }
+    }
+
+    #[test]
+    #[expect(non_snake_case)]
+    fn domain_config__should_require_reconstruction_threshold_directly() {
+        // Given JSON missing reconstruction_threshold (e.g. an old vote_add_domains payload)
+        let bad = r#"{"id":0,"curve":"Secp256k1","purpose":"Sign"}"#;
+
+        // When deserializing as a standalone DomainConfig
+        let result: Result<DomainConfig, _> = serde_json::from_str(bad);
+
+        // Then it is rejected — the standalone path is not the place to back-fill
+        assert!(
+            result.is_err(),
+            "Standalone DomainConfig must require reconstruction_threshold"
+        );
     }
 }

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -726,7 +726,9 @@ mod tests {
     use assert_matches::assert_matches;
     use mpc_primitives::domain::{Curve, DomainId};
     use mpc_primitives::{AttemptId, EpochId, KeyEventId};
-    use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Protocol};
+    use near_mpc_contract_interface::types::{
+        DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
+    };
     use std::collections::BTreeSet;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -886,6 +888,7 @@ mod tests {
                 id: key_event_id.domain_id,
                 curve: Curve::Secp256k1,
                 protocol: Protocol::CaitSith,
+                reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose: DomainPurpose::Sign,
             },
             started,

--- a/crates/node/src/tests/basic_cluster.rs
+++ b/crates/node/src/tests/basic_cluster.rs
@@ -7,7 +7,9 @@ use crate::tests::{
 };
 use crate::tracking::AutoAbortTask;
 use mpc_primitives::domain::{Curve, DomainId};
-use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_time::Clock;
 
 // Make a cluster of four nodes, test that we can generate keyshares
@@ -35,6 +37,7 @@ async fn test_basic_cluster() {
         id: DomainId(0),
         curve: Curve::Secp256k1,
         protocol: Protocol::CaitSith,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: DomainPurpose::Sign,
     };
 
@@ -42,6 +45,7 @@ async fn test_basic_cluster() {
         id: DomainId(1),
         curve: Curve::Edwards25519,
         protocol: Protocol::Frost,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: DomainPurpose::Sign,
     };
 
@@ -49,6 +53,7 @@ async fn test_basic_cluster() {
         id: DomainId(2),
         curve: Curve::Bls12381,
         protocol: Protocol::ConfidentialKeyDerivation,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: DomainPurpose::CKD,
     };
 

--- a/crates/node/src/tests/changing_participant_details.rs
+++ b/crates/node/src/tests/changing_participant_details.rs
@@ -8,7 +8,9 @@ use crate::tests::{
 use crate::tests::{make_key_storage_config, DEFAULT_BLOCK_TIME};
 use crate::tracking::AutoAbortTask;
 use mpc_primitives::domain::{Curve, DomainId};
-use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_time::Clock;
 
 /// Runs a cluster of 3 nodes, but with only 2 participants.
@@ -50,6 +52,7 @@ async fn test_changing_participant_set_test_keyshare_import() {
         id: DomainId(0),
         curve: Curve::Secp256k1,
         protocol: Protocol::CaitSith,
+        reconstruction_threshold: ReconstructionThreshold::new(2),
         purpose: DomainPurpose::Sign,
     };
 

--- a/crates/node/src/tests/faulty.rs
+++ b/crates/node/src/tests/faulty.rs
@@ -7,7 +7,9 @@ use crate::tests::{
 use crate::tracking::AutoAbortTask;
 use mpc_primitives::domain::{Curve, DomainId};
 use near_account_id::AccountId;
-use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_time::Clock;
 use rand::Rng;
 
@@ -39,6 +41,7 @@ async fn test_faulty_cluster() {
         id: DomainId(0),
         curve: Curve::Secp256k1,
         protocol: Protocol::CaitSith,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: DomainPurpose::Sign,
     };
 
@@ -175,6 +178,7 @@ async fn test_indexer_stuck() {
         id: DomainId(0),
         curve: Curve::Secp256k1,
         protocol: Protocol::CaitSith,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: DomainPurpose::Sign,
     };
 

--- a/crates/node/src/tests/multidomain.rs
+++ b/crates/node/src/tests/multidomain.rs
@@ -6,7 +6,9 @@ use crate::tests::{
 };
 use crate::tracking::AutoAbortTask;
 use mpc_primitives::domain::{Curve, DomainId};
-use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_time::Clock;
 
 // Make a cluster of four nodes, test that we can generate keyshares
@@ -38,18 +40,21 @@ async fn test_basic_multidomain() {
             id: DomainId(0),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::Sign,
         },
         DomainConfig {
             id: DomainId(1),
             curve: Curve::Edwards25519,
             protocol: Protocol::Frost,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::Sign,
         },
         DomainConfig {
             id: DomainId(2),
             curve: Curve::Bls12381,
             protocol: Protocol::ConfidentialKeyDerivation,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::CKD,
         },
     ];
@@ -105,18 +110,21 @@ async fn test_basic_multidomain() {
             id: DomainId(3),
             curve: Curve::Edwards25519,
             protocol: Protocol::Frost,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::Sign,
         },
         DomainConfig {
             id: DomainId(4),
             curve: Curve::Secp256k1,
             protocol: Protocol::CaitSith,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::Sign,
         },
         DomainConfig {
             id: DomainId(5),
             curve: Curve::Bls12381,
             protocol: Protocol::ConfidentialKeyDerivation,
+            reconstruction_threshold: ReconstructionThreshold::new(3),
             purpose: DomainPurpose::CKD,
         },
     ];

--- a/crates/node/src/tests/onboarding.rs
+++ b/crates/node/src/tests/onboarding.rs
@@ -18,7 +18,7 @@ use ed25519_dalek::{SigningKey, VerifyingKey};
 use mpc_contract::state::ProtocolContractState;
 use mpc_primitives::domain::{Curve, DomainId};
 use near_mpc_contract_interface::types::{
-    BackupServiceInfo, DestinationNodeInfo, Ed25519PublicKey, Protocol,
+    BackupServiceInfo, DestinationNodeInfo, Ed25519PublicKey, Protocol, ReconstructionThreshold,
 };
 use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Keyset};
 use near_time::Clock;
@@ -107,6 +107,7 @@ async fn test_onboarding() {
         id: DomainId(0),
         curve: Curve::Secp256k1,
         protocol: Protocol::CaitSith,
+        reconstruction_threshold: ReconstructionThreshold::new(2),
         purpose: DomainPurpose::Sign,
     };
 

--- a/crates/node/src/tests/resharing.rs
+++ b/crates/node/src/tests/resharing.rs
@@ -7,7 +7,9 @@ use crate::tests::{
 };
 use crate::tracking::AutoAbortTask;
 use mpc_primitives::domain::{Curve, DomainId};
-use near_mpc_contract_interface::types::{DomainConfig, DomainPurpose, Protocol};
+use near_mpc_contract_interface::types::{
+    DomainConfig, DomainPurpose, Protocol, ReconstructionThreshold,
+};
 use near_time::Clock;
 use rstest::rstest;
 use serial_test::serial;
@@ -59,6 +61,7 @@ async fn test_key_resharing_simple(
         id: DomainId(0),
         curve,
         protocol,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: infer_purpose_from_curve(curve),
     };
 
@@ -182,6 +185,7 @@ async fn test_key_resharing_multistage() {
         id: DomainId(0),
         curve: Curve::Secp256k1,
         protocol: Protocol::CaitSith,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: DomainPurpose::Sign,
     };
 
@@ -388,6 +392,7 @@ async fn test_signature_requests_in_resharing_are_processed() {
         id: DomainId(0),
         curve: Curve::Secp256k1,
         protocol: Protocol::CaitSith,
+        reconstruction_threshold: ReconstructionThreshold::new(3),
         purpose: DomainPurpose::Sign,
     };
 

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -14,7 +14,7 @@ pub mod yield_index;
 pub use account_id::AccountId;
 pub use key_state::{AttemptId, EpochId, KeyEventId};
 pub use participant_id::ParticipantId;
-pub use threshold::Threshold;
+pub use threshold::{ReconstructionThreshold, Threshold};
 pub use yield_index::YieldIndex;
 
 /// Re-exports used by the [`define_hash!`] macro. Not part of the public API.

--- a/crates/primitives/src/threshold.rs
+++ b/crates/primitives/src/threshold.rs
@@ -35,3 +35,42 @@ impl Threshold {
         self.0
     }
 }
+
+/// Per-domain `t` in a t-of-n threshold scheme: shares needed to reconstruct
+/// the secret. Distinct from the network-wide governance threshold.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+#[serde(transparent)]
+pub struct ReconstructionThreshold(u64);
+
+impl ReconstructionThreshold {
+    pub const fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn inner(self) -> u64 {
+        self.0
+    }
+}
+
+impl From<Threshold> for ReconstructionThreshold {
+    fn from(value: Threshold) -> Self {
+        Self(value.value())
+    }
+}

--- a/docs/localnet/args/add_domain.json
+++ b/docs/localnet/args/add_domain.json
@@ -4,24 +4,28 @@
       "id": 0,
       "curve": "Secp256k1",
       "protocol": "CaitSith",
+      "reconstruction_threshold": 2,
       "purpose": "Sign"
     },
     {
       "id": 1,
       "curve": "Edwards25519",
       "protocol": "Frost",
+      "reconstruction_threshold": 2,
       "purpose": "Sign"
     },
     {
       "id": 2,
       "curve": "Bls12381",
       "protocol": "ConfidentialKeyDerivation",
+      "reconstruction_threshold": 2,
       "purpose": "CKD"
     },
     {
       "id": 3,
       "curve": "Secp256k1",
       "protocol": "CaitSith",
+      "reconstruction_threshold": 2,
       "purpose": "ForeignTx"
     }
   ]


### PR DESCRIPTION
Closes #3143

For most tests the specific `ReconstructionThreshold` value was not relevant, so I just added a value that coincided with the already used threshold to keep the status quo. We might want to rethink this and figure if it makes sense to use different thresholds for some tests now that we can.

Notice this does not wire yet the `ReconstructionThreshold` in the node. That will need to be done in a follow-up #3164, as it is a complicated change by itself.


There is yet another piece of the equation here that is not yet handled by this PR, which is resharing (now handled in #3169). After this PR lands, when resharing occurs, the per domain thresholds are checked against the new number of participants, but they cannot be modified as part of the vote, as was the case before. This is not a problem because the thresholds per domains are not wired yet in the node, but would be after that. So probably this needs to be sorted out in tandem with #3164. The idea would be to add per domain thresholds to the resharing vote parameters, which seems enough of a change to deserve its own PR. So I am not sure if it would be better to have this as part of the next release, and then do both this resharing and #3164 in the next. The only problem with this idea is that the thresholds in domains, that are now part of the `add_domain` votes would be fake in the sense that the nodes would still use the governance threshold for everything.