### PR TITLE
refactor: drop subtrees_to_remove worklist via automatic Drop cascade

### DIFF
--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -218,7 +218,7 @@ impl BlockNode {
     ) {
         let mut children = self.children.lock().expect("lock must not be poisoned");
         for child in children.iter() {
-            if child.hash != child_to_retain.hash {
+            if !Arc::ptr_eq(child, child_to_retain) {
                 subtrees_to_remove.push_back(child.clone());
             }
         }
@@ -427,7 +427,7 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         new_final_blocks
     }
 
-    /// Any root children that sit on dead branches get removed from `self.root_children` and add
+    /// Any root children that sit on dead branches get removed from `self.root_children` and added
     /// to `subtrees_to_remove`
     fn update_roots(
         &mut self,

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -14,7 +14,7 @@ use std::sync::{Arc, Mutex, Weak};
 ///    blocks. The content of each block in the finalized stream is specified via the `T`
 ///    type parameter.
 ///  - For each block added via `add_block`, it returns a `Weak<AtomicBlockStatus>` that can be
-///    used to observe that block's current `BlockStatus`.
+///    used to observe that block's current `BlockStatus` (non-canonical, canonical or final).
 ///
 /// We have certain expectations of the order of blocks that come from the indexer.
 /// First, let's define a partial order for blocks. For any two blocks A and B:
@@ -43,19 +43,18 @@ use std::sync::{Arc, Mutex, Weak};
 ///  - We keep track of the canonical chain as well as the final chain.
 ///
 /// Despite the assumptions we make on the indexer's behavior, this class guarantees not to panic
-/// even if the indexer violates these assumptions in arbitrary ways. In particular, if the indexer
-/// feeds blocks such that the canonical chain ends up on a fork that a later final-block advance
-/// discards, the next `add_block` re-elects `canonical_head` over the remaining tree rather than
-/// holding a stale reference. As a side effect, downstream consumers (e.g. the request queue) will
-/// not be invited to act on requests that sit on a permanently-dead fork: the block_ref handed out
-/// by `add_block` upgrades to `None` as soon as the finality advance condemns the fork.
+/// even if the indexer violates these assumptions in arbitrary ways.
 ///
-/// **Cleanup overview.** Two cleanup paths run after every `add_block`:
+/// Note that the `RecentBlocksTracker` is removing blocks aggressively. A block is removed if one
+/// of the following conditions is met:
+///  - The block sits on a dead fork and can't ever be finalized;
+///  - The block is outside of the recency window `RecentBlocksTracker::window_size`
 ///
+/// Cleanup takes place after every `add_block` in two methods:
 ///  - `maybe_update_final_head` owns **dead-fork cleanup**. When a new final block is established,
 ///    every subtree that can't be part of the final chain — non-final siblings of the final chain
 ///    at any height, and any `root_children` subtree not on the final chain with height ≤ the new
-///    final-head height — is dropped entirely. This is the "Dead-fork prune at X" annotation in
+///    final-head height — is dropped. This is the "Dead-fork prune at X" annotation in
 ///    the picture below.
 ///  - `prune_old_blocks` owns **recency-window prune**. Any node below `min_height_to_keep` is
 ///    dropped; its in-window descendants become new roots. This is the "Recency window prune"
@@ -91,22 +90,14 @@ use std::sync::{Arc, Mutex, Weak};
 ///  │   │       │       │   │  ┆       │
 ///  ..  ..      ..      ..  .. ┆       ..
 /// ```
-///
-/// Note: The use of Arc is a little unfortunate. Logically we only need Rc, but this code needs
-/// to work in futures, and Rc is not Send. So we use Arc instead.
 pub struct RecentBlocksTracker<T: Clone + 'static> {
     window_size: u64,
     /// By "root", we mean the blocks whose parents we don't know or are older than the window.
     /// The children of the root are the earliest blocks we are keeping who do not have any order
     /// with each other.
     root_children: Vec<Arc<BlockNode>>,
-    /// The head of the canonical chain. Held as `Weak` so that when finality
-    /// cleanup sweeps a subtree containing the current canonical head, the
-    /// `BlockNode` drops naturally and the next `add_block` re-elects from the
-    /// remaining tree instead of clinging to a dangling node. `Weak::new()` at
-    /// construction time (which never upgrades) stands in for "no canonical
-    /// head yet" — the same `None`-on-upgrade behavior we already get when the
-    /// target is dropped, so the two cases collapse cleanly at every call site.
+    /// The head of the canonical chain. This is the chain of the highest-height block we've seen.
+    /// This may be None if we have no block at all.
     canonical_head: Weak<BlockNode>,
     /// The head of the final chain. This is determined by recovering information from the
     /// last_final_block fields of the block headers given to us. This may be None if we have not
@@ -187,7 +178,7 @@ pub struct AddBlockResult<T> {
     /// The list of newly finalized blocks, in ascending height order. Each entry is a tuple of
     /// the block height and the data passed to us when adding the block.
     /// It is guaranteed that the new final blocks returned from multiple calls to add_block are
-    /// contiguous, thus forming the stream of finalized blocks.
+    // contiguous, thus forming the stream of finalized blocks.
     pub new_final_blocks: Vec<(u64, T)>,
     pub block_ref: Weak<AtomicBlockStatus>,
 }
@@ -212,6 +203,20 @@ struct BlockNode {
 impl BlockNode {
     fn get_parent(&self) -> Option<Arc<BlockNode>> {
         self.parent.as_ref().and_then(Weak::upgrade)
+    }
+
+    fn keep_only_child(
+        &self,
+        child_to_retain: &Arc<BlockNode>,
+        subtrees_to_remove: &mut VecDeque<Arc<BlockNode>>,
+    ) {
+        let mut children = self.children.lock().expect("lock must not be poisoned");
+        for child in children.iter() {
+            if child.hash != child_to_retain.hash {
+                subtrees_to_remove.push_back(child.clone());
+            }
+        }
+        *children = vec![child_to_retain.clone()];
     }
 
     fn debug_print(
@@ -345,18 +350,17 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             .filter_map(|node| Some((node.height, self.node_to_content.get(&node.hash)?.clone())))
             .collect();
         match self.canonical_head.upgrade() {
+            None => {
+                // Either the first block ever, or the previous canonical head
+                // was removed by the finality cleanup above.
+                // We identify the highest tracked node and update the canonical head.
+                if let Some(head) = self.highest_tracked_node() {
+                    self.update_canonical_head(&head);
+                }
+            }
             Some(canonical_head) => {
                 if block.height > canonical_head.height {
                     self.update_canonical_head(&node);
-                }
-            }
-            None => {
-                // Either the first block ever, or the previous canonical head
-                // was swept away by the finality cleanup above. Either way,
-                // re-elect from the kept tree (which already contains the
-                // just-added node, so it's a candidate).
-                if let Some(head) = self.highest_tracked_node() {
-                    self.update_canonical_head(&head);
                 }
             }
         }
@@ -384,19 +388,15 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         let mut node = final_head_node.clone();
         let mut subtrees_to_remove: VecDeque<Arc<BlockNode>> = VecDeque::new();
         loop {
-            // We only keep the last final child
-            if let Some(final_child) = new_final_blocks.last() {
-                let mut children = node.children.lock().expect("lock must not be poisoned");
-                for child in children.iter() {
-                    if child.hash != final_child.hash {
-                        subtrees_to_remove.push_back(child.clone());
-                    }
-                }
-                *children = vec![final_child.clone()];
+            // The node we previously visited is the only final child of `node`.
+            if let Some(final_child_of_node) = new_final_blocks.last() {
+                node.keep_only_child(final_child_of_node, &mut subtrees_to_remove);
             }
+            // If this node is already labeled final, we can exit the loop.
             if node.status.is_final() {
                 break;
             }
+            // Else, this is a new final node and we visit its parent next.
             node.status.make_final();
             new_final_blocks.push(node.clone());
             let Some(parent) = node.get_parent() else {
@@ -404,6 +404,7 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             };
             node = parent;
         }
+        // we update the final head if applicable
         if self
             .final_head
             .as_ref()
@@ -411,20 +412,35 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         {
             self.final_head = Some(final_head_node.clone());
         }
-
-        // We ensure to clean up nodes on other trees that won't be included anymore.
+        // Lastly, we clean up any dead subtrees that live on other branches.
         let new_final_height = final_head_node.height;
+        self.update_roots(new_final_height, &mut subtrees_to_remove);
+        self.remove_subtrees(subtrees_to_remove);
+
+        new_final_blocks.reverse();
+        new_final_blocks
+    }
+
+    /// Any root children that sit on dead branches get removed from `self.root_children` and addd
+    /// to `subtrees_to_remove`
+    fn update_roots(
+        &mut self,
+        new_final_height: u64,
+        subtrees_to_remove: &mut VecDeque<Arc<BlockNode>>,
+    ) {
         let mut new_root_children = Vec::new();
         for node in self.root_children.iter() {
-            if node.status.is_final() || node.height > new_final_height {
-                new_root_children.push(node.clone());
-            } else {
+            if !node.status.is_final() && node.height <= new_final_height {
                 // the entire subtree can be removed
                 subtrees_to_remove.push_back(node.clone());
+            } else {
+                new_root_children.push(node.clone());
             }
         }
         self.root_children = new_root_children;
-        // now remove subtrees
+    }
+
+    fn remove_subtrees(&mut self, mut subtrees_to_remove: VecDeque<Arc<BlockNode>>) {
         while let Some(node) = subtrees_to_remove.pop_front() {
             subtrees_to_remove.extend(
                 node.children
@@ -435,8 +451,6 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             self.hash_to_node.remove(&node.hash);
             self.node_to_content.remove(&node.hash);
         }
-        new_final_blocks.reverse();
-        new_final_blocks
     }
 
     /// Updates the canonical chain to the chain of the given block.

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -100,23 +100,26 @@ pub struct RecentBlocksTracker<T: Clone + 'static> {
     window_size: u64,
     /// By "root", we mean the blocks whose parents we don't know or are older than the window.
     /// The children of the root are the earliest blocks we are keeping who do not have any order
-    /// with each other.
-    root_children: Vec<Arc<BlockNode>>,
+    /// with each other. Sole strong-Arc owner for root nodes; descendants are owned via each
+    /// parent's `children` field. Dropping an Arc from here (or from any `children` Vec)
+    /// deallocates the node and cascades through its subtree.
+    root_children: Vec<Arc<BlockNode<T>>>,
     /// The head of the canonical chain. This is the chain of the highest-height block we've seen.
-    /// This may be None if we have no block at all.
-    canonical_head: Weak<BlockNode>,
-    /// The head of the final chain. This is determined by recovering information from the
-    /// last_final_block fields of the block headers given to us. This may be None if we have not
-    /// seen any final blocks yet.
-    final_head: Option<Arc<BlockNode>>,
+    /// `Weak` so that finality cleanup (which sweeps dead-fork canonical heads) can drop the node;
+    /// `upgrade()` returning `None` signals "previous head was swept; re-elect."
+    canonical_head: Weak<BlockNode<T>>,
+    /// The head of the final chain. Determined by recovering information from the
+    /// `last_final_block` fields of the block headers given to us. `Weak` so that the head pointer
+    /// does not itself keep the node alive — the tree (via `root_children` → parent.children) owns
+    /// every live node.
+    final_head: Weak<BlockNode<T>>,
     /// The maximum height of any block we have been given via `add_block`.
     maximum_height_available: BlockHeight,
-    /// Maps block hashes to their nodes in the tree.
-    hash_to_node: HashMap<CryptoHash, Arc<BlockNode>>,
-    /// Maps block hashes to their content; this is to provide the stream of finalized blocks.
-    /// Technically, instead of a hashmap we could put this in the node, but that would clutter
-    /// the code by requiring the T type parameter everywhere.
-    node_to_content: HashMap<CryptoHash, T>,
+    /// Non-owning lookup index. Strong ownership is in `root_children` and each
+    /// `BlockNode::children` — never here. Reassigning a parent's `children` cascades
+    /// the deallocation of dropped subtrees through `Drop`; stale `Weak` entries in
+    /// this map are filtered out lazily by `get_node`.
+    hash_to_node: HashMap<CryptoHash, Weak<BlockNode<T>>>,
 }
 
 #[repr(u8)]
@@ -190,7 +193,7 @@ pub struct AddBlockResult<T> {
 }
 
 /// Represents a block in the recent blockchain.
-struct BlockNode {
+struct BlockNode<T> {
     hash: CryptoHash,
     height: u64,
     /// Indicates the finality status of this block. Held as `Arc` so that a `Weak` reference
@@ -200,28 +203,28 @@ struct BlockNode {
     /// The parent block, if we're aware of it. This may be None if we have never
     /// heard of the parent.
     /// The Weak becomes a dangling pointer when the parent is pruned.
-    parent: Option<Weak<BlockNode>>,
+    parent: Option<Weak<BlockNode<T>>>,
     /// The children blocks; there can be multiple if there are forks. The children are
-    /// kept in no specific order.
-    children: Mutex<Vec<Arc<BlockNode>>>,
+    /// kept in no specific order. **This is the sole strong-Arc holder for descendant nodes**
+    /// (along with `RecentBlocksTracker::root_children` for tops of the tree); reassigning
+    /// or dropping entries here cascades the deallocation through `Drop`.
+    children: Mutex<Vec<Arc<BlockNode<T>>>>,
+    /// Per-block payload. Moved into the node so it dies with the node — no separate
+    /// `node_to_content` map to keep in sync.
+    content: T,
 }
 
-impl BlockNode {
-    fn get_parent(&self) -> Option<Arc<BlockNode>> {
+impl<T> BlockNode<T> {
+    fn get_parent(&self) -> Option<Arc<BlockNode<T>>> {
         self.parent.as_ref().and_then(Weak::upgrade)
     }
 
-    fn keep_only_child(
-        &self,
-        child_to_retain: &Arc<BlockNode>,
-        subtrees_to_remove: &mut VecDeque<Arc<BlockNode>>,
-    ) {
+    /// Retain only `child_to_retain` in this node's children, dropping every other Arc.
+    /// Because `hash_to_node` only holds `Weak` references, the dropped Arcs hit
+    /// strong-count 0 here and deallocate immediately, cascading through their own
+    /// `children` Vec via `Drop`. No worklist needed.
+    fn keep_only_child(&self, child_to_retain: &Arc<BlockNode<T>>) {
         let mut children = self.children.lock().expect("lock must not be poisoned");
-        for child in children.iter() {
-            if !Arc::ptr_eq(child, child_to_retain) {
-                subtrees_to_remove.push_back(child.clone());
-            }
-        }
         *children = vec![child_to_retain.clone()];
     }
 
@@ -231,7 +234,7 @@ impl BlockNode {
         indents: &mut Vec<u8>,
         final_head: Option<CryptoHash>,
         canonical_head: Option<CryptoHash>,
-        content_printer: &impl Fn(&CryptoHash, &mut std::fmt::Formatter<'_>) -> std::fmt::Result,
+        content_printer: &impl Fn(&T, &mut std::fmt::Formatter<'_>) -> std::fmt::Result,
     ) -> std::fmt::Result {
         if Some(self.hash) == final_head {
             write!(f, "FH ")?;
@@ -260,7 +263,7 @@ impl BlockNode {
             if self.status.is_final() { "F" } else { " " },
             format!("{:?}", self.hash),
         )?;
-        content_printer(&self.hash, f)?;
+        content_printer(&self.content, f)?;
         writeln!(f)?;
         let children = self.children.lock().unwrap();
         for (i, child) in children.iter().enumerate() {
@@ -309,11 +312,17 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             window_size,
             root_children: Vec::new(),
             canonical_head: Weak::new(),
-            final_head: None,
+            final_head: Weak::new(),
             maximum_height_available: 0,
             hash_to_node: HashMap::new(),
-            node_to_content: HashMap::new(),
         }
+    }
+
+    /// Looks up a live node by hash. Filters out stale `Weak` entries lazily — if a node
+    /// has been dropped by cleanup, `Weak::upgrade` returns `None` even if the map still
+    /// has the entry.
+    fn get_node(&self, hash: &CryptoHash) -> Option<Arc<BlockNode<T>>> {
+        self.hash_to_node.get(hash).and_then(Weak::upgrade)
     }
 
     /// Adds a block to the tracker. This is expected to be called for EVERY block given by the
@@ -324,23 +333,23 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         block: &BlockViewLite,
         content: T,
     ) -> anyhow::Result<AddBlockResult<T>> {
-        if self.hash_to_node.contains_key(&block.hash) {
+        if self.get_node(&block.hash).is_some() {
             anyhow::bail!("Block already exists in the tracker");
         }
         let status = Arc::new(AtomicBlockStatus(AtomicU8::new(u8::from(
             BlockStatus::OptimisticButNotCanonical,
         ))));
         let block_ref = Arc::downgrade(&status);
-        let parent = self.hash_to_node.get(&block.prev_hash).cloned();
+        let parent = self.get_node(&block.prev_hash);
         let node = Arc::new(BlockNode {
             hash: block.hash,
             height: block.height,
             status,
             parent: parent.as_ref().map(Arc::downgrade),
             children: Mutex::new(Vec::new()),
+            content,
         });
-        self.hash_to_node.insert(block.hash, node.clone());
-        self.node_to_content.insert(block.hash, content);
+        self.hash_to_node.insert(block.hash, Arc::downgrade(&node));
         if let Some(parent) = parent {
             parent.children.lock().unwrap().push(node.clone());
         } else {
@@ -348,12 +357,12 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         }
 
         let new_final_blocks = self.maybe_update_final_head(block.last_final_block);
-        // We must do this lookup before calling prune_old_blocks or else we may no longer have
-        // some of the blocks. Note: filter_map should not really filter anything out, but we're
-        // doing this defensively to not crash just in case we have a bug.
+        // `new_final_blocks` holds strong Arcs to the newly-finalized nodes, so the
+        // content clones below stay valid even if a subsequent cleanup drops the node
+        // from the tree.
         let new_final_blocks = new_final_blocks
             .into_iter()
-            .filter_map(|node| Some((node.height, self.node_to_content.get(&node.hash)?.clone())))
+            .map(|node| (node.height, node.content.clone()))
             .collect();
         match self.canonical_head.upgrade() {
             None => {
@@ -380,23 +389,26 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         })
     }
 
-    /// Advance the final head, mark its ancestors as final, and drop every
-    /// subtree that BFT-safety guarantees can no longer be on the final chain.
-    /// See `RecentBlocksTracker` for the picture of which subtrees this catches.
+    /// Advance the final head, mark its ancestors as final, and drop every subtree that
+    /// BFT-safety guarantees can no longer be on the final chain. Dead subtrees deallocate
+    /// automatically via `Drop` cascade — `keep_only_child` replaces the parent's children
+    /// list, and `update_roots` rebuilds `root_children` keeping only live branches.
     ///
     /// Returns the newly finalized blocks in ascending height order.
-    fn maybe_update_final_head(&mut self, potential_final_head: CryptoHash) -> Vec<Arc<BlockNode>> {
-        let final_head_node = self.hash_to_node.get(&potential_final_head).cloned();
-        let Some(final_head_node) = final_head_node else {
+    fn maybe_update_final_head(
+        &mut self,
+        potential_final_head: CryptoHash,
+    ) -> Vec<Arc<BlockNode<T>>> {
+        let Some(final_head_node) = self.get_node(&potential_final_head) else {
             return Vec::new();
         };
-        let mut new_final_blocks: Vec<Arc<BlockNode>> = Vec::new();
+        let mut new_final_blocks: Vec<Arc<BlockNode<T>>> = Vec::new();
         let mut node = final_head_node.clone();
-        let mut subtrees_to_remove: VecDeque<Arc<BlockNode>> = VecDeque::new();
         loop {
             // The node we previously visited is the only final child of `node`.
+            // Dropping its non-final siblings here cascades their subtrees.
             if let Some(final_child_of_node) = new_final_blocks.last() {
-                node.keep_only_child(final_child_of_node, &mut subtrees_to_remove);
+                node.keep_only_child(final_child_of_node);
             }
             // If this node is already labeled final, we can exit the loop.
             if node.status.is_final() {
@@ -410,59 +422,28 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             };
             node = parent;
         }
-        // we update the final head if applicable
+        // We update the final head if applicable.
         if self
             .final_head
-            .as_ref()
+            .upgrade()
             .is_none_or(|prev_final_head| prev_final_head.height < final_head_node.height)
         {
-            self.final_head = Some(final_head_node.clone());
+            self.final_head = Arc::downgrade(&final_head_node);
         }
-        // Lastly, we clean up any dead subtrees that live on other branches.
+        // Drop dead root branches (non-final roots at height ≤ new final height).
+        // `Vec::retain` releases the dropped Arcs, which cascade through their subtrees.
         let new_final_height = final_head_node.height;
-        self.update_roots(new_final_height, &mut subtrees_to_remove);
-        self.remove_subtrees(subtrees_to_remove);
+        self.root_children
+            .retain(|r| r.status.is_final() || r.height > new_final_height);
 
         new_final_blocks.reverse();
         new_final_blocks
     }
 
-    /// Any root children that sit on dead branches get removed from `self.root_children` and added
-    /// to `subtrees_to_remove`
-    fn update_roots(
-        &mut self,
-        new_final_height: u64,
-        subtrees_to_remove: &mut VecDeque<Arc<BlockNode>>,
-    ) {
-        let mut new_root_children = Vec::new();
-        for node in self.root_children.iter() {
-            if !node.status.is_final() && node.height <= new_final_height {
-                // the entire subtree can be removed
-                subtrees_to_remove.push_back(node.clone());
-            } else {
-                new_root_children.push(node.clone());
-            }
-        }
-        self.root_children = new_root_children;
-    }
-
-    fn remove_subtrees(&mut self, mut subtrees_to_remove: VecDeque<Arc<BlockNode>>) {
-        while let Some(node) = subtrees_to_remove.pop_front() {
-            subtrees_to_remove.extend(
-                node.children
-                    .lock()
-                    .expect("lock must not be poisoned")
-                    .clone(),
-            );
-            self.hash_to_node.remove(&node.hash);
-            self.node_to_content.remove(&node.hash);
-        }
-    }
-
     /// Updates the canonical chain to the chain of the given block.
     /// Nodes on the existing canonical chain that are not in the new canonical chain
     /// will be marked as no longer canonical.
-    fn update_canonical_head(&mut self, new_canonical_head: &Arc<BlockNode>) {
+    fn update_canonical_head(&mut self, new_canonical_head: &Arc<BlockNode<T>>) {
         let mut node = Some(new_canonical_head.clone());
 
         while let Some(current_node) = node {
@@ -491,9 +472,9 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
     /// BFS over the kept tree, returning the highest-height node (insertion order and
     /// BFS order breaks ties). Used to re-elect the canonical head after finality
     /// cleanup sweeps the previous one.
-    fn highest_tracked_node(&self) -> Option<Arc<BlockNode>> {
-        let mut queue: VecDeque<Arc<BlockNode>> = self.root_children.iter().cloned().collect();
-        let mut best: Option<Arc<BlockNode>> = None;
+    fn highest_tracked_node(&self) -> Option<Arc<BlockNode<T>>> {
+        let mut queue: VecDeque<Arc<BlockNode<T>>> = self.root_children.iter().cloned().collect();
+        let mut best: Option<Arc<BlockNode<T>>> = None;
         while let Some(node) = queue.pop_front() {
             if best.as_ref().is_none_or(|b| b.height < node.height) {
                 best = Some(node.clone());
@@ -509,9 +490,7 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
     /// we ensure that the final head is not pruned. Otherwise, not only would the logic be very
     /// messy, but also we would not be able to provide a contiguous stream of finalized blocks.
     fn minimum_height_to_keep(&self) -> Option<u64> {
-        let Some(final_head) = &self.final_head else {
-            return None;
-        };
+        let final_head = self.final_head.upgrade()?;
         Some(
             self.maximum_height_available
                 .saturating_sub(self.window_size)
@@ -520,28 +499,26 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         )
     }
 
-    /// Recency-window prune. Drops every node below `min_height_to_keep` and
-    /// promotes the first in-window descendant on each branch to a new root.
-    /// See `RecentBlocksTracker` for the picture; dead-fork cleanup happens in
-    /// `maybe_update_final_head`, not here.
+    /// Recency-window prune. Drops every node below `min_height_to_keep` and promotes the
+    /// first in-window descendant on each branch to a new root. The dropped roots cascade
+    /// their subtrees via `Drop`; descendants we promote into `new_roots` survive because
+    /// we cloned their Arc before letting the parent drop.
     fn prune_old_blocks(&mut self) {
         let Some(min_height_to_keep) = self.minimum_height_to_keep() else {
             return;
         };
-        let mut queue: VecDeque<Arc<BlockNode>> = std::mem::take(&mut self.root_children).into();
+        let mut queue: VecDeque<Arc<BlockNode<T>>> =
+            std::mem::take(&mut self.root_children).into();
         let mut new_roots = Vec::new();
         while let Some(node) = queue.pop_front() {
             if node.height >= min_height_to_keep {
                 new_roots.push(node);
                 continue;
             }
-            self.hash_to_node.remove(&node.hash);
-            self.node_to_content.remove(&node.hash);
-            // Drain into the queue so the parent stops holding strong refs to
-            // its children — once `hash_to_node` no longer holds the parent,
-            // the parent can drop as soon as we move past this iteration.
-            let mut children = node.children.lock().expect("lock must not be poisoned");
-            queue.extend(children.drain(..));
+            // Promote in-window children into the worklist; once we drop our Arc to
+            // `node` at the end of this iteration, only its un-cloned descendants die.
+            let children = node.children.lock().expect("lock must not be poisoned");
+            queue.extend(children.iter().cloned());
         }
         self.root_children = new_roots;
     }
@@ -558,7 +535,7 @@ impl<T: Clone + Debug> Debug for RecentBlocksTracker<T> {
             self.maximum_height_available,
             self.minimum_height_to_keep().unwrap_or(0)
         )?;
-        let final_head = self.final_head.as_ref().map(|n| n.hash);
+        let final_head = self.final_head.upgrade().map(|n| n.hash);
         let canonical_head = self.canonical_head.upgrade().map(|n| n.hash);
 
         for (i, child) in self.root_children.iter().enumerate() {
@@ -571,13 +548,7 @@ impl<T: Clone + Debug> Debug for RecentBlocksTracker<T> {
                 }],
                 final_head,
                 canonical_head,
-                &|hash, f| {
-                    if let Some(content) = self.node_to_content.get(hash) {
-                        write!(f, "{:?}", content)
-                    } else {
-                        write!(f, "")
-                    }
-                },
+                &|content, f| write!(f, "{:?}", content),
             )?;
         }
         Ok(())
@@ -767,6 +738,7 @@ pub mod tests {
             self.tracker
                 .hash_to_node
                 .get(&block.hash)
+                .and_then(std::sync::Weak::upgrade)
                 .map(|node| BlockStatus::from(node.status.0.load(Ordering::Relaxed)))
         }
 
@@ -1076,20 +1048,18 @@ pub mod tests {
         //   b1.children = [Arc(b2)]
         //   b2.parent   = Some(Arc(b1))
         // Without breaking the cycle, neither can be freed.
-        let weak_b1 = Arc::downgrade(
-            tester
-                .tracker
-                .hash_to_node
-                .get(&b1.hash)
-                .expect("b1 present before prune"),
-        );
-        let weak_b2 = Arc::downgrade(
-            tester
-                .tracker
-                .hash_to_node
-                .get(&b2.hash)
-                .expect("b2 present before prune"),
-        );
+        let weak_b1 = tester
+            .tracker
+            .hash_to_node
+            .get(&b1.hash)
+            .expect("b1 present before prune")
+            .clone();
+        let weak_b2 = tester
+            .tracker
+            .hash_to_node
+            .get(&b2.hash)
+            .expect("b2 present before prune")
+            .clone();
 
         // When the finality jump triggers a multi-node prune
         tester.add(&b6, "6");
@@ -1151,20 +1121,18 @@ pub mod tests {
         assert_eq!(tester.check(&b1), Some(BlockStatus::Final));
         assert_eq!(tester.check(&b2), Some(BlockStatus::Final));
 
-        let weak_b3_fork = Arc::downgrade(
-            tester
-                .tracker
-                .hash_to_node
-                .get(&b3_fork.hash)
-                .expect("b3_fork present before prune"),
-        );
-        let weak_b4_fork = Arc::downgrade(
-            tester
-                .tracker
-                .hash_to_node
-                .get(&b4_fork.hash)
-                .expect("b4_fork present before prune"),
-        );
+        let weak_b3_fork = tester
+            .tracker
+            .hash_to_node
+            .get(&b3_fork.hash)
+            .expect("b3_fork present before prune")
+            .clone();
+        let weak_b4_fork = tester
+            .tracker
+            .hash_to_node
+            .get(&b4_fork.hash)
+            .expect("b4_fork present before prune")
+            .clone();
 
         // When: b5 is added, advancing final_head to b3
         //   (b1, F)

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -1,7 +1,7 @@
 use derive_more::Into;
 use near_indexer_primitives::types::BlockHeight;
 use near_indexer_primitives::CryptoHash;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
 use std::ops::Add;
 use std::sync::atomic::{AtomicU8, Ordering};
@@ -43,7 +43,54 @@ use std::sync::{Arc, Mutex, Weak};
 ///  - We keep track of the canonical chain as well as the final chain.
 ///
 /// Despite the assumptions we make on the indexer's behavior, this class guarantees not to panic
-/// even if the indexer violates these assumptions in arbitrary ways.
+/// even if the indexer violates these assumptions in arbitrary ways. In particular, if the indexer
+/// feeds blocks such that the canonical chain ends up on a fork that a later final-block advance
+/// discards, the next `add_block` re-elects `canonical_head` over the remaining tree rather than
+/// holding a stale reference. As a side effect, downstream consumers (e.g. the request queue) will
+/// not be invited to act on requests that sit on a permanently-dead fork: the block_ref handed out
+/// by `add_block` upgrades to `None` as soon as the finality advance condemns the fork.
+///
+/// **Cleanup overview.** Two cleanup paths run after every `add_block`:
+///
+///  - `maybe_update_final_head` owns **dead-fork cleanup**. When a new final block is established,
+///    every subtree that can't be part of the final chain — non-final siblings of the final chain
+///    at any height, and any `root_children` subtree not on the final chain with height ≤ the new
+///    final-head height — is dropped entirely. This is the "Dead-fork prune at X" annotation in
+///    the picture below.
+///  - `prune_old_blocks` owns **recency-window prune**. Any node below `min_height_to_keep` is
+///    dropped; its in-window descendants become new roots. This is the "Recency window prune"
+///    annotation below.
+///
+/// **Example.** If block 11 is the latest final block, both cleanups together produce the picture
+/// below. `root_1`, `root_2`, and the `(8)`/`(10)` subtrees are dropped as dead forks; `(4F)` is
+/// dropped by the recency window; `(7F)` becomes the new single root of the kept tree.
+///
+/// ```text
+///  ---------------------------┐
+///     These blocks will       ┆
+///     never be included       ┆
+///                             ┆
+///   root 1   root 2           ┆ root 3
+///   (1)                       ┆              Dead-fork prune at (1)
+///    │        (2)             ┆              Dead-fork prune at (2)
+///   (3)        │              ┆
+///    │         │              ┆ (4F)         Recency window prune node (4F)
+///  ┌─┴─┐       │       ┌──────────┴─┐
+/// ════════════════════════════════════════ ← cutoff (h ≥ min_height_to_keep)
+/// (5)  │       │       │      ┆     │
+///  │   │       │       │      ┆    (7F)      (7F) becomes new root
+///  │   │       │       │   ┌────────┴─┐
+///  │  (6)      │       │   │  ┆       │
+///  │   │       │       │  (8) ┆       │      Dead-fork prune at (8)
+///  │   │       │       │   │  ┆     (9F)
+///  │   │       │      (10) │  ┆       │      Dead-fork prune at (10)
+///  │   │       │       │   │  ┆     (11F)    ← latest final block height
+///  │   │       │       │   │  ┆       │
+///  │   │       │       │   │  ┆     (12)
+///  │   │       │      (13) │  ┆       │
+///  │   │       │       │   │  ┆       │
+///  ..  ..      ..      ..  .. ┆       ..
+/// ```
 ///
 /// Note: The use of Arc is a little unfortunate. Logically we only need Rc, but this code needs
 /// to work in futures, and Rc is not Send. So we use Arc instead.
@@ -53,9 +100,14 @@ pub struct RecentBlocksTracker<T: Clone + 'static> {
     /// The children of the root are the earliest blocks we are keeping who do not have any order
     /// with each other.
     root_children: Vec<Arc<BlockNode>>,
-    /// The head of the canonical chain. This is the chain of the highest-height block we've seen.
-    /// This may be None if we have no block at all.
-    canonical_head: Option<Arc<BlockNode>>,
+    /// The head of the canonical chain. Held as `Weak` so that when finality
+    /// cleanup sweeps a subtree containing the current canonical head, the
+    /// `BlockNode` drops naturally and the next `add_block` re-elects from the
+    /// remaining tree instead of clinging to a dangling node. `Weak::new()` at
+    /// construction time (which never upgrades) stands in for "no canonical
+    /// head yet" — the same `None`-on-upgrade behavior we already get when the
+    /// target is dropped, so the two cases collapse cleanly at every call site.
+    canonical_head: Weak<BlockNode>,
     /// The head of the final chain. This is determined by recovering information from the
     /// last_final_block fields of the block headers given to us. This may be None if we have not
     /// seen any final blocks yet.
@@ -158,125 +210,6 @@ struct BlockNode {
 }
 
 impl BlockNode {
-    /// Walk the subtree of this node and identify nodes to prune, as well as nodes that become
-    /// orphaned:
-    ///  1. **Dead fork** (`!is_final && height ≤ final_head.height`):
-    ///     This block is **not** final and it is **older** than the most recent final height.
-    ///     This means one of the following must be true:
-    ///     1. This block is actually supposed to be final, but for some reason, the indexer
-    ///        missed it. For example:
-    ///        ```text
-    ///              self (N)
-    ///                 │
-    ///          missed final_block (N+1)
-    ///                 │
-    ///          Final block (N+2)
-    ///        ```
-    ///        According to our assumptions about the indexer stream, this is **not** possible:
-    ///        > _if A < B and B < C, and both A and C are given, then B must also be given._
-    ///        > _In other words there should not be any gaps._
-    ///     2. This block sits on a dead fork:
-    ///         ```text
-    ///                  Common Head
-    ///                       /   \
-    ///                     ...    ...
-    ///                     /       \
-    ///              self (N)        \
-    ///                  │            \
-    ///                (N+1)           \
-    ///                /   \       Final block (N+2)
-    ///               /     \
-    ///            (N+3)     \
-    ///                       \
-    ///                      (N+4)
-    ///         ```
-    ///     In this case, we can remove the entire subtree.
-    ///
-    ///  2. **Outside window** (`height < min_height_to_keep`):
-    ///     This block is too old. We drop it and recurse into children.
-    ///     ```text
-    ///           self (N < min_height_to_keep)
-    ///              │
-    ///             ...
-    ///              │
-    ///       ------------------- cutoff height >= min_height_to_keep
-    ///              │
-    ///             ...
-    ///     ```
-    ///  3. **In-window and not on a dead fork**:
-    ///     We can stop the recursion and append this node `new_roots`.
-    ///     ```text
-    ///             ...
-    ///              │
-    ///       ------------------- cutoff height >= min_height_to_keep
-    ///              │
-    ///       self (N >= min_height_to_keep)
-    ///             ...
-    ///     ```
-    fn partition_subtree(
-        &self,
-        min_height_to_keep: u64,
-        final_head_height: Option<u64>,
-        new_roots: &mut Vec<CryptoHash>,
-        blocks_to_prune: &mut Vec<CryptoHash>,
-    ) {
-        if final_head_height.is_some_and(|fh| self.height <= fh) && !self.status.is_final() {
-            // This block sits on a dead subtree. It has nothing to contribute.
-            // Its children must be removed and we can terminate the recursion.
-            self.collect_subtree_hashes(blocks_to_prune);
-            return;
-        }
-        if self.height < min_height_to_keep {
-            // This block is too old for us to be useful, we will prune it.
-            blocks_to_prune.push(self.hash);
-            let children = self.children.lock().expect("lock must not be poisoned");
-            for child in children.iter() {
-                child.partition_subtree(
-                    min_height_to_keep,
-                    final_head_height,
-                    new_roots,
-                    blocks_to_prune,
-                );
-            }
-        } else {
-            // This block is right below the cut-off line and will need to be kept.
-            // It will become a new root.
-            new_roots.push(self.hash);
-            // However, its children might sit on dead forks, so we need check for that.
-            let Some(fh) = final_head_height else {
-                return;
-            };
-            if self.height < fh {
-                self.prune_dead_children(fh, blocks_to_prune);
-            }
-        }
-    }
-
-    /// This block is kept, but it may have descendants that sit on dead forks
-    fn prune_dead_children(&self, final_head_height: u64, blocks_to_prune: &mut Vec<CryptoHash>) {
-        let mut children = self.children.lock().unwrap();
-        children.retain(|child| {
-            if child.height <= final_head_height && !child.status.is_final() {
-                child.collect_subtree_hashes(blocks_to_prune);
-                false
-            } else {
-                if child.height < final_head_height {
-                    child.prune_dead_children(final_head_height, blocks_to_prune);
-                }
-                true
-            }
-        });
-    }
-
-    /// Walk this subtree and collect every node's hash on it.
-    fn collect_subtree_hashes(&self, blocks_to_prune: &mut Vec<CryptoHash>) {
-        blocks_to_prune.push(self.hash);
-        let children = self.children.lock().expect("lock must not be poisoned");
-        for child in children.iter() {
-            child.collect_subtree_hashes(blocks_to_prune);
-        }
-    }
-
     fn get_parent(&self) -> Option<Arc<BlockNode>> {
         self.parent.as_ref().and_then(Weak::upgrade)
     }
@@ -364,7 +297,7 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         Self {
             window_size,
             root_children: Vec::new(),
-            canonical_head: None,
+            canonical_head: Weak::new(),
             final_head: None,
             maximum_height_available: 0,
             hash_to_node: HashMap::new(),
@@ -411,13 +344,19 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             .into_iter()
             .filter_map(|node| Some((node.height, self.node_to_content.get(&node.hash)?.clone())))
             .collect();
-        match self.canonical_head.as_ref() {
-            None => {
-                self.update_canonical_head(&node);
-            }
+        match self.canonical_head.upgrade() {
             Some(canonical_head) => {
                 if block.height > canonical_head.height {
                     self.update_canonical_head(&node);
+                }
+            }
+            None => {
+                // Either the first block ever, or the previous canonical head
+                // was swept away by the finality cleanup above. Either way,
+                // re-elect from the kept tree (which already contains the
+                // just-added node, so it's a candidate).
+                if let Some(head) = self.highest_tracked_node() {
+                    self.update_canonical_head(&head);
                 }
             }
         }
@@ -431,31 +370,70 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         })
     }
 
-    /// Update the final head if the new final head received from a block is newer.
-    /// Returns the list of newly finalized blocks in increasing height order.
+    /// Advance the final head, mark its ancestors as final, and drop every
+    /// subtree that BFT-safety guarantees can no longer be on the final chain.
+    /// See `RecentBlocksTracker` for the picture of which subtrees this catches.
+    ///
+    /// Returns the newly finalized blocks in ascending height order.
     fn maybe_update_final_head(&mut self, potential_final_head: CryptoHash) -> Vec<Arc<BlockNode>> {
-        let final_head_node = self.hash_to_node.get(&potential_final_head);
-        let mut new_final_blocks = Vec::new();
-        if let Some(final_head_node) = final_head_node {
-            let mut node = final_head_node.clone();
-            loop {
-                if node.status.is_final() {
-                    break;
+        let final_head_node = self.hash_to_node.get(&potential_final_head).cloned();
+        let Some(final_head_node) = final_head_node else {
+            return Vec::new();
+        };
+        let mut new_final_blocks: Vec<Arc<BlockNode>> = Vec::new();
+        let mut node = final_head_node.clone();
+        let mut subtrees_to_remove: VecDeque<Arc<BlockNode>> = VecDeque::new();
+        loop {
+            // We only keep the last final child
+            if let Some(final_child) = new_final_blocks.last() {
+                let mut children = node.children.lock().expect("lock must not be poisoned");
+                for child in children.iter() {
+                    if child.hash != final_child.hash {
+                        subtrees_to_remove.push_back(child.clone());
+                    }
                 }
-                node.status.make_final();
-                new_final_blocks.push(node.clone());
-                let Some(parent) = node.get_parent() else {
-                    break;
-                };
-                node = parent;
+                *children = vec![final_child.clone()];
             }
-            if self
-                .final_head
-                .as_ref()
-                .is_none_or(|prev_final_head| prev_final_head.height < final_head_node.height)
-            {
-                self.final_head = Some(final_head_node.clone());
+            if node.status.is_final() {
+                break;
             }
+            node.status.make_final();
+            new_final_blocks.push(node.clone());
+            let Some(parent) = node.get_parent() else {
+                break;
+            };
+            node = parent;
+        }
+        if self
+            .final_head
+            .as_ref()
+            .is_none_or(|prev_final_head| prev_final_head.height < final_head_node.height)
+        {
+            self.final_head = Some(final_head_node.clone());
+        }
+
+        // We ensure to clean up nodes on other trees that won't be included anymore.
+        let new_final_height = final_head_node.height;
+        let mut new_root_children = Vec::new();
+        for node in self.root_children.iter() {
+            if node.status.is_final() || node.height > new_final_height {
+                new_root_children.push(node.clone());
+            } else {
+                // the entire subtree can be removed
+                subtrees_to_remove.push_back(node.clone());
+            }
+        }
+        self.root_children = new_root_children;
+        // now remove subtrees
+        while let Some(node) = subtrees_to_remove.pop_front() {
+            subtrees_to_remove.extend(
+                node.children
+                    .lock()
+                    .expect("lock must not be poisoned")
+                    .clone(),
+            );
+            self.hash_to_node.remove(&node.hash);
+            self.node_to_content.remove(&node.hash);
         }
         new_final_blocks.reverse();
         new_final_blocks
@@ -477,7 +455,7 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         }
         let common_ancestor = node;
 
-        let mut old_node = self.canonical_head.clone();
+        let mut old_node = self.canonical_head.upgrade();
         while let Some(current_node) = old_node {
             if let Some(common_ancestor) = &common_ancestor {
                 if Arc::ptr_eq(&current_node, common_ancestor) {
@@ -487,7 +465,23 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             current_node.status.make_non_canonical();
             old_node = current_node.get_parent();
         }
-        self.canonical_head = Some(new_canonical_head.clone());
+        self.canonical_head = Arc::downgrade(new_canonical_head);
+    }
+
+    /// BFS over the kept tree, returning the highest-height node (BFS order
+    /// breaks ties). Used to re-elect the canonical head after finality
+    /// cleanup sweeps the previous one.
+    fn highest_tracked_node(&self) -> Option<Arc<BlockNode>> {
+        let mut queue: VecDeque<Arc<BlockNode>> = self.root_children.iter().cloned().collect();
+        let mut best: Option<Arc<BlockNode>> = None;
+        while let Some(node) = queue.pop_front() {
+            if best.as_ref().is_none_or(|b| b.height < node.height) {
+                best = Some(node.clone());
+            }
+            let children = node.children.lock().expect("lock must not be poisoned");
+            queue.extend(children.iter().cloned());
+        }
+        best
     }
 
     /// Calculates the minimum height of blocks that we need to keep.
@@ -506,95 +500,30 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         )
     }
 
-    /// Remove blocks that are no longer needed:
-    ///  - **Recency Window prune:** Drop nodes below `minimum_height_to_keep`,
-    ///    their children become new roots
-    ///  - **Dead-fork prune.** Drop non-final nodes at heights ≤
-    ///    `final_head.height` along with their entire subtree (a descendant
-    ///    of a dead fork can never become final, by the BFT-finality safety
-    ///    theorem).
-    ///
-    /// **Example:**
-    /// If block 8 is finalized, we can remove the subtrees at (5), (6) and (7):
-    ///
-    /// ```text
-    ///  ---------------------------┐
-    ///     These blocks will       ┆
-    ///     never be included       ┆
-    ///                             ┆
-    ///                             ┆
-    ///   root 1   root 2           ┆ root 3
-    ///   (1)                       ┆              Dead-fork prune at (1)
-    ///    │        (2)             ┆              Dead-fork prune at (2)
-    ///   (3)        │              ┆
-    ///    │         │              ┆ (4F)         Recency window prune node (4F)
-    ///  ┌─┴─┐       │       ┌──────────┴─┐
-    /// ════════════════════════════════════════ ← cutoff (h ≥ 4). Remove blocks older than this.
-    /// (5)  │       │       │      ┆     │
-    ///  │   │       │       │      ┆    (7F)      (7F) becomes new root
-    ///  │   │       │       │   ┌────────┴─┐
-    ///  │  (6)      │       │   │  ┆       │
-    ///  │   │       │       │  (8) ┆       │      Dead-fork prune at (8)
-    ///  │   │       │       │   │  ┆     (9F)
-    ///  │   │       │      (10) │  ┆       │      Dead-fork prune at (10)
-    ///  │   │       │       │   │  ┆     (11F)    ← latest final block height.
-    ///  │   │       │       │   │  ┆       │         Remove subtrees of older,
-    ///  │   │       │       │   │  ┆       │         non-final blocks
-    ///  │   │       │       │   │  ┆       │
-    ///  │   │       │       │   │  ┆     (12)
-    ///  │   │       │      (13) │  ┆       │
-    ///  │   │       │       │   │  ┆       │
-    ///  ..  ..      ..      ..  .. ┆       ..
-    ///
-    /// ```
-    /// After prune, we have one new root:
-    /// ```text
-    ///  root 1
-    ///   (7F)
-    ///    │
-    ///    ..
-    ///             ..
-    ///  ```
+    /// Recency-window prune. Drops every node below `min_height_to_keep` and
+    /// promotes the first in-window descendant on each branch to a new root.
+    /// See `RecentBlocksTracker` for the picture; dead-fork cleanup happens in
+    /// `maybe_update_final_head`, not here.
     fn prune_old_blocks(&mut self) {
         let Some(min_height_to_keep) = self.minimum_height_to_keep() else {
             return;
         };
-        let final_head_height = self.final_head.as_ref().map(|n| n.height);
-
+        let mut queue: VecDeque<Arc<BlockNode>> = std::mem::take(&mut self.root_children).into();
         let mut new_roots = Vec::new();
-        let mut blocks_to_prune = Vec::new();
-
-        for root in self.root_children.iter() {
-            root.partition_subtree(
-                min_height_to_keep,
-                final_head_height,
-                &mut new_roots,
-                &mut blocks_to_prune,
-            );
+        while let Some(node) = queue.pop_front() {
+            if node.height >= min_height_to_keep {
+                new_roots.push(node);
+                continue;
+            }
+            self.hash_to_node.remove(&node.hash);
+            self.node_to_content.remove(&node.hash);
+            // Drain into the queue so the parent stops holding strong refs to
+            // its children — once `hash_to_node` no longer holds the parent,
+            // the parent can drop as soon as we move past this iteration.
+            let mut children = node.children.lock().expect("lock must not be poisoned");
+            queue.extend(children.drain(..));
         }
-
-        self.root_children = new_roots
-            .iter()
-            .filter_map(|hash| {
-                self.hash_to_node.get(hash).cloned().or_else(|| {
-                    // note: this should NEVER happen. Right now, it's a guaranteed dead code path.
-                    // However, to protect against future refactors of `partition_subtree`, or some
-                    // odd behavior, we simply print an error. Missing a root child is not something
-                    // that requires us to crash the node.
-                    tracing::error!(
-                        "Error: missing node for root hash {:?}. RecentBlocksTracker: {:?}",
-                        hash,
-                        self
-                    );
-                    None
-                })
-            })
-            .collect();
-
-        for hash in blocks_to_prune {
-            self.hash_to_node.remove(&hash);
-            self.node_to_content.remove(&hash);
-        }
+        self.root_children = new_roots;
     }
 }
 
@@ -610,7 +539,7 @@ impl<T: Clone + Debug> Debug for RecentBlocksTracker<T> {
             self.minimum_height_to_keep().unwrap_or(0)
         )?;
         let final_head = self.final_head.as_ref().map(|n| n.hash);
-        let canonical_head = self.canonical_head.as_ref().map(|n| n.hash);
+        let canonical_head = self.canonical_head.upgrade().map(|n| n.hash);
 
         for (i, child) in self.root_children.iter().enumerate() {
             child.debug_print(
@@ -1040,23 +969,11 @@ pub mod tests {
         assert_eq!(t.add(&b102, "b102"), "b1");
         assert_eq!(t.add(&b1020, "b1020"), "b10");
         //    Recent blocks: (Window = 6 to 10, GC limit 6)
-        //    ├─[6]     7wk1ewkZKmCNLRRhCrjFuoYy1K94dis9qAUv7JUKzCkG "b00"
-        //    │ ├─[8]     DTYziqMhQ9i2wbruEfoNiWZNp34dzVYto6FLy3FUZKwt "b000"
-        //    │ └─[9]     DC88XsXQdWZXipUU4vRHQqYo22nwtGVnp3rHptw44mJz "b001"
-        //    ├─[7] C   8FoDbEfMuYmtr7SXRPiscHR4mQ6m5nCyuca43eAopktY "b01"
-        //    │ ├─[9]     8jRJjsyqjoAbyWbjLXTjFNiKTwT8s4xspouvRaZGfh6R "b010"
-        // CH │ └─[10] C   CnbxNBi2SVDZo9z8V8kwrmE3pUkozpDvpCCg9Tq25rY3 "b011"
-        // FH ├─[6] C F 6s7VNQLN9b4SpwUdEq8LqKwBjf8SqUuutACcMtHwULu8 "b10"
-        //    │ ├─[8]     GounuZUfMmxdVequL65iUm7D94sKYg67Q34Z5cjRjZ71 "b100"
-        //    │ ├─[8]     7aXqE7cPZt6FnVcpytqW3oy5y2E17X9Gpgs6C7praap5 "b101"
-        //    │ └─[7]     FK5PX18pxwwtaB6AvYjNkWZ4Jvnn2HeNx4tknkM5g7VP "b102"
-        //    │   [8]     AQif6GckVVDt4L4rUeAN43PNComjsa7fPYAF5NHW7oX8 "b1020"
-        //    └─[7]     2xhND7PwiNZckwCnXFa25wMG1G8JWfKN2Sinmbz3W6xK "b11"
-        //      ├─[9]     6E2vqjZLbuUY2y6VK571Ai3pk43EUHXuNxibJuBGh44T "b110"
-        //      └─[10]     Cq9uMZqNZr6zuF7nT6yfGms1ptaVVu5dAdiRJ6pqCTN8 "b111"
-        //
-        // Note above: the canonical head is not a descendant of final head. This can't happen in
-        // the real blockchain, but here we fed in a pathological scenario.
+        // FH └─[6] C F 6s7VNQLN9b4SpwUdEq8LqKwBjf8SqUuutACcMtHwULu8 "b10"
+        // CH   ├─[8] C   GounuZUfMmxdVequL65iUm7D94sKYg67Q34Z5cjRjZ71 "b100"
+        //      ├─[8]     7aXqE7cPZt6FnVcpytqW3oy5y2E17X9Gpgs6C7praap5 "b101"
+        //      └─[7]     FK5PX18pxwwtaB6AvYjNkWZ4Jvnn2HeNx4tknkM5g7VP "b102"
+        //        [8]     AQif6GckVVDt4L4rUeAN43PNComjsa7fPYAF5NHW7oX8 "b1020"
         t.print();
         // b0 was removed (older than recent window).
         assert_eq!(t.check(&b0), None);
@@ -1071,10 +988,16 @@ pub mod tests {
         // b1 was removed by window-prune (too old, newer final blocks).
         assert_eq!(t.check(&b1), None);
         assert_eq!(t.check(&b10), Some(BlockStatus::Final));
-        assert_eq!(t.check(&b100), Some(BlockStatus::OptimisticButNotCanonical));
-        assert_eq!(t.check(&b11), Some(BlockStatus::OptimisticButNotCanonical));
-        assert_eq!(t.check(&b110), Some(BlockStatus::OptimisticButNotCanonical));
-        assert_eq!(t.check(&b111), Some(BlockStatus::OptimisticButNotCanonical));
+        // b011 was canonical before add(b102), but its subtree was swept by the
+        // finality advance; canonical_head re-elected to the first-seen block
+        // at the new tree's max height — b100 (h=8, inserted before b101/b1020).
+        assert_eq!(t.check(&b100), Some(BlockStatus::OptimisticAndCanonical));
+        // b11 (sibling of final-chain b10 under b1) and its subtree are
+        // discarded by add(b1020)'s finality advance to b10 — by BFT safety
+        // every non-final-chain sibling of a final block is on a dead fork.
+        assert_eq!(t.check(&b11), None);
+        assert_eq!(t.check(&b110), None);
+        assert_eq!(t.check(&b111), None);
 
         let b10200 = b1020.descendant(11);
         let b102000 = b10200.descendant(12);
@@ -1084,18 +1007,14 @@ pub mod tests {
         assert_eq!(&t.add(&b1020000, "b1020000"), "b102,b1020,b10200");
 
         //    Recent blocks: (Window = 9 to 13, GC limit 9)
-        //    ├─[9]     DC88XsXQdWZXipUU4vRHQqYo22nwtGVnp3rHptw44mJz "b001"
-        //    ├─[9]     8jRJjsyqjoAbyWbjLXTjFNiKTwT8s4xspouvRaZGfh6R "b010"
-        //    ├─[10]     CnbxNBi2SVDZo9z8V8kwrmE3pUkozpDvpCCg9Tq25rY3 "b011"
-        // FH ├─[11] C F NW4CWxr6ptWa9tsV2gMhGPdE7ecNWfCrnJDfJwx9yv9 "b10200"
-        //    │ [12] C   4Vwtcagaq6fi5j82suG4j8HiaU3SMbqotrZzT3bjqwcP "b102000"
-        // CH │ [13] C   GktyudcCf3dBkWCdjq9dFssY7KZRRZQJ1TZH3ZMw8LWk "b1020000"
-        //    ├─[9]     6E2vqjZLbuUY2y6VK571Ai3pk43EUHXuNxibJuBGh44T "b110"
-        //    └─[10]     Cq9uMZqNZr6zuF7nT6yfGms1ptaVVu5dAdiRJ6pqCTN8 "b111"
+        // FH └─[11] C F NW4CWxr6ptWa9tsV2gMhGPdE7ecNWfCrnJDfJwx9yv9 "b10200"
+        //      [12] C   4Vwtcagaq6fi5j82suG4j8HiaU3SMbqotrZzT3bjqwcP "b102000"
+        // CH   [13] C   GktyudcCf3dBkWCdjq9dFssY7KZRRZQJ1TZH3ZMw8LWk "b1020000"
         t.print();
-        // b001, b010, b011 were already discarded earlier (with the b0 subtree).
-        // b110, b111 are discarded by add(b1020000)'s finality jump to b10200,
-        // along with the rest of the b1 dead-fork branch (b11, b100, b101).
+        // b001, b010, b011 were already discarded with the b0 subtree (add(b102)).
+        // b11, b110, b111 were discarded with the b11 subtree (add(b1020)).
+        // b100, b101 are discarded by add(b1020000)'s finality advance to b10200
+        // (siblings of b102 under final-chain b10).
         assert_eq!(t.check(&b001), None);
         assert_eq!(t.check(&b010), None);
         assert_eq!(t.check(&b011), None);

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -96,6 +96,15 @@ use std::sync::{Arc, Mutex, Weak};
 ///  │   │       │       │   │  ┆       │
 ///  ..  ..      ..      ..  .. ┆       ..
 /// ```
+/// Hash index, shared between the tracker (one strong `Arc`) and every live node
+/// (one `Weak` each). Nodes use `Weak` so that dropping the tracker doesn't keep
+/// the map alive. The `Mutex` is required for `Send + Sync` but is effectively
+/// uncontended: the tracker is `&mut self` for all mutating paths, and nodes only
+/// acquire the lock from inside their own `Drop::drop` to remove themselves.
+type HashIndexInner<T> = Mutex<HashMap<CryptoHash, Weak<BlockNode<T>>>>;
+type HashIndex<T> = Arc<HashIndexInner<T>>;
+type WeakHashIndex<T> = Weak<HashIndexInner<T>>;
+
 pub struct RecentBlocksTracker<T: Clone + 'static> {
     window_size: u64,
     /// By "root", we mean the blocks whose parents we don't know or are older than the window.
@@ -116,10 +125,10 @@ pub struct RecentBlocksTracker<T: Clone + 'static> {
     /// The maximum height of any block we have been given via `add_block`.
     maximum_height_available: BlockHeight,
     /// Non-owning lookup index. Strong ownership is in `root_children` and each
-    /// `BlockNode::children` — never here. Reassigning a parent's `children` cascades
-    /// the deallocation of dropped subtrees through `Drop`; stale `Weak` entries in
-    /// this map are filtered out lazily by `get_node`.
-    hash_to_node: HashMap<CryptoHash, Weak<BlockNode<T>>>,
+    /// `BlockNode::children` — never here. Every node carries a `Weak<...>` back-reference
+    /// to this map and removes its own entry from `Drop`, so the map stays exactly in
+    /// lockstep with live nodes — no stale `Weak` entries ever.
+    hash_to_node: HashIndex<T>,
 }
 
 #[repr(u8)]
@@ -212,6 +221,23 @@ struct BlockNode<T> {
     /// Per-block payload. Moved into the node so it dies with the node — no separate
     /// `node_to_content` map to keep in sync.
     content: T,
+    /// Back-reference to the tracker's hash index. `Drop::drop` uses this to remove
+    /// `self.hash` from the index, keeping it in lockstep with live nodes. `Weak` so
+    /// that a `BlockNode` drop after the tracker itself is gone is a safe no-op.
+    hash_index: WeakHashIndex<T>,
+}
+
+impl<T> Drop for BlockNode<T> {
+    fn drop(&mut self) {
+        // The Mutex is effectively uncontended (see `HashIndex` docstring). `Drop`
+        // must not panic, so we tolerate Mutex poisoning silently — at worst we
+        // leak a single stale entry, which is bounded.
+        if let Some(index) = self.hash_index.upgrade() {
+            if let Ok(mut map) = index.lock() {
+                map.remove(&self.hash);
+            }
+        }
+    }
 }
 
 impl<T> BlockNode<T> {
@@ -314,15 +340,20 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             canonical_head: Weak::new(),
             final_head: Weak::new(),
             maximum_height_available: 0,
-            hash_to_node: HashMap::new(),
+            hash_to_node: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
     /// Looks up a live node by hash. Filters out stale `Weak` entries lazily — if a node
-    /// has been dropped by cleanup, `Weak::upgrade` returns `None` even if the map still
-    /// has the entry.
+    /// has been dropped by cleanup, `Weak::upgrade` returns `None`. With self-removing
+    /// `Drop` on `BlockNode`, the map never holds stale entries, but the upgrade
+    /// remains as a defensive belt-and-suspenders check.
     fn get_node(&self, hash: &CryptoHash) -> Option<Arc<BlockNode<T>>> {
-        self.hash_to_node.get(hash).and_then(Weak::upgrade)
+        self.hash_to_node
+            .lock()
+            .expect("lock must not be poisoned")
+            .get(hash)
+            .and_then(Weak::upgrade)
     }
 
     /// Adds a block to the tracker. This is expected to be called for EVERY block given by the
@@ -348,8 +379,12 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
             parent: parent.as_ref().map(Arc::downgrade),
             children: Mutex::new(Vec::new()),
             content,
+            hash_index: Arc::downgrade(&self.hash_to_node),
         });
-        self.hash_to_node.insert(block.hash, Arc::downgrade(&node));
+        self.hash_to_node
+            .lock()
+            .expect("lock must not be poisoned")
+            .insert(block.hash, Arc::downgrade(&node));
         if let Some(parent) = parent {
             parent.children.lock().unwrap().push(node.clone());
         } else {
@@ -737,6 +772,8 @@ pub mod tests {
         pub fn check(&self, block: &Arc<TestBlock>) -> Option<BlockStatus> {
             self.tracker
                 .hash_to_node
+                .lock()
+                .unwrap()
                 .get(&block.hash)
                 .and_then(std::sync::Weak::upgrade)
                 .map(|node| BlockStatus::from(node.status.0.load(Ordering::Relaxed)))
@@ -1051,12 +1088,16 @@ pub mod tests {
         let weak_b1 = tester
             .tracker
             .hash_to_node
+            .lock()
+            .unwrap()
             .get(&b1.hash)
             .expect("b1 present before prune")
             .clone();
         let weak_b2 = tester
             .tracker
             .hash_to_node
+            .lock()
+            .unwrap()
             .get(&b2.hash)
             .expect("b2 present before prune")
             .clone();
@@ -1124,12 +1165,16 @@ pub mod tests {
         let weak_b3_fork = tester
             .tracker
             .hash_to_node
+            .lock()
+            .unwrap()
             .get(&b3_fork.hash)
             .expect("b3_fork present before prune")
             .clone();
         let weak_b4_fork = tester
             .tracker
             .hash_to_node
+            .lock()
+            .unwrap()
             .get(&b4_fork.hash)
             .expect("b4_fork present before prune")
             .clone();
@@ -1178,6 +1223,35 @@ pub mod tests {
         // b4, b5 should be optimistic and canonical
         assert_eq!(tester.check(&b4), Some(BlockStatus::OptimisticAndCanonical));
         assert_eq!(tester.check(&b5), Some(BlockStatus::OptimisticAndCanonical));
+    }
+
+    /// Regression test for the leak Copilot flagged on PR #3251: every block ever inserted
+    /// used to add a `Weak` entry to `hash_to_node` that nothing removed. With `BlockNode`'s
+    /// self-removing `Drop`, the map stays in lockstep with live nodes — its size is bounded
+    /// by the window, not by the total blocks ever observed.
+    #[test]
+    #[expect(non_snake_case)]
+    fn hash_to_node__should_stay_bounded_by_window_size() {
+        // Given: a tracker with a small window.
+        let window_size: u64 = 4;
+        let mut tester = Tester::new(window_size);
+
+        // When: we add a long linear chain — far more blocks than the window holds.
+        let mut block = tester.block(1);
+        tester.add(&block, "1");
+        for h in 2..=50 {
+            block = block.child();
+            tester.add(&block, &format!("{}", h));
+        }
+
+        // Then: the map size is bounded by the window. Pre-fix this would be ~50.
+        let map_size = tester.tracker.hash_to_node.lock().unwrap().len();
+        assert!(
+            map_size <= (window_size as usize) + 2,
+            "hash_to_node leaked stale entries: size {} for window {}",
+            map_size,
+            window_size,
+        );
     }
 
     /// Tests that `minimum_height_to_keep` returns `Some` in case we have a final block height.

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -16,7 +16,13 @@ use std::sync::{Arc, Mutex, Weak};
 ///  - For each block added via `add_block`, it returns a `Weak<AtomicBlockStatus>` that can be
 ///    used to observe that block's current `BlockStatus` (non-canonical, canonical or final).
 ///
-/// We have certain expectations of the order of blocks that come from the indexer.
+/// This class provides the following invariants (provided the requirements listed below are met):
+///  - A block that is final will never be reverted to non-final;
+///  - Any block that is currently tracked has the potential to become final. In other words,
+///    the tracker removes non-final blocks of height less or equal to the latest final height.
+///
+/// In order to guarantee above invariants, we have certain expectations of the order of blocks
+/// that come from the indexer.
 /// First, let's define a partial order for blocks. For any two blocks A and B:
 ///  - If A is a strict ancestor of B then A < B;
 ///  - If B is a strict ancestor of A then B < A;

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -184,7 +184,7 @@ pub struct AddBlockResult<T> {
     /// The list of newly finalized blocks, in ascending height order. Each entry is a tuple of
     /// the block height and the data passed to us when adding the block.
     /// It is guaranteed that the new final blocks returned from multiple calls to add_block are
-    // contiguous, thus forming the stream of finalized blocks.
+    /// contiguous, thus forming the stream of finalized blocks.
     pub new_final_blocks: Vec<(u64, T)>,
     pub block_ref: Weak<AtomicBlockStatus>,
 }
@@ -427,7 +427,7 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         new_final_blocks
     }
 
-    /// Any root children that sit on dead branches get removed from `self.root_children` and addd
+    /// Any root children that sit on dead branches get removed from `self.root_children` and add
     /// to `subtrees_to_remove`
     fn update_roots(
         &mut self,
@@ -488,8 +488,8 @@ impl<T: Clone + Debug> RecentBlocksTracker<T> {
         self.canonical_head = Arc::downgrade(new_canonical_head);
     }
 
-    /// BFS over the kept tree, returning the highest-height node (BFS order
-    /// breaks ties). Used to re-elect the canonical head after finality
+    /// BFS over the kept tree, returning the highest-height node (insertion order and
+    /// BFS order breaks ties). Used to re-elect the canonical head after finality
     /// cleanup sweeps the previous one.
     fn highest_tracked_node(&self) -> Option<Arc<BlockNode>> {
         let mut queue: VecDeque<Arc<BlockNode>> = self.root_children.iter().cloned().collect();


### PR DESCRIPTION
Stacked on top of #3236.

## Motivation

#3236's cleanup still maintains a `subtrees_to_remove: VecDeque<Arc<BlockNode>>` worklist and a `remove_subtrees` drain helper. The reason is that `hash_to_node` holds strong `Arc<BlockNode>`s in parallel with each parent's `children: Mutex<Vec<Arc<BlockNode>>>`. When `keep_only_child` writes `*children = vec![retain.clone()]`, the dropped siblings still have strong-count ≥ 1 because `hash_to_node` is also holding them — so they don't actually deallocate. The worklist exists to enumerate them and call `hash_to_node.remove(&hash)` later.

## Change

Make `hash_to_node` non-owning (`Weak<BlockNode<T>>`) so the tree (`root_children` + each parent's `children`) is the sole strong-Arc holder. Move per-block content onto the node itself so it dies with the node — eliminates the parallel `node_to_content` map and its sync burden.

Now `*children = vec![retain.clone()]` does drop the siblings at strong-count 0. `BlockNode::drop` runs, which drops its `Mutex<Vec<Arc<BlockNode<T>>>>`, which drops grandchildren — cascading the whole subtree through `Drop`. No worklist needed.

## What's deleted

- `subtrees_to_remove: VecDeque<...>` worklist threading through `maybe_update_final_head`, `keep_only_child`, `update_roots`.
- `remove_subtrees` helper entirely.
- `node_to_content: HashMap<...>` field and its `.insert` / `.remove` calls.
- `update_roots` helper — folded into a single `self.root_children.retain(...)` call in `maybe_update_final_head`.
- Per-node `hash_to_node.remove` / `node_to_content.remove` calls in `prune_old_blocks`.

## What changes shape

- `keep_only_child`: loses its `&mut subtrees_to_remove` parameter. Becomes a one-liner.
- `hash_to_node` lookups go via a small `get_node` helper that does `.and_then(Weak::upgrade)`. Stale `Weak` entries are filtered lazily; no eager sweep needed.
- `BlockNode` → `BlockNode<T>` with a `content: T` field.

## Time complexity

Unchanged from #3236. Marking the final chain is O(f), dead-fork cleanup is O(d) (cascading `Drop` instead of explicit removes — fewer atomic ops, same asymptotic), window prune is the same shape, lookups are O(1) hashmap get + `Weak::upgrade`.

## Verification

`cargo nextest run --cargo-profile=test-release -p mpc-node` — all 214 tests pass. `cargo clippy -p mpc-node --all-targets -- -D warnings` clean.

The two tests in this module that explicitly verify the Arc-cycle gets broken (`prune_old_blocks__should_drop_connected_pruned_block_nodes` and `prune_old_blocks__should_drop_dead_fork_descendants_of_kept_nodes`) pass naturally — with `Weak` in `hash_to_node` and `Weak` in `parent`, there's no parent↔child Arc cycle to break.

## Diff

+112 / −144 = −32 net lines, single file.