### PR TITLE
ci: don't run CI tests on doc only change prs

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -1,0 +1,41 @@
+# Reusable workflow: detects whether a PR changes.
+#
+# Currently it returns a single `code_changed` boolean used to skip the full CI
+# suite on docs-only PRs. Later this can grow into per-area filters (e.g.
+# `node_changed`, `contract_changed`) so each test job runs only when its
+# sources actually changed.
+
+name: Changes
+
+on:
+  workflow_call:
+    outputs:
+      code_changed:
+        description: "'true' if any non-docs file changed in the PR; 'true' on non-PR events"
+        value: ${{ jobs.detect.outputs.code_changed }}
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code_changed: ${{ steps.filter.outputs.code || 'true' }}
+    steps:
+      - name: Checkout repository
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          persist-credentials: false
+      - name: Detect changed paths
+        if: github.event_name == 'pull_request'
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
+        with:
+          # Match everything, excluding .md and docs/ folder.
+          filters: |
+            code:
+              - '**'
+              - '!**.md'
+              - '!docs/**'

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   detect:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-2x
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -11,7 +11,7 @@ on:
   workflow_call:
     outputs:
       code_changed:
-        description: "'true' if any non-docs file changed in the PR; 'true' on non-PR events"
+        description: "'true' if any non-docs file changed in the PR, or on non-PR events; 'false' only on docs-only PRs"
         value: ${{ jobs.detect.outputs.code_changed }}
 
 jobs:
@@ -33,7 +33,8 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          # Match everything, excluding .md and docs/ folder.
+          # Match everything, excluding .md and docs/ folder (assumes there's no
+          # executable in docs/ folder).
           filters: |
             code:
               - '**'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ on:
     - cron: "5 0 * * 0"
 
 jobs:
+  # Downstream gates use `if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}`.
+  # The `always()` overrides GitHub's implicit `success()` on `needs`, so a
+  # failed detector doesn't silently skip dependents (skipped checks satisfy
+  # required-check rules and could let a PR merge with zero CI signal). Only
+  # an explicit `'false'` (docs-only PR) skips the job.
   changes:
     name: "Detect non-docs changes"
     permissions:
@@ -29,7 +34,7 @@ jobs:
   docker-tee-build:
     name: "Build MPC Node TEE Docker image"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: warp-ubuntu-2404-x64-16x
     timeout-minutes: 60
     permissions:
@@ -63,7 +68,7 @@ jobs:
   docker-rust-launcher-build-and-verify:
     name: "Build Rust Launcher Docker image and verify"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: warp-ubuntu-2404-x64-8x
     timeout-minutes: 60
     permissions:
@@ -102,7 +107,7 @@ jobs:
   mpc-unittests:
     name: "Cargo test: ${{ matrix.group }}"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: ${{ matrix.runner || 'warp-ubuntu-2404-x64-16x' }}
     timeout-minutes: 60
     permissions:
@@ -147,7 +152,7 @@ jobs:
   mpc-contract-reproducible-build:
     name: "MPC contract reproducible build"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: warp-ubuntu-2404-x64-16x
     timeout-minutes: 60
     permissions:
@@ -179,7 +184,7 @@ jobs:
   nix-build-mpc-node:
     name: "Nix build mpc-node"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     permissions:
       contents: read
     uses: ./.github/workflows/nix-build-mpc-node.yml
@@ -187,7 +192,7 @@ jobs:
   fast-ci-checks:
     name: "Fast CI checks"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: warp-ubuntu-2404-x64-8x
     permissions:
       contents: read
@@ -217,7 +222,7 @@ jobs:
   mpc-e2e-tests:
     name: "MPC E2E tests"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: warp-ubuntu-2404-x64-32x
     timeout-minutes: 60
     permissions:
@@ -271,7 +276,7 @@ jobs:
   ci-extra:
     name: "Extra CI checks"
     needs: changes
-    if: needs.changes.outputs.code_changed == 'true'
+    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: warp-ubuntu-2404-x64-2x
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,8 +191,6 @@ jobs:
 
   fast-ci-checks:
     name: "Fast CI checks"
-    needs: changes
-    if: ${{ always() && needs.changes.outputs.code_changed != 'false' }}
     runs-on: warp-ubuntu-2404-x64-8x
     permissions:
       contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,17 @@ on:
     - cron: "5 0 * * 0"
 
 jobs:
+  changes:
+    name: "Detect non-docs changes"
+    permissions:
+      contents: read
+      pull-requests: read
+    uses: ./.github/workflows/changes.yml
+
   docker-tee-build:
     name: "Build MPC Node TEE Docker image"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: warp-ubuntu-2404-x64-16x
     timeout-minutes: 60
     permissions:
@@ -53,6 +62,8 @@ jobs:
 
   docker-rust-launcher-build-and-verify:
     name: "Build Rust Launcher Docker image and verify"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: warp-ubuntu-2404-x64-8x
     timeout-minutes: 60
     permissions:
@@ -90,6 +101,8 @@ jobs:
 
   mpc-unittests:
     name: "Cargo test: ${{ matrix.group }}"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: ${{ matrix.runner || 'warp-ubuntu-2404-x64-16x' }}
     timeout-minutes: 60
     permissions:
@@ -133,6 +146,8 @@ jobs:
 
   mpc-contract-reproducible-build:
     name: "MPC contract reproducible build"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: warp-ubuntu-2404-x64-16x
     timeout-minutes: 60
     permissions:
@@ -163,12 +178,16 @@ jobs:
 
   nix-build-mpc-node:
     name: "Nix build mpc-node"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     permissions:
       contents: read
     uses: ./.github/workflows/nix-build-mpc-node.yml
 
   fast-ci-checks:
     name: "Fast CI checks"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: warp-ubuntu-2404-x64-8x
     permissions:
       contents: read
@@ -197,6 +216,8 @@ jobs:
 
   mpc-e2e-tests:
     name: "MPC E2E tests"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: warp-ubuntu-2404-x64-32x
     timeout-minutes: 60
     permissions:
@@ -249,6 +270,8 @@ jobs:
 
   ci-extra:
     name: "Extra CI checks"
+    needs: changes
+    if: needs.changes.outputs.code_changed == 'true'
     runs-on: warp-ubuntu-2404-x64-2x
     permissions:
       contents: read


### PR DESCRIPTION
Closes: https://github.com/near/mpc/issues/695


Note: we can't just use `paths-ignore` in `pull_request` directly as jobs below won't run then, and one won't be able to merge doc only changes as these jobs are marked as required in our branch protection.