### PR TITLE
chore(cvm-deployment): align user-config.toml example with prod values

### DIFF
--- a/deployment/cvm-deployment/ci-config.toml
+++ b/deployment/cvm-deployment/ci-config.toml
@@ -1,0 +1,78 @@
+# Minimal config for non-TEE CI check.
+# Only needs enough for the launcher to start and pull the MPC node image.
+# Uses mainnet chain_id with embedded genesis to avoid downloading the large
+# testnet genesis file, which requires ~20 GiB of RAM.
+
+[launcher_config]
+image_reference = "nearone/mpc-node"
+port_mappings = [
+    { host = 8080, container = 8080 },
+]
+
+[mpc_node_config]
+home_dir = "/data"
+
+# PCCS endpoints for TDX attestation collateral. The node tries each
+# entry in order until one succeeds. Defaults below: Phala primary,
+# Intel direct as fallback.
+#
+# To add a self-hosted local PCCS (e.g. for an operator running their
+# own), prepend an entry with a `tls` override. See the operator
+# deployment guide's "Self-hosting a local PCCS" appendix for the cert
+# setup. Example (commented):
+#
+#   [[mpc_node_config.pccs_endpoints]]
+#   url = "https://10.0.2.2:8081/"
+#   tls = { override = "ca_cert_pem", ca_cert_pem = "..." }
+
+[[mpc_node_config.pccs_endpoints]]
+url = "https://pccs.phala.network/"
+
+[[mpc_node_config.pccs_endpoints]]
+url = "https://api.trustedservices.intel.com/"
+
+[mpc_node_config.log]
+format = "plain"
+filter = "info"
+
+[mpc_node_config.near_init]
+chain_id = "mainnet"
+boot_nodes = "ed25519:ERguu7jQuYk8pxNsRC6FdezvNsegBPva1GRGqjmtD7i2@10.10.10.10:24567"
+download_genesis = false
+download_config = "rpc"
+
+[mpc_node_config.secrets]
+secret_store_key_hex = "BD399143F5B3126098B0EAA023A0E730"
+backup_encryption_key_hex = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[mpc_node_config.node]
+my_near_account_id = "test_image.near"
+near_responder_account_id = "test_image.near"
+number_of_responder_keys = 1
+web_ui = "0.0.0.0:8080"
+migration_web_ui = "0.0.0.0:8078"
+cores = 4
+
+[mpc_node_config.node.indexer]
+validate_genesis = false
+sync_mode = "Latest"
+concurrency = 1
+mpc_contract_id = "v1.signer"
+finality = "optimistic"
+
+[mpc_node_config.node.triple]
+concurrency = 2
+desired_triples_to_buffer = 128
+timeout_sec = 60
+parallel_triple_generation_stagger_time_sec = 1
+
+[mpc_node_config.node.presignature]
+concurrency = 4
+desired_presignatures_to_buffer = 64
+timeout_sec = 60
+
+[mpc_node_config.node.signature]
+timeout_sec = 60
+
+[mpc_node_config.node.ckd]
+timeout_sec = 60

--- a/deployment/cvm-deployment/launcher_docker_compose_nontee.yaml
+++ b/deployment/cvm-deployment/launcher_docker_compose_nontee.yaml
@@ -10,7 +10,7 @@ services:
 
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - ./user-config.toml:/tapp/user_config:ro
+      - ./ci-config.toml:/tapp/user_config:ro
       - shared-volume:/mnt/shared:rw
       - mpc-data:/data
 

--- a/deployment/cvm-deployment/user-config.toml
+++ b/deployment/cvm-deployment/user-config.toml
@@ -1,12 +1,26 @@
-# Minimal config for non-TEE CI check.
-# Only needs enough for the launcher to start and pull the MPC node image.
-# Uses mainnet chain_id with embedded genesis to avoid downloading the large
-# testnet genesis file, which requires ~20 GiB of RAM.
+# Example user-config.toml for new MPC node operators.
+# Defaults target testnet and mirror what NEAR One runs on its live
+# testnet node. Inline `# mainnet: ...` comments below show the value
+# to use when running on mainnet instead.
+#
+# MUST be replaced with real values before deploying:
+#   - my_near_account_id / near_responder_account_id
+#   - secrets.secret_store_key_hex
+#   - secrets.backup_encryption_key_hex
+# The placeholders below are intentionally non-hex so a forgotten swap
+# fails loudly at node startup.
 
 [launcher_config]
 image_reference = "nearone/mpc-node"
+# Matches the canonical port list in
+# docs/running-an-mpc-node-in-tdx-external-guide.md#required-ports
+# (80 P2P, 8080 web/metrics, 8079 migration, 3030 debug, 24567 DSS).
 port_mappings = [
-    { host = 8080, container = 8080 },
+    { host = 80,    container = 80 },     # MPC P2P (port_override convention)
+    { host = 8080,  container = 8080 },   # web_ui / metrics / /public_data
+    { host = 8079,  container = 8079 },   # migration_web_ui
+    { host = 3030,  container = 3030 },   # debug / telemetry
+    { host = 24567, container = 24567 },  # decentralized state sync
 ]
 
 [mpc_node_config]
@@ -40,9 +54,12 @@ format = "plain"
 filter = "info"
 
 [mpc_node_config.near_init]
-chain_id = "mainnet"
-boot_nodes = "ed25519:ERguu7jQuYk8pxNsRC6FdezvNsegBPva1GRGqjmtD7i2@10.10.10.10:24567"
-download_genesis = false
+chain_id = "testnet"  # mainnet: "mainnet"
+# Testnet boot nodes. For mainnet, replace with the mainnet boot-nodes
+# string from https://near-nodes.io/ or the official nearcore mainnet
+# config.json (rpc.mainnet.near.org).
+boot_nodes = "ed25519:2956bsTqWmXcVmXDSovLYS4HRpdyh51euNCiuQjy1h8Y@65.108.141.230:24567,ed25519:2Ej627FDrHUBA1Mp55qw3zyhACSvJHF25sxtZfyFqasc@65.108.133.7:24567,ed25519:2GorYSFQUWB1But3sXLEM6zARfwb9Pj27QhQMsMpK8Dx@150.136.35.62:24567,ed25519:2nGLw9isJYVqCfaYzA6KHBE9YbtjzGQPPtVcRwYvpJj6@23.88.74.249:24567,ed25519:3VCjDXCbJWNr247wLzBas653C8FT69drtu3vDXbRAG2E@35.188.52.109:24567,ed25519:3wdbS6vbahK7pzgn8r8oFcgFthWvcT8mtXcUgtpQngqW@57.129.88.239:24567,ed25519:49F9yZpbQVefzWegVZYTh18WwFPPcfgvkDmhm7zM5MR4@89.58.28.231:24567,ed25519:4Fx8rLhGobUPVie1FXQCAxFaMQ3Dg6PYMDdm5keZcKW6@84.207.214.228:24567,ed25519:4M63uf6ccsjBkFygqx4T45fKSvKsFFMva9g7FRxjwzTH@176.9.105.103:24568,ed25519:4Rj2NR92umGC4xtXeJFkyCUYymdad3zii1zVEMVnVKqH@5.9.40.211:24567,ed25519:4b5MtShRdtu87BTNoPHX4HDBbZGnm5pjEQoGZk5J7L1w@34.12.14.28:24567,ed25519:4gdz1kjG7ndfbSwgMRtgNYZ7D6reHdnBgZN71U3agwtw@198.244.253.126:24567,ed25519:4qCcK9sWsqCpXzjV6kXxkaLyu5o5UpYNLpQzKFDSjfhA@34.123.242.245:24567,ed25519:4xTqirCWWjJ9QpXQbJLkyUbjRuRBgr4ZVpKMQAs4CjcH@57.128.210.54:24567,ed25519:4xmhjdejr2jWHqpiCrkeGXbrqBt98q9ewZ77WKrAz7JT@148.251.70.186:24567,ed25519:5M9DnL5xecA34RTHnkBpGB8SMXc2NcPvue7784D3GaH4@88.198.57.94:24568,ed25519:5MipaupEtQu7SqdMWsP5mdh2wfHQHgngai2BziCXv2T@185.6.13.181:24567,ed25519:5QmANbVUKooCvHq9qyKTd5cRgp4vYrQrAqjuRrA9M5TT@144.76.43.124:24567,ed25519:5T2wfCxjXT2rFPsyWAAxWnMqLajM24FC2ZWKXA62xbQ1@47.129.128.11:24567,ed25519:5VdRi9UAxjppwL2ku3g2hWXjn4oQZA4i1goEWJxpp9uv@113.172.202.5:24568"
+download_genesis = true
 download_config = "rpc"
 # Bound IP:24567 the node advertises for Tier3 state-sync responses.
 # Replace with the IP your dstack port-forward exposes for :24567.
@@ -53,33 +70,43 @@ download_config = "rpc"
 # external_storage_fallback_threshold = 100
 
 [mpc_node_config.secrets]
-secret_store_key_hex = "BD399143F5B3126098B0EAA023A0E730"
-backup_encryption_key_hex = "0000000000000000000000000000000000000000000000000000000000000000"
+# MUST replace with real values before deploying. The placeholders below
+# are non-hex so startup will fail loudly if not updated.
+# Generate: `openssl rand -hex 16` (16 bytes / 32 hex chars).
+secret_store_key_hex = "REPLACE_ME_WITH_16_BYTE_HEX_KEY_"
+# Generate: `openssl rand -hex 32` (32 bytes / 64 hex chars). On node
+# migration, must match the OLD node's backup_encryption_key.
+backup_encryption_key_hex = "REPLACE_ME_WITH_32_BYTE_HEX_KEY_REPLACE_ME_WITH_32_BYTE_HEX_KEY_"
 
 [mpc_node_config.node]
-my_near_account_id = "test_image.near"
-near_responder_account_id = "test_image.near"
+my_near_account_id = "your-mpc-account.testnet"
+near_responder_account_id = "your-mpc-account.testnet"
 number_of_responder_keys = 1
 web_ui = "0.0.0.0:8080"
 migration_web_ui = "0.0.0.0:8079"
-cores = 4
+# MPC tokio runtime worker threads (separate from the indexer's). Kept
+# below the CVM's attested VCPU=8 so the indexer isn't starved.
+cores = 6
 
 [mpc_node_config.node.indexer]
 validate_genesis = false
 sync_mode = "Latest"
 concurrency = 1
-mpc_contract_id = "v1.signer"
+mpc_contract_id = "v1.signer-prod.testnet"  # mainnet: "v1.signer"
 finality = "optimistic"
+# MPC P2P convention is port 80. Forces it on every peer URL (listen +
+# dial) regardless of the URL's scheme/port.
+port_override = 80
 
 [mpc_node_config.node.triple]
 concurrency = 2
-desired_triples_to_buffer = 128
+desired_triples_to_buffer = 16384
 timeout_sec = 60
 parallel_triple_generation_stagger_time_sec = 1
 
 [mpc_node_config.node.presignature]
-concurrency = 4
-desired_presignatures_to_buffer = 64
+concurrency = 16
+desired_presignatures_to_buffer = 8192
 timeout_sec = 60
 
 [mpc_node_config.node.signature]
@@ -87,3 +114,28 @@ timeout_sec = 60
 
 [mpc_node_config.node.ckd]
 timeout_sec = 60
+
+# Foreign-chain RPC URLs below target testnet networks (Bitcoin testnet,
+# Abstract testnet, Starknet Sepolia). For mainnet, swap each provider's
+# rpc_url for the corresponding mainnet endpoint.
+
+[mpc_node_config.node.foreign_chains.bitcoin]
+timeout_sec = 30
+max_retries = 3
+
+[mpc_node_config.node.foreign_chains.bitcoin.providers.public]
+rpc_url = "https://bitcoin-testnet-rpc.publicnode.com"
+
+[mpc_node_config.node.foreign_chains.abstract]
+timeout_sec = 30
+max_retries = 3
+
+[mpc_node_config.node.foreign_chains.abstract.providers.abstract-testnet]
+rpc_url = "https://api.testnet.abs.xyz"
+
+[mpc_node_config.node.foreign_chains.starknet]
+timeout_sec = 30
+max_retries = 3
+
+[mpc_node_config.node.foreign_chains.starknet.providers.publicnode]
+rpc_url = "https://starknet-sepolia-rpc.publicnode.com"

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -663,25 +663,34 @@ url = "https://api.trustedservices.intel.com/"
 [mpc_node_config.near_init]
 chain_id = "$CHAIN_ID"            # "testnet" or "mainnet"
 boot_nodes = "$BOOT_NODES"        # comma-separated; see the curl snippet below
+download_genesis = true
+download_config = "rpc"
 # tier3_public_addr = "$IP:24567"
 # external_storage_fallback_threshold = 0
 
+[mpc_node_config.secrets]
+secret_store_key_hex = "$SECRET_STORE_KEY"
+backup_encryption_key_hex = "$BACKUP_ENCRYPTION_KEY"
+
 [mpc_node_config.node]
 my_near_account_id = "$MY_MPC_NEAR_ACCOUNT_ID"
+near_responder_account_id = "$MY_MPC_NEAR_ACCOUNT_ID"
 migration_web_ui = "0.0.0.0:8079"  # required; matches the port-forward above
 
 [mpc_node_config.node.indexer]
-mpc_contract_id = "$CONTRACT_ID"  # v1.signer-prod.testnet for Testnet, v1.signer for Mainnet
-
-[mpc_node_config.secrets]
-secret_store_key_hex = "$SECRET_STORE_KEY"
+mpc_contract_id = "$CONTRACT_ID"  # v1.signer-prod.testnet for testnet, v1.signer for mainnet
+validate_genesis = false
+sync_mode = "Latest"
+finality = "optimistic"
+concurrency = 1
+port_override = 80                # MPC P2P convention
 
 [mpc_node_config.log]
 format = "plain"
 filter = "mpc=debug,info"
 ```
 
-The snippet above shows only the fields you are likely to change. Required fields not shown (e.g. `near_responder_account_id`, `number_of_responder_keys`, `web_ui`, and the `indexer` / `triple` / `presignature` / `signature` / `ckd` blocks) are inherited from the [`user-config.toml`](https://github.com/near/mpc/blob/main/deployment/cvm-deployment/user-config.toml) template — always start from that file and edit the highlighted fields rather than building a config from this snippet alone.
+The snippet above shows only the fields you are likely to change. Required fields not shown (e.g. `number_of_responder_keys`, `web_ui`, and the `triple` / `presignature` / `signature` / `ckd` / `foreign_chains` blocks) and inline `# mainnet: …` swap hints are inherited from the [`user-config.toml`](https://github.com/near/mpc/blob/main/deployment/cvm-deployment/user-config.toml) template — always start from that file and edit the highlighted fields rather than building a config from this snippet alone.
 
 Adjust the variables as per your environment.
 
@@ -692,7 +701,7 @@ Adjust the variables as per your environment.
 * `port_mappings` — port forwarding rules for the MPC container. These should be a subset of the port forwarding for the CVM defined in the [Using the Web Interface](#using-the-web-interface) section.
 * `tier3_public_addr` *(optional, under `[mpc_node_config.near_init]`)* — `IP:24567` the node advertises for Tier3 state-sync responses. Applied at first init only; changing later requires a CVM redeploy via the [Node Migration](./node-migration-guide.md) flow.
 * `external_storage_fallback_threshold` *(optional, under `[mpc_node_config.near_init]`)* — DSS attempts per state part before falling back to the external storage bucket. `0` = bucket-only. Same first-init-only constraint as `tier3_public_addr`.
-* A fresh set of boot nodes can be selected using Testnet/Mainnet RPC endpoints. Copy at least 4-5 nodes from curl results into `boot_nodes`.
+* `near_init.boot_nodes` — comma-separated NEAR boot-node list. The testnet template at `deployment/cvm-deployment/user-config.toml` already ships with a working testnet boot-node list, so testnet operators usually don't need to fetch a fresh one. For **mainnet** (or to refresh testnet), select boot nodes from the Testnet/Mainnet RPC endpoints and copy at least 4-5 of them into this field.
   **Important:** Boot nodes must not contain duplicate addresses or peer IDs. Duplicates will cause the node to crash on startup. The command below deduplicates automatically:
 
 ```bash
@@ -1583,7 +1592,7 @@ After all operators have migrated to the new CVM, participants should vote to re
 
 ## Updating the CVM `user-config.toml` with new image information
 
-If the image repository changes, update the `image` field in `user-config.toml`:
+If the image repository changes, update the `image_reference` field in `user-config.toml`:
 
 **Example:**
 

--- a/docs/using-the-launcher-in-nontee-setup.md
+++ b/docs/using-the-launcher-in-nontee-setup.md
@@ -54,7 +54,9 @@ See `deployment/cvm-deployment/launcher_docker_compose_nontee.yaml` for an examp
 
 ### 2. Prepare the user configuration file
 
-Create a `user-config.toml` file (TOML format) with `[launcher_config]` and `[mpc_node_config]` sections. See `deployment/cvm-deployment/user-config.toml` for an example. The `[launcher_config]` section uses an `image_reference` field for the Docker image reference (e.g., `image_reference = "nearone/mpc-node"`).
+Create a `user-config.toml` file (TOML format) with `[launcher_config]` and `[mpc_node_config]` sections. The `[launcher_config]` section uses an `image_reference` field for the Docker image reference (e.g., `image_reference = "nearone/mpc-node"`).
+
+For the non-TEE / local-dev launcher path, use **`deployment/cvm-deployment/ci-config.toml`** as the starting point — it boots cheaply on a small machine using mainnet's embedded genesis. The sibling **`deployment/cvm-deployment/user-config.toml`** is a real testnet operator template with `chain_id = "testnet"` and `download_genesis = true`, which downloads the multi-GB testnet genesis at startup and OOMs small CI/dev runners (see #2720).
 
 This file is read by the launcher and passed into the MPC container.
 


### PR DESCRIPTION
Closes #3257.

The previous `user-config.toml` was a CI smoke-test config the TDX operator guide pointed operators at. This PR splits the two consumers:

- **`ci-config.toml`** (new) — keeps the previous minimal values; the non-TEE CI smoke test mounts it.
- **`user-config.toml`** — real testnet operator template, values cross-validated against `/debug/node_config` on every live mainnet and testnet operator. Inline `# mainnet: …` comments show what to swap for mainnet.
- **`docs/running-an-mpc-node-in-tdx-external-guide.md`** — small additions on top of #3234 (now in main).
- **`docs/using-the-launcher-in-nontee-setup.md`** — points non-TEE / local-dev users at `ci-config.toml` rather than the testnet `user-config.toml`.

### Why two files
CI wants a tiny config that boots cheaply on a small runner; the chain doesn't matter. Operators want production-aligned values and a real chain. CI's trick — `chain_id = "mainnet"` + `download_genesis = false` — only works because nearcore embeds the mainnet genesis in its binary; testnet has no equivalent and downloading it OOMs the runner (PR #2720). One file can't serve both.

### `cores = 6` (live mainnet operators have 12)
CVM VCPU is attested at 8. The MPC tokio runtime is deliberately separate from the indexer's so the indexer isn't starved (`coordinator.rs:238`). 6 leaves 2 vCPUs of headroom.

For reference, all 8 live mainnet operators currently report `cores = 12` via `/debug/node_config` — but those are 12-vCPU legacy GCP VMs (also matches `start.sh:115`'s hardcoded default), not 8-vCPU TDX CVMs. The template targets the launcher / TDX path (attested `VCPU=8` from `deploy-launcher.sh:135`), so `cores = 12` would oversubscribe; `cores = 6` is the right scaled-down value for this audience.

### `foreign_chains` schema notes
- Dropped legacy `api_variant = "standard"` lines. The field is silently accepted but no longer functional in the current node-config schema — see the test `config_parsing__should_succeed_with_legacy_field__api_variant` at `crates/node-config/src/foreign_chains.rs:564`.
- **Forward-looking heads-up:** the design at `docs/design/allowing-per-node-foreign-chain-rpc-configuration.md` (referenced by #3216 / cf0c430f) describes a future shift where operators will write `provider_id` + a token env reference instead of raw `rpc_url`s — the contract will hold `base_url` / `auth_scheme` / `chain_routing`. The contract-side types landed in cf0c430f but the node-side migration hasn't yet, so this PR uses today's `rpc_url` shape. A future PR will need to update this section of `user-config.toml`.

### Operator-guide additions
Update the `user-config.toml` example in `running-an-mpc-node-in-tdx-external-guide.md` to better match the production-aligned template (on top of the schema fixes #3234 already merged).

### Open questions
- `presignature.concurrency 4 → 16` — outside #3257's stated AC; drop if undesired.
- DSS hints stay commented-out (`n1-multichain.near` runs bucket-only; `deploy-tee-cluster.sh` defaults DSS-first — separate decision).
- Mainnet `foreign_chains.*.rpc_url` inline hints not yet added — happy to add (URLs surveyed: `https://bitcoin-rpc.publicnode.com`, `https://api.mainnet.abs.xyz`, `https://starknet-rpc.publicnode.com`).

### Out of scope (separate follow-ups)
- `start.sh:98`, `deployment/testnet/frodo.toml`, `deployment/testnet/sam.toml` still carry stale `desired_triples_to_buffer = 1000000` — live mainnet config is `16384` (verified via `/debug/node_config` on all 8 mainnet operators). Worth cleaning up in a separate PR.

### Effect on existing nodes
No hot-reload. Operators unaffected until they re-pull and restart. Raising buffer ceilings is safe.
