### PR TITLE
ci: production environment for workflows

### DIFF
--- a/.github/workflows/docker_build_node.yml
+++ b/.github/workflows/docker_build_node.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-push-images:
     name: "Build and push Docker node image with commit hash"
     runs-on: warp-ubuntu-2404-x64-16x
+    environment: production
     permissions:
       contents: read
 
@@ -26,8 +27,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
       - name: Allow unprivileged user namespaces (needed by repro-env/podman on Ubuntu 24.04)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/.github/workflows/docker_build_node_gcp.yml
+++ b/.github/workflows/docker_build_node_gcp.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-push-images:
     name: "Build and push Docker node gcp image with commit hash"
     runs-on: warp-ubuntu-2404-x64-16x
+    environment: production
     permissions:
       contents: read
 
@@ -26,8 +27,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
       - name: Allow unprivileged user namespaces (needed by repro-env/podman on Ubuntu 24.04)
         run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0

--- a/.github/workflows/docker_build_rust_launcher.yml
+++ b/.github/workflows/docker_build_rust_launcher.yml
@@ -14,6 +14,7 @@ jobs:
   build-and-push-images:
     name: "Build and push Rust launcher Docker image with commit hash"
     runs-on: warp-ubuntu-2404-x64-8x
+    environment: production
     permissions:
       contents: read
 
@@ -40,8 +41,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
       - name: Build and push Rust launcher image
         run: |

--- a/.github/workflows/docker_launcher_release.yml
+++ b/.github/workflows/docker_launcher_release.yml
@@ -24,15 +24,16 @@ on:
         required: true
         type: string
     secrets:
-      DOCKERHUB_USERNAME:
+      DOCKERHUB_USER:
         required: true
-      DOCKERHUB_TOKEN:
+      DOCKERHUB_PAT:
         required: true
 
 jobs:
   retag-launcher-image:
     name: "Retag launcher image for release"
     runs-on: warp-ubuntu-2404-x64-2x
+    environment: production
     permissions:
       contents: read
 
@@ -40,8 +41,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
       - name: Install skopeo
         run: |

--- a/.github/workflows/docker_node_release.yml
+++ b/.github/workflows/docker_node_release.yml
@@ -32,15 +32,16 @@ on:
         required: true
         type: string
     secrets:
-      DOCKERHUB_USERNAME:
+      DOCKERHUB_USER:
         required: true
-      DOCKERHUB_TOKEN:
+      DOCKERHUB_PAT:
         required: true
 
 jobs:
   retag-node-image:
     name: "Retag node image for release"
     runs-on: warp-ubuntu-2404-x64-2x
+    environment: production
     permissions:
       contents: read
 
@@ -48,8 +49,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
       - name: Install skopeo
         run: |

--- a/.github/workflows/docker_release_legacy.yml
+++ b/.github/workflows/docker_release_legacy.yml
@@ -19,6 +19,7 @@ jobs:
   docker-image-build:
     name: "Build and push Legacy MPC Docker image"
     runs-on: warp-ubuntu-2404-x64-8x
+    environment: production
     permissions:
       contents: read
 
@@ -46,8 +47,8 @@ jobs:
       - name: Login to Docker Hub
         uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PAT }}
 
       - name: Build and push MPC Node Docker image to Docker Hub
         uses: Warpbuilds/build-push-action@ec038a9f4b87a7c7ccb50ac7a26a90d46a610a81 # v6.0.9

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -15,6 +15,7 @@ on:
 jobs:
   build-mpc:
     runs-on: warp-ubuntu-2404-x64-8x
+    environment: production
     permissions:
       contents: read
     steps:
@@ -36,7 +37,7 @@ jobs:
       - name: Failure Slack Notification
         if: failure()
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_INCOMING_WEBHOOK }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}
         uses: act10ns/slack@d96404edccc6d6467fc7f8134a420c851b1e9054 # v2.2.0
         with:
           status: failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,37 +42,40 @@ jobs:
   retag-launcher:
     name: "Retag mpc-launcher"
     needs: release-info
+    environment: production
     uses: ./.github/workflows/docker_launcher_release.yml
     with:
       source-tag: "main-${{ needs.release-info.outputs.short-sha }}"
       release-tag: ${{ needs.release-info.outputs.version }}
     secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}
 
   retag-node:
     name: "Retag mpc-node"
     needs: release-info
+    environment: production
     uses: ./.github/workflows/docker_node_release.yml
     with:
       source-tag: "main-${{ needs.release-info.outputs.short-sha }}"
       release-tag: ${{ needs.release-info.outputs.version }}
       repository: mpc-node
     secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}
 
   retag-node-gcp:
     name: "Retag mpc-node-gcp"
     needs: release-info
+    environment: production
     uses: ./.github/workflows/docker_node_release.yml
     with:
       source-tag: "main-${{ needs.release-info.outputs.short-sha }}"
       release-tag: ${{ needs.release-info.outputs.version }}
       repository: mpc-node-gcp
     secrets:
-      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
-      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+      DOCKERHUB_PAT: ${{ secrets.DOCKERHUB_PAT }}
 
   collect-digests:
     name: "Collect Docker image digests"
@@ -109,6 +112,7 @@ jobs:
   build-contract:
     name: "Build contract"
     needs: release-info
+    environment: production
     runs-on: warp-ubuntu-2404-x64-16x
 
     outputs:


### PR DESCRIPTION
This PR changes the GHA workflows environment to production which contains env protected secrets.
The env is protected to run only on main branch. 

Going further custom builds from non-main branch will not be publishable to dockerhub.

Dockerhub and slack webhook are now in **production** environment.

As soon this PR is merged, old secrets will be removed