### PR TITLE
fix: correctly label succeeded and failed transactions

### DIFF
--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1842,7 +1842,7 @@ impl MpcContract {
     /// only correct interpretation is presence: `Some(_)` vs `None`.
     ///
     /// The `Option<YieldIndex>` shape is retained for JSON wire compatibility with
-    /// out-of-tree consumers; the in-tree caller (`tx_sender::compute_transaction_status`)
+    /// out-of-tree consumers; the in-tree caller (`tx_sender::observe_tx_result`)
     /// only matches on presence. Prefer a `bool`-shaped accessor if one is added.
     ///
     /// Falls back to the legacy single-yield map for in-flight requests inherited

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/contract/tests/abi.rs
-assertion_line: 47
 expression: abi
 ---
 {
@@ -305,7 +304,7 @@ expression: abi
       },
       {
         "name": "get_pending_request",
-        "doc": " Presence check for a pending signature request, exposed as a view call.\n\n **The returned `YieldIndex` is an arbitrary representative, not \"the\" yield\n for this request.** Since the duplicate-request fan-out feature (PR #3187),\n a single request key can have N queued yields; this method returns the head of the\n queue. Callers that need to act on the full set are wrong to use this. The\n only correct interpretation is presence: `Some(_)` vs `None`.\n\n The `Option<YieldIndex>` shape is retained for JSON wire compatibility with\n out-of-tree consumers; the in-tree caller (`tx_sender::compute_transaction_status`)\n only matches on presence. Prefer a `bool`-shaped accessor if one is added.\n\n Falls back to the legacy single-yield map for in-flight requests inherited\n from before the fan-out upgrade.",
+        "doc": " Presence check for a pending signature request, exposed as a view call.\n\n **The returned `YieldIndex` is an arbitrary representative, not \"the\" yield\n for this request.** Since the duplicate-request fan-out feature (PR #3187),\n a single request key can have N queued yields; this method returns the head of the\n queue. Callers that need to act on the full set are wrong to use this. The\n only correct interpretation is presence: `Some(_)` vs `None`.\n\n The `Option<YieldIndex>` shape is retained for JSON wire compatibility with\n out-of-tree consumers; the in-tree caller (`tx_sender::observe_tx_result`)\n only matches on presence. Prefer a `bool`-shaped accessor if one is added.\n\n Falls back to the legacy single-yield map for in-flight requests inherited\n from before the fan-out upgrade.",
         "kind": "view",
         "params": {
           "serialization_type": "json",

--- a/crates/node/src/indexer/tx_sender.rs
+++ b/crates/node/src/indexer/tx_sender.rs
@@ -172,37 +172,40 @@ async fn observe_tx_result(
     match request {
         Respond(respond_args) => {
             // Confirm whether the respond call succeeded by checking whether the
-            // pending signature request still exists in the contract state
+            // pending signature request still exists in the contract state.
+            // A successful respond removes the request from contract state.
             let pending_request_response = indexer_state
                 .view_client
                 .get_pending_request(&indexer_state.mpc_contract_id, &respond_args.request)
                 .await?;
 
             let transaction_status = match pending_request_response {
-                Some(_) => TransactionStatus::Executed,
-                None => TransactionStatus::NotExecuted,
+                Some(_) => TransactionStatus::NotExecuted,
+                None => TransactionStatus::Executed,
             };
 
             Ok(transaction_status)
         }
         CKDRespond(respond_args) => {
             // Confirm whether the respond call succeeded by checking whether the
-            // pending ckd request still exists in the contract state
+            // pending ckd request still exists in the contract state.
+            // A successful respond removes the request from contract state.
             let pending_request_response = indexer_state
                 .view_client
                 .get_pending_ckd_request(&indexer_state.mpc_contract_id, &respond_args.request)
                 .await?;
 
             let transaction_status = match pending_request_response {
-                Some(_) => TransactionStatus::Executed,
-                None => TransactionStatus::NotExecuted,
+                Some(_) => TransactionStatus::NotExecuted,
+                None => TransactionStatus::Executed,
             };
 
             Ok(transaction_status)
         }
         VerifyForeignTransactionRespond(respond_args) => {
             // Confirm whether the respond call succeeded by checking whether the
-            // pending verify foreign tx request still exists in the contract state
+            // pending verify foreign tx request still exists in the contract state.
+            // A successful respond removes the request from contract state.
             let pending_request_response = indexer_state
                 .view_client
                 .get_pending_verify_foreign_tx_request(
@@ -212,8 +215,8 @@ async fn observe_tx_result(
                 .await?;
 
             let transaction_status = match pending_request_response {
-                Some(_) => TransactionStatus::Executed,
-                None => TransactionStatus::NotExecuted,
+                Some(_) => TransactionStatus::NotExecuted,
+                None => TransactionStatus::Executed,
             };
 
             Ok(transaction_status)


### PR DESCRIPTION
closes #3182 