### PR TITLE
feat(config): support query-param auth and optional header scheme

### DIFF
--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -456,9 +456,12 @@ pub fn auth_config_to_rpc_auth(
             scheme,
             token,
         } => {
-            let scheme = scheme.unwrap_or_else(|| "Bearer".to_string());
             let token_value = token.resolve()?;
-            let header_value = HeaderValue::from_str(&format!("{scheme} {token_value}"))?;
+            let header_value_str = match scheme {
+                Some(scheme) => format!("{scheme} {token_value}"),
+                None => token_value,
+            };
+            let header_value = HeaderValue::from_str(&header_value_str)?;
             Ok(RpcAuthentication::CustomHeader {
                 header_name,
                 header_value,
@@ -469,7 +472,14 @@ pub fn auth_config_to_rpc_auth(
             *rpc_url = rpc_url.replace(&placeholder, &token_value);
             Ok(RpcAuthentication::KeyInUrl)
         }
-        AuthConfig::Query { name: _, token: _ } => anyhow::bail!("this is not supported yet"),
+        AuthConfig::Query { name, token } => {
+            let token_value = token.resolve()?;
+            let mut parsed = url::Url::parse(rpc_url)
+                .with_context(|| format!("invalid RPC URL: `{rpc_url}`"))?;
+            parsed.query_pairs_mut().append_pair(&name, &token_value);
+            *rpc_url = parsed.into();
+            Ok(RpcAuthentication::KeyInUrl)
+        }
     }
 }
 
@@ -894,5 +904,129 @@ cores: 4
         // Then
         assert_matches!(result, RpcAuthentication::CustomHeader { .. });
         assert_eq!(url, "https://rpc.example.com/v2/");
+    }
+
+    #[test]
+    fn auth_config_to_rpc_auth__header_auth_with_scheme_prepends_scheme() {
+        // Given
+        let auth = AuthConfig::Header {
+            name: http::HeaderName::from_static("authorization"),
+            scheme: Some("Bearer".to_string()),
+            token: TokenConfig::Val {
+                val: "secret".to_string(),
+            },
+        };
+        let mut url = "https://rpc.example.com".to_string();
+
+        // When
+        let result = auth_config_to_rpc_auth(auth, &mut url).unwrap();
+
+        // Then
+        let RpcAuthentication::CustomHeader { header_value, .. } = result else {
+            panic!("expected CustomHeader, got {result:?}");
+        };
+        assert_eq!(header_value.to_str().unwrap(), "Bearer secret");
+    }
+
+    #[test]
+    fn auth_config_to_rpc_auth__header_auth_without_scheme_uses_raw_token() {
+        // Given: providers like Tatum (`x-api-key`) and NowNodes (`api-key`) use
+        // the raw token as the header value, with no scheme prefix.
+        let auth = AuthConfig::Header {
+            name: http::HeaderName::from_static("x-api-key"),
+            scheme: None,
+            token: TokenConfig::Val {
+                val: "raw-token-value".to_string(),
+            },
+        };
+        let mut url = "https://gateway.example.com".to_string();
+
+        // When
+        let result = auth_config_to_rpc_auth(auth, &mut url).unwrap();
+
+        // Then
+        let RpcAuthentication::CustomHeader { header_value, .. } = result else {
+            panic!("expected CustomHeader, got {result:?}");
+        };
+        assert_eq!(header_value.to_str().unwrap(), "raw-token-value");
+    }
+
+    #[test]
+    fn auth_config_to_rpc_auth__query_auth_appends_param_to_url_without_query() {
+        // Given: providers like Helius use `?api-key=<KEY>` on a URL with no query.
+        let auth = AuthConfig::Query {
+            name: "api-key".to_string(),
+            token: TokenConfig::Val {
+                val: "my-secret-key".to_string(),
+            },
+        };
+        let mut url = "https://mainnet.helius-rpc.com/".to_string();
+
+        // When
+        let result = auth_config_to_rpc_auth(auth, &mut url).unwrap();
+
+        // Then
+        assert_matches!(result, RpcAuthentication::KeyInUrl);
+        assert_eq!(url, "https://mainnet.helius-rpc.com/?api-key=my-secret-key");
+    }
+
+    #[test]
+    fn auth_config_to_rpc_auth__query_auth_appends_param_to_url_with_existing_query() {
+        // Given: dRPC's `?network=ethereum&dkey=<KEY>` form — the URL already has
+        // query parameters and the auth key must be appended with `&`.
+        let auth = AuthConfig::Query {
+            name: "dkey".to_string(),
+            token: TokenConfig::Val {
+                val: "my-drpc-key".to_string(),
+            },
+        };
+        let mut url = "https://lb.drpc.org/ogrpc?network=ethereum".to_string();
+
+        // When
+        let result = auth_config_to_rpc_auth(auth, &mut url).unwrap();
+
+        // Then
+        assert_matches!(result, RpcAuthentication::KeyInUrl);
+        assert_eq!(
+            url,
+            "https://lb.drpc.org/ogrpc?network=ethereum&dkey=my-drpc-key"
+        );
+    }
+
+    #[test]
+    fn auth_config_to_rpc_auth__query_auth_url_encodes_special_characters() {
+        // Given: tokens may contain characters that must be URL-encoded.
+        let auth = AuthConfig::Query {
+            name: "api-key".to_string(),
+            token: TokenConfig::Val {
+                val: "a b+c".to_string(),
+            },
+        };
+        let mut url = "https://rpc.example.com/".to_string();
+
+        // When
+        let result = auth_config_to_rpc_auth(auth, &mut url).unwrap();
+
+        // Then
+        assert_matches!(result, RpcAuthentication::KeyInUrl);
+        assert_eq!(url, "https://rpc.example.com/?api-key=a+b%2Bc");
+    }
+
+    #[test]
+    fn auth_config_to_rpc_auth__query_auth_returns_error_for_invalid_url() {
+        // Given
+        let auth = AuthConfig::Query {
+            name: "api-key".to_string(),
+            token: TokenConfig::Val {
+                val: "secret".to_string(),
+            },
+        };
+        let mut url = "not a valid url".to_string();
+
+        // When
+        let result = auth_config_to_rpc_auth(auth, &mut url);
+
+        // Then
+        result.unwrap_err();
     }
 }


### PR DESCRIPTION
## Summary

Closes two gaps in `auth_config_to_rpc_auth` that block several mainstream RPC providers from being configured:

- **`AuthConfig::Query` is now implemented.** Previously bailed at runtime with `"this is not supported yet"`, so any provider using a query-param API key was unconfigurable. This unblocks Helius (`?api-key=…`), OnFinality (`?apikey=…`), and dRPC (`?dkey=…`).
- **`Header` scheme is now truly optional.** Previously a missing `scheme` silently fell back to `"Bearer"`, producing `Bearer <token>` even for providers that expect a bare token. Tatum (`x-api-key: <token>`) and NowNodes (`api-key: <token>`) now work when `scheme` is omitted; `Bearer` is still emitted when `scheme: Bearer` is set explicitly.

Query values go through `url::Url::query_pairs_mut().append_pair(...)`, which:
- chooses the correct separator (`?` vs `&`) based on existing query state
- URL-encodes special characters in the token

## Why this is a config-only change (no per-provider trait)

The four `AuthConfig` variants (`none` / `header` / `path` / `query`) are a closed set that covers every mainstream RPC provider's auth shape — Alchemy, Ankr, Blockdaemon, BlockPi, Chainstack, dRPC, Helius, Dwellir, GetBlock, Infura, QuickNode, Tatum, NowNodes, OnFinality. Authentication varies in *data* (header name, query name, placeholder string), not in *behavior*, so no per-provider Rust code is needed — just config entries.

## Test plan

- [x] `cargo nextest run --cargo-profile=test-release -p mpc-node 'auth_config_to_rpc_auth'` — 9 tests pass (3 existing + 6 new):
  - `header_auth_with_scheme_prepends_scheme` (existing behavior preserved)
  - `header_auth_without_scheme_uses_raw_token` (new: Tatum / NowNodes shape)
  - `query_auth_appends_param_to_url_without_query` (new: Helius)
  - `query_auth_appends_param_to_url_with_existing_query` (new: dRPC `?network=…&dkey=…`)
  - `query_auth_url_encodes_special_characters` (new: defensive — `a b+c` → `a+b%2Bc`)
  - `query_auth_returns_error_for_invalid_url` (new: malformed URL surfaces an error)
- [x] `cargo clippy -p mpc-node --all-targets --locked -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual smoke test against a live provider with `kind: query` (recommended before relying on Helius/OnFinality/dRPC in production)