### PR TITLE
docs(node-migration-guide): revoke OLD node's signer key after migration

### DIFF
--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -355,25 +355,17 @@ After verifying the migration was successful:
 
 1. **Stop the old node** on the old host.
 
-2. **Revoke the OLD node's signer key on your account.** The OLD CVM's `near_signer_public_key` (the function-call access key you added in Step 5 — either for *this* migration's predecessor, or for an earlier one) is no longer needed once the OLD CVM is decommissioned. Leaving it authorized is a hygiene gap: a forever-authorized but effectively keyless entry on your account, with `unlimited` allowance on the MPC contract.
-
-   List your account's keys to find the OLD signer's public key (it'll be a function-call key targeting `$MPC_CONTRACT_ACCOUNT_ID`, distinct from the one you just added for the NEW node in Step 5):
+2. **Revoke the OLD node's signer key.** The function-call key you added in Step 5 of the previous migration persists on your account with `unlimited` allowance on the MPC contract until explicitly removed. Use `list-keys` to find the OLD signer's public key (distinct from the one you just added in Step 5), then `delete-keys`:
 
    ```bash
-   near account list-keys $SIGNER_ACCOUNT_ID \
-     network-config $NEAR_NETWORK now
-   ```
+   near account list-keys $SIGNER_ACCOUNT_ID network-config $NEAR_NETWORK now
 
-   Then revoke it:
-
-   ```bash
    near account delete-keys $SIGNER_ACCOUNT_ID \
      public-keys <OLD_NODE_SIGNER_PUBLIC_KEY> \
-     network-config $NEAR_NETWORK \
-     sign-with-keychain send
+     network-config $NEAR_NETWORK sign-with-keychain send
    ```
 
-   **Do not** revoke the `backup-cli`'s registered key (the one from Step 2, registered via `register_backup_service`). That's the backup service registration, not a per-CVM credential, and is reused across migrations.
+   Don't revoke the `backup-cli`'s registered key from Step 2 — that's the backup service registration, reused across migrations.
 
 3. **Keep the backup** of keyshares (the contents of `$BACKUP_HOME_DIR`, including the `key` file and the `permanent_keys/` directory with `epoch_<...>_with_<...>_domains` files) for a reasonable period (in case you need to migrate again).
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -355,15 +355,23 @@ After verifying the migration was successful:
 
 1. **Stop the old node** on the old host.
 
-2. **Revoke the OLD node's signer key.** The function-call key you added in Step 5 of the previous migration persists on your account with `unlimited` allowance on the MPC contract until explicitly removed. Use `list-keys` to find the OLD signer's public key (distinct from the one you just added in Step 5), then `delete-keys`:
+2. **Revoke the old node's signer key.** The function-call key you added in Step 5 of the previous migration persists on your account with `unlimited` allowance on the MPC contract until explicitly removed. Use `list-keys` to find the old signer's public key (distinct from the one you just added in Step 5), then `delete-keys`:
 
    ```bash
-   near account list-keys $SIGNER_ACCOUNT_ID network-config $NEAR_NETWORK now
+   near account list-keys \
+     $SIGNER_ACCOUNT_ID \
+     network-config $NEAR_NETWORK \
+     now
 
-   near account delete-keys $SIGNER_ACCOUNT_ID \
+   near account delete-keys \
+     $SIGNER_ACCOUNT_ID \
      public-keys <OLD_NODE_SIGNER_PUBLIC_KEY> \
-     network-config $NEAR_NETWORK sign-with-keychain send
+     network-config $NEAR_NETWORK \
+     sign-with-keychain \
+     send
    ```
+
+   The `public-keys` argument is a comma-separated list (`<k1>,<k2>,…`), so if more than one stale function-call key has accumulated from earlier migrations, you can revoke them all in a single call.
 
    Don't revoke the `backup-cli`'s registered key from Step 2 — that's the backup service registration, reused across migrations.
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -353,9 +353,31 @@ Look for your account in the output. Once the migration is complete, there shoul
 
 After verifying the migration was successful:
 
-1. **Stop the old node** on the old host
-2. **Keep the backup** of keyshares (the contents of `$BACKUP_HOME_DIR`, including the `key` file and the `permanent_keys/` directory with `epoch_<...>_with_<...>_domains` files) for a reasonable period (in case you need to migrate again)
-3. **Securely delete** the old node's data once you're confident the new node is functioning correctly
+1. **Stop the old node** on the old host.
+
+2. **Revoke the OLD node's signer key on your account.** The OLD CVM's `near_signer_public_key` (the function-call access key you added in Step 5 — either for *this* migration's predecessor, or for an earlier one) is no longer needed once the OLD CVM is decommissioned. Leaving it authorized is a hygiene gap: a forever-authorized but effectively keyless entry on your account, with `unlimited` allowance on the MPC contract.
+
+   List your account's keys to find the OLD signer's public key (it'll be a function-call key targeting `$MPC_CONTRACT_ACCOUNT_ID`, distinct from the one you just added for the NEW node in Step 5):
+
+   ```bash
+   near account list-keys $SIGNER_ACCOUNT_ID \
+     network-config $NEAR_NETWORK now
+   ```
+
+   Then revoke it:
+
+   ```bash
+   near account delete-keys $SIGNER_ACCOUNT_ID \
+     public-keys <OLD_NODE_SIGNER_PUBLIC_KEY> \
+     network-config $NEAR_NETWORK \
+     sign-with-keychain send
+   ```
+
+   **Do not** revoke the `backup-cli`'s registered key (the one from Step 2, registered via `register_backup_service`). That's the backup service registration, not a per-CVM credential, and is reused across migrations.
+
+3. **Keep the backup** of keyshares (the contents of `$BACKUP_HOME_DIR`, including the `key` file and the `permanent_keys/` directory with `epoch_<...>_with_<...>_domains` files) for a reasonable period (in case you need to migrate again).
+
+4. **Securely delete** the old node's data once you're confident the new node is functioning correctly.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #3289.

## Summary

Step 9 doesn't tell the operator to revoke the OLD CVM's signer key from their NEAR account. Destroying the CVM makes the private half unrecoverable, but the on-chain function-call entry (with `unlimited` allowance on the MPC contract) persists until explicitly removed.

Adds a Step 9.2 with the `list-keys` → `delete-keys` commands, plus an explicit note **not** to revoke the `backup-cli` registration from Step 2 (that's reused across migrations).