### PR TITLE
docs: add documentation for resharing log entries

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1296,9 +1296,49 @@ To generate a voting command, follow these steps:
    ```
 
 After all participants have voted, the contract will move to a resharing phase.
-You can see this in the node logs (TBD) [#906](https://github.com/near/mpc/issues/906)
 
-And when the resharing has finished look for… (TBD) [#906](https://github.com/near/mpc/issues/906)
+**When resharing starts.** Each node detects the contract state change and logs:
+
+```
+INFO mpc_node::coordinator: A resharing started.
+INFO mpc_node::coordinator: Starting key resharing.
+INFO mpc_node::coordinator: Resharing process is: Some(ResharingContractState { ... })
+```
+
+**During resharing.** Each domain runs its own attempt. Per-attempt progress lines:
+
+```
+INFO mpc_node::providers::<scheme>::key_resharing: Key resharing completed
+INFO mpc_node::key_events: Key resharing attempt <KeyEventId>: committing keyshare.
+INFO mpc_node::key_events: Key resharing attempt <KeyEventId>: sending vote_reshared transaction.
+INFO mpc_node::key_events: Key resharing attempt <KeyEventId> completed successfully.
+```
+
+Where `<scheme>` is `ecdsa`, `eddsa`, or `ckd`.
+
+**When resharing finishes.** Once the contract leaves the Resharing state, each node logs:
+
+```
+INFO mpc_node::coordinator: Concluded resharing state.
+```
+
+You can also confirm on-chain:
+
+```bash
+near contract call-function as-read-only \
+  v1.signer-prod.testnet state \
+  json-args {} network-config testnet now
+```
+
+The response should show `Running` (not `Resharing`) and a new `keyset.epoch_id`.
+
+**If resharing fails.** An attempt that times out or errors logs:
+
+```
+ERROR mpc_node::key_events: Key resharing attempt <KeyEventId> failed: <err>; sending vote_abort_key_event_instance
+```
+
+The contract will retry with a fresh attempt; repeated failures need investigation.
 
 ## Upgrades
 

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1323,7 +1323,7 @@ Where `<scheme>` is `ecdsa`, `eddsa`, or `ckd`. The `epoch_id` is the resharing'
 INFO mpc_node::coordinator: Concluded resharing state.
 ```
 
-You can also confirm on-chain:
+You can also confirm on-chain (replace `v1.signer-prod.testnet` / `testnet` with `v1.signer` / `mainnet` on mainnet):
 
 ```bash
 near contract call-function as-read-only \

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1305,16 +1305,17 @@ INFO mpc_node::coordinator: Starting key resharing.
 INFO mpc_node::coordinator: Resharing process is: Some(ResharingContractState { ... })
 ```
 
-**During resharing.** Each domain runs its own attempt. Per-attempt progress lines:
+**During resharing.** Each domain runs its own attempt. Per-attempt progress lines (in order):
 
 ```
+INFO mpc_node::key_events: Key resharing attempt KeyEventId { epoch_id: EpochId(1), domain_id: DomainId(0), attempt_id: AttemptId(0) }: starting key resharing.
 INFO mpc_node::providers::<scheme>::key_resharing: Key resharing completed
-INFO mpc_node::key_events: Key resharing attempt <KeyEventId>: committing keyshare.
-INFO mpc_node::key_events: Key resharing attempt <KeyEventId>: sending vote_reshared transaction.
-INFO mpc_node::key_events: Key resharing attempt <KeyEventId> completed successfully.
+INFO mpc_node::key_events: Key resharing attempt KeyEventId { ... }: committing keyshare.
+INFO mpc_node::key_events: Key resharing attempt KeyEventId { ... }: sending vote_reshared transaction.
+INFO mpc_node::key_events: Key resharing attempt KeyEventId { ... } completed successfully.
 ```
 
-Where `<scheme>` is `ecdsa`, `eddsa`, or `ckd`.
+Where `<scheme>` is `ecdsa`, `eddsa`, or `ckd`. The `epoch_id` is the resharing's new epoch; `domain_id` identifies which keyspace (each gets its own attempt).
 
 **When resharing finishes.** Once the contract leaves the Resharing state, each node logs:
 
@@ -1335,7 +1336,7 @@ The response should show `Running` (not `Resharing`) and a new `keyset.epoch_id`
 **If resharing fails.** An attempt that times out or errors logs:
 
 ```
-ERROR mpc_node::key_events: Key resharing attempt <KeyEventId> failed: <err>; sending vote_abort_key_event_instance
+ERROR mpc_node::key_events: Key resharing attempt KeyEventId { ... } failed: <err>; sending vote_abort_key_event_instance
 ```
 
 The contract will retry with a fresh attempt; repeated failures need investigation.


### PR DESCRIPTION
Closes #906.

## Summary

- Document `INFO`-level log lines emitted by `coordinator.rs` and `key_events.rs` at each resharing stage (start / per-attempt progress / completion / failure).
- Add a `near contract call-function ... state` snippet operators can run to confirm the contract returned to `Running` with a new `keyset.epoch_id`.
- Cover the error path: `Key resharing attempt ... failed: ...; sending vote_abort_key_event_instance`.

## Test plan

- [ ] Render on GitHub and confirm the surrounding "Voting (vote_new_parameters)" section flows correctly.
- [ ] Spot-check the quoted log lines against `crates/node/src/coordinator.rs` and `crates/node/src/key_events.rs` on `main`.