### PR TITLE
fix(scripts): make `prepare-release.sh` work on BSD/macOS

### DIFF
--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -115,11 +115,15 @@ git-cliff --prepend CHANGELOG.md --unreleased -t "$VERSION"
 
 # --- Bump workspace version in Cargo.toml ---
 
+# `grep -P` (PCRE) and `sed -i` without a suffix are GNU-only; use POSIX
+# forms so this works on both Linux and macOS (BSD userland).
+
 CARGO_TOML="${REPO_ROOT}/Cargo.toml"
-OLD_VERSION=$(grep -Po '(?<=^version = ")[0-9]+\.[0-9]+\.[0-9]+(?=")' "$CARGO_TOML")
+OLD_VERSION=$(awk -F'"' '/^version = "[0-9]+\.[0-9]+\.[0-9]+"/ {print $2; exit}' "$CARGO_TOML")
+[[ -n "$OLD_VERSION" ]] || die "Could not find a workspace 'version = \"X.Y.Z\"' line in $CARGO_TOML."
 
 echo "==> Bumping workspace version: ${OLD_VERSION} -> ${VERSION}"
-sed -i "0,/^version = \"${OLD_VERSION}\"/s//version = \"${VERSION}\"/" "$CARGO_TOML"
+sed -i.bak -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"${VERSION}\"/" "$CARGO_TOML" && rm "${CARGO_TOML}.bak"
 
 # --- Verify contract ABI has changed ---
 


### PR DESCRIPTION
## Summary

The version-bump step in `scripts/prepare-release.sh` is GNU-only:

- `grep -Po '(?<=^version = ")[0-9]+\.[0-9]+\.[0-9]+(?=")'` — PCRE is GNU-only; BSD grep on macOS exits with `grep: invalid option -- P`.
- `sed -i "0,/^version = \"${OLD_VERSION}\"/s//.../"` — BSD `sed -i` requires an explicit backup-suffix argument, and the `0,/pat/` address range is a GNU extension (BSD sed silently no-ops it).

Hit this while preparing the 3.10.0 release on macOS.

## What changed

Two short, POSIX-portable commands replace the original two GNU-only ones:

- `awk -F'"' '/^version = "[0-9]+\.[0-9]+\.[0-9]+"/ {print $2; exit}'` for extraction — splits on `"`, prints the version field, `exit` preserves "first-match-only".
- `sed -i.bak -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"${VERSION}\"/" ... && rm ...bak` for substitution — `-i.bak` (suffix attached, no space) is the portable in-place form; `-E` (ERE) is supported on both GNU and BSD sed.

Also adds an early `die` if no workspace version line is found, so a future Cargo.toml restructure can't silently leave the version unchanged.

## Verification

Dry-ran the new block against a copy of `Cargo.toml`:

- Positive case: `OLD_VERSION=3.9.0`, single-line diff at line 41 (`version = "3.9.0"` → `version = "3.10.0"`), no `.bak` residue.
- Negative case (version line stripped): the `[[ -n "$OLD_VERSION" ]] || die ...` guard fires as expected.