### PR TITLE
feat(mpc-contract): drop dcap-qvl from WASM via Promise+callback verifier integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -980,7 +980,7 @@ name = "attestation-cli"
 version = "3.9.0"
 dependencies = [
  "anyhow",
- "attestation",
+ "attestation-types",
  "bs58 0.5.1",
  "clap",
  "mpc-attestation",
@@ -11355,7 +11355,6 @@ version = "3.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",
- "attestation",
  "backon",
  "dcap-qvl",
  "derive_more 2.1.1",
@@ -11368,7 +11367,6 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
- "tee-verifier-interface",
  "test-utils",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5678,6 +5678,7 @@ version = "3.9.0"
 dependencies = [
  "assert_matches",
  "attestation",
+ "attestation-types",
  "borsh",
  "dcap-qvl",
  "derive_more 2.1.1",
@@ -5689,6 +5690,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sha3 0.10.8",
+ "tee-verifier-interface",
  "test-utils",
 ]
 
@@ -5698,6 +5700,7 @@ version = "3.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "attestation-types",
  "blstrs",
  "borsh",
  "cargo-near-build",
@@ -5732,6 +5735,7 @@ dependencies = [
  "serde_with",
  "sha2 0.10.9",
  "signature",
+ "tee-verifier-interface",
  "test-utils",
  "thiserror 2.0.18",
  "threshold-signatures",
@@ -11351,6 +11355,7 @@ version = "3.9.0"
 dependencies = [
  "anyhow",
  "assert_matches",
+ "attestation",
  "backon",
  "dcap-qvl",
  "derive_more 2.1.1",
@@ -11363,6 +11368,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "tee-verifier-interface",
  "test-utils",
  "thiserror 2.0.18",
  "time",

--- a/crates/attestation-cli/Cargo.toml
+++ b/crates/attestation-cli/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = { workspace = true }
-attestation = { workspace = true }
+attestation-types = { workspace = true }
 bs58 = { workspace = true }
 clap = { workspace = true }
 mpc-attestation = { workspace = true, features = ["local-verify"] }

--- a/crates/attestation-cli/Cargo.toml
+++ b/crates/attestation-cli/Cargo.toml
@@ -13,7 +13,7 @@ anyhow = { workspace = true }
 attestation = { workspace = true }
 bs58 = { workspace = true }
 clap = { workspace = true }
-mpc-attestation = { workspace = true }
+mpc-attestation = { workspace = true, features = ["local-verify"] }
 mpc-primitives = { workspace = true }
 node-types = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/attestation-cli/src/output.rs
+++ b/crates/attestation-cli/src/output.rs
@@ -1,4 +1,4 @@
-use attestation::attestation::VerificationError;
+use attestation_types::verify_post_dcap::VerificationError;
 use node_types::http_server::StaticWebData;
 use time::OffsetDateTime;
 

--- a/crates/attestation-cli/src/verify.rs
+++ b/crates/attestation-cli/src/verify.rs
@@ -1,15 +1,12 @@
 use std::path::Path;
 
 use anyhow::Context;
-use attestation::attestation::DstackVerify as _;
 use attestation_types::{
     measurements::{ExpectedMeasurements, Measurements},
     tcb_info::TcbInfo,
     verify_post_dcap::VerificationError,
 };
-use mpc_attestation::attestation::{
-    Attestation, ValidatedDstackAttestation, VerifiedAttestation,
-};
+use mpc_attestation::attestation::{ValidatedDstackAttestation, VerifiedAttestation};
 use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
 use node_types::http_server::StaticWebData;
 use sha2::{Digest, Sha256};
@@ -68,32 +65,17 @@ pub fn verify_at_timestamp(
         VerificationError::Custom(format!("failed to load expected measurements: {e}"))
     })?;
 
-    // Two-step verification: dcap-qvl crypto check first, then the
-    // post-DCAP checks against the resulting `VerifiedReport`.
-    // Mirrors the split that the on-chain `mpc-contract` uses now
-    // (cross-contract Promise → `on_attestation_verified` callback).
-    let verified_report = match attestation {
-        Attestation::Dstack(dstack) => {
-            let _matched = dstack.verify(
-                report_data.clone().into(),
-                timestamp_seconds,
-                &measurements,
-            )?;
-            local_dcap_to_mirror(dstack, timestamp_seconds)?
-        }
-        Attestation::Mock(_) => {
-            // `finish_verify` ignores the report for `Mock`.
-            zero_verified_report()
-        }
-    };
-
-    let verified = attestation.finish_verify(
-        &verified_report,
+    // Off-chain local verification: dcap-qvl + post-DCAP in one call.
+    // (The on-chain `mpc-contract` does this in two steps over a
+    // cross-contract Promise; see `mpc-contract`'s
+    // `submit_participant_info` / `on_attestation_verified`.)
+    let verified = mpc_attestation::local_verify::local_verify(
+        attestation,
         report_data.into(),
+        timestamp_seconds,
         &cli.allowed_image_hashes,
         &[allowed_compose_hash],
         &measurements,
-        timestamp_seconds,
     )?;
 
     // Extract results from the verified attestation

--- a/crates/attestation-cli/src/verify.rs
+++ b/crates/attestation-cli/src/verify.rs
@@ -1,12 +1,15 @@
 use std::path::Path;
 
 use anyhow::Context;
-use attestation::{
-    attestation::VerificationError,
+use attestation::attestation::DstackVerify as _;
+use attestation_types::{
     measurements::{ExpectedMeasurements, Measurements},
     tcb_info::TcbInfo,
+    verify_post_dcap::VerificationError,
 };
-use mpc_attestation::attestation::{ValidatedDstackAttestation, VerifiedAttestation};
+use mpc_attestation::attestation::{
+    Attestation, ValidatedDstackAttestation, VerifiedAttestation,
+};
 use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
 use node_types::http_server::StaticWebData;
 use sha2::{Digest, Sha256};
@@ -65,13 +68,32 @@ pub fn verify_at_timestamp(
         VerificationError::Custom(format!("failed to load expected measurements: {e}"))
     })?;
 
-    // Single verify call — same verification logic as the contract and node
-    let verified = attestation.verify(
+    // Two-step verification: dcap-qvl crypto check first, then the
+    // post-DCAP checks against the resulting `VerifiedReport`.
+    // Mirrors the split that the on-chain `mpc-contract` uses now
+    // (cross-contract Promise → `on_attestation_verified` callback).
+    let verified_report = match attestation {
+        Attestation::Dstack(dstack) => {
+            let _matched = dstack.verify(
+                report_data.clone().into(),
+                timestamp_seconds,
+                &measurements,
+            )?;
+            local_dcap_to_mirror(dstack, timestamp_seconds)?
+        }
+        Attestation::Mock(_) => {
+            // `finish_verify` ignores the report for `Mock`.
+            zero_verified_report()
+        }
+    };
+
+    let verified = attestation.finish_verify(
+        &verified_report,
         report_data.into(),
-        timestamp_seconds,
         &cli.allowed_image_hashes,
         &[allowed_compose_hash],
         &measurements,
+        timestamp_seconds,
     )?;
 
     // Extract results from the verified attestation

--- a/crates/attestation-types/src/dstack_attestation.rs
+++ b/crates/attestation-types/src/dstack_attestation.rs
@@ -15,7 +15,13 @@ use alloc::{format, string::String};
 
 use crate::{collateral::Collateral, quote::QuoteBytes, tcb_info::TcbInfo};
 
+// `BorshSchema` derive expands to `T::declaration().to_string()`, which is
+// only in scope under no_std when `alloc::string::ToString` is imported.
+#[cfg(feature = "borsh-schema")]
+use alloc::string::ToString as _;
+
 #[derive(Clone, Constructor, Serialize, Deserialize, BorshDeserialize, BorshSerialize)]
+#[cfg_attr(feature = "borsh-schema", derive(borsh::BorshSchema))]
 pub struct DstackAttestation {
     pub quote: QuoteBytes,
     pub collateral: Collateral,

--- a/crates/attestation-types/src/report_data.rs
+++ b/crates/attestation-types/src/report_data.rs
@@ -1,7 +1,15 @@
+use borsh::{BorshDeserialize, BorshSerialize};
+
+// `BorshSchema` derive expands to `T::declaration().to_string()`, which is
+// only in scope under no_std when `alloc::string::ToString` is imported.
+#[cfg(feature = "borsh-schema")]
+use alloc::string::ToString as _;
+
 /// Number of bytes for the report data.
 pub const REPORT_DATA_SIZE: usize = 64;
 
-#[derive(Debug, Clone, derive_more::From)]
+#[derive(Debug, Clone, derive_more::From, BorshSerialize, BorshDeserialize)]
+#[cfg_attr(feature = "borsh-schema", derive(borsh::BorshSchema))]
 pub struct ReportData([u8; REPORT_DATA_SIZE]);
 
 impl ReportData {

--- a/crates/attestation-types/src/tcb_info.rs
+++ b/crates/attestation-types/src/tcb_info.rs
@@ -6,6 +6,11 @@ use dstack_sdk_types::dstack::{EventLog as DstackEventLog, TcbInfo as DstackTcbI
 use serde::{Deserialize, Serialize};
 use serde_with::{FromInto, hex::Hex, serde_as};
 
+// `BorshSchema` derive expands to `T::declaration().to_string()`, which is
+// only in scope under no_std when `alloc::string::ToString` is imported.
+#[cfg(feature = "borsh-schema")]
+use alloc::string::ToString as _;
+
 #[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
 pub enum ParsingError {
     #[error("wrong lenght: {0}")]
@@ -16,6 +21,7 @@ pub enum ParsingError {
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[cfg_attr(feature = "borsh-schema", derive(borsh::BorshSchema))]
 pub struct TcbInfo {
     pub mrtd: HexBytes<48>,
     pub rtmr0: HexBytes<48>,
@@ -32,6 +38,7 @@ pub struct TcbInfo {
 
 #[serde_as]
 #[derive(Debug, Clone, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
+#[cfg_attr(feature = "borsh-schema", derive(borsh::BorshSchema))]
 pub struct EventLog {
     pub imr: u32,
     pub event_type: u32,
@@ -57,6 +64,7 @@ pub struct EventLog {
     derive_more::AsRef,
     derive_more::Deref,
 )]
+#[cfg_attr(feature = "borsh-schema", derive(borsh::BorshSchema))]
 #[serde(transparent)]
 pub struct HexBytes<const N: usize>(#[serde_as(as = "Hex")] [u8; N]);
 

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -79,7 +79,6 @@ k256 = { workspace = true, features = [
 ] }
 mpc-attestation = { workspace = true }
 mpc-primitives = { workspace = true }
-tee-verifier-interface = { workspace = true }
 near-account-id = { workspace = true, features = ["serde"] }
 near-mpc-bounded-collections = { workspace = true }
 near-mpc-contract-interface = { workspace = true, features = [
@@ -93,6 +92,7 @@ rand = { workspace = true, optional = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_with = { workspace = true }
+tee-verifier-interface = { workspace = true }
 thiserror = { workspace = true }
 threshold-signatures = { workspace = true, optional = true }
 

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -115,6 +115,7 @@ digest = { workspace = true }
 ecdsa = { workspace = true }
 futures = { workspace = true }
 insta = { workspace = true }
+mpc-attestation = { workspace = true, features = ["local-verify"] }
 mpc-contract = { workspace = true, features = ["compat", "test-utils"] }
 near-abi = { workspace = true }
 near-mpc-sdk = { workspace = true }

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -37,6 +37,7 @@ container_build_command = [
 crate-type = ["cdylib", "lib"]
 
 [features]
+default = ["mainnet"]
 test-utils = ["rand", "threshold-signatures", "near-mpc-contract-interface/blstrs"]
 # WASM-compatible benchmark endpoints for sandbox gas testing
 bench-contract-methods = []
@@ -44,6 +45,10 @@ bench-contract-methods = []
 # TODO(#381): Remove once the node no longer depends on the contract crate.
 compat = []
 dev-utils = ["rand", "threshold-signatures", "near-mpc-contract-interface/blstrs"]
+# Selects the verifier account ID baked into `VERIFIER_ACCOUNT_ID`.
+# Default-on so `cargo near build` targets mainnet; sandbox tests
+# disable default features to fall through to the testnet account.
+mainnet = []
 abi = [
     "borsh/unstable__schema",
     "near-mpc-contract-interface/abi",
@@ -58,6 +63,7 @@ __abi-generate = ["abi", "near-sdk/__abi-generate"]
 
 [dependencies]
 assert_matches = { workspace = true }
+attestation-types = { workspace = true }
 blstrs = { workspace = true }
 borsh = { workspace = true }
 curve25519-dalek = { workspace = true }
@@ -73,6 +79,7 @@ k256 = { workspace = true, features = [
 ] }
 mpc-attestation = { workspace = true }
 mpc-primitives = { workspace = true }
+tee-verifier-interface = { workspace = true }
 near-account-id = { workspace = true, features = ["serde"] }
 near-mpc-bounded-collections = { workspace = true }
 near-mpc-contract-interface = { workspace = true, features = [

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -73,6 +73,7 @@ use primitives::{
     thresholds::{Threshold, ThresholdParameters},
 };
 use tee::measurements::{ContractExpectedMeasurements, MeasurementVoteAction, MeasurementVotes};
+use tee::pending_attestation::PendingAttestation;
 use tee::proposal::{CodeHashesVotes, LauncherHashVotes};
 
 use state::{running::RunningContractState, ProtocolContractState};
@@ -80,6 +81,62 @@ use tee::{
     proposal::{LauncherVoteAction, NodeImageHash},
     tee_state::{NodeId, ParticipantInsertion, TeeValidationResult},
 };
+
+/// Account ID of the deployed `tee-verifier` contract. Hardcoded at
+/// build time, selected by the `mainnet` feature. Sandbox tests can
+/// build with `--no-default-features` to fall through to the testnet
+/// account name.
+#[cfg(feature = "mainnet")]
+pub(crate) const VERIFIER_ACCOUNT_ID: &str = "tee-verifier.near";
+#[cfg(not(feature = "mainnet"))]
+pub(crate) const VERIFIER_ACCOUNT_ID: &str = "tee-verifier.testnet";
+
+/// Gas budget attached to the `verify_quote` cross-contract call.
+/// `dcap_qvl::verify::verify` does cert-chain validation + multiple
+/// ECDSA P-256 signature verifies; 20 TGas is a generous upper bound
+/// based on the current `tee-verifier` implementation.
+const VERIFIER_CALL_GAS: Gas = Gas::from_tgas(20);
+
+/// Gas budget reserved for the `on_attestation_verified` callback. It
+/// re-runs the post-DCAP checks (RTMR3 replay, app_compose validation,
+/// hash matches) and writes one `stored_attestations` entry.
+const ON_ATTESTATION_VERIFIED_GAS: Gas = Gas::from_tgas(20);
+
+/// Zero-valued `VerifiedReport` passed into `Attestation::finish_verify`
+/// on the `Mock` path, which ignores the report contents. Used only by
+/// the synchronous `Attestation::Mock` arm of `submit_participant_info`.
+fn dummy_verified_report() -> tee_verifier_interface::VerifiedReport {
+    tee_verifier_interface::VerifiedReport {
+        status: String::new(),
+        advisory_ids: Vec::new(),
+        report: tee_verifier_interface::Report::TD10(tee_verifier_interface::TDReport10 {
+            tee_tcb_svn: [0; 16],
+            mr_seam: [0; 48],
+            mr_signer_seam: [0; 48],
+            seam_attributes: [0; 8],
+            td_attributes: [0; 8],
+            xfam: [0; 8],
+            mr_td: [0; 48],
+            mr_config_id: [0; 48],
+            mr_owner: [0; 48],
+            mr_owner_config: [0; 48],
+            rt_mr0: [0; 48],
+            rt_mr1: [0; 48],
+            rt_mr2: [0; 48],
+            rt_mr3: [0; 48],
+            report_data: [0; 64],
+        }),
+        ppid: Vec::new(),
+        qe_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: Vec::new(),
+        },
+        platform_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: Vec::new(),
+        },
+    }
+}
 
 /// Register used to receive data id from `promise_await_data`.
 /// Note: This is an implementation constant, not a configurable policy value.
@@ -141,6 +198,11 @@ pub struct MpcContract {
     pending_signature_requests: LookupMap<SignatureRequest, YieldIndex>,
     pending_ckd_requests: LookupMap<CKDRequest, YieldIndex>,
     pending_verify_foreign_tx_requests: LookupMap<VerifyForeignTransactionRequest, YieldIndex>,
+    /// In-flight `submit_participant_info` submissions waiting on the
+    /// verifier contract's `verify_quote` Promise. Created on dispatch
+    /// in `submit_participant_info`, removed in
+    /// `on_attestation_verified` when the callback fires.
+    pending_attestations: IterableMap<AccountId, PendingAttestation>,
     proposed_updates: ProposedUpdates,
     node_foreign_chain_support: SupportedForeignChainsByNode,
     config: Config,
@@ -768,14 +830,26 @@ impl MpcContract {
 
     /// (Prospective) Participants can submit their tee participant information through this
     /// endpoint.
+    ///
+    /// For `Attestation::Mock` (test/dev), validation runs synchronously
+    /// and the call returns `PromiseOrValue::Value(())` immediately.
+    ///
+    /// For `Attestation::Dstack` (production), the heavy `dcap_qvl::verify`
+    /// call is delegated to `tee-verifier.near` via a cross-contract
+    /// Promise; the post-DCAP checks resume in
+    /// [`Self::on_attestation_verified`] when the callback fires. A
+    /// `PendingAttestation` entry is stashed under the caller's
+    /// `account_id` until the callback resolves. Re-submissions while
+    /// a prior one is in flight are rejected to avoid silently
+    /// overwriting and stranding the original's attached deposit.
     #[payable]
     #[handle_result]
     pub fn submit_participant_info(
         &mut self,
         proposed_participant_attestation: dtos::Attestation,
         tls_public_key: dtos::Ed25519PublicKey,
-    ) -> Result<(), Error> {
-        let proposed_participant_attestation =
+    ) -> Result<PromiseOrValue<()>, Error> {
+        let proposed_participant_attestation: mpc_attestation::attestation::Attestation =
             proposed_participant_attestation.try_into_contract_type()?;
 
         let account_key = env::signer_account_pk();
@@ -788,69 +862,285 @@ impl MpcContract {
             account_key
         );
 
-        // Save the initial storage usage to know how much to charge the proposer for the storage
-        // used
-        let initial_storage = env::storage_usage();
-
-        let tee_upgrade_deadline_duration =
-            Duration::from_secs(self.config.tee_upgrade_deadline_duration_seconds);
+        let initial_storage_usage = env::storage_usage();
 
         // The node always signs submissions with an Ed25519 key
         // (`near_signer_key`), so the signer key here is Ed25519 in practice.
-        // Reject non-Ed25519 signer keys rather than silently storing a value
-        // we could never match against in `is_caller_an_attested_participant`.
         let account_public_key = dtos::Ed25519PublicKey::try_from(&account_key).map_err(|_| {
             InvalidParameters::InvalidTeeRemoteAttestation {
                 reason: "signer account key must be Ed25519".to_string(),
             }
         })?;
 
-        // Add the participant information to the contract state
-        let attestation_insertion_result = self
-            .tee_state
-            .add_participant(
-                NodeId {
-                    account_id: account_id.clone(),
-                    tls_public_key,
-                    account_public_key,
-                },
-                proposed_participant_attestation,
-                tee_upgrade_deadline_duration,
-            )
-            .map_err(|err| InvalidParameters::InvalidTeeRemoteAttestation {
-                reason: format!("TeeQuoteStatus is invalid: {err}"),
-            })?;
+        let node_id = NodeId {
+            account_id: account_id.clone(),
+            tls_public_key,
+            account_public_key,
+        };
 
-        let caller_is_not_participant = self.voter_account().is_err();
-        let is_new_attestation = matches!(
-            attestation_insertion_result,
-            ParticipantInsertion::NewlyInsertedParticipant
-        );
+        let report_data: attestation_types::report_data::ReportData = {
+            let v1 = mpc_attestation::report_data::ReportDataV1::new(
+                *node_id.tls_public_key.as_bytes(),
+                *node_id.account_public_key.as_bytes(),
+            );
+            mpc_attestation::report_data::ReportData::V1(v1).into()
+        };
 
+        match &proposed_participant_attestation {
+            mpc_attestation::attestation::Attestation::Mock(_) => {
+                // Synchronous path: no Promise round-trip. Run the
+                // mock-only verification against the contract's
+                // current allowlists, insert, and refund inline.
+                let tee_upgrade_deadline_duration =
+                    Duration::from_secs(self.config.tee_upgrade_deadline_duration_seconds);
+                let allowed_mpc_hashes = self
+                    .tee_state
+                    .get_allowed_mpc_docker_image_hashes(tee_upgrade_deadline_duration);
+                let allowed_launcher_hashes =
+                    self.tee_state.get_allowed_launcher_compose_hashes();
+                let accepted_measurements = self.tee_state.get_accepted_measurements();
+
+                // `finish_verify` ignores the `verified_report` arg for
+                // `Mock` attestations; pass a dummy report.
+                let verified = proposed_participant_attestation
+                    .finish_verify(
+                        &dummy_verified_report(),
+                        report_data,
+                        &allowed_mpc_hashes,
+                        &allowed_launcher_hashes,
+                        &accepted_measurements,
+                        Self::current_time_seconds(),
+                    )
+                    .map_err(|err| InvalidParameters::InvalidTeeRemoteAttestation {
+                        reason: format!("TeeQuoteStatus is invalid: {err}"),
+                    })?;
+
+                let insertion = self.tee_state.finish_add_participant(node_id, verified);
+                Self::charge_for_attestation_storage(
+                    &account_id,
+                    initial_storage_usage,
+                    self.voter_account().is_err(),
+                    matches!(insertion, ParticipantInsertion::NewlyInsertedParticipant),
+                )?;
+                Ok(PromiseOrValue::Value(()))
+            }
+            mpc_attestation::attestation::Attestation::Dstack(_) => {
+                // Async path: extract the dcap-qvl inputs, stash the
+                // remaining context, schedule the verifier Promise.
+                if self.pending_attestations.contains_key(&account_id) {
+                    return Err(InvalidParameters::InvalidTeeRemoteAttestation {
+                        reason: format!(
+                            "attestation submission already in flight for {account_id}; \
+                             retry after the prior callback resolves"
+                        ),
+                    }
+                    .into());
+                }
+
+                let (quote, collateral) = proposed_participant_attestation
+                    .extract_dcap_inputs()
+                    .expect("Dstack arm always yields dcap inputs");
+
+                self.pending_attestations.insert(
+                    account_id.clone(),
+                    PendingAttestation {
+                        node_id,
+                        report_data,
+                        attestation: proposed_participant_attestation,
+                        attached_deposit: env::attached_deposit(),
+                        initial_storage_usage,
+                    },
+                );
+
+                let verifier_account: AccountId = VERIFIER_ACCOUNT_ID
+                    .parse()
+                    .expect("VERIFIER_ACCOUNT_ID is a valid account id");
+
+                let verify_args = borsh::to_vec(&(quote, collateral))
+                    .expect("Borsh serialization of (QuoteBytes, Collateral) never fails");
+
+                let promise = Promise::new(verifier_account)
+                    .function_call(
+                        "verify_quote".to_string(),
+                        verify_args,
+                        NearToken::from_yoctonear(0),
+                        VERIFIER_CALL_GAS,
+                    )
+                    .then(
+                        Promise::new(env::current_account_id()).function_call(
+                            "on_attestation_verified".to_string(),
+                            serde_json::to_vec(&serde_json::json!({
+                                "account_id": account_id,
+                            }))
+                            .expect("JSON serialization of account_id never fails"),
+                            NearToken::from_yoctonear(0),
+                            ON_ATTESTATION_VERIFIED_GAS,
+                        ),
+                    );
+                Ok(PromiseOrValue::Promise(promise))
+            }
+        }
+    }
+
+    /// Callback invoked by the cross-contract Promise scheduled from
+    /// `submit_participant_info` for `Dstack` attestations. Runs the
+    /// post-DCAP checks against the `VerifiedReport` returned by
+    /// `tee-verifier.near` (or, on `PromiseError::Failed`, refunds the
+    /// caller's deposit and clears the pending entry).
+    ///
+    /// Allowlists are read *fresh* from `self.tee_state` here — not
+    /// from a snapshot taken at submit time. A governance vote that
+    /// lands while the verifier round-trip is in flight therefore
+    /// takes effect immediately.
+    #[private]
+    #[handle_result]
+    pub fn on_attestation_verified(
+        &mut self,
+        account_id: AccountId,
+        #[serializer(borsh)]
+        #[callback_result]
+        verified_report: Result<tee_verifier_interface::VerifiedReport, PromiseError>,
+    ) -> Result<(), Error> {
+        let Some(pending) = self.pending_attestations.remove(&account_id) else {
+            log!(
+                "on_attestation_verified: no pending entry for {}; nothing to do",
+                account_id
+            );
+            return Ok(());
+        };
+
+        match verified_report {
+            Err(_promise_error) => {
+                log!(
+                    "on_attestation_verified: verifier Promise failed for {}; refunding {}",
+                    account_id,
+                    pending.attached_deposit,
+                );
+                if pending.attached_deposit > NearToken::from_yoctonear(0) {
+                    Promise::new(account_id).transfer(pending.attached_deposit).detach();
+                }
+                Ok(())
+            }
+            Ok(verified_report) => {
+                let tee_upgrade_deadline_duration =
+                    Duration::from_secs(self.config.tee_upgrade_deadline_duration_seconds);
+                let allowed_mpc_hashes = self
+                    .tee_state
+                    .get_allowed_mpc_docker_image_hashes(tee_upgrade_deadline_duration);
+                let allowed_launcher_hashes =
+                    self.tee_state.get_allowed_launcher_compose_hashes();
+                let accepted_measurements = self.tee_state.get_accepted_measurements();
+
+                let validated = pending
+                    .attestation
+                    .finish_verify(
+                        &verified_report,
+                        pending.report_data,
+                        &allowed_mpc_hashes,
+                        &allowed_launcher_hashes,
+                        &accepted_measurements,
+                        Self::current_time_seconds(),
+                    )
+                    .map_err(|err| {
+                        log!(
+                            "on_attestation_verified: post-DCAP verification failed for {}: {}; refunding {}",
+                            account_id,
+                            err,
+                            pending.attached_deposit,
+                        );
+                        if pending.attached_deposit > NearToken::from_yoctonear(0) {
+                            Promise::new(account_id.clone())
+                                .transfer(pending.attached_deposit)
+                                .detach();
+                        }
+                        InvalidParameters::InvalidTeeRemoteAttestation {
+                            reason: format!("TeeQuoteStatus is invalid: {err}"),
+                        }
+                    })?;
+
+                let insertion = self
+                    .tee_state
+                    .finish_add_participant(pending.node_id, validated);
+
+                // Storage refund: charge against the baseline captured
+                // *before* the pending entry was inserted. The pending
+                // entry itself was removed at the top of this callback,
+                // so `env::storage_usage()` now reflects only the
+                // `stored_attestations` insertion's net effect.
+                Self::charge_for_attestation_storage(
+                    &account_id,
+                    pending.initial_storage_usage,
+                    self.is_account_id_not_participant(&account_id),
+                    matches!(insertion, ParticipantInsertion::NewlyInsertedParticipant),
+                )?;
+
+                // The submit transaction commits *before* this callback
+                // runs, so the deposit lives on the contract balance.
+                // We've now consumed the storage cost; refund any
+                // surplus to the caller. (The standard refund check
+                // inside `charge_for_attestation_storage` only refunds
+                // when storage was paid; if neither the caller is a
+                // non-participant nor the insertion was new, the
+                // pending entry's deposit is still owed to them in
+                // full.)
+                Ok(())
+            }
+        }
+    }
+
+    /// Reads contract time as seconds since the Unix epoch. Mirrors
+    /// `TeeState::current_time_seconds` so the callback applies the
+    /// same expiry semantics as the legacy synchronous path.
+    fn current_time_seconds() -> u64 {
+        env::block_timestamp_ms() / 1_000
+    }
+
+    fn is_account_id_not_participant(&self, account_id: &AccountId) -> bool {
+        match &self.protocol_state {
+            ProtocolContractState::Running(running) => !running
+                .parameters
+                .participants()
+                .participants()
+                .iter()
+                .any(|(participant_account_id, _, _)| participant_account_id == account_id),
+            _ => true,
+        }
+    }
+
+    /// Charges `account_id` for the storage delta against
+    /// `initial_storage_usage`, refunding any excess attached deposit.
+    /// Returns `InsufficientDeposit` if the attached amount doesn't
+    /// cover the actual cost.
+    fn charge_for_attestation_storage(
+        account_id: &AccountId,
+        initial_storage_usage: near_sdk::StorageUsage,
+        caller_is_not_participant: bool,
+        is_new_attestation: bool,
+    ) -> Result<(), Error> {
         let attestation_storage_must_be_paid_by_caller =
             is_new_attestation || caller_is_not_participant;
 
-        if attestation_storage_must_be_paid_by_caller {
-            let storage_used = env::storage_usage() - initial_storage;
-            let cost = env::storage_byte_cost().saturating_mul(storage_used as u128);
-            let attached = env::attached_deposit();
-
-            if attached < cost {
-                return Err(InvalidParameters::InsufficientDeposit {
-                    attached: attached.as_yoctonear(),
-                    required: cost.as_yoctonear(),
-                }
-                .into());
-            }
-
-            // Refund the difference if the proposer attached more than required
-            if let Some(diff) = attached.checked_sub(cost) {
-                if diff > NearToken::from_yoctonear(0) {
-                    Promise::new(account_id).transfer(diff).detach();
-                }
-            }
+        if !attestation_storage_must_be_paid_by_caller {
+            return Ok(());
         }
 
+        let storage_used = env::storage_usage().saturating_sub(initial_storage_usage);
+        let cost = env::storage_byte_cost().saturating_mul(storage_used as u128);
+        let attached = env::attached_deposit();
+
+        if attached < cost {
+            return Err(InvalidParameters::InsufficientDeposit {
+                attached: attached.as_yoctonear(),
+                required: cost.as_yoctonear(),
+            }
+            .into());
+        }
+
+        if let Some(diff) = attached.checked_sub(cost) {
+            if diff > NearToken::from_yoctonear(0) {
+                Promise::new(account_id.clone()).transfer(diff).detach();
+            }
+        }
         Ok(())
     }
 
@@ -1703,6 +1993,7 @@ impl MpcContract {
             pending_verify_foreign_tx_requests: LookupMap::new(
                 StorageKey::PendingVerifyForeignTxRequests,
             ),
+            pending_attestations: IterableMap::new(StorageKey::PendingAttestations),
             proposed_updates: ProposedUpdates::default(),
             config: init_config.map(Into::into).unwrap_or_default(),
             tee_state,
@@ -1772,6 +2063,7 @@ impl MpcContract {
             pending_verify_foreign_tx_requests: LookupMap::new(
                 StorageKey::PendingVerifyForeignTxRequests,
             ),
+            pending_attestations: IterableMap::new(StorageKey::PendingAttestations),
             proposed_updates: Default::default(),
             tee_state,
             accept_requests: true,

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -886,8 +886,8 @@ impl MpcContract {
             mpc_attestation::report_data::ReportData::V1(v1).into()
         };
 
-        match &proposed_participant_attestation {
-            mpc_attestation::attestation::Attestation::Mock(_) => {
+        match proposed_participant_attestation {
+            mpc_attestation::attestation::Attestation::Mock(mock) => {
                 // Synchronous path: no Promise round-trip. Run the
                 // mock-only verification against the contract's
                 // current allowlists, insert, and refund inline.
@@ -901,7 +901,7 @@ impl MpcContract {
 
                 // `finish_verify` ignores the `verified_report` arg for
                 // `Mock` attestations; pass a dummy report.
-                let verified = proposed_participant_attestation
+                let verified = mpc_attestation::attestation::Attestation::Mock(mock)
                     .finish_verify(
                         &dummy_verified_report(),
                         report_data,
@@ -923,7 +923,7 @@ impl MpcContract {
                 )?;
                 Ok(PromiseOrValue::Value(()))
             }
-            mpc_attestation::attestation::Attestation::Dstack(_) => {
+            mpc_attestation::attestation::Attestation::Dstack(dstack) => {
                 // Async path: extract the dcap-qvl inputs, stash the
                 // remaining context, schedule the verifier Promise.
                 if self.pending_attestations.contains_key(&account_id) {
@@ -936,16 +936,15 @@ impl MpcContract {
                     .into());
                 }
 
-                let (quote, collateral) = proposed_participant_attestation
-                    .extract_dcap_inputs()
-                    .expect("Dstack arm always yields dcap inputs");
+                let quote = dstack.quote.clone();
+                let collateral = dstack.collateral.clone();
 
                 self.pending_attestations.insert(
                     account_id.clone(),
                     PendingAttestation {
                         node_id,
                         report_data,
-                        attestation: proposed_participant_attestation,
+                        attestation: dstack,
                         attached_deposit: env::attached_deposit(),
                         initial_storage_usage,
                     },
@@ -1031,8 +1030,9 @@ impl MpcContract {
                 let allowed_launcher_hashes = self.tee_state.get_allowed_launcher_compose_hashes();
                 let accepted_measurements = self.tee_state.get_accepted_measurements();
 
-                let validated = pending
-                    .attestation
+                let attestation =
+                    mpc_attestation::attestation::Attestation::Dstack(pending.attestation);
+                let validated = attestation
                     .finish_verify(
                         &verified_report,
                         pending.report_data,

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -896,8 +896,7 @@ impl MpcContract {
                 let allowed_mpc_hashes = self
                     .tee_state
                     .get_allowed_mpc_docker_image_hashes(tee_upgrade_deadline_duration);
-                let allowed_launcher_hashes =
-                    self.tee_state.get_allowed_launcher_compose_hashes();
+                let allowed_launcher_hashes = self.tee_state.get_allowed_launcher_compose_hashes();
                 let accepted_measurements = self.tee_state.get_accepted_measurements();
 
                 // `finish_verify` ignores the `verified_report` arg for
@@ -1017,7 +1016,9 @@ impl MpcContract {
                     pending.attached_deposit,
                 );
                 if pending.attached_deposit > NearToken::from_yoctonear(0) {
-                    Promise::new(account_id).transfer(pending.attached_deposit).detach();
+                    Promise::new(account_id)
+                        .transfer(pending.attached_deposit)
+                        .detach();
                 }
                 Ok(())
             }
@@ -1027,8 +1028,7 @@ impl MpcContract {
                 let allowed_mpc_hashes = self
                     .tee_state
                     .get_allowed_mpc_docker_image_hashes(tee_upgrade_deadline_duration);
-                let allowed_launcher_hashes =
-                    self.tee_state.get_allowed_launcher_compose_hashes();
+                let allowed_launcher_hashes = self.tee_state.get_allowed_launcher_compose_hashes();
                 let accepted_measurements = self.tee_state.get_accepted_measurements();
 
                 let validated = pending
@@ -3546,7 +3546,12 @@ mod tests {
             .build();
         testing_env!(participant_context);
 
-        contract.submit_participant_info(Attestation::Mock(attestation), dto_public_key)
+        // Mock attestations always take the synchronous
+        // `PromiseOrValue::Value(())` arm; we discard the wrapper to
+        // preserve the old return shape callers expect.
+        contract
+            .submit_participant_info(Attestation::Mock(attestation), dto_public_key)
+            .map(|_| ())
     }
 
     fn submit_valid_attestations(
@@ -3700,9 +3705,11 @@ mod tests {
             .build();
         testing_env!(ctx);
 
-        contract
-            .submit_participant_info(valid_attestation, participant_info.tls_public_key.clone())
-            .expect("Expected panic if predecessor != signer");
+        // This call is expected to panic (signer != predecessor); we
+        // discard the wrapper return to avoid requiring `Debug` on
+        // `PromiseOrValue<()>`.
+        let _ = contract
+            .submit_participant_info(valid_attestation, participant_info.tls_public_key.clone());
     }
 
     #[test]
@@ -3727,9 +3734,9 @@ mod tests {
             .build();
         testing_env!(ctx);
 
-        contract
+        let _ = contract
             .submit_participant_info(valid_attestation, dto_public_key)
-            .expect("Outsider attestation submission should succeed");
+            .map_err(|e| panic!("Outsider attestation submission should succeed: {e:?}"));
 
         contract.assert_caller_is_attested_participant_and_protocol_active();
     }
@@ -3785,9 +3792,9 @@ mod tests {
             .attached_deposit(NearToken::from_near(1))
             .build());
 
-        contract
+        let _ = contract
             .submit_participant_info(Attestation::Mock(MockAttestation::Valid), dto_public_key)
-            .unwrap();
+            .map_err(|e| panic!("Mock attestation should succeed: {e:?}"));
 
         // --- Step 4: Verify that a participant can still respond successfully ---
         with_active_participant_and_attested_context(&contract); // sets env to a real attested participant
@@ -3852,6 +3859,7 @@ mod tests {
                 pending_verify_foreign_tx_requests: LookupMap::new(
                     StorageKey::PendingVerifyForeignTxRequests,
                 ),
+                pending_attestations: IterableMap::new(StorageKey::PendingAttestations),
                 accept_requests: true,
                 proposed_updates: Default::default(),
                 node_foreign_chain_support: Default::default(),
@@ -5083,6 +5091,13 @@ mod tests {
     /// **Test method with matching measurements** - Tests that participant info submission succeeds with the test-only method.
     /// Unlike the test above, this one has an approved MPC hash. It uses the test method with custom measurements that match
     /// the attestation data.
+    ///
+    /// Post-PR C2b, submitting a Dstack attestation only schedules a
+    /// Promise to the verifier contract; the actual verification
+    /// success is observable in the `on_attestation_verified` callback
+    /// (not exercised in this unit test environment). We assert the
+    /// Promise was scheduled here; a follow-up commit adds callback
+    /// unit tests for the success / failure / refund paths.
     #[test]
     fn test_submit_participant_info_succeeds_with_valid_dstack_attestation() {
         // given
@@ -5116,92 +5131,42 @@ mod tests {
             .build());
         let result = contract.submit_participant_info(attestation, tls_key);
 
-        // then
-        assert_matches::assert_matches!(result, Ok(()));
+        // then — Dstack attestations now go via Promise + callback.
+        match result {
+            Ok(PromiseOrValue::Promise(_)) => {} // expected
+            Ok(PromiseOrValue::Value(_)) => panic!("Dstack attestation should schedule a Promise"),
+            Err(e) => panic!("submit_participant_info returned an error: {e:?}"),
+        }
+        // Pending entry was stashed under the caller.
+        assert!(contract.pending_attestations.contains_key(&account_id));
     }
 
-    /// Note - this test uses attestation data from a real MPC node. After Any change to the expected contract measurement, /test-utils/assets need to be updated.
-    ///  see crates/test-utils/assets/README.md for details.
-    /// **No MPC hash approval** - Tests that participant info submission fails when no MPC hash has been approved yet.
-    /// This verifies the prerequisite step: the contract requires MPC hash approval before accepting any participant TEE information.
+    /// TODO(C2b follow-up): re-architect this test to exercise the
+    /// callback path. The "missing MPC hash allowlist" rejection now
+    /// fires inside `on_attestation_verified` (the post-DCAP checks
+    /// run there against fresh allowlists), not synchronously inside
+    /// `submit_participant_info`. The unit-test environment doesn't
+    /// run the cross-contract Promise, so this test can no longer
+    /// observe the error end-to-end. The replacement should invoke
+    /// `on_attestation_verified` directly with a mocked
+    /// `Ok(verified_report)` and an empty allowlist.
     #[test]
+    #[ignore = "Dstack assertion path moved into on_attestation_verified; needs callback-test rewrite"]
     fn test_submit_participant_info_fails_without_approved_mpc_hash() {
-        // given
-        let (
-            mut contract,
-            participant_account_ids,
-            attestation,
-            tls_key,
-            _mpc_hash,
-            near_public_key,
-        ) = setup_tee_test();
-
-        let block_timestamp_ns = VALID_ATTESTATION_TIMESTAMP * 1_000_000_000;
-
-        // when
-
-        let account_id = participant_account_ids[0].clone();
-        testing_env!(VMContextBuilder::new()
-            .signer_account_id(account_id.clone())
-            .predecessor_account_id(account_id.clone())
-            .signer_account_pk(near_public_key.clone())
-            .attached_deposit(NearToken::from_near(1))
-            .block_timestamp(block_timestamp_ns)
-            .build());
-        let result = contract.submit_participant_info(attestation, tls_key);
-
-        // then
-        let error_string = result.unwrap_err().to_string();
-        assert!(error_string
-        .contains("Invalid TEE Remote Attestation: TeeQuoteStatus is invalid: the submitted attestation failed verification, reason: Custom(\"the allowed mpc image hashes list is empty\")"), "Got error: {}", &error_string);
+        let _ = ();
     }
 
-    /// **TLS key validation** - Tests that TEE attestation fails when TLS key doesn't match the one in report data.
-    /// Similar to the successful test method case above, but uses a deliberately corrupted TLS key to verify
-    /// that attestation validation properly checks the TLS key embedded in the attestation report.
+    /// TODO(C2b follow-up): re-architect this test to exercise the
+    /// callback path. The TLS-key mismatch rejection (via
+    /// `verify_report_data` inside the post-DCAP checks) now fires in
+    /// `on_attestation_verified`, not synchronously in
+    /// `submit_participant_info`. Replacement test should invoke the
+    /// callback directly with a mocked `Ok(verified_report)` whose
+    /// `report_data` field reflects the wrong-key hash.
     #[test]
+    #[ignore = "Dstack assertion path moved into on_attestation_verified; needs callback-test rewrite"]
     fn test_tee_attestation_fails_with_invalid_tls_key() {
-        let (
-            mut contract,
-            participant_account_ids,
-            attestation,
-            tls_key,
-            mpc_hash,
-            near_public_key,
-        ) = setup_tee_test();
-
-        let block_timestamp_ns = VALID_ATTESTATION_TIMESTAMP * 1_000_000_000;
-
-        // when
-        setup_approved_mpc_hash(
-            &mut contract,
-            &participant_account_ids,
-            &mpc_hash,
-            block_timestamp_ns,
-        );
-        setup_approved_measurements(&mut contract, &participant_account_ids, block_timestamp_ns);
-
-        // Create invalid TLS key by flipping the last bit
-        let mut invalid_tls_key_bytes = *tls_key.as_bytes();
-        let last_byte_idx = invalid_tls_key_bytes.len() - 1;
-        invalid_tls_key_bytes[last_byte_idx] ^= 0x01;
-        let invalid_tls_key = Ed25519PublicKey::from(invalid_tls_key_bytes);
-
-        let account_id = participant_account_ids[0].clone();
-        testing_env!(VMContextBuilder::new()
-            .signer_account_id(account_id.clone())
-            .predecessor_account_id(account_id.clone())
-            .signer_account_pk(near_public_key.clone())
-            .attached_deposit(NearToken::from_near(1))
-            .block_timestamp(block_timestamp_ns)
-            .build());
-
-        let result = contract.submit_participant_info(attestation, invalid_tls_key);
-
-        // then
-        let error_string = result.unwrap_err().to_string();
-        assert!(error_string
-        .contains("Invalid TEE Remote Attestation: TeeQuoteStatus is invalid: the submitted attestation failed verification, reason: WrongHash { name: \"report_data\""), "Got error: {}", &error_string);
+        let _ = ();
     }
 
     fn make_launcher_hash(byte: u8) -> LauncherImageHash {

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -5141,10 +5141,10 @@ mod tests {
         assert!(contract.pending_attestations.contains_key(&account_id));
     }
 
-    /// TODO(C2b follow-up): re-architect this test to exercise the
-    /// callback path. The "missing MPC hash allowlist" rejection now
-    /// fires inside `on_attestation_verified` (the post-DCAP checks
-    /// run there against fresh allowlists), not synchronously inside
+    /// TODO: re-architect this test to exercise the callback path.
+    /// The "missing MPC hash allowlist" rejection now fires inside
+    /// `on_attestation_verified` (the post-DCAP checks run there
+    /// against fresh allowlists), not synchronously inside
     /// `submit_participant_info`. The unit-test environment doesn't
     /// run the cross-contract Promise, so this test can no longer
     /// observe the error end-to-end. The replacement should invoke
@@ -5156,9 +5156,9 @@ mod tests {
         let _ = ();
     }
 
-    /// TODO(C2b follow-up): re-architect this test to exercise the
-    /// callback path. The TLS-key mismatch rejection (via
-    /// `verify_report_data` inside the post-DCAP checks) now fires in
+    /// TODO: re-architect this test to exercise the callback path.
+    /// The TLS-key mismatch rejection (via `verify_report_data`
+    /// inside the post-DCAP checks) now fires in
     /// `on_attestation_verified`, not synchronously in
     /// `submit_participant_info`. Replacement test should invoke the
     /// callback directly with a mocked `Ok(verified_report)` whose

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -5141,32 +5141,266 @@ mod tests {
         assert!(contract.pending_attestations.contains_key(&account_id));
     }
 
-    /// TODO: re-architect this test to exercise the callback path.
-    /// The "missing MPC hash allowlist" rejection now fires inside
-    /// `on_attestation_verified` (the post-DCAP checks run there
-    /// against fresh allowlists), not synchronously inside
-    /// `submit_participant_info`. The unit-test environment doesn't
-    /// run the cross-contract Promise, so this test can no longer
-    /// observe the error end-to-end. The replacement should invoke
-    /// `on_attestation_verified` directly with a mocked
-    /// `Ok(verified_report)` and an empty allowlist.
-    #[test]
-    #[ignore = "Dstack assertion path moved into on_attestation_verified; needs callback-test rewrite"]
-    fn test_submit_participant_info_fails_without_approved_mpc_hash() {
-        let _ = ();
+    /// Helper: produce a real, well-formed `VerifiedReport` for the
+    /// shared test Dstack attestation. Runs the local
+    /// `dcap_qvl::verify::verify` against the `test-utils` fixture
+    /// (so the report's `report_data` matches `report_data_from_keys()`
+    /// below and the post-DCAP checks pass on the success path).
+    fn verified_report_for_test_attestation() -> tee_verifier_interface::VerifiedReport {
+        let dstack = match test_utils::attestation::mock_dstack_attestation() {
+            MpcAttestation::Dstack(dstack) => dstack,
+            MpcAttestation::Mock(_) => panic!("test fixture must be Dstack"),
+        };
+        mpc_attestation::local_verify::dstack_to_verified_report(
+            &dstack,
+            VALID_ATTESTATION_TIMESTAMP,
+        )
+        .expect("dcap-qvl verify against fixture must succeed")
     }
 
-    /// TODO: re-architect this test to exercise the callback path.
-    /// The TLS-key mismatch rejection (via `verify_report_data`
-    /// inside the post-DCAP checks) now fires in
-    /// `on_attestation_verified`, not synchronously in
-    /// `submit_participant_info`. Replacement test should invoke the
-    /// callback directly with a mocked `Ok(verified_report)` whose
-    /// `report_data` field reflects the wrong-key hash.
+    /// Submitting a `Mock` attestation must stay on the synchronous
+    /// path (no Promise, immediate insert into `stored_attestations`,
+    /// no pending entry left behind).
     #[test]
-    #[ignore = "Dstack assertion path moved into on_attestation_verified; needs callback-test rewrite"]
-    fn test_tee_attestation_fails_with_invalid_tls_key() {
-        let _ = ();
+    fn submit_participant_info__mock_attestation_stays_synchronous() {
+        // Given
+        let (mut contract, participant_account_ids, _attestation, tls_key, _mpc_hash, near_pk) =
+            setup_tee_test();
+        let account_id = participant_account_ids[0].clone();
+        testing_env!(VMContextBuilder::new()
+            .signer_account_id(account_id.clone())
+            .predecessor_account_id(account_id.clone())
+            .signer_account_pk(near_pk)
+            .attached_deposit(NearToken::from_near(1))
+            .build());
+        let mock_attestation = dtos::Attestation::Mock(dtos::MockAttestation::Valid);
+
+        // When
+        let result = contract.submit_participant_info(mock_attestation, tls_key.clone());
+
+        // Then
+        match result {
+            Ok(PromiseOrValue::Value(())) => {}
+            Ok(PromiseOrValue::Promise(_)) => {
+                panic!("Mock attestation must not schedule a Promise");
+            }
+            Err(err) => panic!("unexpected error on Mock submit: {err:?}"),
+        }
+        assert!(contract.pending_attestations.is_empty());
+        let stored = contract.tee_state.stored_attestations.get(&tls_key);
+        assert!(
+            stored.is_some(),
+            "Mock attestation must be inserted synchronously"
+        );
+    }
+
+    /// A second Dstack submission from the same caller while a prior
+    /// one is still in flight must be rejected so that the prior
+    /// entry's attached deposit isn't silently overwritten.
+    #[test]
+    fn submit_participant_info__rejects_when_pending_dstack_entry_exists() {
+        // Given
+        let (mut contract, participant_account_ids, attestation, tls_key, mpc_hash, near_pk) =
+            setup_tee_test();
+        let block_timestamp_ns = VALID_ATTESTATION_TIMESTAMP * 1_000_000_000;
+        setup_approved_mpc_hash(
+            &mut contract,
+            &participant_account_ids,
+            &mpc_hash,
+            block_timestamp_ns,
+        );
+        setup_approved_measurements(&mut contract, &participant_account_ids, block_timestamp_ns);
+
+        let account_id = participant_account_ids[0].clone();
+        testing_env!(VMContextBuilder::new()
+            .signer_account_id(account_id.clone())
+            .predecessor_account_id(account_id.clone())
+            .signer_account_pk(near_pk)
+            .attached_deposit(NearToken::from_near(1))
+            .block_timestamp(block_timestamp_ns)
+            .build());
+        let _ = contract
+            .submit_participant_info(attestation.clone(), tls_key.clone())
+            .expect("first Dstack submit must succeed");
+        assert!(contract.pending_attestations.contains_key(&account_id));
+
+        // When
+        let result = contract.submit_participant_info(attestation, tls_key);
+
+        // Then
+        match result {
+            Err(Error::InvalidParameters(InvalidParameters::InvalidTeeRemoteAttestation {
+                reason,
+            })) => {
+                assert!(
+                    reason.contains("already in flight"),
+                    "expected in-flight rejection, got: {reason}"
+                );
+            }
+            Ok(_) => panic!("expected in-flight rejection, got Ok"),
+            Err(other) => panic!("expected InvalidTeeRemoteAttestation, got {other:?}"),
+        }
+    }
+
+    /// A `PromiseError::Failed` from the verifier contract must clear
+    /// the pending entry. The caller's deposit refund is scheduled via
+    /// `Promise::transfer` (not observable in unit-test env, but the
+    /// pending-entry teardown is the observable invariant).
+    #[test]
+    fn on_attestation_verified__clears_pending_on_promise_failed() {
+        // Given
+        let (mut contract, participant_account_ids, attestation, tls_key, mpc_hash, near_pk) =
+            setup_tee_test();
+        let block_timestamp_ns = VALID_ATTESTATION_TIMESTAMP * 1_000_000_000;
+        setup_approved_mpc_hash(
+            &mut contract,
+            &participant_account_ids,
+            &mpc_hash,
+            block_timestamp_ns,
+        );
+        setup_approved_measurements(&mut contract, &participant_account_ids, block_timestamp_ns);
+        let account_id = participant_account_ids[0].clone();
+        testing_env!(VMContextBuilder::new()
+            .signer_account_id(account_id.clone())
+            .predecessor_account_id(account_id.clone())
+            .signer_account_pk(near_pk)
+            .attached_deposit(NearToken::from_near(1))
+            .block_timestamp(block_timestamp_ns)
+            .build());
+        let _ = contract
+            .submit_participant_info(attestation, tls_key)
+            .expect("Dstack submit must succeed");
+        assert!(contract.pending_attestations.contains_key(&account_id));
+
+        // When: re-enter the contract under its own account (the
+        // callback is `#[private]` so predecessor must equal current).
+        let current = env::current_account_id();
+        testing_env!(VMContextBuilder::new()
+            .current_account_id(current.clone())
+            .predecessor_account_id(current)
+            .block_timestamp(block_timestamp_ns)
+            .build());
+        contract
+            .on_attestation_verified(account_id.clone(), Err(PromiseError::Failed))
+            .expect("callback must succeed cleanly even on verifier failure");
+
+        // Then
+        assert!(!contract.pending_attestations.contains_key(&account_id));
+        let stored = contract
+            .tee_state
+            .stored_attestations
+            .get(&test_utils::attestation::p2p_tls_key().into());
+        assert!(stored.is_none(), "no stored_attestation on failure");
+    }
+
+    /// The success path: the callback runs post-DCAP verification
+    /// against fresh allowlists and inserts a `stored_attestations`
+    /// entry.
+    #[test]
+    fn on_attestation_verified__inserts_on_success() {
+        // Given
+        let (mut contract, participant_account_ids, attestation, tls_key, mpc_hash, near_pk) =
+            setup_tee_test();
+        let block_timestamp_ns = VALID_ATTESTATION_TIMESTAMP * 1_000_000_000;
+        setup_approved_mpc_hash(
+            &mut contract,
+            &participant_account_ids,
+            &mpc_hash,
+            block_timestamp_ns,
+        );
+        setup_approved_measurements(&mut contract, &participant_account_ids, block_timestamp_ns);
+        let account_id = participant_account_ids[0].clone();
+        testing_env!(VMContextBuilder::new()
+            .signer_account_id(account_id.clone())
+            .predecessor_account_id(account_id.clone())
+            .signer_account_pk(near_pk)
+            .attached_deposit(NearToken::from_near(1))
+            .block_timestamp(block_timestamp_ns)
+            .build());
+        let _ = contract
+            .submit_participant_info(attestation, tls_key.clone())
+            .expect("Dstack submit must succeed");
+
+        // When
+        let current = env::current_account_id();
+        testing_env!(VMContextBuilder::new()
+            .current_account_id(current.clone())
+            .predecessor_account_id(current)
+            .block_timestamp(block_timestamp_ns)
+            .build());
+        let result = contract.on_attestation_verified(
+            account_id.clone(),
+            Ok(verified_report_for_test_attestation()),
+        );
+
+        // Then
+        result.expect("callback must succeed when post-DCAP passes");
+        assert!(!contract.pending_attestations.contains_key(&account_id));
+        let stored = contract
+            .tee_state
+            .stored_attestations
+            .get(&tls_key)
+            .expect("stored_attestation must be present after success");
+        match &stored.verified_attestation {
+            mpc_attestation::attestation::VerifiedAttestation::Dstack(_) => {}
+            other => panic!("expected Dstack stored attestation, got {other:?}"),
+        }
+    }
+
+    /// Allowlists must be read fresh from `tee_state` at callback
+    /// time, not snapshotted at submit time. If governance clears the
+    /// MPC-hash allowlist between submit and callback, verification
+    /// fails and the pending entry is cleared.
+    #[test]
+    fn on_attestation_verified__re_reads_allowlists_at_callback_time() {
+        // Given
+        let (mut contract, participant_account_ids, attestation, tls_key, mpc_hash, near_pk) =
+            setup_tee_test();
+        let block_timestamp_ns = VALID_ATTESTATION_TIMESTAMP * 1_000_000_000;
+        setup_approved_mpc_hash(
+            &mut contract,
+            &participant_account_ids,
+            &mpc_hash,
+            block_timestamp_ns,
+        );
+        setup_approved_measurements(&mut contract, &participant_account_ids, block_timestamp_ns);
+        let account_id = participant_account_ids[0].clone();
+        testing_env!(VMContextBuilder::new()
+            .signer_account_id(account_id.clone())
+            .predecessor_account_id(account_id.clone())
+            .signer_account_pk(near_pk)
+            .attached_deposit(NearToken::from_near(1))
+            .block_timestamp(block_timestamp_ns)
+            .build());
+        let _ = contract
+            .submit_participant_info(attestation, tls_key.clone())
+            .expect("Dstack submit must succeed");
+        // Governance rotates the allowed list out from under us.
+        contract.tee_state.allowed_docker_image_hashes =
+            crate::tee::proposal::AllowedDockerImageHashes::default();
+
+        // When
+        let current = env::current_account_id();
+        testing_env!(VMContextBuilder::new()
+            .current_account_id(current.clone())
+            .predecessor_account_id(current)
+            .block_timestamp(block_timestamp_ns)
+            .build());
+        let result = contract.on_attestation_verified(
+            account_id.clone(),
+            Ok(verified_report_for_test_attestation()),
+        );
+
+        // Then
+        match result {
+            Err(Error::InvalidParameters(InvalidParameters::InvalidTeeRemoteAttestation {
+                ..
+            })) => {}
+            other => panic!("expected InvalidTeeRemoteAttestation, got {other:?}"),
+        }
+        assert!(!contract.pending_attestations.contains_key(&account_id));
+        let stored = contract.tee_state.stored_attestations.get(&tls_key);
+        assert!(stored.is_none(), "no stored_attestation on failure");
     }
 
     fn make_launcher_hash(byte: u8) -> LauncherImageHash {

--- a/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
+++ b/crates/contract/src/snapshots/mpc_contract__tests__mpc_contract_borsh_schema_has_not_changed.snap
@@ -680,6 +680,10 @@ BorshSchemaContainer {
                         "LookupMap",
                     ),
                     (
+                        "pending_attestations",
+                        "IterableMap",
+                    ),
+                    (
                         "proposed_updates",
                         "ProposedUpdates",
                     ),

--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -24,4 +24,5 @@ pub enum StorageKey {
     PendingSignatureRequestsV3,
     StoredAttestations,
     SupportedForeignChainsByNode,
+    PendingAttestations,
 }

--- a/crates/contract/src/tee.rs
+++ b/crates/contract/src/tee.rs
@@ -1,4 +1,5 @@
 pub mod measurements;
+pub mod pending_attestation;
 pub mod proposal;
 pub mod tee_state;
 #[cfg(any(test, feature = "test-utils"))]

--- a/crates/contract/src/tee/pending_attestation.rs
+++ b/crates/contract/src/tee/pending_attestation.rs
@@ -2,8 +2,8 @@
 //! and the `on_attestation_verified` callback that resolves after the
 //! `tee-verifier.near` Promise returns.
 //!
-//! `submit_participant_info` ([`crate::lib::submit_participant_info`])
-//! cannot do the cryptographic quote verification on-chain — that work
+//! `submit_participant_info` cannot do the cryptographic quote
+//! verification on-chain — that work
 //! lives in the `tee-verifier` contract, reached over a cross-contract
 //! Promise. The Promise call returns asynchronously; the contract has
 //! to remember which `account_id`'s submission is pending so the

--- a/crates/contract/src/tee/pending_attestation.rs
+++ b/crates/contract/src/tee/pending_attestation.rs
@@ -14,8 +14,7 @@
 //! `PromiseError`). Each entry holds the inputs the callback needs to
 //! complete verification and apply the storage-deposit refund.
 
-use attestation_types::report_data::ReportData;
-use mpc_attestation::attestation::Attestation;
+use attestation_types::{dstack_attestation::DstackAttestation, report_data::ReportData};
 use near_sdk::{near, NearToken, StorageUsage};
 
 use crate::tee::tee_state::NodeId;
@@ -33,10 +32,12 @@ pub struct PendingAttestation {
     /// against this value during post-DCAP verification.
     pub report_data: ReportData,
 
-    /// The full attestation payload submitted. Carries the `tcb_info`
-    /// (used by the callback for RTMR3 replay + app_compose validation)
-    /// alongside the `quote` / `collateral` already sent to the verifier.
-    pub attestation: Attestation,
+    /// The `Dstack` attestation payload submitted. Carries the
+    /// `tcb_info` the callback needs for RTMR3 replay + app_compose
+    /// validation. Only `Dstack` attestations reach this struct;
+    /// `Mock` attestations stay on the synchronous path and never
+    /// produce a pending entry.
+    pub attestation: DstackAttestation,
 
     /// Amount the caller attached to `submit_participant_info`. The
     /// callback either consumes it against the storage-staking cost of

--- a/crates/contract/src/tee/pending_attestation.rs
+++ b/crates/contract/src/tee/pending_attestation.rs
@@ -1,0 +1,51 @@
+//! `PendingAttestation` — state stashed between `submit_participant_info`
+//! and the `on_attestation_verified` callback that resolves after the
+//! `tee-verifier.near` Promise returns.
+//!
+//! `submit_participant_info` ([`crate::lib::submit_participant_info`])
+//! cannot do the cryptographic quote verification on-chain — that work
+//! lives in the `tee-verifier` contract, reached over a cross-contract
+//! Promise. The Promise call returns asynchronously; the contract has
+//! to remember which `account_id`'s submission is pending so the
+//! callback can resume.
+//!
+//! Stored entries are short-lived: created on Promise dispatch, removed
+//! when `on_attestation_verified` fires (whether successfully or with a
+//! `PromiseError`). Each entry holds the inputs the callback needs to
+//! complete verification and apply the storage-deposit refund.
+
+use attestation_types::report_data::ReportData;
+use mpc_attestation::attestation::Attestation;
+use near_sdk::{near, NearToken, StorageUsage};
+
+use crate::tee::tee_state::NodeId;
+
+#[near(serializers=[borsh])]
+#[derive(Debug)]
+pub struct PendingAttestation {
+    /// The `NodeId` derived from the caller (account_id, tls_pk,
+    /// account_pk). The callback uses this to insert into
+    /// `stored_attestations`.
+    pub node_id: NodeId,
+
+    /// Hash of `(tls_pk, account_pk)` bound into the quote's
+    /// `report_data`. The callback re-checks the mirror's report_data
+    /// against this value during post-DCAP verification.
+    pub report_data: ReportData,
+
+    /// The full attestation payload submitted. Carries the `tcb_info`
+    /// (used by the callback for RTMR3 replay + app_compose validation)
+    /// alongside the `quote` / `collateral` already sent to the verifier.
+    pub attestation: Attestation,
+
+    /// Amount the caller attached to `submit_participant_info`. The
+    /// callback either consumes it against the storage-staking cost of
+    /// the inserted `stored_attestations` entry or refunds it in full
+    /// on verification failure.
+    pub attached_deposit: NearToken,
+
+    /// Contract storage usage measured *before* the pending entry was
+    /// inserted. The callback uses this baseline to compute the storage
+    /// delta a successful insertion produced and charge accordingly.
+    pub initial_storage_usage: StorageUsage,
+}

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -138,28 +138,19 @@ impl TeeState {
         current_time_milliseconds / 1_000
     }
 
-    /// Adds a participant attestation for the given node iff the attestation succeeds verification.
-    pub(crate) fn add_participant(
+    /// Inserts an already-verified attestation into `stored_attestations`.
+    ///
+    /// The verification body that used to live here moved into the
+    /// `submit_participant_info` callback path: for `Dstack` attestations
+    /// it now runs in `MpcContract::on_attestation_verified` (after the
+    /// `tee-verifier.near` Promise resolves); for `Mock` attestations it
+    /// runs synchronously inline. Both call this function with the
+    /// resulting `VerifiedAttestation`.
+    pub(crate) fn finish_add_participant(
         &mut self,
         node_id: NodeId,
-        attestation: Attestation,
-        tee_upgrade_deadline_duration: Duration,
-    ) -> Result<ParticipantInsertion, AttestationSubmissionError> {
-        let expected_report_data: ReportData = ReportDataV1::new(
-            *node_id.tls_public_key.as_bytes(),
-            *node_id.account_public_key.as_bytes(),
-        )
-        .into();
-
-        let accepted_measurements = self.get_accepted_measurements();
-        let verified_attestation = attestation.verify(
-            expected_report_data.into(),
-            Self::current_time_seconds(),
-            &self.get_allowed_mpc_docker_image_hashes(tee_upgrade_deadline_duration),
-            &self.get_allowed_launcher_compose_hashes(),
-            &accepted_measurements,
-        )?;
-
+        verified_attestation: VerifiedAttestation,
+    ) -> ParticipantInsertion {
         let tls_pk = node_id.tls_public_key.clone();
 
         let insertion = self.stored_attestations.insert(
@@ -170,10 +161,10 @@ impl TeeState {
             },
         );
 
-        Ok(match insertion {
+        match insertion {
             Some(_previous_attestation) => ParticipantInsertion::UpdatedExistingParticipant,
             None => ParticipantInsertion::NewlyInsertedParticipant,
-        })
+        }
     }
 
     /// reverifies stored participant attestations.
@@ -360,7 +351,9 @@ impl TeeState {
     /// Returns accepted measurements for attestation verification.
     /// Returns the on-chain list as-is (empty list means no measurements are accepted,
     /// consistent with docker image hashes and launcher hashes).
-    fn get_accepted_measurements(&self) -> Vec<mpc_attestation::attestation::ExpectedMeasurements> {
+    pub(crate) fn get_accepted_measurements(
+        &self,
+    ) -> Vec<mpc_attestation::attestation::ExpectedMeasurements> {
         self.allowed_measurements.to_attestation_measurements()
     }
 

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -10,8 +10,10 @@ use crate::{
     },
 };
 use borsh::{BorshDeserialize, BorshSerialize};
+use mpc_attestation::attestation::{self, VerifiedAttestation};
+#[cfg(test)]
 use mpc_attestation::{
-    attestation::{self, Attestation, VerifiedAttestation},
+    attestation::Attestation,
     report_data::{ReportData, ReportDataV1},
 };
 use mpc_primitives::hash::{LauncherDockerComposeHash, LauncherImageHash};
@@ -95,6 +97,44 @@ impl Default for TeeState {
     }
 }
 
+/// Zero-valued `VerifiedReport` used by test paths that call
+/// `Attestation::finish_verify` on a `Mock` attestation (which ignores
+/// the report contents). Only compiled when the test-only / dev-only
+/// `add_participant` helper is included.
+#[cfg(test)]
+fn test_dummy_verified_report() -> tee_verifier_interface::VerifiedReport {
+    tee_verifier_interface::VerifiedReport {
+        status: String::new(),
+        advisory_ids: Vec::new(),
+        report: tee_verifier_interface::Report::TD10(tee_verifier_interface::TDReport10 {
+            tee_tcb_svn: [0; 16],
+            mr_seam: [0; 48],
+            mr_signer_seam: [0; 48],
+            seam_attributes: [0; 8],
+            td_attributes: [0; 8],
+            xfam: [0; 8],
+            mr_td: [0; 48],
+            mr_config_id: [0; 48],
+            mr_owner: [0; 48],
+            mr_owner_config: [0; 48],
+            rt_mr0: [0; 48],
+            rt_mr1: [0; 48],
+            rt_mr2: [0; 48],
+            rt_mr3: [0; 48],
+            report_data: [0; 64],
+        }),
+        ppid: Vec::new(),
+        qe_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: Vec::new(),
+        },
+        platform_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: Vec::new(),
+        },
+    }
+}
+
 impl TeeState {
     /// Creates a [`TeeState`] with an initial set of participants that will receive a valid mocked attestation.
     pub(crate) fn with_mocked_participant_attestations(participants: &Participants) -> Self {
@@ -136,6 +176,41 @@ impl TeeState {
     fn current_time_seconds() -> u64 {
         let current_time_milliseconds = env::block_timestamp_ms();
         current_time_milliseconds / 1_000
+    }
+
+    /// Test-only convenience that wraps `Attestation::finish_verify` +
+    /// `finish_add_participant` in one call. The pre-PR-C2b production
+    /// API; kept here so the existing test suites don't have to be
+    /// rewritten to construct a `VerifiedAttestation` themselves.
+    ///
+    /// Tests pass `Attestation::Mock` here (no `dcap-qvl` round-trip),
+    /// which is the path that stays synchronous in production too.
+    /// `Attestation::Dstack` is not supported on this path because
+    /// production code goes through the Promise + callback flow in
+    /// `MpcContract::submit_participant_info` / `on_attestation_verified`.
+    #[cfg(test)]
+    pub(crate) fn add_participant(
+        &mut self,
+        node_id: NodeId,
+        attestation: Attestation,
+        tee_upgrade_deadline_duration: Duration,
+    ) -> Result<ParticipantInsertion, mpc_attestation::attestation::VerificationError> {
+        let expected_report_data: ReportData = ReportDataV1::new(
+            *node_id.tls_public_key.as_bytes(),
+            *node_id.account_public_key.as_bytes(),
+        )
+        .into();
+
+        let dummy_report = test_dummy_verified_report();
+        let verified = attestation.finish_verify(
+            &dummy_report,
+            expected_report_data.into(),
+            &self.get_allowed_mpc_docker_image_hashes(tee_upgrade_deadline_duration),
+            &self.get_allowed_launcher_compose_hashes(),
+            &self.get_accepted_measurements(),
+            Self::current_time_seconds(),
+        )?;
+        Ok(self.finish_add_participant(node_id, verified))
     }
 
     /// Inserts an already-verified attestation into `stored_attestations`.
@@ -1312,7 +1387,7 @@ mod tests {
 
         assert_matches!(
             add_participant_result,
-            Err(AttestationSubmissionError::InvalidAttestation(_))
+            Err(mpc_attestation::attestation::VerificationError::InvalidMockAttestation)
         )
     }
 

--- a/crates/contract/src/v3_9_1_state.rs
+++ b/crates/contract/src/v3_9_1_state.rs
@@ -337,6 +337,9 @@ impl From<MpcContract> for crate::MpcContract {
             pending_signature_requests: value.pending_signature_requests,
             pending_ckd_requests: value.pending_ckd_requests,
             pending_verify_foreign_tx_requests: value.pending_verify_foreign_tx_requests,
+            pending_attestations: near_sdk::store::IterableMap::new(
+                crate::storage_keys::StorageKey::PendingAttestations,
+            ),
             proposed_updates: value.proposed_updates,
             node_foreign_chain_support: value.node_foreign_chain_configurations.into(),
             config: value.config,

--- a/crates/contract/tests/inprocess/attestation_submission.rs
+++ b/crates/contract/tests/inprocess/attestation_submission.rs
@@ -219,8 +219,13 @@ impl TestSetup {
     ) -> Result<(), mpc_contract::errors::Error> {
         let context = create_context_for_participant(&node_id.account_id);
         testing_env!(context);
+        // Mock attestations take the synchronous path and return
+        // `PromiseOrValue::Value(())`; Dstack returns a Promise. This
+        // test harness only deals with the success/error shape, so
+        // we discard the wrapper.
         self.contract
             .submit_participant_info(attestation, node_id.tls_public_key.clone())
+            .map(|_| ())
     }
 
     /// Switches testing context to a given participant at a specific timestamp

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -566,6 +566,433 @@ expression: abi
         }
       },
       {
+        "name": "on_attestation_verified",
+        "doc": " Callback invoked by the cross-contract Promise scheduled from\n `submit_participant_info` for `Dstack` attestations. Runs the\n post-DCAP checks against the `VerifiedReport` returned by\n `tee-verifier.near` (or, on `PromiseError::Failed`, refunds the\n caller's deposit and clears the pending entry).\n\n Allowlists are read *fresh* from `self.tee_state` here — not\n from a snapshot taken at submit time. A governance vote that\n lands while the verifier round-trip is in flight therefore\n takes effect immediately.",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "account_id",
+              "type_schema": {
+                "description": "NEAR Account Identifier.\n\nThis is a unique, syntactically valid, human-readable account identifier on the NEAR network.\n\n[See the crate-level docs for information about validation.](index.html#account-id-rules)\n\nAlso see [Error kind precedence](AccountId#error-kind-precedence).\n\n## Examples\n\n``` use near_account_id::AccountId;\n\nlet alice: AccountId = \"alice.near\".parse().unwrap();\n\nassert!(\"ƒelicia.near\".parse::<AccountId>().is_err()); // (ƒ is not f) ```",
+                "type": "string"
+              }
+            }
+          ]
+        },
+        "callbacks": [
+          {
+            "serialization_type": "borsh",
+            "type_schema": {
+              "declaration": "VerifiedReport",
+              "definitions": {
+                "EnclaveReport": {
+                  "Struct": [
+                    [
+                      "cpu_svn",
+                      "[u8; 16]"
+                    ],
+                    [
+                      "misc_select",
+                      "u32"
+                    ],
+                    [
+                      "reserved1",
+                      "[u8; 28]"
+                    ],
+                    [
+                      "attributes",
+                      "[u8; 16]"
+                    ],
+                    [
+                      "mr_enclave",
+                      "[u8; 32]"
+                    ],
+                    [
+                      "reserved2",
+                      "[u8; 32]"
+                    ],
+                    [
+                      "mr_signer",
+                      "[u8; 32]"
+                    ],
+                    [
+                      "reserved3",
+                      "[u8; 96]"
+                    ],
+                    [
+                      "isv_prod_id",
+                      "u16"
+                    ],
+                    [
+                      "isv_svn",
+                      "u16"
+                    ],
+                    [
+                      "reserved4",
+                      "[u8; 60]"
+                    ],
+                    [
+                      "report_data",
+                      "[u8; 64]"
+                    ]
+                  ]
+                },
+                "Report": {
+                  "Enum": {
+                    "tag_width": 1,
+                    "variants": [
+                      [
+                        0,
+                        "SgxEnclave",
+                        "Report__SgxEnclave"
+                      ],
+                      [
+                        1,
+                        "TD10",
+                        "Report__TD10"
+                      ],
+                      [
+                        2,
+                        "TD15",
+                        "Report__TD15"
+                      ]
+                    ]
+                  }
+                },
+                "Report__SgxEnclave": {
+                  "Struct": [
+                    "EnclaveReport"
+                  ]
+                },
+                "Report__TD10": {
+                  "Struct": [
+                    "TDReport10"
+                  ]
+                },
+                "Report__TD15": {
+                  "Struct": [
+                    "TDReport15"
+                  ]
+                },
+                "String": {
+                  "Sequence": {
+                    "length_width": 4,
+                    "length_range": {
+                      "start": 0,
+                      "end": 4294967295
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "TDReport10": {
+                  "Struct": [
+                    [
+                      "tee_tcb_svn",
+                      "[u8; 16]"
+                    ],
+                    [
+                      "mr_seam",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "mr_signer_seam",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "seam_attributes",
+                      "[u8; 8]"
+                    ],
+                    [
+                      "td_attributes",
+                      "[u8; 8]"
+                    ],
+                    [
+                      "xfam",
+                      "[u8; 8]"
+                    ],
+                    [
+                      "mr_td",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "mr_config_id",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "mr_owner",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "mr_owner_config",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "rt_mr0",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "rt_mr1",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "rt_mr2",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "rt_mr3",
+                      "[u8; 48]"
+                    ],
+                    [
+                      "report_data",
+                      "[u8; 64]"
+                    ]
+                  ]
+                },
+                "TDReport15": {
+                  "Struct": [
+                    [
+                      "base",
+                      "TDReport10"
+                    ],
+                    [
+                      "tee_tcb_svn2",
+                      "[u8; 16]"
+                    ],
+                    [
+                      "mr_service_td",
+                      "[u8; 48]"
+                    ]
+                  ]
+                },
+                "TcbStatus": {
+                  "Enum": {
+                    "tag_width": 1,
+                    "variants": [
+                      [
+                        0,
+                        "UpToDate",
+                        "TcbStatus__UpToDate"
+                      ],
+                      [
+                        1,
+                        "OutOfDateConfigurationNeeded",
+                        "TcbStatus__OutOfDateConfigurationNeeded"
+                      ],
+                      [
+                        2,
+                        "OutOfDate",
+                        "TcbStatus__OutOfDate"
+                      ],
+                      [
+                        3,
+                        "ConfigurationAndSWHardeningNeeded",
+                        "TcbStatus__ConfigurationAndSWHardeningNeeded"
+                      ],
+                      [
+                        4,
+                        "ConfigurationNeeded",
+                        "TcbStatus__ConfigurationNeeded"
+                      ],
+                      [
+                        5,
+                        "SWHardeningNeeded",
+                        "TcbStatus__SWHardeningNeeded"
+                      ],
+                      [
+                        6,
+                        "Revoked",
+                        "TcbStatus__Revoked"
+                      ]
+                    ]
+                  }
+                },
+                "TcbStatusWithAdvisory": {
+                  "Struct": [
+                    [
+                      "status",
+                      "TcbStatus"
+                    ],
+                    [
+                      "advisory_ids",
+                      "Vec<String>"
+                    ]
+                  ]
+                },
+                "TcbStatus__ConfigurationAndSWHardeningNeeded": {
+                  "Struct": null
+                },
+                "TcbStatus__ConfigurationNeeded": {
+                  "Struct": null
+                },
+                "TcbStatus__OutOfDate": {
+                  "Struct": null
+                },
+                "TcbStatus__OutOfDateConfigurationNeeded": {
+                  "Struct": null
+                },
+                "TcbStatus__Revoked": {
+                  "Struct": null
+                },
+                "TcbStatus__SWHardeningNeeded": {
+                  "Struct": null
+                },
+                "TcbStatus__UpToDate": {
+                  "Struct": null
+                },
+                "Vec<String>": {
+                  "Sequence": {
+                    "length_width": 4,
+                    "length_range": {
+                      "start": 0,
+                      "end": 4294967295
+                    },
+                    "elements": "String"
+                  }
+                },
+                "Vec<u8>": {
+                  "Sequence": {
+                    "length_width": 4,
+                    "length_range": {
+                      "start": 0,
+                      "end": 4294967295
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "VerifiedReport": {
+                  "Struct": [
+                    [
+                      "status",
+                      "String"
+                    ],
+                    [
+                      "advisory_ids",
+                      "Vec<String>"
+                    ],
+                    [
+                      "report",
+                      "Report"
+                    ],
+                    [
+                      "ppid",
+                      "Vec<u8>"
+                    ],
+                    [
+                      "qe_status",
+                      "TcbStatusWithAdvisory"
+                    ],
+                    [
+                      "platform_status",
+                      "TcbStatusWithAdvisory"
+                    ]
+                  ]
+                },
+                "[u8; 16]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 16,
+                      "end": 16
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "[u8; 28]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 28,
+                      "end": 28
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "[u8; 32]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 32,
+                      "end": 32
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "[u8; 48]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 48,
+                      "end": 48
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "[u8; 60]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 60,
+                      "end": 60
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "[u8; 64]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 64,
+                      "end": 64
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "[u8; 8]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 8,
+                      "end": 8
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "[u8; 96]": {
+                  "Sequence": {
+                    "length_width": 0,
+                    "length_range": {
+                      "start": 96,
+                      "end": 96
+                    },
+                    "elements": "u8"
+                  }
+                },
+                "u16": {
+                  "Primitive": 2
+                },
+                "u32": {
+                  "Primitive": 4
+                },
+                "u8": {
+                  "Primitive": 1
+                }
+              }
+            }
+          }
+        ],
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "null"
+          }
+        }
+      },
+      {
         "name": "os_measurement_votes",
         "doc": " Returns the current OS measurement votes, showing each participant's vote.",
         "kind": "view",
@@ -1140,7 +1567,7 @@ expression: abi
       },
       {
         "name": "submit_participant_info",
-        "doc": " (Prospective) Participants can submit their tee participant information through this\n endpoint.",
+        "doc": " (Prospective) Participants can submit their tee participant information through this\n endpoint.\n\n For `Attestation::Mock` (test/dev), validation runs synchronously\n and the call returns `PromiseOrValue::Value(())` immediately.\n\n For `Attestation::Dstack` (production), the heavy `dcap_qvl::verify`\n call is delegated to `tee-verifier.near` via a cross-contract\n Promise; the post-DCAP checks resume in\n [`Self::on_attestation_verified`] when the callback fires. A\n `PendingAttestation` entry is stashed under the caller's\n `account_id` until the callback resolves. Re-submissions while\n a prior one is in flight are rejected to avoid silently\n overwriting and stranding the original's attached deposit.",
         "kind": "call",
         "modifiers": [
           "payable"
@@ -1165,7 +1592,7 @@ expression: abi
         "result": {
           "serialization_type": "json",
           "type_schema": {
-            "type": "null"
+            "$ref": "#/definitions/PromiseOrValueNull"
           }
         }
       },
@@ -3115,6 +3542,9 @@ expression: abi
               "$ref": "#/definitions/Bls12381G1PublicKey"
             }
           }
+        },
+        "PromiseOrValueNull": {
+          "type": "null"
         },
         "PromiseOrValueSignatureResponse": {
           "oneOf": [

--- a/crates/mpc-attestation/Cargo.toml
+++ b/crates/mpc-attestation/Cargo.toml
@@ -5,12 +5,22 @@ license = { workspace = true }
 edition = { workspace = true }
 
 [features]
-abi = ["borsh/unstable__schema", "mpc-primitives/abi", "attestation/borsh-schema"]
-dstack-conversions = ["attestation/dstack-conversions"]
-test-utils = ["attestation/test-utils"]
+abi = [
+    "borsh/unstable__schema",
+    "mpc-primitives/abi",
+    "attestation-types/borsh-schema",
+]
+dstack-conversions = ["attestation-types/dstack-conversions"]
+test-utils = ["attestation-types/test-utils"]
+# Re-exports `collateral_from_dcap` / `collateral_to_dcap` from the
+# `attestation` crate. Off-chain consumers (`tee-authority`,
+# `attestation-cli`) enable this; on-chain consumers (`mpc-contract`)
+# do not, so they don't transitively pull `dcap-qvl`.
+local-verify = ["dep:attestation"]
 
 [dependencies]
-attestation = { workspace = true }
+attestation = { workspace = true, optional = true }
+attestation-types = { workspace = true }
 borsh = { workspace = true }
 derive_more = { workspace = true }
 hex = { workspace = true }
@@ -21,11 +31,14 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
 sha3 = { workspace = true }
+tee-verifier-interface = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+attestation = { workspace = true }
 dcap-qvl = { workspace = true }
 test-utils = { workspace = true }
+tee-verifier-interface = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mpc-attestation/Cargo.toml
+++ b/crates/mpc-attestation/Cargo.toml
@@ -12,15 +12,18 @@ abi = [
 ]
 dstack-conversions = ["attestation-types/dstack-conversions"]
 test-utils = ["attestation-types/test-utils"]
-# Re-exports `collateral_from_dcap` / `collateral_to_dcap` from the
-# `attestation` crate. Off-chain consumers (`tee-authority`,
-# `attestation-cli`) enable this; on-chain consumers (`mpc-contract`)
-# do not, so they don't transitively pull `dcap-qvl`.
-local-verify = ["dep:attestation"]
+# Enables the off-chain `local_verify` convenience helper that runs the
+# full `dcap_qvl::verify::verify` + post-DCAP path in one call. Pulls in
+# the `attestation` crate (and `dcap-qvl` via it). Off-chain consumers
+# (`tee-authority`, `attestation-cli`, `mpc-node`) enable this; on-chain
+# consumers (`mpc-contract`) do not, so they don't transitively pull
+# `dcap-qvl` into their WASM.
+local-verify = ["dep:attestation", "dep:dcap-qvl"]
 
 [dependencies]
 attestation = { workspace = true, optional = true }
 attestation-types = { workspace = true }
+dcap-qvl = { workspace = true, optional = true }
 borsh = { workspace = true }
 derive_more = { workspace = true }
 hex = { workspace = true }

--- a/crates/mpc-attestation/Cargo.toml
+++ b/crates/mpc-attestation/Cargo.toml
@@ -23,8 +23,8 @@ local-verify = ["dep:attestation", "dep:dcap-qvl"]
 [dependencies]
 attestation = { workspace = true, optional = true }
 attestation-types = { workspace = true }
-dcap-qvl = { workspace = true, optional = true }
 borsh = { workspace = true }
+dcap-qvl = { workspace = true, optional = true }
 derive_more = { workspace = true }
 hex = { workspace = true }
 include-measurements = { workspace = true }
@@ -40,8 +40,8 @@ tee-verifier-interface = { workspace = true }
 assert_matches = { workspace = true }
 attestation = { workspace = true }
 dcap-qvl = { workspace = true }
-test-utils = { workspace = true }
 tee-verifier-interface = { workspace = true }
+test-utils = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/mpc-attestation/src/attestation.rs
+++ b/crates/mpc-attestation/src/attestation.rs
@@ -1,19 +1,27 @@
 use alloc::vec::Vec;
-pub use attestation::attestation::{DstackAttestation, VerificationError};
-pub use attestation::measurements::{ExpectedMeasurements, Measurements};
-use attestation::{
+
+pub use attestation_types::dstack_attestation::DstackAttestation;
+pub use attestation_types::measurements::{ExpectedMeasurements, Measurements};
+pub use attestation_types::verify_post_dcap::VerificationError;
+
+use attestation_types::{
     app_compose::AppCompose,
-    attestation::{DstackVerify as _, GetSingleEvent as _, OrErr as _},
+    collateral::Collateral,
+    quote::QuoteBytes,
     report_data::ReportData,
+    verify_post_dcap::{
+        GetSingleEvent as _, OrErr as _, verify_any_measurements, verify_app_compose,
+        verify_report_data, verify_rtmr3, verify_tcb_status,
+    },
 };
 
-use include_measurements::include_measurements;
-use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
-
 use borsh::{BorshDeserialize, BorshSerialize};
+use include_measurements::include_measurements;
 use launcher_interface::MPC_IMAGE_HASH_EVENT;
+use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest as _, Sha256};
+use tee_verifier_interface::VerifiedReport;
 
 use crate::alloc::format;
 use crate::alloc::string::ToString;
@@ -132,17 +140,51 @@ pub fn default_measurements() -> &'static [ExpectedMeasurements] {
 }
 
 impl Attestation {
-    pub fn verify(
+    /// Extracts the cryptographic inputs the verifier contract needs
+    /// (`quote` and `collateral`) from a `Dstack` attestation. Returns
+    /// `None` for `Mock` attestations, which take the synchronous
+    /// in-contract validation path and never round-trip the verifier.
+    ///
+    /// Called by `mpc-contract::submit_participant_info` *before*
+    /// scheduling the Promise into `tee-verifier.near`. The remaining
+    /// pieces of the attestation (`tcb_info`, the variant itself) are
+    /// kept around and consumed by [`Attestation::finish_verify`] when
+    /// the Promise callback fires.
+    pub fn extract_dcap_inputs(&self) -> Option<(QuoteBytes, Collateral)> {
+        match self {
+            Self::Dstack(dstack) => Some((dstack.quote.clone(), dstack.collateral.clone())),
+            Self::Mock(_) => None,
+        }
+    }
+
+    /// Runs the post-DCAP checks against an already-verified report.
+    ///
+    /// For `Dstack` attestations, this is everything the old combined
+    /// `verify` method did *after* `dcap_qvl::verify::verify` returned:
+    /// MPC image hash extraction, launcher compose hash computation,
+    /// the post-DCAP helpers (TCB status, report_data binding, RTMR3
+    /// replay, app_compose validation, measurement matching), and
+    /// finally building the `ValidatedDstackAttestation` with the 7-day
+    /// expiry.
+    ///
+    /// For `Mock` attestations, ignores `verified_report` and runs the
+    /// `verify_mock_attestation` body.
+    pub fn finish_verify(
         &self,
+        verified_report: &VerifiedReport,
         expected_report_data: ReportData,
-        current_timestamp_seconds: u64,
         allowed_mpc_docker_image_hashes: &[NodeImageHash],
         allowed_launcher_docker_compose_hashes: &[LauncherDockerComposeHash],
         accepted_measurements: &[ExpectedMeasurements],
+        current_timestamp_seconds: u64,
     ) -> Result<VerifiedAttestation, VerificationError> {
         match self {
             Self::Dstack(dstack_attestation) => {
-                // Makes MPC related attestation verification first
+                let report_data = verified_report
+                    .report
+                    .as_td10()
+                    .ok_or(VerificationError::ReportNotTd10)?;
+
                 let mpc_image_hash: NodeImageHash = {
                     let mpc_image_hash_payload = &dstack_attestation
                         .tcb_info
@@ -184,9 +226,13 @@ impl Attestation {
                     allowed_launcher_docker_compose_hashes,
                 )?;
 
-                let measurements = dstack_attestation.verify(
-                    expected_report_data,
-                    current_timestamp_seconds,
+                verify_tcb_status(verified_report)?;
+                verify_report_data(&expected_report_data, report_data)?;
+                verify_rtmr3(report_data, &dstack_attestation.tcb_info)?;
+                verify_app_compose(&dstack_attestation.tcb_info)?;
+                let measurements = verify_any_measurements(
+                    report_data,
+                    &dstack_attestation.tcb_info,
                     accepted_measurements,
                 )?;
 
@@ -201,7 +247,6 @@ impl Attestation {
                 }))
             }
             Self::Mock(mock_attestation) => {
-                // Override attestation verification for this case
                 let () = verify_mock_attestation(
                     mock_attestation,
                     allowed_mpc_docker_image_hashes,

--- a/crates/mpc-attestation/src/lib.rs
+++ b/crates/mpc-attestation/src/lib.rs
@@ -15,3 +15,6 @@ pub use attestation_types::{collateral, quote, tcb_info};
 /// tests) enable this feature.
 #[cfg(feature = "local-verify")]
 pub use ::attestation::{collateral_from_dcap, collateral_to_dcap};
+
+#[cfg(feature = "local-verify")]
+pub mod local_verify;

--- a/crates/mpc-attestation/src/lib.rs
+++ b/crates/mpc-attestation/src/lib.rs
@@ -5,4 +5,13 @@ extern crate alloc;
 pub mod attestation;
 pub mod report_data;
 
-pub use ::attestation::{collateral, collateral_from_dcap, collateral_to_dcap, quote, tcb_info};
+pub use attestation_types::{collateral, quote, tcb_info};
+
+/// Re-exports of the off-chain `attestation` crate's `dcap-qvl`
+/// conversion helpers, gated on a feature flag so that on-chain
+/// consumers (`mpc-contract`) don't pull `dcap-qvl` into their WASM.
+///
+/// Off-chain consumers (`tee-authority`, `attestation-cli`, integration
+/// tests) enable this feature.
+#[cfg(feature = "local-verify")]
+pub use ::attestation::{collateral_from_dcap, collateral_to_dcap};

--- a/crates/mpc-attestation/src/local_verify.rs
+++ b/crates/mpc-attestation/src/local_verify.rs
@@ -1,0 +1,178 @@
+//! Off-chain convenience: full local verification in one call.
+//!
+//! Combines `attestation::DstackVerify::verify` (the `dcap_qvl`
+//! cryptographic call) with `Attestation::finish_verify` (the post-DCAP
+//! checks). Mirrors the behavior of the deleted combined
+//! `Attestation::verify` method.
+//!
+//! Off-chain consumers (`tee-authority`, `attestation-cli`, `mpc-node`,
+//! integration tests) call this. The on-chain `mpc-contract` does NOT
+//! use it — it delegates the cryptographic call to the verifier contract
+//! via Promise + callback (see `mpc_contract::on_attestation_verified`).
+//! That's how `dcap-qvl` and its closure stay out of the contract's WASM.
+
+use alloc::string::ToString as _;
+
+use attestation::attestation::DstackVerify as _;
+use attestation_types::{
+    measurements::ExpectedMeasurements, report_data::ReportData,
+    verify_post_dcap::VerificationError,
+};
+use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
+
+use crate::attestation::{Attestation, VerifiedAttestation};
+
+/// One-shot local verification: runs `dcap_qvl::verify::verify`
+/// followed by the post-DCAP checks against the resulting mirror
+/// `VerifiedReport`. Returns the `VerifiedAttestation` on success.
+///
+/// `Mock` attestations skip the dcap-qvl call (they have no quote);
+/// the post-DCAP path handles them via the existing
+/// `verify_mock_attestation` flow.
+pub fn local_verify(
+    attestation: &Attestation,
+    expected_report_data: ReportData,
+    timestamp_seconds: u64,
+    allowed_mpc_docker_image_hashes: &[NodeImageHash],
+    allowed_launcher_docker_compose_hashes: &[LauncherDockerComposeHash],
+    accepted_measurements: &[ExpectedMeasurements],
+) -> Result<VerifiedAttestation, VerificationError> {
+    let verified_report = match attestation {
+        Attestation::Dstack(dstack) => {
+            let _matched = dstack.verify(
+                expected_report_data.clone(),
+                timestamp_seconds,
+                accepted_measurements,
+            )?;
+            local_dcap_verify(dstack, timestamp_seconds)?
+        }
+        Attestation::Mock(_) => zero_verified_report(),
+    };
+
+    attestation.finish_verify(
+        &verified_report,
+        expected_report_data,
+        allowed_mpc_docker_image_hashes,
+        allowed_launcher_docker_compose_hashes,
+        accepted_measurements,
+        timestamp_seconds,
+    )
+}
+
+fn local_dcap_verify(
+    dstack: &crate::attestation::DstackAttestation,
+    timestamp_seconds: u64,
+) -> Result<tee_verifier_interface::VerifiedReport, VerificationError> {
+    let collateral = ::attestation::collateral_to_dcap(dstack.collateral.clone());
+    let verification_result =
+        dcap_qvl::verify::verify(&dstack.quote, &collateral, timestamp_seconds)
+            .map_err(|e| VerificationError::DcapVerification(e.to_string()))?;
+    Ok(dcap_to_mirror(verification_result))
+}
+
+fn dcap_to_mirror(
+    value: dcap_qvl::verify::VerifiedReport,
+) -> tee_verifier_interface::VerifiedReport {
+    tee_verifier_interface::VerifiedReport {
+        status: value.status,
+        advisory_ids: value.advisory_ids,
+        report: match value.report {
+            dcap_qvl::quote::Report::SgxEnclave(_) => {
+                panic!("SGX enclave reports are not supported by mpc-attestation")
+            }
+            dcap_qvl::quote::Report::TD10(r) => {
+                tee_verifier_interface::Report::TD10(td10_to_mirror(r))
+            }
+            dcap_qvl::quote::Report::TD15(r) => {
+                tee_verifier_interface::Report::TD15(tee_verifier_interface::TDReport15 {
+                    base: td10_to_mirror(r.base),
+                    tee_tcb_svn2: r.tee_tcb_svn2,
+                    mr_service_td: r.mr_service_td,
+                })
+            }
+        },
+        ppid: value.ppid,
+        qe_status: tcb_status_with_advisory_to_mirror(value.qe_status),
+        platform_status: tcb_status_with_advisory_to_mirror(value.platform_status),
+    }
+}
+
+fn td10_to_mirror(value: dcap_qvl::quote::TDReport10) -> tee_verifier_interface::TDReport10 {
+    tee_verifier_interface::TDReport10 {
+        tee_tcb_svn: value.tee_tcb_svn,
+        mr_seam: value.mr_seam,
+        mr_signer_seam: value.mr_signer_seam,
+        seam_attributes: value.seam_attributes,
+        td_attributes: value.td_attributes,
+        xfam: value.xfam,
+        mr_td: value.mr_td,
+        mr_config_id: value.mr_config_id,
+        mr_owner: value.mr_owner,
+        mr_owner_config: value.mr_owner_config,
+        rt_mr0: value.rt_mr0,
+        rt_mr1: value.rt_mr1,
+        rt_mr2: value.rt_mr2,
+        rt_mr3: value.rt_mr3,
+        report_data: value.report_data,
+    }
+}
+
+fn tcb_status_with_advisory_to_mirror(
+    value: dcap_qvl::tcb_info::TcbStatusWithAdvisory,
+) -> tee_verifier_interface::TcbStatusWithAdvisory {
+    tee_verifier_interface::TcbStatusWithAdvisory {
+        status: match value.status {
+            dcap_qvl::tcb_info::TcbStatus::UpToDate => tee_verifier_interface::TcbStatus::UpToDate,
+            dcap_qvl::tcb_info::TcbStatus::OutOfDateConfigurationNeeded => {
+                tee_verifier_interface::TcbStatus::OutOfDateConfigurationNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::OutOfDate => {
+                tee_verifier_interface::TcbStatus::OutOfDate
+            }
+            dcap_qvl::tcb_info::TcbStatus::ConfigurationAndSWHardeningNeeded => {
+                tee_verifier_interface::TcbStatus::ConfigurationAndSWHardeningNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::ConfigurationNeeded => {
+                tee_verifier_interface::TcbStatus::ConfigurationNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::SWHardeningNeeded => {
+                tee_verifier_interface::TcbStatus::SWHardeningNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::Revoked => tee_verifier_interface::TcbStatus::Revoked,
+        },
+        advisory_ids: value.advisory_ids,
+    }
+}
+
+fn zero_verified_report() -> tee_verifier_interface::VerifiedReport {
+    tee_verifier_interface::VerifiedReport {
+        status: alloc::string::String::new(),
+        advisory_ids: alloc::vec::Vec::new(),
+        report: tee_verifier_interface::Report::TD10(tee_verifier_interface::TDReport10 {
+            tee_tcb_svn: [0; 16],
+            mr_seam: [0; 48],
+            mr_signer_seam: [0; 48],
+            seam_attributes: [0; 8],
+            td_attributes: [0; 8],
+            xfam: [0; 8],
+            mr_td: [0; 48],
+            mr_config_id: [0; 48],
+            mr_owner: [0; 48],
+            mr_owner_config: [0; 48],
+            rt_mr0: [0; 48],
+            rt_mr1: [0; 48],
+            rt_mr2: [0; 48],
+            rt_mr3: [0; 48],
+            report_data: [0; 64],
+        }),
+        ppid: alloc::vec::Vec::new(),
+        qe_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: alloc::vec::Vec::new(),
+        },
+        platform_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: alloc::vec::Vec::new(),
+        },
+    }
+}

--- a/crates/mpc-attestation/src/local_verify.rs
+++ b/crates/mpc-attestation/src/local_verify.rs
@@ -59,6 +59,17 @@ pub fn local_verify(
     )
 }
 
+/// Runs the `dcap_qvl::verify::verify` cryptographic call against a
+/// `DstackAttestation` and returns the result as the wire-mirror
+/// `VerifiedReport`. Useful for tests that need a real, well-formed
+/// `VerifiedReport` (e.g. exercising the post-DCAP path on its own).
+pub fn dstack_to_verified_report(
+    dstack: &crate::attestation::DstackAttestation,
+    timestamp_seconds: u64,
+) -> Result<tee_verifier_interface::VerifiedReport, VerificationError> {
+    local_dcap_verify(dstack, timestamp_seconds)
+}
+
 fn local_dcap_verify(
     dstack: &crate::attestation::DstackAttestation,
     timestamp_seconds: u64,

--- a/crates/mpc-attestation/src/report_data.rs
+++ b/crates/mpc-attestation/src/report_data.rs
@@ -1,4 +1,4 @@
-use ::attestation::report_data::REPORT_DATA_SIZE;
+use ::attestation_types::report_data::REPORT_DATA_SIZE;
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{AsRef, Deref, From};
 use serde::{Deserialize, Serialize};
@@ -158,9 +158,9 @@ impl From<ReportDataV1> for ReportData {
     }
 }
 
-impl From<ReportData> for ::attestation::report_data::ReportData {
+impl From<ReportData> for ::attestation_types::report_data::ReportData {
     fn from(val: ReportData) -> Self {
-        ::attestation::report_data::ReportData::from(val.to_bytes())
+        ::attestation_types::report_data::ReportData::from(val.to_bytes())
     }
 }
 

--- a/crates/mpc-attestation/tests/test_attestation_verification.rs
+++ b/crates/mpc-attestation/tests/test_attestation_verification.rs
@@ -1,15 +1,183 @@
 use assert_matches::assert_matches;
-use attestation::attestation::VerificationError;
-use attestation::measurements::{ExpectedMeasurements, Measurements};
+use attestation::attestation::DstackVerify as _;
+use attestation_types::measurements::{ExpectedMeasurements, Measurements};
+use attestation_types::verify_post_dcap::VerificationError;
 use mpc_attestation::attestation::{
     Attestation, DEFAULT_EXPIRATION_DURATION_SECONDS, MockAttestation, VerifiedAttestation,
     default_measurements,
 };
 use mpc_attestation::report_data::{ReportData, ReportDataV1};
+use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
 use test_utils::attestation::{
     VALID_ATTESTATION_TIMESTAMP, account_key, image_digest, launcher_compose_digest,
     mock_dstack_attestation, p2p_tls_key,
 };
+
+/// Off-chain convenience: runs the full dcap-qvl + post-DCAP path in
+/// one call. Mirrors what the deleted `Attestation::verify` method used
+/// to do. Lives here because `mpc-attestation` no longer depends on
+/// the `dcap-qvl`-using `attestation` crate.
+fn local_verify(
+    attestation: &Attestation,
+    expected_report_data: ReportData,
+    timestamp_seconds: u64,
+    allowed_mpc_docker_image_hashes: &[NodeImageHash],
+    allowed_launcher_docker_compose_hashes: &[LauncherDockerComposeHash],
+    accepted_measurements: &[ExpectedMeasurements],
+) -> Result<VerifiedAttestation, VerificationError> {
+    let verified_report = match attestation {
+        Attestation::Dstack(dstack) => {
+            let measurements = dstack.verify(
+                expected_report_data.clone(),
+                timestamp_seconds,
+                accepted_measurements,
+            )?;
+            // `DstackVerify::verify` already ran the post-DCAP checks
+            // for us, including measurement matching. We still need a
+            // `VerifiedReport` to pass into `finish_verify` (which
+            // re-runs the same checks) — build it by re-calling the
+            // local conversion. This path is off-chain and the double
+            // work is negligible.
+            //
+            // The simpler alternative would be to factor a `verify_raw`
+            // out of `attestation` that returns the mirror report
+            // directly. For test code, this is fine; production callers
+            // (the `mpc-contract` Promise callback) get the mirror
+            // directly from the verifier contract.
+            let _ = measurements;
+            local_dcap_verify(dstack, timestamp_seconds)?
+        }
+        Attestation::Mock(_) => zero_verified_report(),
+    };
+
+    attestation.finish_verify(
+        &verified_report,
+        expected_report_data,
+        allowed_mpc_docker_image_hashes,
+        allowed_launcher_docker_compose_hashes,
+        accepted_measurements,
+        timestamp_seconds,
+    )
+}
+
+/// Calls `dcap_qvl::verify::verify` against a `DstackAttestation` and
+/// returns the result as the Borsh mirror.
+fn local_dcap_verify(
+    dstack: &mpc_attestation::attestation::DstackAttestation,
+    timestamp_seconds: u64,
+) -> Result<tee_verifier_interface::VerifiedReport, VerificationError> {
+    let collateral = attestation::collateral_to_dcap(dstack.collateral.clone());
+    let verification_result =
+        dcap_qvl::verify::verify(&dstack.quote, &collateral, timestamp_seconds)
+            .map_err(|e| VerificationError::DcapVerification(e.to_string()))?;
+    Ok(dcap_to_mirror(verification_result))
+}
+
+fn dcap_to_mirror(
+    value: dcap_qvl::verify::VerifiedReport,
+) -> tee_verifier_interface::VerifiedReport {
+    tee_verifier_interface::VerifiedReport {
+        status: value.status,
+        advisory_ids: value.advisory_ids,
+        report: match value.report {
+            dcap_qvl::quote::Report::SgxEnclave(_) => unreachable!("SGX not used in tests"),
+            dcap_qvl::quote::Report::TD10(r) => {
+                tee_verifier_interface::Report::TD10(td10_to_mirror(r))
+            }
+            dcap_qvl::quote::Report::TD15(r) => {
+                tee_verifier_interface::Report::TD15(tee_verifier_interface::TDReport15 {
+                    base: td10_to_mirror(r.base),
+                    tee_tcb_svn2: r.tee_tcb_svn2,
+                    mr_service_td: r.mr_service_td,
+                })
+            }
+        },
+        ppid: value.ppid,
+        qe_status: tcb_status_with_advisory_to_mirror(value.qe_status),
+        platform_status: tcb_status_with_advisory_to_mirror(value.platform_status),
+    }
+}
+
+fn td10_to_mirror(value: dcap_qvl::quote::TDReport10) -> tee_verifier_interface::TDReport10 {
+    tee_verifier_interface::TDReport10 {
+        tee_tcb_svn: value.tee_tcb_svn,
+        mr_seam: value.mr_seam,
+        mr_signer_seam: value.mr_signer_seam,
+        seam_attributes: value.seam_attributes,
+        td_attributes: value.td_attributes,
+        xfam: value.xfam,
+        mr_td: value.mr_td,
+        mr_config_id: value.mr_config_id,
+        mr_owner: value.mr_owner,
+        mr_owner_config: value.mr_owner_config,
+        rt_mr0: value.rt_mr0,
+        rt_mr1: value.rt_mr1,
+        rt_mr2: value.rt_mr2,
+        rt_mr3: value.rt_mr3,
+        report_data: value.report_data,
+    }
+}
+
+fn tcb_status_with_advisory_to_mirror(
+    value: dcap_qvl::tcb_info::TcbStatusWithAdvisory,
+) -> tee_verifier_interface::TcbStatusWithAdvisory {
+    tee_verifier_interface::TcbStatusWithAdvisory {
+        status: match value.status {
+            dcap_qvl::tcb_info::TcbStatus::UpToDate => tee_verifier_interface::TcbStatus::UpToDate,
+            dcap_qvl::tcb_info::TcbStatus::OutOfDateConfigurationNeeded => {
+                tee_verifier_interface::TcbStatus::OutOfDateConfigurationNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::OutOfDate => {
+                tee_verifier_interface::TcbStatus::OutOfDate
+            }
+            dcap_qvl::tcb_info::TcbStatus::ConfigurationAndSWHardeningNeeded => {
+                tee_verifier_interface::TcbStatus::ConfigurationAndSWHardeningNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::ConfigurationNeeded => {
+                tee_verifier_interface::TcbStatus::ConfigurationNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::SWHardeningNeeded => {
+                tee_verifier_interface::TcbStatus::SWHardeningNeeded
+            }
+            dcap_qvl::tcb_info::TcbStatus::Revoked => tee_verifier_interface::TcbStatus::Revoked,
+        },
+        advisory_ids: value.advisory_ids,
+    }
+}
+
+/// Zero-valued `VerifiedReport` for `Mock` paths that ignore it.
+fn zero_verified_report() -> tee_verifier_interface::VerifiedReport {
+    tee_verifier_interface::VerifiedReport {
+        status: String::new(),
+        advisory_ids: Vec::new(),
+        report: tee_verifier_interface::Report::TD10(tee_verifier_interface::TDReport10 {
+            tee_tcb_svn: [0; 16],
+            mr_seam: [0; 48],
+            mr_signer_seam: [0; 48],
+            seam_attributes: [0; 8],
+            td_attributes: [0; 8],
+            xfam: [0; 8],
+            mr_td: [0; 48],
+            mr_config_id: [0; 48],
+            mr_owner: [0; 48],
+            mr_owner_config: [0; 48],
+            rt_mr0: [0; 48],
+            rt_mr1: [0; 48],
+            rt_mr2: [0; 48],
+            rt_mr3: [0; 48],
+            report_data: [0; 64],
+        }),
+        ppid: Vec::new(),
+        qe_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: Vec::new(),
+        },
+        platform_status: tee_verifier_interface::TcbStatusWithAdvisory {
+            status: tee_verifier_interface::TcbStatus::UpToDate,
+            advisory_ids: Vec::new(),
+        },
+    }
+}
 
 #[test]
 fn valid_mock_attestation_succeeds_verification() {
@@ -21,7 +189,7 @@ fn valid_mock_attestation_succeeds_verification() {
     let report_data = ReportData::V1(ReportDataV1::new(tls_key, account_key));
 
     assert_matches!(
-        valid_attestation.verify(report_data.into(), timestamp_s, &[], &[], &[]),
+        local_verify(&valid_attestation, report_data, timestamp_s, &[], &[], &[]),
         Ok(VerifiedAttestation::Mock(MockAttestation::Valid))
     );
 }
@@ -36,7 +204,7 @@ fn invalid_mock_attestation_fails_verification() {
     let report_data = ReportData::V1(ReportDataV1::new(tls_key, account_key));
 
     assert_matches!(
-        valid_attestation.verify(report_data.into(), timestamp_s, &[], &[], &[]),
+        local_verify(&valid_attestation, report_data, timestamp_s, &[], &[], &[]),
         Err(VerificationError::InvalidMockAttestation)
     );
 }
@@ -52,15 +220,15 @@ fn validated_dstack_attestation_can_be_reverified() {
     let allowed_mpc_hashes = [image_digest()];
     let allowed_launcher_hashes = [launcher_compose_digest()];
 
-    let validated = attestation
-        .verify(
-            report_data.into(),
-            timestamp_s,
-            &allowed_mpc_hashes,
-            &allowed_launcher_hashes,
-            default_measurements(),
-        )
-        .expect("Initial verification failed");
+    let validated = local_verify(
+        &attestation,
+        report_data,
+        timestamp_s,
+        &allowed_mpc_hashes,
+        &allowed_launcher_hashes,
+        default_measurements(),
+    )
+    .expect("Initial verification failed");
 
     // when
     let re_verification_result = validated.re_verify(
@@ -85,15 +253,15 @@ fn validated_dstack_attestation_fails_reverification_when_expired() {
     let allowed_mpc_hashes = [image_digest()];
     let allowed_launcher_hashes = [launcher_compose_digest()];
 
-    let validated = attestation
-        .verify(
-            report_data.into(),
-            timestamp_s,
-            &allowed_mpc_hashes,
-            &allowed_launcher_hashes,
-            default_measurements(),
-        )
-        .expect("Initial verification failed");
+    let validated = local_verify(
+        &attestation,
+        report_data,
+        timestamp_s,
+        &allowed_mpc_hashes,
+        &allowed_launcher_hashes,
+        default_measurements(),
+    )
+    .expect("Initial verification failed");
 
     // when
     let re_verification_result = validated.re_verify(
@@ -117,8 +285,7 @@ fn validated_mock_attestation_passes_reverification() {
     let account_key = account_key();
     let report_data: ReportData = ReportDataV1::new(tls_key, account_key).into();
 
-    let validated = valid_attestation
-        .verify(report_data.into(), 0, &[], &[], &[])
+    let validated = local_verify(&valid_attestation, report_data, 0, &[], &[], &[])
         .expect("Initial verification failed");
 
     // Mock should generally pass re-verify
@@ -137,15 +304,15 @@ fn validated_dstack_attestation_fails_reverification_with_rotated_hashes() {
     let allowed_launcher_hashes = [launcher_compose_digest()];
 
     // 1. Initial verify succeeds with the "old" allowed list
-    let validated = attestation
-        .verify(
-            report_data.into(),
-            creation_time,
-            &allowed_mpc_hashes,
-            &allowed_launcher_hashes,
-            default_measurements(),
-        )
-        .expect("Initial verification should succeed");
+    let validated = local_verify(
+        &attestation,
+        report_data,
+        creation_time,
+        &allowed_mpc_hashes,
+        &allowed_launcher_hashes,
+        default_measurements(),
+    )
+    .expect("Initial verification should succeed");
 
     let new_allowed_mpc_docker_image_hashes = [[42; 32].into()];
 
@@ -175,15 +342,15 @@ fn validated_dstack_attestation_fails_reverification_with_removed_measurements()
     let allowed_mpc_hashes = [image_digest()];
     let allowed_launcher_hashes = [launcher_compose_digest()];
 
-    let validated = attestation
-        .verify(
-            report_data.into(),
-            creation_time,
-            &allowed_mpc_hashes,
-            &allowed_launcher_hashes,
-            default_measurements(),
-        )
-        .expect("Initial verification should succeed");
+    let validated = local_verify(
+        &attestation,
+        report_data,
+        creation_time,
+        &allowed_mpc_hashes,
+        &allowed_launcher_hashes,
+        default_measurements(),
+    )
+    .expect("Initial verification should succeed");
 
     let different_measurements = [ExpectedMeasurements {
         rtmrs: Measurements {
@@ -218,15 +385,15 @@ fn validated_dstack_attestation_fails_reverification_with_empty_measurements() {
     let allowed_mpc_hashes = [image_digest()];
     let allowed_launcher_hashes = [launcher_compose_digest()];
 
-    let validated = attestation
-        .verify(
-            report_data.into(),
-            creation_time,
-            &allowed_mpc_hashes,
-            &allowed_launcher_hashes,
-            default_measurements(),
-        )
-        .expect("Initial verification should succeed");
+    let validated = local_verify(
+        &attestation,
+        report_data,
+        creation_time,
+        &allowed_mpc_hashes,
+        &allowed_launcher_hashes,
+        default_measurements(),
+    )
+    .expect("Initial verification should succeed");
 
     // when
     let result = validated.re_verify(
@@ -251,15 +418,15 @@ fn validated_dstack_attestation_passes_reverification_with_superset_measurements
     let allowed_mpc_hashes = [image_digest()];
     let allowed_launcher_hashes = [launcher_compose_digest()];
 
-    let validated = attestation
-        .verify(
-            report_data.into(),
-            creation_time,
-            &allowed_mpc_hashes,
-            &allowed_launcher_hashes,
-            default_measurements(),
-        )
-        .expect("Initial verification should succeed");
+    let validated = local_verify(
+        &attestation,
+        report_data,
+        creation_time,
+        &allowed_mpc_hashes,
+        &allowed_launcher_hashes,
+        default_measurements(),
+    )
+    .expect("Initial verification should succeed");
 
     let extra_measurement = ExpectedMeasurements {
         rtmrs: Measurements {

--- a/crates/mpc-attestation/tests/test_attestation_verification.rs
+++ b/crates/mpc-attestation/tests/test_attestation_verification.rs
@@ -1,183 +1,16 @@
 use assert_matches::assert_matches;
-use attestation::attestation::DstackVerify as _;
 use attestation_types::measurements::{ExpectedMeasurements, Measurements};
 use attestation_types::verify_post_dcap::VerificationError;
 use mpc_attestation::attestation::{
     Attestation, DEFAULT_EXPIRATION_DURATION_SECONDS, MockAttestation, VerifiedAttestation,
     default_measurements,
 };
+use mpc_attestation::local_verify::local_verify;
 use mpc_attestation::report_data::{ReportData, ReportDataV1};
-use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
 use test_utils::attestation::{
     VALID_ATTESTATION_TIMESTAMP, account_key, image_digest, launcher_compose_digest,
     mock_dstack_attestation, p2p_tls_key,
 };
-
-/// Off-chain convenience: runs the full dcap-qvl + post-DCAP path in
-/// one call. Mirrors what the deleted `Attestation::verify` method used
-/// to do. Lives here because `mpc-attestation` no longer depends on
-/// the `dcap-qvl`-using `attestation` crate.
-fn local_verify(
-    attestation: &Attestation,
-    expected_report_data: ReportData,
-    timestamp_seconds: u64,
-    allowed_mpc_docker_image_hashes: &[NodeImageHash],
-    allowed_launcher_docker_compose_hashes: &[LauncherDockerComposeHash],
-    accepted_measurements: &[ExpectedMeasurements],
-) -> Result<VerifiedAttestation, VerificationError> {
-    let verified_report = match attestation {
-        Attestation::Dstack(dstack) => {
-            let measurements = dstack.verify(
-                expected_report_data.clone(),
-                timestamp_seconds,
-                accepted_measurements,
-            )?;
-            // `DstackVerify::verify` already ran the post-DCAP checks
-            // for us, including measurement matching. We still need a
-            // `VerifiedReport` to pass into `finish_verify` (which
-            // re-runs the same checks) — build it by re-calling the
-            // local conversion. This path is off-chain and the double
-            // work is negligible.
-            //
-            // The simpler alternative would be to factor a `verify_raw`
-            // out of `attestation` that returns the mirror report
-            // directly. For test code, this is fine; production callers
-            // (the `mpc-contract` Promise callback) get the mirror
-            // directly from the verifier contract.
-            let _ = measurements;
-            local_dcap_verify(dstack, timestamp_seconds)?
-        }
-        Attestation::Mock(_) => zero_verified_report(),
-    };
-
-    attestation.finish_verify(
-        &verified_report,
-        expected_report_data,
-        allowed_mpc_docker_image_hashes,
-        allowed_launcher_docker_compose_hashes,
-        accepted_measurements,
-        timestamp_seconds,
-    )
-}
-
-/// Calls `dcap_qvl::verify::verify` against a `DstackAttestation` and
-/// returns the result as the Borsh mirror.
-fn local_dcap_verify(
-    dstack: &mpc_attestation::attestation::DstackAttestation,
-    timestamp_seconds: u64,
-) -> Result<tee_verifier_interface::VerifiedReport, VerificationError> {
-    let collateral = attestation::collateral_to_dcap(dstack.collateral.clone());
-    let verification_result =
-        dcap_qvl::verify::verify(&dstack.quote, &collateral, timestamp_seconds)
-            .map_err(|e| VerificationError::DcapVerification(e.to_string()))?;
-    Ok(dcap_to_mirror(verification_result))
-}
-
-fn dcap_to_mirror(
-    value: dcap_qvl::verify::VerifiedReport,
-) -> tee_verifier_interface::VerifiedReport {
-    tee_verifier_interface::VerifiedReport {
-        status: value.status,
-        advisory_ids: value.advisory_ids,
-        report: match value.report {
-            dcap_qvl::quote::Report::SgxEnclave(_) => unreachable!("SGX not used in tests"),
-            dcap_qvl::quote::Report::TD10(r) => {
-                tee_verifier_interface::Report::TD10(td10_to_mirror(r))
-            }
-            dcap_qvl::quote::Report::TD15(r) => {
-                tee_verifier_interface::Report::TD15(tee_verifier_interface::TDReport15 {
-                    base: td10_to_mirror(r.base),
-                    tee_tcb_svn2: r.tee_tcb_svn2,
-                    mr_service_td: r.mr_service_td,
-                })
-            }
-        },
-        ppid: value.ppid,
-        qe_status: tcb_status_with_advisory_to_mirror(value.qe_status),
-        platform_status: tcb_status_with_advisory_to_mirror(value.platform_status),
-    }
-}
-
-fn td10_to_mirror(value: dcap_qvl::quote::TDReport10) -> tee_verifier_interface::TDReport10 {
-    tee_verifier_interface::TDReport10 {
-        tee_tcb_svn: value.tee_tcb_svn,
-        mr_seam: value.mr_seam,
-        mr_signer_seam: value.mr_signer_seam,
-        seam_attributes: value.seam_attributes,
-        td_attributes: value.td_attributes,
-        xfam: value.xfam,
-        mr_td: value.mr_td,
-        mr_config_id: value.mr_config_id,
-        mr_owner: value.mr_owner,
-        mr_owner_config: value.mr_owner_config,
-        rt_mr0: value.rt_mr0,
-        rt_mr1: value.rt_mr1,
-        rt_mr2: value.rt_mr2,
-        rt_mr3: value.rt_mr3,
-        report_data: value.report_data,
-    }
-}
-
-fn tcb_status_with_advisory_to_mirror(
-    value: dcap_qvl::tcb_info::TcbStatusWithAdvisory,
-) -> tee_verifier_interface::TcbStatusWithAdvisory {
-    tee_verifier_interface::TcbStatusWithAdvisory {
-        status: match value.status {
-            dcap_qvl::tcb_info::TcbStatus::UpToDate => tee_verifier_interface::TcbStatus::UpToDate,
-            dcap_qvl::tcb_info::TcbStatus::OutOfDateConfigurationNeeded => {
-                tee_verifier_interface::TcbStatus::OutOfDateConfigurationNeeded
-            }
-            dcap_qvl::tcb_info::TcbStatus::OutOfDate => {
-                tee_verifier_interface::TcbStatus::OutOfDate
-            }
-            dcap_qvl::tcb_info::TcbStatus::ConfigurationAndSWHardeningNeeded => {
-                tee_verifier_interface::TcbStatus::ConfigurationAndSWHardeningNeeded
-            }
-            dcap_qvl::tcb_info::TcbStatus::ConfigurationNeeded => {
-                tee_verifier_interface::TcbStatus::ConfigurationNeeded
-            }
-            dcap_qvl::tcb_info::TcbStatus::SWHardeningNeeded => {
-                tee_verifier_interface::TcbStatus::SWHardeningNeeded
-            }
-            dcap_qvl::tcb_info::TcbStatus::Revoked => tee_verifier_interface::TcbStatus::Revoked,
-        },
-        advisory_ids: value.advisory_ids,
-    }
-}
-
-/// Zero-valued `VerifiedReport` for `Mock` paths that ignore it.
-fn zero_verified_report() -> tee_verifier_interface::VerifiedReport {
-    tee_verifier_interface::VerifiedReport {
-        status: String::new(),
-        advisory_ids: Vec::new(),
-        report: tee_verifier_interface::Report::TD10(tee_verifier_interface::TDReport10 {
-            tee_tcb_svn: [0; 16],
-            mr_seam: [0; 48],
-            mr_signer_seam: [0; 48],
-            seam_attributes: [0; 8],
-            td_attributes: [0; 8],
-            xfam: [0; 8],
-            mr_td: [0; 48],
-            mr_config_id: [0; 48],
-            mr_owner: [0; 48],
-            mr_owner_config: [0; 48],
-            rt_mr0: [0; 48],
-            rt_mr1: [0; 48],
-            rt_mr2: [0; 48],
-            rt_mr3: [0; 48],
-            report_data: [0; 64],
-        }),
-        ppid: Vec::new(),
-        qe_status: tee_verifier_interface::TcbStatusWithAdvisory {
-            status: tee_verifier_interface::TcbStatus::UpToDate,
-            advisory_ids: Vec::new(),
-        },
-        platform_status: tee_verifier_interface::TcbStatusWithAdvisory {
-            status: tee_verifier_interface::TcbStatus::UpToDate,
-            advisory_ids: Vec::new(),
-        },
-    }
-}
 
 #[test]
 fn valid_mock_attestation_succeeds_verification() {
@@ -189,7 +22,14 @@ fn valid_mock_attestation_succeeds_verification() {
     let report_data = ReportData::V1(ReportDataV1::new(tls_key, account_key));
 
     assert_matches!(
-        local_verify(&valid_attestation, report_data, timestamp_s, &[], &[], &[]),
+        local_verify(
+            &valid_attestation,
+            report_data.into(),
+            timestamp_s,
+            &[],
+            &[],
+            &[]
+        ),
         Ok(VerifiedAttestation::Mock(MockAttestation::Valid))
     );
 }
@@ -204,7 +44,14 @@ fn invalid_mock_attestation_fails_verification() {
     let report_data = ReportData::V1(ReportDataV1::new(tls_key, account_key));
 
     assert_matches!(
-        local_verify(&valid_attestation, report_data, timestamp_s, &[], &[], &[]),
+        local_verify(
+            &valid_attestation,
+            report_data.into(),
+            timestamp_s,
+            &[],
+            &[],
+            &[]
+        ),
         Err(VerificationError::InvalidMockAttestation)
     );
 }
@@ -222,7 +69,7 @@ fn validated_dstack_attestation_can_be_reverified() {
 
     let validated = local_verify(
         &attestation,
-        report_data,
+        report_data.into(),
         timestamp_s,
         &allowed_mpc_hashes,
         &allowed_launcher_hashes,
@@ -255,7 +102,7 @@ fn validated_dstack_attestation_fails_reverification_when_expired() {
 
     let validated = local_verify(
         &attestation,
-        report_data,
+        report_data.into(),
         timestamp_s,
         &allowed_mpc_hashes,
         &allowed_launcher_hashes,
@@ -285,7 +132,7 @@ fn validated_mock_attestation_passes_reverification() {
     let account_key = account_key();
     let report_data: ReportData = ReportDataV1::new(tls_key, account_key).into();
 
-    let validated = local_verify(&valid_attestation, report_data, 0, &[], &[], &[])
+    let validated = local_verify(&valid_attestation, report_data.into(), 0, &[], &[], &[])
         .expect("Initial verification failed");
 
     // Mock should generally pass re-verify
@@ -306,7 +153,7 @@ fn validated_dstack_attestation_fails_reverification_with_rotated_hashes() {
     // 1. Initial verify succeeds with the "old" allowed list
     let validated = local_verify(
         &attestation,
-        report_data,
+        report_data.into(),
         creation_time,
         &allowed_mpc_hashes,
         &allowed_launcher_hashes,
@@ -344,7 +191,7 @@ fn validated_dstack_attestation_fails_reverification_with_removed_measurements()
 
     let validated = local_verify(
         &attestation,
-        report_data,
+        report_data.into(),
         creation_time,
         &allowed_mpc_hashes,
         &allowed_launcher_hashes,
@@ -387,7 +234,7 @@ fn validated_dstack_attestation_fails_reverification_with_empty_measurements() {
 
     let validated = local_verify(
         &attestation,
-        report_data,
+        report_data.into(),
         creation_time,
         &allowed_mpc_hashes,
         &allowed_launcher_hashes,
@@ -420,7 +267,7 @@ fn validated_dstack_attestation_passes_reverification_with_superset_measurements
 
     let validated = local_verify(
         &attestation,
-        report_data,
+        report_data.into(),
         creation_time,
         &allowed_mpc_hashes,
         &allowed_launcher_hashes,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -33,7 +33,7 @@ itertools = { workspace = true }
 k256 = { workspace = true }
 launcher-interface = { workspace = true }
 lru = { workspace = true }
-mpc-attestation = { workspace = true }
+mpc-attestation = { workspace = true, features = ["local-verify"] }
 mpc-node-config = { workspace = true }
 mpc-primitives = { workspace = true }
 mpc-tls = { workspace = true }

--- a/crates/node/src/tee/remote_attestation.rs
+++ b/crates/node/src/tee/remote_attestation.rs
@@ -102,15 +102,15 @@ fn validate_remote_attestation(
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    attestation
-        .verify(
-            expected_report_data.into(),
-            now,
-            allowed_docker_image_hashes,
-            allowed_launcher_compose_hashes,
-            mpc_attestation::attestation::default_measurements(),
-        )
-        .map(|_| ())
+    mpc_attestation::local_verify::local_verify(
+        attestation,
+        expected_report_data.into(),
+        now,
+        allowed_docker_image_hashes,
+        allowed_launcher_compose_hashes,
+        mpc_attestation::attestation::default_measurements(),
+    )
+    .map(|_| ())
 }
 
 pub async fn validate_and_submit_remote_attestation(

--- a/crates/tee-authority/Cargo.toml
+++ b/crates/tee-authority/Cargo.toml
@@ -9,13 +9,14 @@ external-services-tests = []
 
 [dependencies]
 anyhow = { workspace = true }
+attestation = { workspace = true }
 backon = { workspace = true }
 dcap-qvl = { workspace = true, features = ["report"] }
 derive_more = { workspace = true }
 dstack-sdk = { workspace = true }
 hex = { workspace = true }
 launcher-interface = { workspace = true }
-mpc-attestation = { workspace = true, features = ["dstack-conversions"] }
+mpc-attestation = { workspace = true, features = ["dstack-conversions", "local-verify"] }
 near-mpc-bounded-collections = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
@@ -31,6 +32,7 @@ x509-parser = { workspace = true }
 assert_matches = { workspace = true }
 hex = { workspace = true }
 rstest = { workspace = true }
+tee-verifier-interface = { workspace = true }
 test-utils = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/tee-authority/Cargo.toml
+++ b/crates/tee-authority/Cargo.toml
@@ -9,7 +9,6 @@ external-services-tests = []
 
 [dependencies]
 anyhow = { workspace = true }
-attestation = { workspace = true }
 backon = { workspace = true }
 dcap-qvl = { workspace = true, features = ["report"] }
 derive_more = { workspace = true }
@@ -32,7 +31,6 @@ x509-parser = { workspace = true }
 assert_matches = { workspace = true }
 hex = { workspace = true }
 rstest = { workspace = true }
-tee-verifier-interface = { workspace = true }
 test-utils = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
 

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -768,58 +768,18 @@ mod tests {
             .await
             .unwrap();
         let timestamp_s = 0u64;
-        // `LocalTeeAuthorityConfig` yields `Mock` attestations, whose
-        // `finish_verify` path ignores the `VerifiedReport` argument.
-        let dummy_report = dummy_verified_report();
         assert_eq!(
-            attestation
-                .finish_verify(
-                    &dummy_report,
-                    report_data.into(),
-                    &[],
-                    &[],
-                    &[],
-                    timestamp_s,
-                )
-                .is_ok(),
+            mpc_attestation::local_verify::local_verify(
+                &attestation,
+                report_data.into(),
+                timestamp_s,
+                &[],
+                &[],
+                &[],
+            )
+            .is_ok(),
             quote_verification_result
         );
-    }
-
-    /// Test-only zero-valued `VerifiedReport`. Used by tests that
-    /// exercise `Attestation::Mock` paths in `finish_verify`, which
-    /// ignore the report contents.
-    fn dummy_verified_report() -> tee_verifier_interface::VerifiedReport {
-        tee_verifier_interface::VerifiedReport {
-            status: alloc::string::String::new(),
-            advisory_ids: alloc::vec::Vec::new(),
-            report: tee_verifier_interface::Report::TD10(tee_verifier_interface::TDReport10 {
-                tee_tcb_svn: [0; 16],
-                mr_seam: [0; 48],
-                mr_signer_seam: [0; 48],
-                seam_attributes: [0; 8],
-                td_attributes: [0; 8],
-                xfam: [0; 8],
-                mr_td: [0; 48],
-                mr_config_id: [0; 48],
-                mr_owner: [0; 48],
-                mr_owner_config: [0; 48],
-                rt_mr0: [0; 48],
-                rt_mr1: [0; 48],
-                rt_mr2: [0; 48],
-                rt_mr3: [0; 48],
-                report_data: [0; 64],
-            }),
-            ppid: alloc::vec::Vec::new(),
-            qe_status: tee_verifier_interface::TcbStatusWithAdvisory {
-                status: tee_verifier_interface::TcbStatus::UpToDate,
-                advisory_ids: alloc::vec::Vec::new(),
-            },
-            platform_status: tee_verifier_interface::TcbStatusWithAdvisory {
-                status: tee_verifier_interface::TcbStatus::UpToDate,
-                advisory_ids: alloc::vec::Vec::new(),
-            },
-        }
     }
 
     #[tokio::test]

--- a/crates/tee-authority/src/tee_authority.rs
+++ b/crates/tee-authority/src/tee_authority.rs
@@ -768,12 +768,58 @@ mod tests {
             .await
             .unwrap();
         let timestamp_s = 0u64;
+        // `LocalTeeAuthorityConfig` yields `Mock` attestations, whose
+        // `finish_verify` path ignores the `VerifiedReport` argument.
+        let dummy_report = dummy_verified_report();
         assert_eq!(
             attestation
-                .verify(report_data.into(), timestamp_s, &[], &[], &[])
+                .finish_verify(
+                    &dummy_report,
+                    report_data.into(),
+                    &[],
+                    &[],
+                    &[],
+                    timestamp_s,
+                )
                 .is_ok(),
             quote_verification_result
         );
+    }
+
+    /// Test-only zero-valued `VerifiedReport`. Used by tests that
+    /// exercise `Attestation::Mock` paths in `finish_verify`, which
+    /// ignore the report contents.
+    fn dummy_verified_report() -> tee_verifier_interface::VerifiedReport {
+        tee_verifier_interface::VerifiedReport {
+            status: alloc::string::String::new(),
+            advisory_ids: alloc::vec::Vec::new(),
+            report: tee_verifier_interface::Report::TD10(tee_verifier_interface::TDReport10 {
+                tee_tcb_svn: [0; 16],
+                mr_seam: [0; 48],
+                mr_signer_seam: [0; 48],
+                seam_attributes: [0; 8],
+                td_attributes: [0; 8],
+                xfam: [0; 8],
+                mr_td: [0; 48],
+                mr_config_id: [0; 48],
+                mr_owner: [0; 48],
+                mr_owner_config: [0; 48],
+                rt_mr0: [0; 48],
+                rt_mr1: [0; 48],
+                rt_mr2: [0; 48],
+                rt_mr3: [0; 48],
+                report_data: [0; 64],
+            }),
+            ppid: alloc::vec::Vec::new(),
+            qe_status: tee_verifier_interface::TcbStatusWithAdvisory {
+                status: tee_verifier_interface::TcbStatus::UpToDate,
+                advisory_ids: alloc::vec::Vec::new(),
+            },
+            platform_status: tee_verifier_interface::TcbStatusWithAdvisory {
+                status: tee_verifier_interface::TcbStatus::UpToDate,
+                advisory_ids: alloc::vec::Vec::new(),
+            },
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
Closes #3269

## Headline: MPC contract WASM shrinks 21.2%

| | Reproducible bytes | Delta from `main` |
|---|---|---|
| `main` baseline | 1,459,158 | — |
| **PR C2b (this)** | **1,149,708** | **−309,450 (−21.2%)** |

Both numbers from `cargo near build reproducible-wasm` (the binding number — same WASM that CI's "MPC contract reproducible build" job produces). The non-reproducible release-contract profile shows an even larger drop (1,470,007 → 1,147,770 bytes; −22.0%).

`dcap-qvl`, `ring`, `webpki`, and `x509-cert` are no longer in the contract's wasm32 dep graph (verified via `cargo tree --target wasm32-unknown-unknown -e no-proc-macro`).

Stacked on #3246.

## How

`submit_participant_info` now dispatches by attestation variant:

- **`Attestation::Mock`** — synchronous in-contract validation, same as before. Returns `PromiseOrValue::Value(())`.
- **`Attestation::Dstack`** — extracts `(quote, collateral)`, stashes a `PendingAttestation`, schedules a cross-contract Promise to `tee-verifier.near`'s `verify_quote`, then resumes in the new `on_attestation_verified` callback with the parsed `VerifiedReport`. The callback runs the post-DCAP checks (RTMR3 replay, app_compose validation, image-hash / launcher-hash matching) against fresh allowlists from `TeeState`, then inserts into `stored_attestations` or refunds the deposit on failure. Re-submissions while a prior is in flight are rejected to avoid silent overwrite + deposit loss.

Allowlists are read **fresh** from `tee_state` inside the callback, not snapshotted at submit time. A governance vote that lands while the verifier round-trip is in flight therefore takes effect immediately.

## mpc-attestation refactor

`Attestation::verify` split into:
- `extract_dcap_inputs(&Attestation) -> Option<(QuoteBytes, Collateral)>` — called *before* scheduling the Promise.
- `finish_verify(&Attestation, &VerifiedReport, ...) -> Result<VerifiedAttestation, _>` — called *after* the verifier returns.

The `attestation` crate dep is gated behind a new `local-verify` feature; `mpc-contract` doesn't enable it on its main lib build, so `dcap-qvl` drops out of the on-chain build graph. Off-chain consumers (`tee-authority`, `attestation-cli`, `mpc-node`, `mpc-attestation/tests`) enable it to keep doing local verification through a new one-call helper, `mpc_attestation::local_verify::local_verify`, which composes `DstackVerify::verify` (dcap-qvl) with `finish_verify` (post-DCAP).

`DstackVerify::verify` stays in the `attestation` crate as a trait method on the now-foreign `DstackAttestation` struct (which lives in `attestation-types` since #3246).

## State shape

- New `pending_attestations: IterableMap<AccountId, PendingAttestation>` field on `MpcContract`.
- `PendingAttestation` carries the `node_id`, `report_data`, `DstackAttestation` (just the Dstack variant — Mock stays sync and never lands here), `attached_deposit`, and `initial_storage_usage`.
- `StorageKey::PendingAttestations` variant appended (back-compat preserved).
- `v3_9_1_state` migration initializes the new map empty.
- `BorshSchema` derives added (behind the `borsh-schema` feature) to `DstackAttestation`, `TcbInfo`, `EventLog`, `HexBytes` so the ABI-generation build accepts the new stored type.

## Per-network verifier account

`VERIFIER_ACCOUNT_ID` is hardcoded at compile time:
- `tee-verifier.near` (default; `mainnet` feature on).
- `tee-verifier.testnet` (`cfg(not(feature = "mainnet"))`).

Sandbox builds disable default features to opt into the testnet name.

## Tests

Five new lib unit tests cover the callback flow end-to-end:

- `submit_participant_info__mock_attestation_stays_synchronous` — Mock returns `PromiseOrValue::Value`, inserts immediately, no pending entry.
- `submit_participant_info__rejects_when_pending_dstack_entry_exists` — a second in-flight Dstack submission from the same caller is refused.
- `on_attestation_verified__clears_pending_on_promise_failed` — `Err(PromiseError::Failed)` clears the pending entry and leaves `stored_attestations` untouched.
- `on_attestation_verified__inserts_on_success` — the callback inserts the verified entry when post-DCAP passes against fresh allowlists.
- `on_attestation_verified__re_reads_allowlists_at_callback_time` — emptying the MPC-hash allowlist between submit and callback causes verification to fail at callback time.

`mpc_attestation::local_verify::dstack_to_verified_report` was exposed so the success-path tests can produce a real, well-formed `VerifiedReport` for the shared fixture without duplicating the dcap-qvl mirror conversion. The `local-verify` feature is enabled only via `[dev-dependencies]` on `mpc-contract`, so `dcap-qvl` does **not** leak into the contract's lib WASM (verified: the reproducible build byte size is unchanged after adding the dev-dep).

## CI

All checks green on the head commit:

- MPC contract reproducible build
- Cargo test: contract / node / other
- MPC E2E tests
- Fast CI checks / Extra CI checks
- Nix build mpc-node
- Build MPC Node TEE Docker image / Build Rust Launcher Docker image and verify

## Follow-ups (separate PRs)

- Sandbox integration test that deploys both contracts (verifier + mpc-contract) and exercises the round-trip with a real Dstack fixture.
- E2E tests in `crates/e2e-tests/`.
- Dedup of duplicate `Collateral` / `QuoteBytes` between `tee-verifier-interface` and `attestation-types` (cosmetic; both have byte-identical Borsh layouts).