### PR TITLE
docs: tighten PCCS TLS-mode wording across operator guide + template

### DIFF
--- a/deployment/cvm-deployment/user-config.toml
+++ b/deployment/cvm-deployment/user-config.toml
@@ -25,8 +25,9 @@ home_dir = "/data"
 #   url = "https://10.0.2.2:8081/"
 #   tls = { override = "ca_cert_pem", ca_cert_pem = "..." }
 #
-# `tls = { override = "insecure" }` disables TLS for any URL (no
-# loopback enforcement, only a WARN). Use only for local PCCS.
+# `tls = { override = "insecure" }` disables TLS certificate/hostname
+# verification for any URL (no loopback enforcement, only a WARN). Use
+# only for local PCCS.
 
 [[mpc_node_config.pccs_endpoints]]
 url = "https://pccs.phala.network/"

--- a/deployment/cvm-deployment/user-config.toml
+++ b/deployment/cvm-deployment/user-config.toml
@@ -24,6 +24,9 @@ home_dir = "/data"
 #   [[mpc_node_config.pccs_endpoints]]
 #   url = "https://10.0.2.2:8081/"
 #   tls = { override = "ca_cert_pem", ca_cert_pem = "..." }
+#
+# `tls = { override = "insecure" }` disables TLS for any URL (no
+# loopback enforcement, only a WARN). Use only for local PCCS.
 
 [[mpc_node_config.pccs_endpoints]]
 url = "https://pccs.phala.network/"

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1625,8 +1625,9 @@ echo | openssl s_client -showcerts -connect 127.0.0.1:8081 \
 
 ### Configure the MPC node
 
-In `user-config.toml`, pin the **root CA** (not the leaf — the server
-presents the leaf, which chains to the root):
+In `user-config.toml`, add the **root CA** as a trust anchor (default
+public-CA roots remain active). The server presents the leaf, which
+chains to this root:
 
 ```toml
 [[mpc_node_config.pccs_endpoints]]
@@ -1648,3 +1649,7 @@ Disables all TLS certificate validation (cert chain *and* hostname).
 The startup log emits a clearly-labeled WARN when this mode is active.
 Acceptable for local-host bring-up before you've provisioned a proper
 cert; not recommended for any persistent setup.
+
+The code does **not** enforce loopback-only — `insecure` disables TLS
+for any URL configured. It is the operator's responsibility to use this
+value correctly. The startup WARN is the only guardrail.

--- a/docs/securing-mpc-with-tee-design-doc.md
+++ b/docs/securing-mpc-with-tee-design-doc.md
@@ -447,7 +447,7 @@ Beyond the TDX quote itself, attestation requires PCCS-supplied collateral — T
 
 - **Endpoint configuration and fallback.** Operators list one or more PCCS endpoints in `pccs_endpoints`. The node tries each in order until one returns valid collateral. When the field is unspecified, the node falls back to a single default endpoint (Phala).
 
-- **TLS trust.** PCCS endpoints use standard public-CA trust roots by default. Each entry optionally accepts a TLS override: `tls.override = "ca_cert_pem"` adds a self-signed root as an additional trust anchor — the default public-CA roots remain active. `tls.override = "insecure"` disables TLS validation entirely. Both overrides are intended for self-hosted local PCCS deployments only.
+- **TLS trust.** PCCS endpoints use standard public-CA trust roots by default. Each entry optionally accepts a TLS override: `tls.override = "ca_cert_pem"` (with a `tls.ca_cert_pem` PEM body) adds a self-signed root as an additional trust anchor — the default public-CA roots remain active. `tls.override = "insecure"` disables TLS validation entirely. Both overrides are intended for self-hosted local PCCS deployments only.
 
 - **Freshness validation.** Collateral older than 7 days is rejected. The threshold applies uniformly to `tcb_info.issueDate`, `qe_identity.issueDate`, and the PCK CRL `thisUpdate`. A stale response from one endpoint causes the node to fall back to the next.
 


### PR DESCRIPTION
## Summary

Three small doc fixes + one optional clarification (closes #3162):

- **Operator guide `ca_cert_pem`**: "pin" → "trust anchor (default public-CA roots remain active)". Matches the design doc and the actual `add_root_certificate()` semantics.
- **Operator guide `insecure`**: note that the code does **not** enforce loopback-only; the startup WARN is the only guardrail.
- **`user-config.toml`**: 1-line warning mirroring the `insecure` note.
- **Design doc** (optional): parenthetical noting `ca_cert_pem` mode requires the `tls.ca_cert_pem` PEM body field.

Closes #3162.
