### PR TITLE
refactor: extract apply_near_config_patches helper

### DIFF
--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -179,7 +179,7 @@ fn apply_near_config_patches(
 }
 
 #[cfg(test)]
-#[allow(non_snake_case)] // tests follow `<system_under_test>__should_<assertion>` convention
+#[expect(non_snake_case)] // tests follow `<system_under_test>__should_<assertion>` convention
 mod tests {
     use super::*;
     use mpc_node_config::ChainId;
@@ -252,7 +252,10 @@ mod tests {
         apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
 
         // Then
-        assert_eq!(config["network"]["addr"], serde_json::json!("51.68.219.13:24567"));
+        assert_eq!(
+            config["network"]["addr"],
+            serde_json::json!("51.68.219.13:24567")
+        );
         assert_eq!(config["rpc"]["addr"], serde_json::json!("0.0.0.0:13030"));
     }
 

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -138,27 +138,8 @@ fn patch_near_config(
     let mut config: serde_json::Value =
         serde_json::from_str(&raw).context("failed to parse NEAR config.json")?;
 
-    config["store"]["load_mem_tries_for_tracked_shards"] = serde_json::Value::Bool(true);
-
-    let is_localnet = near_init.chain_id.is_localnet();
-    if is_localnet {
-        config["state_sync_enabled"] = serde_json::Value::Bool(false);
-    } else {
-        config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"] =
-            serde_json::json!(0);
-    }
-
-    // Track the shard that hosts the MPC contract.
     let contract_id = node_config.indexer.mpc_contract_id.to_string();
-    config["tracked_shards_config"] = serde_json::json!({ "Accounts": [contract_id] });
-
-    // Override listen addresses when running multiple nodes on one machine.
-    if let Some(rpc_addr) = &near_init.rpc_addr {
-        config["rpc"]["addr"] = serde_json::Value::String(rpc_addr.clone());
-    }
-    if let Some(network_addr) = &near_init.network_addr {
-        config["network"]["addr"] = serde_json::Value::String(network_addr.clone());
-    }
+    apply_near_config_patches(&mut config, near_init, &contract_id);
 
     let patched =
         serde_json::to_string_pretty(&config).context("failed to re-serialize NEAR config.json")?;
@@ -167,4 +148,127 @@ fn patch_near_config(
 
     tracing::info!("NEAR node config.json patched successfully");
     Ok(())
+}
+
+/// Pure JSON-manipulation half of [`patch_near_config`], extracted so it can
+/// be unit-tested without filesystem I/O or constructing a full `ConfigFile`.
+fn apply_near_config_patches(
+    config: &mut serde_json::Value,
+    near_init: &NearInitConfig,
+    mpc_contract_id: &str,
+) {
+    config["store"]["load_mem_tries_for_tracked_shards"] = serde_json::Value::Bool(true);
+
+    if near_init.chain_id.is_localnet() {
+        config["state_sync_enabled"] = serde_json::Value::Bool(false);
+    } else {
+        config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"] =
+            serde_json::json!(0);
+    }
+
+    // Track the shard that hosts the MPC contract.
+    config["tracked_shards_config"] = serde_json::json!({ "Accounts": [mpc_contract_id] });
+
+    // Override listen addresses when running multiple nodes on one machine.
+    if let Some(rpc_addr) = &near_init.rpc_addr {
+        config["rpc"]["addr"] = serde_json::Value::String(rpc_addr.clone());
+    }
+    if let Some(network_addr) = &near_init.network_addr {
+        config["network"]["addr"] = serde_json::Value::String(network_addr.clone());
+    }
+}
+
+#[cfg(test)]
+#[allow(non_snake_case)] // tests follow `<system_under_test>__should_<assertion>` convention
+mod tests {
+    use super::*;
+    use mpc_node_config::ChainId;
+
+    fn near_init(chain_id: ChainId) -> NearInitConfig {
+        NearInitConfig {
+            chain_id,
+            boot_nodes: None,
+            genesis_path: None,
+            download_config: None,
+            download_config_url: None,
+            download_genesis: false,
+            download_genesis_url: None,
+            download_genesis_records_url: None,
+            rpc_addr: None,
+            network_addr: None,
+        }
+    }
+
+    fn empty_config_json() -> serde_json::Value {
+        serde_json::json!({
+            "store": {},
+            "network": {},
+            "rpc": {},
+            "state_sync": { "sync": { "ExternalStorage": {} } }
+        })
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_load_mem_tries() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["store"]["load_mem_tries_for_tracked_shards"],
+            serde_json::json!(true)
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_tracked_shards_to_contract_account() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(
+            config["tracked_shards_config"],
+            serde_json::json!({ "Accounts": ["v1.signer-prod.testnet"] })
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_network_and_rpc_addr_when_provided() {
+        // Given
+        let mut config = empty_config_json();
+        let mut init = near_init(ChainId::Testnet);
+        init.network_addr = Some("51.68.219.13:24567".to_string());
+        init.rpc_addr = Some("0.0.0.0:13030".to_string());
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then
+        assert_eq!(config["network"]["addr"], serde_json::json!("51.68.219.13:24567"));
+        assert_eq!(config["rpc"]["addr"], serde_json::json!("0.0.0.0:13030"));
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_disable_state_sync_for_localnet() {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Localnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "mpc-contract.test.near");
+
+        // Then
+        assert_eq!(config["state_sync_enabled"], serde_json::json!(false));
+        assert!(config["state_sync"]["sync"]["ExternalStorage"]
+            .get("external_storage_fallback_threshold")
+            .is_none());
+    }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -261,8 +261,12 @@ mod tests {
 
     #[test]
     fn apply_near_config_patches__should_disable_state_sync_for_localnet() {
-        // Given
+        // Given — pre-populate the threshold with a sentinel so the negative
+        // assertion below is meaningful (otherwise the test passes even if
+        // the function does nothing).
         let mut config = empty_config_json();
+        config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"] =
+            serde_json::json!(999);
         let init = near_init(ChainId::Localnet);
 
         // When
@@ -270,8 +274,27 @@ mod tests {
 
         // Then
         assert_eq!(config["state_sync_enabled"], serde_json::json!(false));
-        assert!(config["state_sync"]["sync"]["ExternalStorage"]
-            .get("external_storage_fallback_threshold")
-            .is_none());
+        // Localnet branch must not touch the threshold — sentinel survives.
+        assert_eq!(
+            config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"],
+            serde_json::json!(999)
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_set_external_storage_fallback_threshold_for_non_localnet()
+    {
+        // Given
+        let mut config = empty_config_json();
+        let init = near_init(ChainId::Testnet);
+
+        // When
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
+
+        // Then — non-localnet path writes the historical hardcoded 0.
+        assert_eq!(
+            config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"],
+            serde_json::json!(0)
+        );
     }
 }

--- a/crates/node/src/config/start.rs
+++ b/crates/node/src/config/start.rs
@@ -260,25 +260,53 @@ mod tests {
     }
 
     #[test]
-    fn apply_near_config_patches__should_disable_state_sync_for_localnet() {
-        // Given — pre-populate the threshold with a sentinel so the negative
-        // assertion below is meaningful (otherwise the test passes even if
-        // the function does nothing).
+    fn apply_near_config_patches__should_preserve_existing_network_and_rpc_addr_when_unset() {
+        // Given — pre-populate network/rpc addr so we can prove the function
+        // leaves them alone when the operator hasn't set the override.
         let mut config = empty_config_json();
-        config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"] =
-            serde_json::json!(999);
-        let init = near_init(ChainId::Localnet);
+        config["network"]["addr"] = serde_json::json!("downloaded-network-addr:24567");
+        config["rpc"]["addr"] = serde_json::json!("downloaded-rpc-addr:3030");
+        let init = near_init(ChainId::Testnet);
 
         // When
-        apply_near_config_patches(&mut config, &init, "mpc-contract.test.near");
+        apply_near_config_patches(&mut config, &init, "v1.signer-prod.testnet");
 
-        // Then
-        assert_eq!(config["state_sync_enabled"], serde_json::json!(false));
-        // Localnet branch must not touch the threshold — sentinel survives.
+        // Then — sentinels survive (don't-clobber-downloaded-config contract).
         assert_eq!(
-            config["state_sync"]["sync"]["ExternalStorage"]["external_storage_fallback_threshold"],
-            serde_json::json!(999)
+            config["network"]["addr"],
+            serde_json::json!("downloaded-network-addr:24567")
         );
+        assert_eq!(
+            config["rpc"]["addr"],
+            serde_json::json!("downloaded-rpc-addr:3030")
+        );
+    }
+
+    #[test]
+    fn apply_near_config_patches__should_disable_state_sync_for_localnet() {
+        // is_localnet() returns true for both Localnet and Sandbox; cover both
+        // so a future split of the variants doesn't silently regress one arm.
+        for chain_id in [ChainId::Localnet, ChainId::Sandbox] {
+            // Given — pre-populate the threshold with a sentinel so the negative
+            // assertion below is meaningful (otherwise the test passes even if
+            // the function does nothing).
+            let mut config = empty_config_json();
+            config["state_sync"]["sync"]["ExternalStorage"]
+                ["external_storage_fallback_threshold"] = serde_json::json!(999);
+            let init = near_init(chain_id);
+
+            // When
+            apply_near_config_patches(&mut config, &init, "mpc-contract.test.near");
+
+            // Then
+            assert_eq!(config["state_sync_enabled"], serde_json::json!(false));
+            // Localnet branch must not touch the threshold — sentinel survives.
+            assert_eq!(
+                config["state_sync"]["sync"]["ExternalStorage"]
+                    ["external_storage_fallback_threshold"],
+                serde_json::json!(999)
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
- Extracts the pure JSON half of `patch_near_config` into `apply_near_config_patches`.
- Adds 6 regression tests; no behavior change.
- Prep for stacking #3188 on top.

Closes #3190.
