### PR TITLE
feat(node): enable decentralised state sync (DSS)

### DIFF
--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -403,6 +403,8 @@ impl MpcNodeSetup {
                 download_genesis_records_url: None,
                 rpc_addr: Some(format!("0.0.0.0:{}", self.ports.near_rpc)),
                 network_addr: Some(format!("0.0.0.0:{}", self.ports.near_network)),
+                tier3_public_addr: None,
+                external_storage_fallback_threshold: None,
             }),
             node: ConfigFile {
                 my_near_account_id: signer.clone(),

--- a/crates/node-config/src/start.rs
+++ b/crates/node-config/src/start.rs
@@ -108,6 +108,19 @@ pub struct NearInitConfig {
     /// Override the NEAR node network (indexer) listen address (e.g. "0.0.0.0:24568").
     /// Useful when running multiple nodes on the same machine.
     pub network_addr: Option<String>,
+    /// Override the public address advertised for Tier3 state-sync responses
+    /// (e.g. "203.0.113.5:24567"). Required on multi-IP hosts where outbound
+    /// source IP differs from the bound IP — auto-discovery picks the
+    /// outbound IP and DSS times out. Patches into nearcore's
+    /// `network.experimental.tier3_public_addr` config field.
+    pub tier3_public_addr: Option<String>,
+    /// Override how many P2P (DSS) state-sync attempts to make before falling
+    /// back to the external storage bucket. `0` (current default) means
+    /// "go straight to bucket, never use DSS." A moderate value enables
+    /// DSS-first with bucket as a safety net; a very large value effectively
+    /// disables the bucket fallback. Patches into nearcore's
+    /// `state_sync.sync.ExternalStorage.external_storage_fallback_threshold`.
+    pub external_storage_fallback_threshold: Option<u64>,
 }
 
 /// Encryption keys needed at startup.

--- a/crates/node/src/cli.rs
+++ b/crates/node/src/cli.rs
@@ -201,6 +201,8 @@ impl InitConfigArgs {
             download_genesis_records_url: self.download_genesis_records_url,
             rpc_addr: None,
             network_addr: None,
+            tier3_public_addr: None,
+            external_storage_fallback_threshold: None,
         }
     }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -162,8 +162,9 @@ fn apply_near_config_patches(
     if near_init.chain_id.is_localnet() {
         config["state_sync_enabled"] = serde_json::Value::Bool(false);
     } else {
+        let storage_fallback_threshold = near_init.external_storage_fallback_threshold.unwrap_or(0);
         config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"] =
-            serde_json::json!(0);
+            serde_json::json!(storage_fallback_threshold);
     }
 
     // Track the shard that hosts the MPC contract.
@@ -175,6 +176,10 @@ fn apply_near_config_patches(
     }
     if let Some(network_addr) = &near_init.network_addr {
         config["network"]["addr"] = serde_json::Value::String(network_addr.clone());
+    }
+    if let Some(tier3) = &near_init.tier3_public_addr {
+        config["network"]["experimental"]["tier3_public_addr"] =
+            serde_json::Value::String(tier3.clone());
     }
 }
 
@@ -196,6 +201,8 @@ mod tests {
             download_genesis_records_url: None,
             rpc_addr: None,
             network_addr: None,
+            tier3_public_addr: None,
+            external_storage_fallback_threshold: None,
         }
     }
 
@@ -323,6 +330,55 @@ mod tests {
         assert_eq!(
             config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"],
             serde_json::json!(0)
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_tier3_public_addr_when_provided() {
+        // Given
+        let mut config = empty_config_json();
+        let mut init = near_init(ChainId::Testnet);
+        init.tier3_public_addr = Some("46.105.87.136:24567".to_string());
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["network"]["experimental"]["tier3_public_addr"],
+            serde_json::json!("46.105.87.136:24567")
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_omit_tier3_public_addr_when_unset() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert!(config["network"]["experimental"]
+            .get("tier3_public_addr")
+            .is_none());
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_use_configured_fallback_threshold() {
+        // Given
+        let mut config = empty_config_json();
+        let mut init = near_init(ChainId::Testnet);
+        init.external_storage_fallback_threshold = Some(1000);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"],
+            serde_json::json!(1000)
         );
     }
 }

--- a/deployment/cvm-deployment/user-config.toml
+++ b/deployment/cvm-deployment/user-config.toml
@@ -44,6 +44,13 @@ chain_id = "mainnet"
 boot_nodes = "ed25519:ERguu7jQuYk8pxNsRC6FdezvNsegBPva1GRGqjmtD7i2@10.10.10.10:24567"
 download_genesis = false
 download_config = "rpc"
+# Bound IP:24567 the node advertises for Tier3 state-sync responses.
+# Replace with the IP your dstack port-forward exposes for :24567.
+# tier3_public_addr = "10.10.10.10:24567"
+# DSS attempts per state part before falling back to the external
+# storage bucket. 0 = bucket-only (never run DSS); 100 = DSS-first with
+# bucket as a safety net.
+# external_storage_fallback_threshold = 100
 
 [mpc_node_config.secrets]
 secret_store_key_hex = "BD399143F5B3126098B0EAA023A0E730"

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -629,6 +629,8 @@ Adjust the variables as per your environment.
 * `port_mappings` — port forwarding rules for the MPC container. These should be a subset of the port forwarding for the CVM defined in [Port Mapping](#using-the-web-interface)
 * `tier3_public_addr` *(optional)* — `IP:24567` the node advertises for Tier3 state-sync responses
 * `external_storage_fallback_threshold` *(optional)* — DSS attempts per state part before falling back to the external storage bucket. `0` = bucket-only
+
+> **Note:** `tier3_public_addr` and `external_storage_fallback_threshold` are applied only at first init (when `config.json` doesn't yet exist in the node's data directory). To change them on an already-initialized node, hand-edit `<home_dir>/config.json` or wipe the data dir and let init regenerate it.
 * A fresh set of boot nodes can be selected using Testnet/Mainnet RPC endpoints. Copy at least 4-5 nodes from curl results into `near_boot_nodes`.
   **Important:** Boot nodes must not contain duplicate addresses or peer IDs. Duplicates will cause the node to crash on startup. The command below deduplicates automatically:
 

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -627,6 +627,8 @@ Adjust the variables as per your environment.
 * `my_near_account_id` — use the NEAR account ID created in the previous step
 * `mpc_contract_id` — **v1.signer-prod.testnet** for testnet, **v1.signer** for mainnet
 * `port_mappings` — port forwarding rules for the MPC container. These should be a subset of the port forwarding for the CVM defined in [Port Mapping](#using-the-web-interface)
+* `tier3_public_addr` *(optional)* — `IP:24567` the node advertises for Tier3 state-sync responses
+* `external_storage_fallback_threshold` *(optional)* — DSS attempts per state part before falling back to the external storage bucket. `0` = bucket-only
 * A fresh set of boot nodes can be selected using Testnet/Mainnet RPC endpoints. Copy at least 4-5 nodes from curl results into `near_boot_nodes`.
   **Important:** Boot nodes must not contain duplicate addresses or peer IDs. Duplicates will cause the node to crash on startup. The command below deduplicates automatically:
 

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -627,10 +627,8 @@ Adjust the variables as per your environment.
 * `my_near_account_id` — use the NEAR account ID created in the previous step
 * `mpc_contract_id` — **v1.signer-prod.testnet** for testnet, **v1.signer** for mainnet
 * `port_mappings` — port forwarding rules for the MPC container. These should be a subset of the port forwarding for the CVM defined in [Port Mapping](#using-the-web-interface)
-* `tier3_public_addr` *(optional)* — `IP:24567` the node advertises for Tier3 state-sync responses
-* `external_storage_fallback_threshold` *(optional)* — DSS attempts per state part before falling back to the external storage bucket. `0` = bucket-only
-
-> **Note:** `tier3_public_addr` and `external_storage_fallback_threshold` are applied only at first init (when `config.json` doesn't yet exist in the node's data directory). To change them on an already-initialized node, hand-edit `<home_dir>/config.json` or wipe the data dir and let init regenerate it.
+* `tier3_public_addr` *(optional)* — `IP:24567` the node advertises for Tier3 state-sync responses. Applied at first init only; changing later requires a CVM redeploy via the [Node Migration](./node-migration-guide.md) flow.
+* `external_storage_fallback_threshold` *(optional)* — DSS attempts per state part before falling back to the external storage bucket. `0` = bucket-only. Same first-init-only constraint as `tier3_public_addr`.
 * A fresh set of boot nodes can be selected using Testnet/Mainnet RPC endpoints. Copy at least 4-5 nodes from curl results into `near_boot_nodes`.
   **Important:** Boot nodes must not contain duplicate addresses or peer IDs. Duplicates will cause the node to crash on startup. The command below deduplicates automatically:
 

--- a/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
@@ -815,6 +815,9 @@ render_node_files_range() {
     export EXTERNAL_MPC_LOCAL_DEBUG_PORT="127.0.0.1:${local_dbg_port}"
     export EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC="${ip}:${STATE_SYNC_PORT}"
     export EXTERNAL_MPC_MAIN_PORT="${ip}:${MAIN_PORT}"
+
+    export TIER3_PUBLIC_ADDR="${ip}:${STATE_SYNC_PORT}"
+    export EXTERNAL_STORAGE_FALLBACK_THRESHOLD="${EXTERNAL_STORAGE_FALLBACK_THRESHOLD:-100}"
         local future_port
     future_port="$(future_port_for_i "$i")"
 

--- a/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
@@ -816,9 +816,14 @@ render_node_files_range() {
     export EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC="${ip}:${STATE_SYNC_PORT}"
     export EXTERNAL_MPC_MAIN_PORT="${ip}:${MAIN_PORT}"
 
-    export TIER3_PUBLIC_ADDR="${ip}:${STATE_SYNC_PORT}"
-    export EXTERNAL_STORAGE_FALLBACK_THRESHOLD="${EXTERNAL_STORAGE_FALLBACK_THRESHOLD:-100}"
-        local future_port
+    # DSS state-sync fields are only meaningful for testnet; localnet
+    # disables state sync entirely (apply_near_config_patches's localnet
+    # branch sets state_sync_enabled = false).
+    if [ "$MODE" = "testnet" ]; then
+        export TIER3_PUBLIC_ADDR="${ip}:${STATE_SYNC_PORT}"
+        export EXTERNAL_STORAGE_FALLBACK_THRESHOLD="${EXTERNAL_STORAGE_FALLBACK_THRESHOLD:-100}"
+    fi
+    local future_port
     future_port="$(future_port_for_i "$i")"
 
     export EXTERNAL_MPC_FUTURE_PORT="${ip}:${future_port}"

--- a/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
@@ -853,6 +853,13 @@ render_node_files_range() {
     export PORTS_TOML
     PORTS_TOML="$(ports_to_toml "$PORTS")"
 
+    # envsubst doesn't understand bash's ${VAR:?msg} fail-fast syntax — only
+    # plain $VAR / ${VAR} — so validate required template inputs here, before
+    # the substitution, where bash's :?msg form does work.
+    if [ "$MODE" = "testnet" ]; then
+        : "${TIER3_PUBLIC_ADDR:?TIER3_PUBLIC_ADDR must be set before rendering the testnet template}"
+        : "${EXTERNAL_STORAGE_FALLBACK_THRESHOLD:?EXTERNAL_STORAGE_FALLBACK_THRESHOLD must be set before rendering the testnet template}"
+    fi
     envsubst <"$ENV_TPL" >"$env_out"
     envsubst <"$CONF_TPL" >"$conf_out"
 

--- a/localnet/tee/scripts/rust-launcher/how-to-run-deploy-tee-cluster.md
+++ b/localnet/tee/scripts/rust-launcher/how-to-run-deploy-tee-cluster.md
@@ -239,6 +239,24 @@ export FORCE_RECOLLECT=1
 export FORCE_REINIT_ARGS=1
 ```
 
+### DSS state sync (testnet only)
+
+For `MODE=testnet`, the script enables DSS-first state sync by default
+(localnet disables state sync entirely, so these have no effect there):
+
+- `TIER3_PUBLIC_ADDR` is auto-derived per-node as `${ip}:${STATE_SYNC_PORT}` —
+  not user-overridable.
+- `EXTERNAL_STORAGE_FALLBACK_THRESHOLD` defaults to `100`. Override to
+  change behavior:
+
+```bash
+# Bucket-only (DSS never runs):
+export EXTERNAL_STORAGE_FALLBACK_THRESHOLD=0
+
+# More P2P retries before falling back to the bucket:
+export EXTERNAL_STORAGE_FALLBACK_THRESHOLD=1000
+```
+
 ---
 
 ## Running the Script (Fresh Run)

--- a/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
@@ -18,8 +18,8 @@ chain_id = "testnet"
 boot_nodes = "${NEAR_BOOT_NODES}"
 download_genesis = true
 download_config = "rpc"
-tier3_public_addr = "${TIER3_PUBLIC_ADDR}"
-external_storage_fallback_threshold = ${EXTERNAL_STORAGE_FALLBACK_THRESHOLD}
+tier3_public_addr = "${TIER3_PUBLIC_ADDR:?TIER3_PUBLIC_ADDR must be set; deploy-tee-cluster.sh sets it from MODE=testnet}"
+external_storage_fallback_threshold = ${EXTERNAL_STORAGE_FALLBACK_THRESHOLD:?EXTERNAL_STORAGE_FALLBACK_THRESHOLD must be set; deploy-tee-cluster.sh defaults it to 100}
 
 [mpc_node_config.secrets]
 secret_store_key_hex = "${MPC_SECRET_STORE_KEY}"

--- a/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
@@ -18,8 +18,8 @@ chain_id = "testnet"
 boot_nodes = "${NEAR_BOOT_NODES}"
 download_genesis = true
 download_config = "rpc"
-tier3_public_addr = "${TIER3_PUBLIC_ADDR:?TIER3_PUBLIC_ADDR must be set; deploy-tee-cluster.sh sets it from MODE=testnet}"
-external_storage_fallback_threshold = ${EXTERNAL_STORAGE_FALLBACK_THRESHOLD:?EXTERNAL_STORAGE_FALLBACK_THRESHOLD must be set; deploy-tee-cluster.sh defaults it to 100}
+tier3_public_addr = "${TIER3_PUBLIC_ADDR}"
+external_storage_fallback_threshold = ${EXTERNAL_STORAGE_FALLBACK_THRESHOLD}
 
 [mpc_node_config.secrets]
 secret_store_key_hex = "${MPC_SECRET_STORE_KEY}"

--- a/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
@@ -18,6 +18,8 @@ chain_id = "testnet"
 boot_nodes = "${NEAR_BOOT_NODES}"
 download_genesis = true
 download_config = "rpc"
+tier3_public_addr = "${TIER3_PUBLIC_ADDR}"
+external_storage_fallback_threshold = ${EXTERNAL_STORAGE_FALLBACK_THRESHOLD}
 
 [mpc_node_config.secrets]
 secret_store_key_hex = "${MPC_SECRET_STORE_KEY}"


### PR DESCRIPTION
DSS state sync is currently disabled in practice because `apply_near_config_patches` hardcoded `external_storage_fallback_threshold = 0` (bucket-only); on multi-IP hosts neard's auto-discovery also picks the wrong outbound IP for Tier3 replies. This PR adds two optional fields so operators can opt into DSS and override the advertised Tier3 address.

- Adds `tier3_public_addr` and `external_storage_fallback_threshold` to `NearInitConfig` (under `[mpc_node_config.near_init]` in the launcher TOML).
- Threads both through `deploy-tee-cluster.sh`, the testnet TOML template, and the example `user-config.toml`; lists them in the TDX operator guide.
- 3 new unit tests covering the new fields.
- Validated end-to-end on a 2-node TDX testnet cluster: DSS sync, full DKG, on-chain ECDSA signature returned ([tx](https://explorer.testnet.near.org/transactions/24jPGKYiGSSsE8kHNSr9VnrcCdVoKFU7TkpHmbu4pLCW)).

Stacked on #3189.

Closes #1734.
