### PR TITLE
feat(tee-verifier): stateless `dcap_qvl::verify` wrapper contract

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11371,6 +11371,7 @@ dependencies = [
  "tee-verifier",
  "tee-verifier-interface",
  "test-utils",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11360,6 +11360,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tee-verifier"
+version = "3.9.0"
+dependencies = [
+ "borsh",
+ "dcap-qvl",
+ "getrandom 0.2.17",
+ "hex",
+ "near-sdk",
+ "tee-verifier-interface",
+ "test-utils",
+]
+
+[[package]]
 name = "tee-verifier-interface"
 version = "3.11.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11361,13 +11361,14 @@ dependencies = [
 
 [[package]]
 name = "tee-verifier"
-version = "3.9.0"
+version = "3.11.0"
 dependencies = [
  "borsh",
  "dcap-qvl",
  "getrandom 0.2.17",
  "hex",
  "near-sdk",
+ "tee-verifier",
  "tee-verifier-interface",
  "test-utils",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11368,6 +11368,7 @@ dependencies = [
  "getrandom 0.2.17",
  "hex",
  "near-sdk",
+ "rstest",
  "tee-verifier",
  "tee-verifier-interface",
  "test-utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11372,7 +11372,6 @@ dependencies = [
  "tee-verifier",
  "tee-verifier-interface",
  "test-utils",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
     "crates/tee-authority",
     "crates/tee-context",
     "crates/tee-launcher",
+    "crates/tee-verifier",
     "crates/tee-verifier-interface",
     "crates/test-migration-contract",
     "crates/test-parallel-contract",
@@ -67,6 +68,7 @@ near-mpc-sdk = { path = "crates/near-mpc-sdk", version = "0.0.1" }
 near-mpc-signature-verifier = { path = "crates/near-mpc-signature-verifier", version = "0.0.1" }
 node-types = { path = "crates/node-types" }
 tee-authority = { path = "crates/tee-authority" }
+tee-verifier-interface = { path = "crates/tee-verifier-interface" }
 test-port-allocator = { path = "crates/test-port-allocator" }
 test-utils = { path = "crates/test-utils" }
 threshold-signatures = { path = "crates/threshold-signatures" }

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -1,0 +1,48 @@
+[package]
+name = "tee-verifier"
+version = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+repository = "https://github.com/near/mpc"
+
+[package.metadata.cargo-shear]
+ignored = ["borsh"]
+
+[package.metadata.near.reproducible_build]
+image = "sourcescan/cargo-near:0.17.0-rust-1.86.0"
+image_digest = "sha256:1784ca6310f3496f0048356ce420921c8f5fdf71ee8124d43a2e1ceb1f70db8a"
+passed_env = []
+container_build_command = [
+    "cargo",
+    "near",
+    "build",
+    "non-reproducible-wasm",
+    "--locked",
+    "--features",
+    "abi",
+]
+
+[lib]
+crate-type = ["cdylib", "lib"]
+
+[features]
+# Enabled by `cargo near build` (via `--features near-sdk/__abi-generate`)
+# and required for ABI / Borsh schema generation. Pulls in
+# `borsh/unstable__schema` and `BorshSchema` derives on the wire types.
+abi = ["borsh/unstable__schema", "tee-verifier-interface/borsh-schema"]
+
+[dependencies]
+borsh = { workspace = true }
+dcap-qvl = { workspace = true }
+near-sdk = { workspace = true }
+tee-verifier-interface = { workspace = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { workspace = true, features = ["custom"] }
+
+[dev-dependencies]
+hex = { workspace = true }
+test-utils = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -45,6 +45,7 @@ getrandom = { workspace = true, features = ["custom"] }
 
 [dev-dependencies]
 hex = { workspace = true }
+rstest = { workspace = true }
 tee-verifier = { path = ".", features = ["test-utils"] }
 test-utils = { workspace = true }
 

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -4,9 +4,6 @@ version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
 
-[package.metadata.cargo-shear]
-ignored = ["borsh"]
-
 [package.metadata.near.reproducible_build]
 image = "sourcescan/cargo-near:0.21.1-rust-1.93.0"
 image_digest = "sha256:79b789c81ba19ec30794a6b1046b02dcaf5c055994b22cc7c9af67ab5096b095"

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -8,8 +8,8 @@ edition = { workspace = true }
 ignored = ["borsh"]
 
 [package.metadata.near.reproducible_build]
-image = "sourcescan/cargo-near:0.17.0-rust-1.86.0"
-image_digest = "sha256:1784ca6310f3496f0048356ce420921c8f5fdf71ee8124d43a2e1ceb1f70db8a"
+image = "sourcescan/cargo-near:0.21.1-rust-1.93.0"
+image_digest = "sha256:79b789c81ba19ec30794a6b1046b02dcaf5c055994b22cc7c9af67ab5096b095"
 passed_env = []
 container_build_command = [
     "cargo",

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -14,6 +14,7 @@ container_build_command = [
     "build",
     "non-reproducible-wasm",
     "--locked",
+    "--profile=release-contract",
     "--features",
     "abi",
 ]

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -38,7 +38,6 @@ borsh = { workspace = true }
 dcap-qvl = { workspace = true }
 near-sdk = { workspace = true }
 tee-verifier-interface = { workspace = true }
-thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["custom"] }

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -3,7 +3,6 @@ name = "tee-verifier"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
-repository = "https://github.com/near/mpc"
 
 [package.metadata.cargo-shear]
 ignored = ["borsh"]

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -30,6 +30,9 @@ crate-type = ["cdylib", "lib"]
 # and required for ABI / Borsh schema generation. Pulls in
 # `borsh/unstable__schema` and `BorshSchema` derives on the wire types.
 abi = ["borsh/unstable__schema", "tee-verifier-interface/borsh-schema"]
+# Enables `near_sdk::testing_env!` for tests; the workspace `near-sdk`
+# dependency no longer turns on `unit-testing` by default.
+test-utils = ["near-sdk/unit-testing"]
 
 [dependencies]
 borsh = { workspace = true }
@@ -42,6 +45,7 @@ getrandom = { workspace = true, features = ["custom"] }
 
 [dev-dependencies]
 hex = { workspace = true }
+tee-verifier = { path = ".", features = ["test-utils"] }
 test-utils = { workspace = true }
 
 [lints]

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -39,6 +39,7 @@ borsh = { workspace = true }
 dcap-qvl = { workspace = true }
 near-sdk = { workspace = true }
 tee-verifier-interface = { workspace = true }
+thiserror = { workspace = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 getrandom = { workspace = true, features = ["custom"] }

--- a/crates/tee-verifier/src/conversions.rs
+++ b/crates/tee-verifier/src/conversions.rs
@@ -1,0 +1,122 @@
+//! Conversions between `dcap_qvl`'s types and the Borsh-mirrored types in
+//! `tee-verifier-interface`.
+//!
+//! These conversions live here (in the contract crate that already
+//! depends on `dcap-qvl`) rather than in `tee-verifier-interface`, so
+//! that the interface crate stays free of `dcap-qvl` and can be linked
+//! into consumer contracts without dragging in `ring`/`webpki`/X.509
+//! parsing.
+//!
+//! Free functions are used rather than `From`/`Into` impls because the
+//! orphan rule forbids implementing a foreign trait between two foreign
+//! types from a third crate.
+
+use dcap_qvl::{quote as dq_quote, tcb_info as dq_tcb, verify as dq_verify};
+use tee_verifier_interface::{
+    Collateral, EnclaveReport, QuoteBytes, Report, TDReport10, TDReport15, TcbStatus,
+    TcbStatusWithAdvisory, VerifiedReport,
+};
+
+pub fn collateral_to_dcap(value: Collateral) -> dcap_qvl::QuoteCollateralV3 {
+    dcap_qvl::QuoteCollateralV3 {
+        pck_crl_issuer_chain: value.pck_crl_issuer_chain,
+        root_ca_crl: value.root_ca_crl,
+        pck_crl: value.pck_crl,
+        tcb_info_issuer_chain: value.tcb_info_issuer_chain,
+        tcb_info: value.tcb_info,
+        tcb_info_signature: value.tcb_info_signature,
+        qe_identity_issuer_chain: value.qe_identity_issuer_chain,
+        qe_identity: value.qe_identity,
+        qe_identity_signature: value.qe_identity_signature,
+        pck_certificate_chain: value.pck_certificate_chain,
+    }
+}
+
+pub fn quote_bytes_to_vec(value: QuoteBytes) -> Vec<u8> {
+    value.0
+}
+
+pub fn verified_report(value: dq_verify::VerifiedReport) -> VerifiedReport {
+    VerifiedReport {
+        status: value.status,
+        advisory_ids: value.advisory_ids,
+        report: report(value.report),
+        ppid: value.ppid,
+        qe_status: tcb_status_with_advisory(value.qe_status),
+        platform_status: tcb_status_with_advisory(value.platform_status),
+    }
+}
+
+fn report(value: dq_quote::Report) -> Report {
+    match value {
+        dq_quote::Report::SgxEnclave(r) => Report::SgxEnclave(enclave_report(r)),
+        dq_quote::Report::TD10(r) => Report::TD10(td_report_10(r)),
+        dq_quote::Report::TD15(r) => Report::TD15(td_report_15(r)),
+    }
+}
+
+fn td_report_10(value: dq_quote::TDReport10) -> TDReport10 {
+    TDReport10 {
+        tee_tcb_svn: value.tee_tcb_svn,
+        mr_seam: value.mr_seam,
+        mr_signer_seam: value.mr_signer_seam,
+        seam_attributes: value.seam_attributes,
+        td_attributes: value.td_attributes,
+        xfam: value.xfam,
+        mr_td: value.mr_td,
+        mr_config_id: value.mr_config_id,
+        mr_owner: value.mr_owner,
+        mr_owner_config: value.mr_owner_config,
+        rt_mr0: value.rt_mr0,
+        rt_mr1: value.rt_mr1,
+        rt_mr2: value.rt_mr2,
+        rt_mr3: value.rt_mr3,
+        report_data: value.report_data,
+    }
+}
+
+fn td_report_15(value: dq_quote::TDReport15) -> TDReport15 {
+    TDReport15 {
+        base: td_report_10(value.base),
+        tee_tcb_svn2: value.tee_tcb_svn2,
+        mr_service_td: value.mr_service_td,
+    }
+}
+
+fn enclave_report(value: dq_quote::EnclaveReport) -> EnclaveReport {
+    EnclaveReport {
+        cpu_svn: value.cpu_svn,
+        misc_select: value.misc_select,
+        reserved1: value.reserved1,
+        attributes: value.attributes,
+        mr_enclave: value.mr_enclave,
+        reserved2: value.reserved2,
+        mr_signer: value.mr_signer,
+        reserved3: value.reserved3,
+        isv_prod_id: value.isv_prod_id,
+        isv_svn: value.isv_svn,
+        reserved4: value.reserved4,
+        report_data: value.report_data,
+    }
+}
+
+fn tcb_status(value: dq_tcb::TcbStatus) -> TcbStatus {
+    match value {
+        dq_tcb::TcbStatus::UpToDate => TcbStatus::UpToDate,
+        dq_tcb::TcbStatus::OutOfDateConfigurationNeeded => TcbStatus::OutOfDateConfigurationNeeded,
+        dq_tcb::TcbStatus::OutOfDate => TcbStatus::OutOfDate,
+        dq_tcb::TcbStatus::ConfigurationAndSWHardeningNeeded => {
+            TcbStatus::ConfigurationAndSWHardeningNeeded
+        }
+        dq_tcb::TcbStatus::ConfigurationNeeded => TcbStatus::ConfigurationNeeded,
+        dq_tcb::TcbStatus::SWHardeningNeeded => TcbStatus::SWHardeningNeeded,
+        dq_tcb::TcbStatus::Revoked => TcbStatus::Revoked,
+    }
+}
+
+fn tcb_status_with_advisory(value: dq_tcb::TcbStatusWithAdvisory) -> TcbStatusWithAdvisory {
+    TcbStatusWithAdvisory {
+        status: tcb_status(value.status),
+        advisory_ids: value.advisory_ids,
+    }
+}

--- a/crates/tee-verifier/src/conversions.rs
+++ b/crates/tee-verifier/src/conversions.rs
@@ -1,15 +1,9 @@
 //! Conversions between `dcap_qvl`'s types and the Borsh-mirrored types in
-//! `tee-verifier-interface`.
+//! `tee-verifier-interface`. They live here, not in the interface crate, so
+//! that crate stays `no_std` and free of `dcap-qvl`.
 //!
-//! These conversions live here (in the contract crate that already
-//! depends on `dcap-qvl`) rather than in `tee-verifier-interface`, so
-//! that the interface crate stays free of `dcap-qvl` and can be linked
-//! into consumer contracts without dragging in `ring`/`webpki`/X.509
-//! parsing.
-//!
-//! Free functions are used rather than `From`/`Into` impls because the
-//! orphan rule forbids implementing a foreign trait between two foreign
-//! types from a third crate.
+//! Mapped with the local [`IntoDcapType`] / [`IntoInterfaceType`] traits. We
+//! can not use [`From`] and [`Into`] due to the [*orphan rule*](https://doc.rust-lang.org/reference/items/implementations.html#orphan-rules).
 
 use dcap_qvl::{quote as dq_quote, tcb_info as dq_tcb, verify as dq_verify};
 use tee_verifier_interface::{
@@ -17,106 +11,329 @@ use tee_verifier_interface::{
     TcbStatusWithAdvisory, VerifiedReport,
 };
 
-pub fn collateral_to_dcap(value: Collateral) -> dcap_qvl::QuoteCollateralV3 {
-    dcap_qvl::QuoteCollateralV3 {
-        pck_crl_issuer_chain: value.pck_crl_issuer_chain,
-        root_ca_crl: value.root_ca_crl,
-        pck_crl: value.pck_crl,
-        tcb_info_issuer_chain: value.tcb_info_issuer_chain,
-        tcb_info: value.tcb_info,
-        tcb_info_signature: value.tcb_info_signature,
-        qe_identity_issuer_chain: value.qe_identity_issuer_chain,
-        qe_identity: value.qe_identity,
-        qe_identity_signature: value.qe_identity_signature,
-        pck_certificate_chain: value.pck_certificate_chain,
-    }
+/// Converts an interface type into its `dcap_qvl` counterpart `T`.
+pub(crate) trait IntoDcapType<T> {
+    fn into_dcap_type(self) -> T;
 }
 
-pub fn quote_bytes_to_vec(value: QuoteBytes) -> Vec<u8> {
-    value.0
+/// Converts a `dcap_qvl` type into its `tee-verifier-interface` counterpart `T`.
+pub(crate) trait IntoInterfaceType<T> {
+    fn into_interface_type(self) -> T;
 }
 
-pub fn verified_report(value: dq_verify::VerifiedReport) -> VerifiedReport {
-    VerifiedReport {
-        status: value.status,
-        advisory_ids: value.advisory_ids,
-        report: report(value.report),
-        ppid: value.ppid,
-        qe_status: tcb_status_with_advisory(value.qe_status),
-        platform_status: tcb_status_with_advisory(value.platform_status),
-    }
-}
-
-fn report(value: dq_quote::Report) -> Report {
-    match value {
-        dq_quote::Report::SgxEnclave(r) => Report::SgxEnclave(enclave_report(r)),
-        dq_quote::Report::TD10(r) => Report::TD10(td_report_10(r)),
-        dq_quote::Report::TD15(r) => Report::TD15(td_report_15(r)),
-    }
-}
-
-fn td_report_10(value: dq_quote::TDReport10) -> TDReport10 {
-    TDReport10 {
-        tee_tcb_svn: value.tee_tcb_svn,
-        mr_seam: value.mr_seam,
-        mr_signer_seam: value.mr_signer_seam,
-        seam_attributes: value.seam_attributes,
-        td_attributes: value.td_attributes,
-        xfam: value.xfam,
-        mr_td: value.mr_td,
-        mr_config_id: value.mr_config_id,
-        mr_owner: value.mr_owner,
-        mr_owner_config: value.mr_owner_config,
-        rt_mr0: value.rt_mr0,
-        rt_mr1: value.rt_mr1,
-        rt_mr2: value.rt_mr2,
-        rt_mr3: value.rt_mr3,
-        report_data: value.report_data,
-    }
-}
-
-fn td_report_15(value: dq_quote::TDReport15) -> TDReport15 {
-    TDReport15 {
-        base: td_report_10(value.base),
-        tee_tcb_svn2: value.tee_tcb_svn2,
-        mr_service_td: value.mr_service_td,
-    }
-}
-
-fn enclave_report(value: dq_quote::EnclaveReport) -> EnclaveReport {
-    EnclaveReport {
-        cpu_svn: value.cpu_svn,
-        misc_select: value.misc_select,
-        reserved1: value.reserved1,
-        attributes: value.attributes,
-        mr_enclave: value.mr_enclave,
-        reserved2: value.reserved2,
-        mr_signer: value.mr_signer,
-        reserved3: value.reserved3,
-        isv_prod_id: value.isv_prod_id,
-        isv_svn: value.isv_svn,
-        reserved4: value.reserved4,
-        report_data: value.report_data,
-    }
-}
-
-fn tcb_status(value: dq_tcb::TcbStatus) -> TcbStatus {
-    match value {
-        dq_tcb::TcbStatus::UpToDate => TcbStatus::UpToDate,
-        dq_tcb::TcbStatus::OutOfDateConfigurationNeeded => TcbStatus::OutOfDateConfigurationNeeded,
-        dq_tcb::TcbStatus::OutOfDate => TcbStatus::OutOfDate,
-        dq_tcb::TcbStatus::ConfigurationAndSWHardeningNeeded => {
-            TcbStatus::ConfigurationAndSWHardeningNeeded
+impl IntoDcapType<dcap_qvl::QuoteCollateralV3> for Collateral {
+    fn into_dcap_type(self) -> dcap_qvl::QuoteCollateralV3 {
+        dcap_qvl::QuoteCollateralV3 {
+            pck_crl_issuer_chain: self.pck_crl_issuer_chain,
+            root_ca_crl: self.root_ca_crl,
+            pck_crl: self.pck_crl,
+            tcb_info_issuer_chain: self.tcb_info_issuer_chain,
+            tcb_info: self.tcb_info,
+            tcb_info_signature: self.tcb_info_signature,
+            qe_identity_issuer_chain: self.qe_identity_issuer_chain,
+            qe_identity: self.qe_identity,
+            qe_identity_signature: self.qe_identity_signature,
+            pck_certificate_chain: self.pck_certificate_chain,
         }
-        dq_tcb::TcbStatus::ConfigurationNeeded => TcbStatus::ConfigurationNeeded,
-        dq_tcb::TcbStatus::SWHardeningNeeded => TcbStatus::SWHardeningNeeded,
-        dq_tcb::TcbStatus::Revoked => TcbStatus::Revoked,
     }
 }
 
-fn tcb_status_with_advisory(value: dq_tcb::TcbStatusWithAdvisory) -> TcbStatusWithAdvisory {
-    TcbStatusWithAdvisory {
-        status: tcb_status(value.status),
-        advisory_ids: value.advisory_ids,
+impl IntoDcapType<Vec<u8>> for QuoteBytes {
+    fn into_dcap_type(self) -> Vec<u8> {
+        self.0
+    }
+}
+
+impl IntoInterfaceType<VerifiedReport> for dq_verify::VerifiedReport {
+    fn into_interface_type(self) -> VerifiedReport {
+        VerifiedReport {
+            status: self.status,
+            advisory_ids: self.advisory_ids,
+            report: self.report.into_interface_type(),
+            ppid: self.ppid,
+            qe_status: self.qe_status.into_interface_type(),
+            platform_status: self.platform_status.into_interface_type(),
+        }
+    }
+}
+
+impl IntoInterfaceType<Report> for dq_quote::Report {
+    fn into_interface_type(self) -> Report {
+        match self {
+            dq_quote::Report::SgxEnclave(r) => Report::SgxEnclave(r.into_interface_type()),
+            dq_quote::Report::TD10(r) => Report::TD10(r.into_interface_type()),
+            dq_quote::Report::TD15(r) => Report::TD15(r.into_interface_type()),
+        }
+    }
+}
+
+impl IntoInterfaceType<TDReport10> for dq_quote::TDReport10 {
+    fn into_interface_type(self) -> TDReport10 {
+        TDReport10 {
+            tee_tcb_svn: self.tee_tcb_svn,
+            mr_seam: self.mr_seam,
+            mr_signer_seam: self.mr_signer_seam,
+            seam_attributes: self.seam_attributes,
+            td_attributes: self.td_attributes,
+            xfam: self.xfam,
+            mr_td: self.mr_td,
+            mr_config_id: self.mr_config_id,
+            mr_owner: self.mr_owner,
+            mr_owner_config: self.mr_owner_config,
+            rt_mr0: self.rt_mr0,
+            rt_mr1: self.rt_mr1,
+            rt_mr2: self.rt_mr2,
+            rt_mr3: self.rt_mr3,
+            report_data: self.report_data,
+        }
+    }
+}
+
+impl IntoInterfaceType<TDReport15> for dq_quote::TDReport15 {
+    fn into_interface_type(self) -> TDReport15 {
+        TDReport15 {
+            base: self.base.into_interface_type(),
+            tee_tcb_svn2: self.tee_tcb_svn2,
+            mr_service_td: self.mr_service_td,
+        }
+    }
+}
+
+impl IntoInterfaceType<EnclaveReport> for dq_quote::EnclaveReport {
+    fn into_interface_type(self) -> EnclaveReport {
+        EnclaveReport {
+            cpu_svn: self.cpu_svn,
+            misc_select: self.misc_select,
+            reserved1: self.reserved1,
+            attributes: self.attributes,
+            mr_enclave: self.mr_enclave,
+            reserved2: self.reserved2,
+            mr_signer: self.mr_signer,
+            reserved3: self.reserved3,
+            isv_prod_id: self.isv_prod_id,
+            isv_svn: self.isv_svn,
+            reserved4: self.reserved4,
+            report_data: self.report_data,
+        }
+    }
+}
+
+impl IntoInterfaceType<TcbStatus> for dq_tcb::TcbStatus {
+    fn into_interface_type(self) -> TcbStatus {
+        match self {
+            dq_tcb::TcbStatus::UpToDate => TcbStatus::UpToDate,
+            dq_tcb::TcbStatus::OutOfDateConfigurationNeeded => {
+                TcbStatus::OutOfDateConfigurationNeeded
+            }
+            dq_tcb::TcbStatus::OutOfDate => TcbStatus::OutOfDate,
+            dq_tcb::TcbStatus::ConfigurationAndSWHardeningNeeded => {
+                TcbStatus::ConfigurationAndSWHardeningNeeded
+            }
+            dq_tcb::TcbStatus::ConfigurationNeeded => TcbStatus::ConfigurationNeeded,
+            dq_tcb::TcbStatus::SWHardeningNeeded => TcbStatus::SWHardeningNeeded,
+            dq_tcb::TcbStatus::Revoked => TcbStatus::Revoked,
+        }
+    }
+}
+
+impl IntoInterfaceType<TcbStatusWithAdvisory> for dq_tcb::TcbStatusWithAdvisory {
+    fn into_interface_type(self) -> TcbStatusWithAdvisory {
+        TcbStatusWithAdvisory {
+            status: self.status.into_interface_type(),
+            advisory_ids: self.advisory_ids,
+        }
+    }
+}
+
+/// Pins the Borsh wire layout of each `tee-verifier-interface` mirror type
+/// against its `dcap_qvl` counterpart.
+///
+/// The conversions above already make the compiler reject an upstream rename,
+/// removal, type change, or added variant; the drift they miss is a same-name
+/// *reordering* of fields or variants, which silently changes the Borsh layout.
+/// Each test builds both sides by the same field/variant names and asserts
+/// equal Borsh bytes, so a reorder diverges — even for fieldless enum variants.
+/// This relies on every field having a distinct fill value (`[1; _]`, `[2; _]`,
+/// ...): a swap of two same-typed fields is only observable when they differ.
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    /// Asserts the two values encode to identical Borsh bytes.
+    fn assert_same_borsh_bytes<I: borsh::BorshSerialize, D: borsh::BorshSerialize>(
+        interface: &I,
+        dcap: &D,
+    ) {
+        let interface_bytes = borsh::to_vec(interface).expect("interface should serialize");
+        let dcap_bytes = borsh::to_vec(dcap).expect("dcap should serialize");
+        assert_eq!(interface_bytes, dcap_bytes);
+    }
+
+    fn sample_collateral() -> Collateral {
+        Collateral {
+            pck_crl_issuer_chain: "issuer-chain".into(),
+            root_ca_crl: vec![1, 2, 3],
+            pck_crl: vec![4, 5, 6],
+            tcb_info_issuer_chain: "tcb-issuer".into(),
+            tcb_info: "tcb-info-json".into(),
+            tcb_info_signature: vec![7, 8],
+            qe_identity_issuer_chain: "qe-issuer".into(),
+            qe_identity: "qe-identity-json".into(),
+            qe_identity_signature: vec![9, 10],
+            pck_certificate_chain: Some("pck-chain".into()),
+        }
+    }
+
+    fn dcap_td10() -> dq_quote::TDReport10 {
+        dq_quote::TDReport10 {
+            tee_tcb_svn: [1; 16],
+            mr_seam: [2; 48],
+            mr_signer_seam: [3; 48],
+            seam_attributes: [4; 8],
+            td_attributes: [5; 8],
+            xfam: [6; 8],
+            mr_td: [7; 48],
+            mr_config_id: [8; 48],
+            mr_owner: [9; 48],
+            mr_owner_config: [10; 48],
+            rt_mr0: [11; 48],
+            rt_mr1: [12; 48],
+            rt_mr2: [13; 48],
+            rt_mr3: [14; 48],
+            report_data: [15; 64],
+        }
+    }
+
+    fn dcap_td15() -> dq_quote::TDReport15 {
+        dq_quote::TDReport15 {
+            base: dcap_td10(),
+            tee_tcb_svn2: [16; 16],
+            mr_service_td: [17; 48],
+        }
+    }
+
+    fn dcap_sgx() -> dq_quote::EnclaveReport {
+        dq_quote::EnclaveReport {
+            cpu_svn: [1; 16],
+            misc_select: 42,
+            reserved1: [2; 28],
+            attributes: [3; 16],
+            mr_enclave: [4; 32],
+            reserved2: [5; 32],
+            mr_signer: [6; 32],
+            reserved3: [7; 96],
+            isv_prod_id: 8,
+            isv_svn: 9,
+            reserved4: [10; 60],
+            report_data: [11; 64],
+        }
+    }
+
+    fn dcap_verified_report(report: dq_quote::Report) -> dq_verify::VerifiedReport {
+        dq_verify::VerifiedReport {
+            status: "UpToDate".into(),
+            advisory_ids: vec!["INTEL-SA-00001".into()],
+            report,
+            ppid: vec![0xAB; 16],
+            qe_status: dq_tcb::TcbStatusWithAdvisory {
+                status: dq_tcb::TcbStatus::UpToDate,
+                advisory_ids: vec![],
+            },
+            platform_status: dq_tcb::TcbStatusWithAdvisory {
+                status: dq_tcb::TcbStatus::ConfigurationNeeded,
+                advisory_ids: vec!["INTEL-SA-00002".into()],
+            },
+        }
+    }
+
+    /// Name-equal `dcap_qvl` counterpart of an interface [`TcbStatus`]. The
+    /// exhaustive `match` makes the compiler flag an upstream variant
+    /// rename/removal; the byte comparison in the test catches a reorder.
+    fn dcap_tcb_status(status: &TcbStatus) -> dq_tcb::TcbStatus {
+        match status {
+            TcbStatus::UpToDate => dq_tcb::TcbStatus::UpToDate,
+            TcbStatus::OutOfDateConfigurationNeeded => {
+                dq_tcb::TcbStatus::OutOfDateConfigurationNeeded
+            }
+            TcbStatus::OutOfDate => dq_tcb::TcbStatus::OutOfDate,
+            TcbStatus::ConfigurationAndSWHardeningNeeded => {
+                dq_tcb::TcbStatus::ConfigurationAndSWHardeningNeeded
+            }
+            TcbStatus::ConfigurationNeeded => dq_tcb::TcbStatus::ConfigurationNeeded,
+            TcbStatus::SWHardeningNeeded => dq_tcb::TcbStatus::SWHardeningNeeded,
+            TcbStatus::Revoked => dq_tcb::TcbStatus::Revoked,
+        }
+    }
+
+    #[test]
+    fn collateral__should_match_dcap_borsh_layout() {
+        let interface = sample_collateral();
+        let dcap = interface.clone().into_dcap_type();
+        assert_same_borsh_bytes(&interface, &dcap);
+    }
+
+    #[test]
+    fn td_report_10__should_match_dcap_borsh_layout() {
+        let dcap = dcap_td10();
+        let interface: TDReport10 = dcap.into_interface_type();
+        assert_same_borsh_bytes(&interface, &dcap);
+    }
+
+    #[test]
+    fn td_report_15__should_match_dcap_borsh_layout() {
+        let dcap = dcap_td15();
+        let interface: TDReport15 = dcap.into_interface_type();
+        assert_same_borsh_bytes(&interface, &dcap);
+    }
+
+    #[test]
+    fn enclave_report__should_match_dcap_borsh_layout() {
+        let dcap = dcap_sgx();
+        let interface: EnclaveReport = dcap.into_interface_type();
+        assert_same_borsh_bytes(&interface, &dcap);
+    }
+
+    #[rstest]
+    #[case::sgx(dq_quote::Report::SgxEnclave(dcap_sgx()))]
+    #[case::td10(dq_quote::Report::TD10(dcap_td10()))]
+    #[case::td15(dq_quote::Report::TD15(dcap_td15()))]
+    fn report__should_match_dcap_borsh_layout(#[case] dcap: dq_quote::Report) {
+        let interface: Report = dcap.clone().into_interface_type();
+        assert_same_borsh_bytes(&interface, &dcap);
+    }
+
+    #[rstest]
+    #[case(TcbStatus::UpToDate)]
+    #[case(TcbStatus::OutOfDateConfigurationNeeded)]
+    #[case(TcbStatus::OutOfDate)]
+    #[case(TcbStatus::ConfigurationAndSWHardeningNeeded)]
+    #[case(TcbStatus::ConfigurationNeeded)]
+    #[case(TcbStatus::SWHardeningNeeded)]
+    #[case(TcbStatus::Revoked)]
+    fn tcb_status__should_match_dcap_borsh_layout(#[case] status: TcbStatus) {
+        let dcap = dcap_tcb_status(&status);
+        assert_same_borsh_bytes(&status, &dcap);
+    }
+
+    #[test]
+    fn tcb_status_with_advisory__should_match_dcap_borsh_layout() {
+        let dcap = dq_tcb::TcbStatusWithAdvisory {
+            status: dq_tcb::TcbStatus::ConfigurationNeeded,
+            advisory_ids: vec!["INTEL-SA-00003".into()],
+        };
+        let interface: TcbStatusWithAdvisory = dcap.clone().into_interface_type();
+        assert_same_borsh_bytes(&interface, &dcap);
+    }
+
+    #[rstest]
+    #[case::sgx(dq_quote::Report::SgxEnclave(dcap_sgx()))]
+    #[case::td10(dq_quote::Report::TD10(dcap_td10()))]
+    #[case::td15(dq_quote::Report::TD15(dcap_td15()))]
+    fn verified_report__should_match_dcap_borsh_layout(#[case] report: dq_quote::Report) {
+        let dcap = dcap_verified_report(report);
+        let interface: VerifiedReport = dcap.clone().into_interface_type();
+        assert_same_borsh_bytes(&interface, &dcap);
     }
 }

--- a/crates/tee-verifier/src/lib.rs
+++ b/crates/tee-verifier/src/lib.rs
@@ -1,0 +1,59 @@
+//! Stateless TEE attestation verifier contract.
+//!
+//! Wraps `dcap_qvl::verify::verify` in a single `verify_quote` method. The
+//! contract holds no state and has no admin; verifier-internal policy (the
+//! `dcap-qvl` version, Intel root certs, etc.) is bound to the deployed
+//! code hash. Per-team allowlists, report-data binding, and other
+//! post-DCAP checks live in the caller, not here.
+//!
+//! See `docs/design/attestation-verifier-contract.md` for the design.
+
+use near_sdk::{env, near};
+use tee_verifier_interface::{Collateral, QuoteBytes, VerifiedReport};
+
+mod conversions;
+
+// `dcap-qvl`'s `contract` feature pulls in `getrandom` but doesn't enable
+// any backend. On `wasm32-unknown-unknown` we register a custom impl that
+// returns `UNSUPPORTED`. Quote verification should not draw any randomness;
+// if it ever does, the call fails loudly rather than silently with zeros.
+#[cfg(target_arch = "wasm32")]
+fn randomness_unsupported(_buf: &mut [u8]) -> Result<(), getrandom::Error> {
+    Err(getrandom::Error::UNSUPPORTED)
+}
+#[cfg(target_arch = "wasm32")]
+getrandom::register_custom_getrandom!(randomness_unsupported);
+
+#[derive(Debug, Default)]
+#[near(contract_state)]
+pub struct TeeVerifier {}
+
+#[near]
+impl TeeVerifier {
+    /// Verify a TDX / SGX quote against Intel collateral.
+    ///
+    /// Calls `dcap_qvl::verify::verify` with the current block timestamp
+    /// and returns the parsed `VerifiedReport` on success. The caller is
+    /// responsible for any post-DCAP policy (RTMR3 replay, report-data
+    /// binding, measurement allowlist matching, etc.).
+    ///
+    /// On verification failure, panics with the upstream error rendered as
+    /// a string. Callers should treat this as a `PromiseResult::Failed` in
+    /// their callback.
+    ///
+    /// Borsh I/O on both arguments and return value.
+    #[result_serializer(borsh)]
+    pub fn verify_quote(
+        &self,
+        #[serializer(borsh)] quote: QuoteBytes,
+        #[serializer(borsh)] collateral: Collateral,
+    ) -> VerifiedReport {
+        let now_seconds = env::block_timestamp_ms() / 1000;
+        let quote_bytes = conversions::quote_bytes_to_vec(quote);
+        let collateral = conversions::collateral_to_dcap(collateral);
+        match dcap_qvl::verify::verify(&quote_bytes, &collateral, now_seconds) {
+            Ok(report) => conversions::verified_report(report),
+            Err(err) => env::panic_str(&format!("dcap verification failed: {err:?}")),
+        }
+    }
+}

--- a/crates/tee-verifier/src/lib.rs
+++ b/crates/tee-verifier/src/lib.rs
@@ -58,7 +58,7 @@ impl TeeVerifier {
         match dcap_qvl::verify::verify(&quote_bytes, &collateral, now_seconds) {
             Ok(report) => VerificationResult::Verified(report.into_interface_type()),
             Err(err) => {
-                VerificationResult::Rejected(VerifierError::DcapVerification(format!("{err}")))
+                VerificationResult::Rejected(VerifierError::DcapVerification(err.to_string()))
             }
         }
     }

--- a/crates/tee-verifier/src/lib.rs
+++ b/crates/tee-verifier/src/lib.rs
@@ -12,9 +12,10 @@ use near_sdk::{FunctionError, env, near};
 use tee_verifier_interface::{Collateral, QuoteBytes, VerifiedReport};
 
 mod conversions;
+use conversions::{IntoDcapType as _, IntoInterfaceType as _};
 
 /// Failure returned by [`TeeVerifier::verify_quote`].
-#[derive(Debug, Clone, thiserror::Error)]
+#[derive(Debug, thiserror::Error)]
 pub enum VerifierError {
     /// `dcap_qvl::verify::verify` rejected the quote / collateral.
     #[error("dcap verification failed: {0}")]
@@ -58,10 +59,10 @@ impl TeeVerifier {
         #[serializer(borsh)] collateral: Collateral,
     ) -> Result<VerifiedReport, VerifierError> {
         let now_seconds = env::block_timestamp_ms() / 1000;
-        let quote_bytes = conversions::quote_bytes_to_vec(quote);
-        let collateral = conversions::collateral_to_dcap(collateral);
+        let quote_bytes: Vec<u8> = quote.into_dcap_type();
+        let collateral = collateral.into_dcap_type();
         dcap_qvl::verify::verify(&quote_bytes, &collateral, now_seconds)
-            .map(conversions::verified_report)
-            .map_err(|err| VerifierError::DcapVerification(format!("{err:?}")))
+            .map(|report| report.into_interface_type())
+            .map_err(|err| VerifierError::DcapVerification(format!("{err}")))
     }
 }

--- a/crates/tee-verifier/src/lib.rs
+++ b/crates/tee-verifier/src/lib.rs
@@ -8,25 +8,11 @@
 //!
 //! See `docs/design/attestation-verifier-contract.md` for the design.
 
-use near_sdk::{FunctionError, env, near};
-use tee_verifier_interface::{Collateral, QuoteBytes, VerifiedReport};
+use near_sdk::{env, near};
+use tee_verifier_interface::{Collateral, QuoteBytes, VerificationResult, VerifierError};
 
 mod conversions;
 use conversions::{IntoDcapType as _, IntoInterfaceType as _};
-
-/// Failure returned by [`TeeVerifier::verify_quote`].
-#[derive(Debug, thiserror::Error)]
-pub enum VerifierError {
-    /// `dcap_qvl::verify::verify` rejected the quote / collateral.
-    #[error("dcap verification failed: {0}")]
-    DcapVerification(String),
-}
-
-impl FunctionError for VerifierError {
-    fn panic(&self) -> ! {
-        env::panic_str(&self.to_string())
-    }
-}
 
 // `dcap-qvl`'s `contract` feature pulls in `getrandom` but doesn't enable
 // any backend. On `wasm32-unknown-unknown` we register a custom impl that
@@ -48,21 +34,32 @@ impl TeeVerifier {
     /// Verify a TDX quote against Intel collateral.
     ///
     /// Calls `dcap_qvl::verify::verify` with the current block timestamp
-    /// and returns the parsed `VerifiedReport` on success. The caller is
-    /// responsible for any post-DCAP policy (RTMR3 replay, report-data
-    /// binding, measurement allowlist matching, etc.).
-    #[handle_result]
+    /// and returns `VerificationResult::Verified(report)` on success. The
+    /// caller is responsible for any post-DCAP policy (RTMR3 replay,
+    /// report-data binding, measurement allowlist matching, etc.).
+    ///
+    /// A rejected quote returns [`VerificationResult::Rejected`] as the
+    /// **value** of a *successful* receipt — deliberately not via
+    /// `#[handle_result]`. near-sdk serializes the returned enum through
+    /// `env::value_return`, so an on-chain caller's `#[callback_result]` sees
+    /// `Ok(VerificationResult::Rejected(_))` and can distinguish "verifier
+    /// rejected this quote" from `Err(PromiseError::Failed)` ("verifier
+    /// unreachable / crashed / timed out"). A failed receipt would carry no
+    /// payload and collapse both into the same opaque failure.
     #[result_serializer(borsh)]
     pub fn verify_quote(
         &self,
         #[serializer(borsh)] quote: QuoteBytes,
         #[serializer(borsh)] collateral: Collateral,
-    ) -> Result<VerifiedReport, VerifierError> {
+    ) -> VerificationResult {
         let now_seconds = env::block_timestamp_ms() / 1000;
         let quote_bytes: Vec<u8> = quote.into_dcap_type();
         let collateral = collateral.into_dcap_type();
-        dcap_qvl::verify::verify(&quote_bytes, &collateral, now_seconds)
-            .map(|report| report.into_interface_type())
-            .map_err(|err| VerifierError::DcapVerification(format!("{err}")))
+        match dcap_qvl::verify::verify(&quote_bytes, &collateral, now_seconds) {
+            Ok(report) => VerificationResult::Verified(report.into_interface_type()),
+            Err(err) => {
+                VerificationResult::Rejected(VerifierError::DcapVerification(format!("{err}")))
+            }
+        }
     }
 }

--- a/crates/tee-verifier/src/lib.rs
+++ b/crates/tee-verifier/src/lib.rs
@@ -8,10 +8,24 @@
 //!
 //! See `docs/design/attestation-verifier-contract.md` for the design.
 
-use near_sdk::{env, near};
+use near_sdk::{FunctionError, env, near};
 use tee_verifier_interface::{Collateral, QuoteBytes, VerifiedReport};
 
 mod conversions;
+
+/// Failure returned by [`TeeVerifier::verify_quote`].
+#[derive(Debug, Clone, thiserror::Error)]
+pub enum VerifierError {
+    /// `dcap_qvl::verify::verify` rejected the quote / collateral.
+    #[error("dcap verification failed: {0}")]
+    DcapVerification(String),
+}
+
+impl FunctionError for VerifierError {
+    fn panic(&self) -> ! {
+        env::panic_str(&self.to_string())
+    }
+}
 
 // `dcap-qvl`'s `contract` feature pulls in `getrandom` but doesn't enable
 // any backend. On `wasm32-unknown-unknown` we register a custom impl that
@@ -30,30 +44,24 @@ pub struct TeeVerifier {}
 
 #[near]
 impl TeeVerifier {
-    /// Verify a TDX / SGX quote against Intel collateral.
+    /// Verify a TDX quote against Intel collateral.
     ///
     /// Calls `dcap_qvl::verify::verify` with the current block timestamp
     /// and returns the parsed `VerifiedReport` on success. The caller is
     /// responsible for any post-DCAP policy (RTMR3 replay, report-data
     /// binding, measurement allowlist matching, etc.).
-    ///
-    /// On verification failure, panics with the upstream error rendered as
-    /// a string. Callers should treat this as a `PromiseResult::Failed` in
-    /// their callback.
-    ///
-    /// Borsh I/O on both arguments and return value.
+    #[handle_result]
     #[result_serializer(borsh)]
     pub fn verify_quote(
         &self,
         #[serializer(borsh)] quote: QuoteBytes,
         #[serializer(borsh)] collateral: Collateral,
-    ) -> VerifiedReport {
+    ) -> Result<VerifiedReport, VerifierError> {
         let now_seconds = env::block_timestamp_ms() / 1000;
         let quote_bytes = conversions::quote_bytes_to_vec(quote);
         let collateral = conversions::collateral_to_dcap(collateral);
-        match dcap_qvl::verify::verify(&quote_bytes, &collateral, now_seconds) {
-            Ok(report) => conversions::verified_report(report),
-            Err(err) => env::panic_str(&format!("dcap verification failed: {err:?}")),
-        }
+        dcap_qvl::verify::verify(&quote_bytes, &collateral, now_seconds)
+            .map(conversions::verified_report)
+            .map_err(|err| VerifierError::DcapVerification(format!("{err:?}")))
     }
 }

--- a/crates/tee-verifier/tests/verify_quote.rs
+++ b/crates/tee-verifier/tests/verify_quote.rs
@@ -1,0 +1,73 @@
+//! Integration test for the stateless `tee-verifier` contract.
+//!
+//! Calls `TeeVerifier::verify_quote` directly (no Promise round-trip)
+//! with a real Dstack quote+collateral fixture taken from `test-utils`,
+//! and asserts that the returned `VerifiedReport` carries the
+//! `UpToDate` TCB status and a TD10 report.
+
+#![allow(non_snake_case)]
+
+use near_sdk::test_utils::VMContextBuilder;
+use near_sdk::testing_env;
+use std::time::Duration;
+use tee_verifier::TeeVerifier;
+use tee_verifier_interface::{Collateral, QuoteBytes};
+use test_utils::attestation::{VALID_ATTESTATION_TIMESTAMP, collateral as collateral_json, quote};
+
+fn make_collateral() -> Collateral {
+    // `test_utils::attestation::collateral()` returns a `serde_json::Value`
+    // matching `attestation::Collateral`'s JSON shape. We re-parse it
+    // into the interface crate's mirror type by extracting the same
+    // field names that `dcap_qvl::QuoteCollateralV3` uses.
+    let v = collateral_json();
+    Collateral {
+        pck_crl_issuer_chain: v["pck_crl_issuer_chain"].as_str().unwrap().to_string(),
+        root_ca_crl: hex::decode(v["root_ca_crl"].as_str().unwrap()).unwrap(),
+        pck_crl: hex::decode(v["pck_crl"].as_str().unwrap()).unwrap(),
+        tcb_info_issuer_chain: v["tcb_info_issuer_chain"].as_str().unwrap().to_string(),
+        tcb_info: v["tcb_info"].as_str().unwrap().to_string(),
+        tcb_info_signature: hex::decode(v["tcb_info_signature"].as_str().unwrap()).unwrap(),
+        qe_identity_issuer_chain: v["qe_identity_issuer_chain"].as_str().unwrap().to_string(),
+        qe_identity: v["qe_identity"].as_str().unwrap().to_string(),
+        qe_identity_signature: hex::decode(v["qe_identity_signature"].as_str().unwrap()).unwrap(),
+        pck_certificate_chain: v
+            .get("pck_certificate_chain")
+            .and_then(|s| s.as_str())
+            .map(str::to_string),
+    }
+}
+
+fn make_quote_bytes() -> QuoteBytes {
+    QuoteBytes(Vec::from(quote()))
+}
+
+#[test]
+fn verify_quote__should_return_up_to_date_td10_report_for_valid_fixture() {
+    // Given
+    let block_timestamp_ns = Duration::from_secs(VALID_ATTESTATION_TIMESTAMP).as_nanos() as u64;
+    testing_env!(
+        VMContextBuilder::new()
+            .block_timestamp(block_timestamp_ns)
+            .build()
+    );
+    let contract = TeeVerifier::default();
+    let quote = make_quote_bytes();
+    let collateral = make_collateral();
+
+    // When
+    let report = contract.verify_quote(quote, collateral);
+
+    // Then
+    assert_eq!(report.status, "UpToDate");
+    assert!(report.advisory_ids.is_empty());
+    let td10 = report
+        .report
+        .as_td10()
+        .expect("fixture is a TD10 attestation");
+    // The fixture's report_data is 64 bytes; we only check shape, not exact contents,
+    // because that's bound to the keys baked into the fixture.
+    assert_eq!(td10.report_data.len(), 64);
+    assert_eq!(td10.mr_td.len(), 48);
+    assert_eq!(td10.rt_mr0.len(), 48);
+    assert_eq!(td10.rt_mr3.len(), 48);
+}

--- a/crates/tee-verifier/tests/verify_quote.rs
+++ b/crates/tee-verifier/tests/verify_quote.rs
@@ -55,7 +55,9 @@ fn verify_quote__should_return_up_to_date_td10_report_for_valid_fixture() {
     let collateral = make_collateral();
 
     // When
-    let report = contract.verify_quote(quote, collateral);
+    let report = contract
+        .verify_quote(quote, collateral)
+        .expect("valid fixture should verify");
 
     // Then
     assert_eq!(report.status, "UpToDate");

--- a/crates/tee-verifier/tests/verify_quote.rs
+++ b/crates/tee-verifier/tests/verify_quote.rs
@@ -2,8 +2,12 @@
 //!
 //! Calls `TeeVerifier::verify_quote` directly (no Promise round-trip)
 //! with a real Dstack quote+collateral fixture taken from `test-utils`,
-//! and asserts the returned `VerifiedReport` matches the fixture's known
-//! value in full.
+//! and asserts the returned [`VerificationResult`]:
+//!
+//! - a valid quote yields [`VerificationResult::Verified`] carrying the
+//!   parsed report;
+//! - an invalid quote yields [`VerificationResult::Rejected`], returned as
+//!   the value of a successful call rather than a panic.
 
 #![allow(non_snake_case)]
 
@@ -11,7 +15,8 @@ use near_sdk::{test_utils::VMContextBuilder, testing_env};
 use std::time::Duration;
 use tee_verifier::TeeVerifier;
 use tee_verifier_interface::{
-    Collateral, QuoteBytes, Report, TDReport10, TcbStatus, TcbStatusWithAdvisory, VerifiedReport,
+    Collateral, QuoteBytes, Report, TDReport10, TcbStatus, TcbStatusWithAdvisory,
+    VerificationResult, VerifiedReport, VerifierError,
 };
 use test_utils::attestation::{VALID_ATTESTATION_TIMESTAMP, collateral as collateral_json, quote};
 
@@ -42,26 +47,30 @@ fn make_quote_bytes() -> QuoteBytes {
     QuoteBytes(Vec::from(quote()))
 }
 
-#[test]
-fn verify_quote__should_return_up_to_date_td10_report_for_valid_fixture() {
-    // Given
+/// Sets a VM context whose block timestamp makes the fixture's collateral
+/// current, so DCAP verification of the valid fixture succeeds.
+fn set_valid_timestamp_context() {
     let block_timestamp_ns = Duration::from_secs(VALID_ATTESTATION_TIMESTAMP).as_nanos() as u64;
     testing_env!(
         VMContextBuilder::new()
             .block_timestamp(block_timestamp_ns)
             .build()
     );
+}
+
+#[test]
+fn verify_quote__should_return_verified_td10_report_for_valid_fixture() {
+    // Given
+    set_valid_timestamp_context();
     let contract = TeeVerifier::default();
     let quote = make_quote_bytes();
     let collateral = make_collateral();
 
     // When
-    let report = contract
-        .verify_quote(quote, collateral)
-        .expect("valid fixture should verify");
+    let result = contract.verify_quote(quote, collateral);
 
     // Then
-    let expected = VerifiedReport {
+    let expected_report = VerifiedReport {
         status: "UpToDate".to_string(),
         advisory_ids: vec![],
         report: Report::TD10(TDReport10 {
@@ -113,7 +122,51 @@ fn verify_quote__should_return_up_to_date_td10_report_for_valid_fixture() {
             advisory_ids: vec![],
         },
     };
-    assert_eq!(report, expected);
+    assert_eq!(result, VerificationResult::Verified(expected_report));
+}
+
+#[test]
+fn verify_quote__should_reject_without_panicking_for_invalid_quote() {
+    // Given: a structurally broken quote against otherwise-valid collateral.
+    set_valid_timestamp_context();
+    let contract = TeeVerifier::default();
+    let invalid_quote = QuoteBytes(vec![0u8; 16]);
+    let collateral = make_collateral();
+
+    // When
+    let result = contract.verify_quote(invalid_quote, collateral);
+
+    // Then: a Rejected value, not a panic, and it carries a reason.
+    assert!(
+        matches!(
+            result,
+            VerificationResult::Rejected(VerifierError::DcapVerification(_))
+        ),
+        "expected Rejected(DcapVerification(_)), got {result:?}"
+    );
+}
+
+#[test]
+fn verify_quote__should_reject_valid_quote_with_mismatched_collateral() {
+    // Given: the real fixture quote, but collateral whose signed material has
+    // been corrupted so the DCAP signature chain no longer matches.
+    set_valid_timestamp_context();
+    let contract = TeeVerifier::default();
+    let quote = make_quote_bytes();
+    let mut collateral = make_collateral();
+    collateral.tcb_info = String::from("{}");
+
+    // When
+    let result = contract.verify_quote(quote, collateral);
+
+    // Then
+    assert!(
+        matches!(
+            result,
+            VerificationResult::Rejected(VerifierError::DcapVerification(_))
+        ),
+        "expected Rejected(DcapVerification(_)), got {result:?}"
+    );
 }
 
 fn hex_arr<const N: usize>(s: &str) -> [u8; N] {

--- a/crates/tee-verifier/tests/verify_quote.rs
+++ b/crates/tee-verifier/tests/verify_quote.rs
@@ -50,7 +50,9 @@ fn make_quote_bytes() -> QuoteBytes {
 /// Sets a VM context whose block timestamp makes the fixture's collateral
 /// current, so DCAP verification of the valid fixture succeeds.
 fn set_valid_timestamp_context() {
-    let block_timestamp_ns = Duration::from_secs(VALID_ATTESTATION_TIMESTAMP).as_nanos() as u64;
+    let block_timestamp_ns =
+        u64::try_from(Duration::from_secs(VALID_ATTESTATION_TIMESTAMP).as_nanos())
+            .expect("fixture timestamp in nanoseconds fits in u64");
     testing_env!(
         VMContextBuilder::new()
             .block_timestamp(block_timestamp_ns)

--- a/crates/tee-verifier/tests/verify_quote.rs
+++ b/crates/tee-verifier/tests/verify_quote.rs
@@ -2,16 +2,17 @@
 //!
 //! Calls `TeeVerifier::verify_quote` directly (no Promise round-trip)
 //! with a real Dstack quote+collateral fixture taken from `test-utils`,
-//! and asserts that the returned `VerifiedReport` carries the
-//! `UpToDate` TCB status and a TD10 report.
+//! and asserts the returned `VerifiedReport` matches the fixture's known
+//! value in full.
 
 #![allow(non_snake_case)]
 
-use near_sdk::test_utils::VMContextBuilder;
-use near_sdk::testing_env;
+use near_sdk::{test_utils::VMContextBuilder, testing_env};
 use std::time::Duration;
 use tee_verifier::TeeVerifier;
-use tee_verifier_interface::{Collateral, QuoteBytes};
+use tee_verifier_interface::{
+    Collateral, QuoteBytes, Report, TDReport10, TcbStatus, TcbStatusWithAdvisory, VerifiedReport,
+};
 use test_utils::attestation::{VALID_ATTESTATION_TIMESTAMP, collateral as collateral_json, quote};
 
 fn make_collateral() -> Collateral {
@@ -60,16 +61,64 @@ fn verify_quote__should_return_up_to_date_td10_report_for_valid_fixture() {
         .expect("valid fixture should verify");
 
     // Then
-    assert_eq!(report.status, "UpToDate");
-    assert!(report.advisory_ids.is_empty());
-    let td10 = report
-        .report
-        .as_td10()
-        .expect("fixture is a TD10 attestation");
-    // The fixture's report_data is 64 bytes; we only check shape, not exact contents,
-    // because that's bound to the keys baked into the fixture.
-    assert_eq!(td10.report_data.len(), 64);
-    assert_eq!(td10.mr_td.len(), 48);
-    assert_eq!(td10.rt_mr0.len(), 48);
-    assert_eq!(td10.rt_mr3.len(), 48);
+    let expected = VerifiedReport {
+        status: "UpToDate".to_string(),
+        advisory_ids: vec![],
+        report: Report::TD10(TDReport10 {
+            tee_tcb_svn: hex_arr("0b010400000000000000000000000000"),
+            mr_seam: hex_arr(
+                "7bf063280e94fb051f5dd7b1fc59ce9aac42bb961df8d44b709c9b0ff87a7b4df648657ba6d1189589feab1d5a3c9a9d",
+            ),
+            mr_signer_seam: hex_arr(
+                "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            ),
+            seam_attributes: hex_arr("0000000000000000"),
+            td_attributes: hex_arr("0000001000000000"),
+            xfam: hex_arr("e702060000000000"),
+            mr_td: hex_arr(
+                "f06dfda6dce1cf904d4e2bab1dc370634cf95cefa2ceb2de2eee127c9382698090d7a4a13e14c536ec6c9c3c8fa87077",
+            ),
+            mr_config_id: hex_arr(
+                "01cb9b2d6204f5e44238b75f69e3a3069550734c0d99ebdd3be507c238a261d8fa000000000000000000000000000000",
+            ),
+            mr_owner: hex_arr(
+                "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            ),
+            mr_owner_config: hex_arr(
+                "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+            ),
+            rt_mr0: hex_arr(
+                "e673be2f70beefb70b48a6109eed4715d7270d4683b3bf356fa25fafbf1aa76e39e9127e6e688ccda98bdab1d4d47f46",
+            ),
+            rt_mr1: hex_arr(
+                "b598fde9491427341bc4683b75d10d3e36770af3a36a6954d8b6b7b22aa66358f13e1f172e51b7d6e6710d99a8d8532f",
+            ),
+            rt_mr2: hex_arr(
+                "c812d42bfff1c75382e91a37c867ab117b97eb5e8d6797488928ea38e5fd38b5ed2f87d9613d392507f1c3af94657c93",
+            ),
+            rt_mr3: hex_arr(
+                "b7662ac19c27af648a939be042684bbdb43bb3dddf4cd17bb21f4d455ab1926c6ee57038152fc46ddea392c47eb2af27",
+            ),
+            report_data: hex_arr(
+                "00014ee5e70e861db29a95224e48a47c016ab03c61238333319af7614593cd155ba531073edd69921742beb1c510ff4339480000000000000000000000000000",
+            ),
+        }),
+        ppid: hex::decode("d208dfb1002346ae1bb4ef2a3c055292").unwrap(),
+        qe_status: TcbStatusWithAdvisory {
+            status: TcbStatus::UpToDate,
+            advisory_ids: vec![],
+        },
+        platform_status: TcbStatusWithAdvisory {
+            status: TcbStatus::UpToDate,
+            advisory_ids: vec![],
+        },
+    };
+    assert_eq!(report, expected);
+}
+
+fn hex_arr<const N: usize>(s: &str) -> [u8; N] {
+    hex::decode(s)
+        .expect("valid hex")
+        .try_into()
+        .expect("correct length")
 }

--- a/crates/tee-verifier/tests/verify_quote.rs
+++ b/crates/tee-verifier/tests/verify_quote.rs
@@ -9,7 +9,7 @@
 //! - an invalid quote yields [`VerificationResult::Rejected`], returned as
 //!   the value of a successful call rather than a panic.
 
-#![allow(non_snake_case)]
+#![expect(non_snake_case)]
 
 use near_sdk::{test_utils::VMContextBuilder, testing_env};
 use std::time::Duration;


### PR DESCRIPTION
Closes #3266

## Overview

Adds `tee-verifier`: a stateless TEE attestation verifier contract.

It wraps `dcap_qvl::verify::verify` in a single `verify_quote` method. The contract holds no state and has no admin — verifier-internal policy (the `dcap-qvl` version, Intel root certs, etc.) is bound to the deployed code hash. Per-team allowlists, report-data binding, and other post-DCAP checks live in the caller, not here.

This moves the heavy `dcap-qvl` / `ring` / `webpki` / `x509-cert` closure out of any contract that needs quote verification and into this one contract, reached over a cross-contract call using the DTOs from #3235.

Builds on #3235 (PR #3235); part of the stack tracked by #3264. See `docs/design/attestation-verifier-contract.md` for the design.
