### PR TITLE
chore: bump nearcore to 2.12 rc 1, bumps rust to 1.93

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,7 +18,16 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
- "gimli",
+ "gimli 0.32.3",
+]
+
+[[package]]
+name = "addr2line"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59317f77929f0e679d39364702289274de2f0f0b22cbf50b2b8cff2169a0b27a"
+dependencies = [
+ "gimli 0.33.0",
 ]
 
 [[package]]
@@ -316,7 +325,7 @@ dependencies = [
  "derive_more 2.1.1",
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "k256",
  "keccak-asm",
@@ -377,7 +386,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -449,7 +458,7 @@ dependencies = [
  "alloy-sol-macro-input",
  "const-hex",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "proc-macro-error2",
  "proc-macro2",
  "quote",
@@ -1005,18 +1014,16 @@ dependencies = [
 
 [[package]]
 name = "attohttpc"
-version = "0.19.1"
+version = "0.28.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262c3f7f5d61249d8c00e5546e2685cd15ebeeb1bc0f3cc5449350a1cb07319e"
+checksum = "07a9b245ba0739fc90935094c29adbaee3f977218b5fb95e822e261cda7f56a3"
 dependencies = [
- "http 0.2.12",
+ "http 1.4.0",
  "log",
  "native-tls",
- "openssl",
  "serde",
  "serde_json",
  "url",
- "wildmatch",
 ]
 
 [[package]]
@@ -1055,15 +1062,16 @@ dependencies = [
 
 [[package]]
 name = "aws-creds"
-version = "0.30.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeeee1a5defa63cba39097a510dfe63ef53658fc8995202a610f6a8a4d03639"
+checksum = "ba912106484991c456adb3364338a2534d0818bd9374b324b608074e3b55f581"
 dependencies = [
  "attohttpc",
- "dirs 4.0.0",
+ "home",
+ "log",
+ "quick-xml 0.32.0",
  "rust-ini",
  "serde",
- "serde-xml-rs",
  "thiserror 1.0.69",
  "time",
  "url",
@@ -1093,9 +1101,9 @@ dependencies = [
 
 [[package]]
 name = "aws-region"
-version = "0.25.5"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9aed3f9c7eac9be28662fdb3b0f4d1951e812f7c64fed4f0327ba702f459b3b"
+checksum = "8369408b4c9287bbaa8f5030814167b29a4999920ae45670d531d10511c3843e"
 dependencies = [
  "thiserror 1.0.69",
 ]
@@ -1126,7 +1134,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -1147,7 +1155,7 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1181,11 +1189,11 @@ version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "cfg-if 1.0.4",
  "libc",
  "miniz_oxide",
- "object",
+ "object 0.37.3",
  "rustc-demangle",
  "windows-link",
 ]
@@ -1694,6 +1702,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1739,6 +1756,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "chain-gateway"
 version = "3.10.0"
 dependencies = [
@@ -1751,10 +1779,10 @@ dependencies = [
  "near-account-id 2.6.0",
  "near-async",
  "near-client",
- "near-crypto 2.11.1",
+ "near-crypto 2.12.0-rc.1",
  "near-indexer",
  "near-indexer-primitives",
- "near-o11y 2.11.1",
+ "near-o11y 2.12.0-rc.1",
  "near-sdk",
  "near-store",
  "nearcore",
@@ -1946,6 +1974,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86b9c4c00838774a6d902ef931eff7470720c51d90c2e32cfe15dc304737b3f"
+dependencies = [
+ "castaway",
+ "cfg-if 1.0.4",
+ "itoa",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2012,6 +2053,26 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "const-random"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e00182fe74b066627d63b85fd550ac2998d4b0bd86bfed477a0ae4c7c71359"
+dependencies = [
+ "const-random-macro",
+]
+
+[[package]]
+name = "const-random-macro"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
+dependencies = [
+ "getrandom 0.2.17",
+ "once_cell",
+ "tiny-keccak",
+]
 
 [[package]]
 name = "const_format"
@@ -2092,7 +2153,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -2129,6 +2190,15 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
+name = "cpp_demangle"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
@@ -2160,7 +2230,16 @@ version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb1ffe339f197d6645b4d3037edf67c13cd3aa8871f29c2c9c046c729c1b9a17"
 dependencies = [
- "cranelift-assembler-x64-meta",
+ "cranelift-assembler-x64-meta 0.123.8",
+]
+
+[[package]]
+name = "cranelift-assembler-x64"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c80cf55a351448317210f26c434be761bcb25e7b36116ec92f89540b73e2833"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.132.0",
 ]
 
 [[package]]
@@ -2169,7 +2248,16 @@ version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e81a21df73d1b12ed19eba481c08de8891e179e1870ed28d6e397f7746108f5"
 dependencies = [
- "cranelift-srcgen",
+ "cranelift-srcgen 0.123.8",
+]
+
+[[package]]
+name = "cranelift-assembler-x64-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07937ca8617b340162fe3a4716be885b5847e9b56d6c7a89abbe4d42340fdc91"
+dependencies = [
+ "cranelift-srcgen 0.132.0",
 ]
 
 [[package]]
@@ -2178,7 +2266,17 @@ version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cf917d0180c15c945c13c8dde615d32a015769513b29158f728311d85a8f80d"
 dependencies = [
- "cranelift-entity",
+ "cranelift-entity 0.123.8",
+]
+
+[[package]]
+name = "cranelift-bforest"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88217b08180882436d54c0133274885c590698ae854e352bede1cda041230800"
+dependencies = [
+ "cranelift-entity 0.132.0",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -2192,25 +2290,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-bitset"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5c3cf7ba29fa56e56040848e34835d4e45988b2760ef212413409af95ffd8c1"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
+]
+
+[[package]]
 name = "cranelift-codegen"
 version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4e3a5d7300e4b44933dcf2947399945abe3f30f92c789b496ad72949e3ee15a6"
 dependencies = [
  "bumpalo",
- "cranelift-assembler-x64",
- "cranelift-bforest",
- "cranelift-bitset",
- "cranelift-codegen-meta",
- "cranelift-codegen-shared",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-isle",
- "gimli",
+ "cranelift-assembler-x64 0.123.8",
+ "cranelift-bforest 0.123.8",
+ "cranelift-bitset 0.123.8",
+ "cranelift-codegen-meta 0.123.8",
+ "cranelift-codegen-shared 0.123.8",
+ "cranelift-control 0.123.8",
+ "cranelift-entity 0.123.8",
+ "cranelift-isle 0.123.8",
+ "gimli 0.32.3",
  "hashbrown 0.15.5",
  "log",
- "pulley-interpreter",
- "regalloc2",
+ "pulley-interpreter 36.0.8",
+ "regalloc2 0.12.2",
  "rustc-hash 2.1.2",
  "serde",
  "smallvec",
@@ -2219,16 +2328,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-codegen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe1aac2efd4cba2047845fce38a68519935a30e20c8a6294ba7e2f448fe722d"
+dependencies = [
+ "bumpalo",
+ "cranelift-assembler-x64 0.132.0",
+ "cranelift-bforest 0.132.0",
+ "cranelift-bitset 0.132.0",
+ "cranelift-codegen-meta 0.132.0",
+ "cranelift-codegen-shared 0.132.0",
+ "cranelift-control 0.132.0",
+ "cranelift-entity 0.132.0",
+ "cranelift-isle 0.132.0",
+ "gimli 0.33.0",
+ "hashbrown 0.17.0",
+ "libm",
+ "log",
+ "pulley-interpreter 45.0.0",
+ "regalloc2 0.15.1",
+ "rustc-hash 2.1.2",
+ "serde",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmtime-internal-core",
+]
+
+[[package]]
 name = "cranelift-codegen-meta"
 version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "becdb5c3111800d7f8e666fe5f35693bfc77de4401bfcaea19815caf7c482fb9"
 dependencies = [
- "cranelift-assembler-x64-meta",
- "cranelift-codegen-shared",
- "cranelift-srcgen",
+ "cranelift-assembler-x64-meta 0.123.8",
+ "cranelift-codegen-shared 0.123.8",
+ "cranelift-srcgen 0.123.8",
  "heck 0.5.0",
- "pulley-interpreter",
+ "pulley-interpreter 36.0.8",
+]
+
+[[package]]
+name = "cranelift-codegen-meta"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0909eaf9d6f18f5bf802d50608cb4368ac340fbd03cc44f2888d1cfcc3faa64e"
+dependencies = [
+ "cranelift-assembler-x64-meta 0.132.0",
+ "cranelift-codegen-shared 0.132.0",
+ "cranelift-srcgen 0.132.0",
+ "heck 0.5.0",
+ "pulley-interpreter 45.0.0",
 ]
 
 [[package]]
@@ -2236,6 +2386,12 @@ name = "cranelift-codegen-shared"
 version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8fa77efffa12934971f757e154b16dd5e369a7f388a0f3adff74aadfd4c5a1d"
+
+[[package]]
+name = "cranelift-codegen-shared"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c95a8da8be283f49cda7d0ef228c94f10d791e517b27b0c7e282dadd2e79ce45"
 
 [[package]]
 name = "cranelift-control"
@@ -2247,14 +2403,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cranelift-control"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5b19c81145146da1f7afda2e7f52111842fe6793512e740ad5cf3f5639e6212"
+dependencies = [
+ "arbitrary",
+]
+
+[[package]]
 name = "cranelift-entity"
 version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bdc9832a010e0d411439aa016e1664dd23ca5c8953bf26b90fe34ad4b76822d"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.123.8",
  "serde",
  "serde_derive",
+]
+
+[[package]]
+name = "cranelift-entity"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a55309b47e6633ab05821304206cb1e92952e845b1224985562bb7ac1e92323"
+dependencies = [
+ "cranelift-bitset 0.132.0",
+ "serde",
+ "serde_derive",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -2263,7 +2440,19 @@ version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9530b689b7c3accdbb32263ca318e19ab3bcf616d3a160c8456537c99b4c565b"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.123.8",
+ "log",
+ "smallvec",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-frontend"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "064d2d3533d9608f1cf44c8899cf2f7f33feb70300b0fb83e687b0d9e7b91147"
+dependencies = [
+ "cranelift-codegen 0.132.0",
  "log",
  "smallvec",
  "target-lexicon 0.13.5",
@@ -2276,12 +2465,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fcd3258a4d87376f2681c72269a42009286a3d3707b2af4024ba5b3750ad477"
 
 [[package]]
+name = "cranelift-isle"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ac4e0bc095b2dab2212d1e99d7a74b62afc1485db023f1c0cb34a68758f7bd1"
+
+[[package]]
 name = "cranelift-native"
 version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "642c5703a22b58abccbf46f46c0dae65f0535bbe725beec70527a1ffcbbc1d34"
 dependencies = [
- "cranelift-codegen",
+ "cranelift-codegen 0.123.8",
+ "libc",
+ "target-lexicon 0.13.5",
+]
+
+[[package]]
+name = "cranelift-native"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09a40053f5cb925451dd1d57393d14ad3145c8e0786701c27b5415ebb9a3ba4f"
+dependencies = [
+ "cranelift-codegen 0.132.0",
  "libc",
  "target-lexicon 0.13.5",
 ]
@@ -2291,6 +2497,12 @@ name = "cranelift-srcgen"
 version = "0.123.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d200dcd5a37de108ec1329e0ba924e2badd2c0ef2343c338310135159ae454e2"
+
+[[package]]
+name = "cranelift-srcgen"
+version = "0.132.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3ceab9a53f7d362c89841fbaa8e63e44d47c40e91dc96ee6f777fca5d6b323b"
 
 [[package]]
 name = "crc"
@@ -2932,9 +3144,12 @@ checksum = "aeda16ab4059c5fd2a83f2b9c9e9c981327b18aa8e3b313f7e6563799d4f093e"
 
 [[package]]
 name = "dlv-list"
-version = "0.3.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0688c2a7f92e427f44895cd63841bff7b29f8d7a1648b9e7e07a4a365b2e1257"
+checksum = "442039f5147480ba31067cb00ada1adae6892028e40e45fc5de7b7df6dcc1b5f"
+dependencies = [
+ "const-random",
+]
 
 [[package]]
 name = "document-features"
@@ -3930,6 +4145,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
 ]
@@ -3951,7 +4167,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "gimli"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7f043f89559805f8c7cacc432749b2fa0d0a0a9ee46ce47164ed5ba7f126c"
+dependencies = [
+ "fnv",
+ "hashbrown 0.16.1",
+ "indexmap 2.14.0",
  "stable_deref_trait",
 ]
 
@@ -4001,25 +4229,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.13.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -4030,7 +4239,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http 1.4.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -4104,6 +4313,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4405,7 +4616,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.3.27",
  "http 0.2.12",
  "http-body 0.4.6",
  "httparse",
@@ -4429,7 +4639,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -4475,19 +4685,6 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
@@ -4520,7 +4717,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration 0.7.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -4758,12 +4955,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -4789,7 +4986,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "232929e1d75fe899576a3d5c7416ad0d88dbfbb3c3d6aa00873a7408a50ddb88"
 dependencies = [
  "ahash 0.8.12",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "is-terminal",
  "itoa",
  "log",
@@ -4812,7 +5009,7 @@ dependencies = [
  "crossbeam-utils",
  "dashmap",
  "env_logger",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "log",
  "num-format",
@@ -5254,9 +5451,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -5571,9 +5768,9 @@ dependencies = [
 
 [[package]]
 name = "minidom"
-version = "0.15.2"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f45614075738ce1b77a1768912a60c0227525971b03e09122a05b8a34a2a6278"
+checksum = "e394a0e3c7ccc2daea3dffabe82f09857b6b510cb25af87d54bf3e910ac1642d"
 dependencies = [
  "rxml",
 ]
@@ -5801,21 +5998,21 @@ dependencies = [
  "near-account-id 2.6.0",
  "near-async",
  "near-client",
- "near-config-utils 2.11.1",
- "near-crypto 2.11.1",
+ "near-config-utils 2.12.0-rc.1",
+ "near-crypto 2.12.0-rc.1",
  "near-indexer",
  "near-indexer-primitives",
  "near-mpc-bounded-collections",
  "near-mpc-contract-interface",
  "near-mpc-crypto-types",
- "near-o11y 2.11.1",
+ "near-o11y 2.12.0-rc.1",
  "near-sdk",
- "near-time 2.11.1",
+ "near-time 2.12.0-rc.1",
  "node-types",
  "num_enum",
  "pprof",
  "pprof_util",
- "prometheus",
+ "prometheus 0.13.4",
  "rand 0.8.6",
  "regex",
  "rocksdb",
@@ -6022,17 +6219,18 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "crossbeam-channel",
  "futures",
  "near-async-derive",
- "near-o11y 2.11.1",
- "near-time 2.11.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
+ "thread-priority",
  "time",
  "tokio",
  "tokio-util",
@@ -6041,8 +6239,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6051,8 +6249,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -6060,8 +6258,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6074,19 +6272,19 @@ dependencies = [
  "lru 0.16.4",
  "near-async",
  "near-cache",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.11.1",
+ "near-crypto 2.12.0-rc.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
  "near-pool",
- "near-primitives 2.11.1",
- "near-schema-checker-lib 2.11.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
  "near-store",
- "near-vm-runner 2.11.1",
+ "near-vm-runner 2.12.0-rc.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -6098,7 +6296,6 @@ dependencies = [
  "strum 0.24.1",
  "tempfile",
  "thiserror 2.0.18",
- "thread-priority",
  "time",
  "tokio",
  "tracing",
@@ -6155,19 +6352,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.1.1",
- "near-config-utils 2.11.1",
- "near-crypto 2.11.1",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
- "near-primitives 2.11.1",
- "near-time 2.11.1",
+ "near-config-utils 2.12.0-rc.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "serde",
@@ -6180,33 +6377,33 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
- "near-crypto 2.11.1",
- "near-primitives 2.11.1",
- "near-time 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
  "near-async",
  "near-chain",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-chunks-primitives",
- "near-crypto 2.11.1",
+ "near-crypto 2.12.0-rc.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.11.1",
+ "near-o11y 2.12.0-rc.1",
  "near-pool",
- "near-primitives 2.11.1",
+ "near-primitives 2.12.0-rc.1",
  "near-store",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -6218,17 +6415,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.11.1",
+ "near-primitives 2.12.0-rc.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6239,22 +6436,22 @@ dependencies = [
  "near-async",
  "near-cache",
  "near-chain",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.11.1",
+ "near-crypto 2.12.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-network",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
  "near-pool",
- "near-primitives 2.11.1",
+ "near-primitives 2.12.0-rc.1",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.11.1",
+ "near-vm-runner 2.12.0-rc.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -6262,7 +6459,7 @@ dependencies = [
  "rayon",
  "reed-solomon-erasure",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rust-s3",
  "serde",
  "serde_json",
@@ -6279,14 +6476,14 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.11.1",
- "near-primitives 2.11.1",
- "near-time 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.18",
@@ -6331,8 +6528,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -6419,8 +6616,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "blake2",
  "borsh",
@@ -6430,9 +6627,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id 2.6.0",
- "near-config-utils 2.11.1",
- "near-schema-checker-lib 2.11.1",
- "near-stdx 2.11.1",
+ "near-config-utils 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
+ "near-stdx 2.12.0-rc.1",
  "primitive-types 0.10.1",
  "rand 0.8.6",
  "secp256k1 0.27.0",
@@ -6444,14 +6641,14 @@ dependencies = [
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
- "near-chain-configs 2.11.1",
- "near-o11y 2.11.1",
- "near-primitives 2.11.1",
- "near-time 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -6459,18 +6656,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
  "near-cache",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-chain-primitives",
- "near-crypto 2.11.1",
- "near-o11y 2.11.1",
- "near-primitives 2.11.1",
- "near-schema-checker-lib 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -6478,22 +6675,21 @@ dependencies = [
  "primitive-types 0.10.1",
  "rand 0.8.6",
  "rand_hc",
- "rayon",
  "serde",
  "tracing",
 ]
 
 [[package]]
 name = "near-external-storage"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "futures",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "object_store",
  "percent-encoding",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
  "rust-s3",
  "serde",
  "serde_json",
@@ -6529,10 +6725,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
- "near-primitives-core 2.11.1",
+ "near-primitives-core 2.12.0-rc.1",
 ]
 
 [[package]]
@@ -6548,22 +6744,22 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "futures",
  "near-async",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.11.1",
+ "near-config-utils 2.12.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-indexer-primitives",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
- "near-primitives 2.11.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -6575,35 +6771,41 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
- "near-primitives 2.11.1",
+ "near-primitives 2.12.0-rc.1",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "axum",
  "bs58 0.4.0",
  "easy-ext",
+ "futures",
  "near-async",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
+ "near-chain-primitives",
  "near-client",
  "near-client-primitives",
+ "near-epoch-manager",
  "near-jsonrpc-client-internal",
- "near-jsonrpc-primitives 2.11.1",
+ "near-jsonrpc-primitives 2.12.0-rc.1",
  "near-network",
- "near-o11y 2.11.1",
- "near-primitives 2.11.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-store",
+ "parking_lot 0.12.5",
  "serde",
  "serde_json",
  "tokio",
  "tower-http",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -6646,13 +6848,13 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "futures",
- "near-jsonrpc-primitives 2.11.1",
- "near-primitives 2.11.1",
- "reqwest 0.12.28",
+ "near-jsonrpc-primitives 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "url",
@@ -6695,16 +6897,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "arbitrary",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-client-primitives",
- "near-crypto 2.11.1",
- "near-primitives 2.11.1",
- "near-schema-checker-lib 2.11.1",
- "near-time 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6756,12 +6958,12 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "near-account-id 2.6.0",
- "near-chain-configs 2.11.1",
- "near-primitives 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
  "serde_json",
 ]
 
@@ -6855,14 +7057,15 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "arc-swap",
  "borsh",
  "bytes",
  "bytesize",
+ "dashmap",
  "enum-map",
  "futures",
  "futures-util",
@@ -6871,12 +7074,12 @@ dependencies = [
  "lru 0.16.4",
  "named-lock",
  "near-async",
- "near-chain-configs 2.11.1",
- "near-crypto 2.11.1",
- "near-fmt 2.11.1",
- "near-o11y 2.11.1",
- "near-primitives 2.11.1",
- "near-schema-checker-lib 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-fmt 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.5",
@@ -6910,7 +7113,7 @@ dependencies = [
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "parking_lot 0.12.5",
- "prometheus",
+ "prometheus 0.13.4",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6922,19 +7125,18 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 2.11.1",
- "near-primitives-core 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-primitives-core 2.12.0-rc.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
- "parking_lot 0.12.5",
- "prometheus",
+ "prometheus 0.14.0",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -7003,14 +7205,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id 2.6.0",
- "near-primitives-core 2.11.1",
- "near-schema-checker-lib 2.11.1",
+ "near-primitives-core 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -7021,13 +7223,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "borsh",
- "near-crypto 2.11.1",
- "near-o11y 2.11.1",
- "near-primitives 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
  "rand 0.8.6",
 ]
 
@@ -7158,8 +7360,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -7174,13 +7376,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto 2.11.1",
- "near-fmt 2.11.1",
- "near-parameters 2.11.1",
- "near-primitives-core 2.11.1",
- "near-schema-checker-lib 2.11.1",
- "near-stdx 2.11.1",
- "near-time 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-fmt 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
+ "near-primitives-core 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
+ "near-stdx 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
  "num-rational 0.3.2",
  "ordered-float 4.6.0",
  "primitive-types 0.10.1",
@@ -7270,8 +7472,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -7281,7 +7483,7 @@ dependencies = [
  "enum-map",
  "near-account-id 2.6.0",
  "near-gas",
- "near-schema-checker-lib 2.11.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
  "near-token",
  "num-rational 0.3.2",
  "serde",
@@ -7293,8 +7495,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "axum",
  "derive_more 2.1.1",
@@ -7303,14 +7505,14 @@ dependencies = [
  "insta",
  "near-account-id 2.6.0",
  "near-async",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.11.1",
+ "near-crypto 2.12.0-rc.1",
  "near-network",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
- "near-primitives 2.11.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
  "node-runtime",
  "serde",
  "serde_json",
@@ -7364,8 +7566,8 @@ checksum = "8dcb2d2f8e5adcc3829eb17306d17ae99b3c314202d1556747d672f2d83c1546"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -7399,11 +7601,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
- "near-schema-checker-core 2.11.1",
- "near-schema-checker-macro 2.11.1",
+ "near-schema-checker-core 2.12.0-rc.1",
+ "near-schema-checker-macro 2.12.0-rc.1",
 ]
 
 [[package]]
@@ -7426,8 +7628,8 @@ checksum = "5b61eccf333a27e5dc076290f9eb59b18fc848188377bf3e99e0fe0a93627e18"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 
 [[package]]
 name = "near-sdk"
@@ -7495,13 +7697,13 @@ checksum = "563c78530cad21d0af0cdfdf56f3143941e55f93adfacb4df300ed3fb2290064"
 
 [[package]]
 name = "near-stdx"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 
 [[package]]
 name = "near-store"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -7518,18 +7720,18 @@ dependencies = [
  "itoa",
  "lru 0.16.4",
  "near-async",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-chain-primitives",
- "near-crypto 2.11.1",
+ "near-crypto 2.12.0-rc.1",
  "near-external-storage",
- "near-fmt 2.11.1",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
- "near-primitives 2.11.1",
- "near-schema-checker-lib 2.11.1",
- "near-stdx 2.11.1",
- "near-time 2.11.1",
- "near-vm-runner 2.11.1",
+ "near-fmt 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
+ "near-stdx 2.12.0-rc.1",
+ "near-time 2.12.0-rc.1",
+ "near-vm-runner 2.12.0-rc.1",
  "num_cpus",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -7546,6 +7748,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "zstd",
 ]
 
 [[package]]
@@ -7556,13 +7759,13 @@ checksum = "c7c212278351251aa342eab33a9d64f99294bc5784cda10107867a72dda699bb"
 
 [[package]]
 name = "near-telemetry"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "futures",
  "near-async",
- "near-o11y 2.11.1",
- "reqwest 0.12.28",
+ "near-o11y 2.12.0-rc.1",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "tracing",
@@ -7602,8 +7805,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -7624,8 +7827,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.0",
@@ -7640,8 +7843,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -7659,8 +7862,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.0",
@@ -7700,7 +7903,7 @@ dependencies = [
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "prefix-sum-vec",
- "prometheus",
+ "prometheus 0.13.4",
  "rand 0.8.6",
  "rayon",
  "ripemd",
@@ -7715,40 +7918,42 @@ dependencies = [
  "wasm-encoder 0.236.1",
  "wasmparser 0.236.1",
  "wasmparser 0.78.2",
- "wasmtime",
+ "wasmtime 36.0.8",
  "zeropool-bn",
 ]
 
 [[package]]
 name = "near-vm-runner"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "blst",
  "borsh",
  "bytesize",
+ "dashmap",
  "ed25519-dalek",
  "enum-map",
  "finite-wasm 0.5.0",
  "finite-wasm 0.6.0",
  "lru 0.16.4",
  "memoffset 0.8.0",
- "near-crypto 2.11.1",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
- "near-primitives-core 2.11.1",
- "near-schema-checker-lib 2.11.1",
- "near-stdx 2.11.1",
+ "near-crypto 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
+ "near-primitives-core 2.12.0-rc.1",
+ "near-schema-checker-lib 2.12.0-rc.1",
+ "near-stdx 2.12.0-rc.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
  "near-vm-types",
  "near-vm-vm",
  "num-rational 0.3.2",
+ "p256",
  "parking_lot 0.12.5",
  "prefix-sum-vec",
- "prometheus",
+ "prometheus 0.14.0",
  "rand 0.8.6",
  "rayon",
  "ripemd",
@@ -7763,16 +7968,16 @@ dependencies = [
  "wasm-encoder 0.236.1",
  "wasmparser 0.236.1",
  "wasmparser 0.78.2",
- "wasmtime",
+ "wasmtime 45.0.0",
  "zeropool-bn",
 ]
 
 [[package]]
 name = "near-vm-types"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "num-traits",
  "rkyv",
  "thiserror 2.0.18",
@@ -7780,8 +7985,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "backtrace",
  "cc",
@@ -7801,12 +8006,12 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.11.1",
- "near-vm-runner 2.11.1",
+ "near-primitives-core 2.12.0-rc.1",
+ "near-vm-runner 2.12.0-rc.1",
 ]
 
 [[package]]
@@ -7873,8 +8078,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7887,33 +8092,34 @@ dependencies = [
  "itertools 0.14.0",
  "near-async",
  "near-chain",
- "near-chain-configs 2.11.1",
+ "near-chain-configs 2.12.0-rc.1",
  "near-chain-primitives",
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.11.1",
- "near-crypto 2.11.1",
+ "near-config-utils 2.12.0-rc.1",
+ "near-crypto 2.12.0-rc.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-jsonrpc",
- "near-jsonrpc-primitives 2.11.1",
+ "near-jsonrpc-primitives 2.12.0-rc.1",
  "near-mainnet-res",
  "near-network",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
  "near-pool",
- "near-primitives 2.11.1",
+ "near-primitives 2.12.0-rc.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.11.1",
+ "near-vm-runner 2.12.0-rc.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "rand 0.8.6",
- "reqwest 0.12.28",
+ "reqwest 0.13.3",
+ "rocksdb",
  "serde",
  "serde_ignored",
  "serde_json",
@@ -7941,21 +8147,22 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.11.1"
-source = "git+https://github.com/near/nearcore?tag=2.11.1#a9d7c997a7c147267ca2dd7bb2ab9dc286713de0"
+version = "2.12.0-rc.1"
+source = "git+https://github.com/near/nearcore?tag=2.12.0-rc.1#aab31b0e88bc9f6d8854c06212f00c2decd244fc"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
  "bytesize",
  "dashmap",
  "itertools 0.14.0",
- "near-crypto 2.11.1",
- "near-o11y 2.11.1",
- "near-parameters 2.11.1",
- "near-primitives 2.11.1",
- "near-primitives-core 2.11.1",
+ "near-async",
+ "near-crypto 2.12.0-rc.1",
+ "near-o11y 2.12.0-rc.1",
+ "near-parameters 2.12.0-rc.1",
+ "near-primitives 2.12.0-rc.1",
+ "near-primitives-core 2.12.0-rc.1",
  "near-store",
- "near-vm-runner 2.11.1",
+ "near-vm-runner 2.12.0-rc.1",
  "near-wallet-contract",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -8068,9 +8275,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-format"
@@ -8190,22 +8397,36 @@ checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "crc32fast",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
+ "memchr",
+]
+
+[[package]]
+name = "object"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e5a6c098c7a3b6547378093f5cc30bc54fd361ce711e05293a5cc589562739b"
+dependencies = [
+ "crc32fast",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
 [[package]]
 name = "object_store"
-version = "0.12.5"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbfbfff40aeccab00ec8a910b57ca8ecf4319b335c542f2edcd19dd25a1e2a00"
+checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
- "futures",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
  "http 1.4.0",
  "http-body-util",
  "humantime",
@@ -8213,11 +8434,11 @@ dependencies = [
  "itertools 0.14.0",
  "parking_lot 0.12.5",
  "percent-encoding",
- "quick-xml 0.38.4",
- "rand 0.9.4",
+ "quick-xml 0.39.4",
+ "rand 0.10.1",
  "reqwest 0.12.28",
  "ring",
- "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -8424,12 +8645,24 @@ dependencies = [
 
 [[package]]
 name = "ordered-multimap"
-version = "0.4.3"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccd746e37177e1711c20dd619a1620f34f5c8b569c53590a72dedd5344d8924a"
+checksum = "49203cdcae0030493bad186b28da2fa25645fa276a51b6fec8010d281e02ef79"
 dependencies = [
  "dlv-list",
- "hashbrown 0.12.3",
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -8880,6 +9113,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
+
+[[package]]
 name = "primitive-types"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8992,6 +9234,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
+dependencies = [
+ "cfg-if 1.0.4",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot 0.12.5",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "proptest"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9060,7 +9316,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9073,7 +9329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -9121,7 +9377,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4aeaa1f2460f1d348eeaeed86aea999ce98c1bded6f089ff8514c9d9dbdc973"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "protobuf",
  "protobuf-support",
@@ -9165,10 +9421,22 @@ version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35eaba3163b9faf1d707f0704a7370bfdbe73622c766acdaf1fa4addb87510de"
 dependencies = [
- "cranelift-bitset",
+ "cranelift-bitset 0.123.8",
  "log",
- "pulley-macros",
+ "pulley-macros 36.0.8",
  "wasmtime-internal-math",
+]
+
+[[package]]
+name = "pulley-interpreter"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9204ad9435f2a6fe3bd13bba52389fb8488fa20ba497e35c5d2db638166019d"
+dependencies = [
+ "cranelift-bitset 0.132.0",
+ "log",
+ "pulley-macros 45.0.0",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -9176,6 +9444,17 @@ name = "pulley-macros"
 version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac294897a29ce07919714f9f25c11a819d75759d47eb9f3273845ffea5a5760d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pulley-macros"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53009b033747e0d79a76549a744da58e84c9da8076492c7e6d491fdc6cc41b95"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -9199,9 +9478,19 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.36.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
 dependencies = [
  "memchr",
  "serde",
@@ -9214,6 +9503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
+ "serde",
 ]
 
 [[package]]
@@ -9332,6 +9622,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
+dependencies = [
+ "chacha20",
+ "getrandom 0.4.2",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9370,6 +9671,12 @@ dependencies = [
  "getrandom 0.3.4",
  "serde",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_hc"
@@ -9564,6 +9871,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "regalloc2"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2c52737737f8609e94f975dee22854a2d5c125772d4b1cf292120f4d45c186"
+dependencies = [
+ "allocator-api2",
+ "bumpalo",
+ "hashbrown 0.17.0",
+ "log",
+ "rustc-hash 2.1.2",
+ "smallvec",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9621,48 +9942,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile 1.0.4",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tokio-util",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -9670,17 +9949,16 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "hickory-resolver",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -9696,7 +9974,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
@@ -9721,20 +9999,23 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2",
  "hickory-resolver",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -9745,8 +10026,9 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tokio-util",
  "tower",
@@ -9816,7 +10098,7 @@ dependencies = [
  "bytecheck",
  "bytes",
  "hashbrown 0.17.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "munge",
  "ptr_meta",
  "rancor",
@@ -10015,9 +10297,9 @@ dependencies = [
 
 [[package]]
 name = "rust-ini"
-version = "0.18.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
+checksum = "796e8d2b6696392a43bea58116b667fb4c29727dc5abd27d6acf338bb4f688c7"
 dependencies = [
  "cfg-if 1.0.4",
  "ordered-multimap",
@@ -10025,28 +10307,31 @@ dependencies = [
 
 [[package]]
 name = "rust-s3"
-version = "0.32.3"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6009d9d4cf910505534d62d380a0aa305805a2af0b5c3ad59a3024a0715b847"
+checksum = "8ea86af11ea9703eaca42a5bbcf7289d271b6e0e3894f7f9c5232aab09fae29a"
 dependencies = [
  "async-trait",
  "aws-creds",
  "aws-region",
- "base64 0.13.1",
+ "base64 0.22.1",
  "block_on_proc",
+ "bytes",
  "cfg-if 1.0.4",
+ "futures",
  "hex",
  "hmac 0.12.1",
- "http 0.2.12",
+ "http 1.4.0",
  "log",
  "maybe-async",
  "md5",
  "minidom",
  "percent-encoding",
- "reqwest 0.11.27",
+ "quick-xml 0.36.2",
+ "reqwest 0.12.28",
  "serde",
- "serde-xml-rs",
  "serde_derive",
+ "serde_json",
  "sha2 0.10.9",
  "thiserror 1.0.69",
  "time",
@@ -10161,24 +10446,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10268,20 +10535,22 @@ dependencies = [
 
 [[package]]
 name = "rxml"
-version = "0.9.1"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a98f186c7a2f3abbffb802984b7f1dfd65dac8be1aafdaabbca4137f53f0dff7"
+checksum = "65bc94b580d0f5a6b7a2d604e597513d3c673154b52ddeccd1d5c32360d945ee"
 dependencies = [
  "bytes",
  "rxml_validation",
- "smartstring",
 ]
 
 [[package]]
 name = "rxml_validation"
-version = "0.9.1"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22a197350ece202f19a166d1ad6d9d6de145e1d2a8ef47db299abe164dbd7530"
+checksum = "826e80413b9a35e9d33217b3dcac04cf95f6559d15944b93887a08be5496c4a4"
+dependencies = [
+ "compact_str",
+]
 
 [[package]]
 name = "ryu"
@@ -10572,18 +10841,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-xml-rs"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65162e9059be2f6a3421ebbb4fef3e74b7d9e7c60c50a0e292c6239f19f1edfa"
-dependencies = [
- "log",
- "serde",
- "thiserror 1.0.69",
- "xml-rs",
-]
-
-[[package]]
 name = "serde_bytes"
 version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10640,7 +10897,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -10720,7 +10977,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "schemars 0.8.22",
  "schemars 0.9.0",
  "schemars 1.2.1",
@@ -10748,7 +11005,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "itoa",
  "ryu",
  "serde",
@@ -10991,17 +11248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "smartstring"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fb72c633efbaa2dd666986505016c32c3044395ceaf881518399d2f4127ee29"
-dependencies = [
- "autocfg",
- "static_assertions",
- "version_check",
-]
-
-[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11163,7 +11409,7 @@ version = "12.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baa911a28a62823aaf2cc2e074212492a3ee69d0d926cc8f5b12b4a108ff5c0c"
 dependencies = [
- "cpp_demangle",
+ "cpp_demangle 0.5.1",
  "rustc-demangle",
  "symbolic-common",
 ]
@@ -11204,12 +11450,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -11245,34 +11485,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -11648,9 +11867,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -11663,15 +11882,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -11835,7 +12054,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -11868,7 +12087,7 @@ version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
@@ -11882,7 +12101,7 @@ version = "0.25.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da053d28fe57e2c9d21b48261e14e7b4c8b670b54d2c684847b91feaf4c7dac5"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
  "winnow 1.0.1",
@@ -11945,7 +12164,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "bytes",
- "h2 0.4.13",
+ "h2",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -11955,7 +12174,7 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "socket2 0.6.3",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-stream",
@@ -11985,10 +12204,10 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -12371,7 +12590,7 @@ version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fcc29c80c21c31608227e0912b2d7fddba57ad76b606890627ba8ee7964e993"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "serde",
  "serde_json",
  "utoipa-gen",
@@ -12590,13 +12809,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-encoder"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac92cf547bc18d27ecc521015c08c353b4f18b84ab388bb6d1b6b682c620d9b6"
+dependencies = [
+ "leb128fmt",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
 name = "wasm-metadata"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "wasm-encoder 0.244.0",
  "wasmparser 0.244.0",
 ]
@@ -12661,7 +12890,7 @@ checksum = "4abf1132c1fdf747d56bbc1bb52152400c70f336870f968b85e89ea422198ae3"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver 1.0.27",
  "serde",
 ]
@@ -12674,7 +12903,7 @@ checksum = "a9b1e81f3eb254cf7404a82cee6926a4a3ccc5aad80cc3d43608a070c67aa1d7"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver 1.0.27",
  "serde",
 ]
@@ -12687,8 +12916,21 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "semver 1.0.27",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa4439c5eee9df71ee0c6efb37f63b1fcb1fec38f85f5142c54e7ed05d33091a"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "semver 1.0.27",
+ "serde",
 ]
 
 [[package]]
@@ -12713,27 +12955,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmprinter"
+version = "0.248.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b264a5410b008d4d199a92bf536eae703cbd614482fc1ec53831cf19e1c183"
+dependencies = [
+ "anyhow",
+ "termcolor",
+ "wasmparser 0.248.0",
+]
+
+[[package]]
 name = "wasmtime"
 version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2060d93be880840d764ab537464b916e22c07758ac5d43e5f07cc86fec6d1bec"
 dependencies = [
- "addr2line",
+ "addr2line 0.25.1",
  "anyhow",
  "bitflags 2.11.0",
  "bumpalo",
  "cc",
  "cfg-if 1.0.4",
  "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "libc",
  "log",
  "mach2",
  "memfd",
- "object",
+ "object 0.37.3",
  "once_cell",
  "postcard",
- "pulley-interpreter",
+ "pulley-interpreter 36.0.8",
  "rayon",
  "rustix 1.1.4",
  "serde",
@@ -12741,17 +12994,56 @@ dependencies = [
  "smallvec",
  "target-lexicon 0.13.5",
  "wasmparser 0.236.1",
- "wasmtime-environ",
+ "wasmtime-environ 36.0.8",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-cranelift",
- "wasmtime-internal-fiber",
- "wasmtime-internal-jit-debug",
- "wasmtime-internal-jit-icache-coherence",
+ "wasmtime-internal-cranelift 36.0.8",
+ "wasmtime-internal-fiber 36.0.8",
+ "wasmtime-internal-jit-debug 36.0.8",
+ "wasmtime-internal-jit-icache-coherence 36.0.8",
  "wasmtime-internal-math",
  "wasmtime-internal-slab",
- "wasmtime-internal-unwinder",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-unwinder 36.0.8",
+ "wasmtime-internal-versioned-export-macros 36.0.8",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d35aec1e932d00a7c941f816ad589e65ad8db948b9e971bf8ec655a1669f1f67"
+dependencies = [
+ "addr2line 0.26.1",
+ "async-trait",
+ "bitflags 2.11.0",
+ "bumpalo",
+ "cc",
+ "cfg-if 1.0.4",
+ "libc",
+ "log",
+ "mach2",
+ "memfd",
+ "object 0.39.1",
+ "once_cell",
+ "postcard",
+ "pulley-interpreter 45.0.0",
+ "rayon",
+ "rustix 1.1.4",
+ "serde",
+ "serde_derive",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.248.0",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift 45.0.0",
+ "wasmtime-internal-fiber 45.0.0",
+ "wasmtime-internal-jit-debug 45.0.0",
+ "wasmtime-internal-jit-icache-coherence 45.0.0",
+ "wasmtime-internal-unwinder 45.0.0",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
+ "wasmtime-internal-winch",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12761,12 +13053,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "902f991ca8c2e5abc03119eb5d7f7f57da1b7c2123addb8214b49c188737711e"
 dependencies = [
  "anyhow",
- "cranelift-bitset",
- "cranelift-entity",
- "gimli",
- "indexmap 2.13.0",
+ "cranelift-bitset 0.123.8",
+ "cranelift-entity 0.123.8",
+ "gimli 0.32.3",
+ "indexmap 2.14.0",
  "log",
- "object",
+ "object 0.37.3",
  "postcard",
  "serde",
  "serde_derive",
@@ -12775,6 +13067,35 @@ dependencies = [
  "wasm-encoder 0.236.1",
  "wasmparser 0.236.1",
  "wasmprinter 0.236.1",
+]
+
+[[package]]
+name = "wasmtime-environ"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7da3dcce82a7e784121c19c8c9c5f69a743088264ff5212033e4a1f1b9dfaaf"
+dependencies = [
+ "anyhow",
+ "cpp_demangle 0.4.5",
+ "cranelift-bforest 0.132.0",
+ "cranelift-bitset 0.132.0",
+ "cranelift-entity 0.132.0",
+ "gimli 0.33.0",
+ "hashbrown 0.17.0",
+ "indexmap 2.14.0",
+ "log",
+ "object 0.39.1",
+ "postcard",
+ "rustc-demangle",
+ "serde",
+ "serde_derive",
+ "sha2 0.10.9",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "wasm-encoder 0.248.0",
+ "wasmparser 0.248.0",
+ "wasmprinter 0.248.0",
+ "wasmtime-internal-core",
 ]
 
 [[package]]
@@ -12787,6 +13108,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmtime-internal-core"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bdae4b55b15a23d774b15f6e7cd90ae0d0aa17c47c12b4db098b3dd11ba9d58"
+dependencies = [
+ "hashbrown 0.17.0",
+ "libm",
+ "serde",
+]
+
+[[package]]
 name = "wasmtime-internal-cranelift"
 version = "36.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12794,23 +13126,50 @@ checksum = "54eb7fc20c8692dc96148365d7a00a1b79fee810833c75bdf8ec073a46e4721a"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.4",
- "cranelift-codegen",
- "cranelift-control",
- "cranelift-entity",
- "cranelift-frontend",
- "cranelift-native",
- "gimli",
+ "cranelift-codegen 0.123.8",
+ "cranelift-control 0.123.8",
+ "cranelift-entity 0.123.8",
+ "cranelift-frontend 0.123.8",
+ "cranelift-native 0.123.8",
+ "gimli 0.32.3",
  "itertools 0.14.0",
  "log",
- "object",
- "pulley-interpreter",
+ "object 0.37.3",
+ "pulley-interpreter 36.0.8",
  "smallvec",
  "target-lexicon 0.13.5",
  "thiserror 2.0.18",
  "wasmparser 0.236.1",
- "wasmtime-environ",
+ "wasmtime-environ 36.0.8",
  "wasmtime-internal-math",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros 36.0.8",
+]
+
+[[package]]
+name = "wasmtime-internal-cranelift"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5773b36b87566239b020f1d01aa753a35626df85030485e40e36fc42a97acf4f"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cranelift-codegen 0.132.0",
+ "cranelift-control 0.132.0",
+ "cranelift-entity 0.132.0",
+ "cranelift-frontend 0.132.0",
+ "cranelift-native 0.132.0",
+ "gimli 0.33.0",
+ "itertools 0.14.0",
+ "log",
+ "object 0.39.1",
+ "pulley-interpreter 45.0.0",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-core",
+ "wasmtime-internal-unwinder 45.0.0",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
 ]
 
 [[package]]
@@ -12825,8 +13184,23 @@ dependencies = [
  "libc",
  "rustix 1.1.4",
  "wasmtime-internal-asm-macros",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros 36.0.8",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-fiber"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402cce4bba4c8c92a6fbaff39a6b23f8aa626d64b218ecf6dd3eeee8705cf096"
+dependencies = [
+ "cc",
+ "cfg-if 1.0.4",
+ "libc",
+ "rustix 1.1.4",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12836,7 +13210,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1eeaab071a646d9ae205266adf186c63fa6d077d36b0b33628dd6c3d321d3195"
 dependencies = [
  "cc",
- "wasmtime-internal-versioned-export-macros",
+ "wasmtime-internal-versioned-export-macros 36.0.8",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-debug"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b426a5d0ec9c11a1a4525ed4e973b7caf40223b6d392588bb9f6468e4ae9d29"
+dependencies = [
+ "cc",
+ "wasmtime-internal-versioned-export-macros 45.0.0",
 ]
 
 [[package]]
@@ -12849,6 +13233,18 @@ dependencies = [
  "cfg-if 1.0.4",
  "libc",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "wasmtime-internal-jit-icache-coherence"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a312ba8bb77955dcd44294a223e7f124c3071ff966583d385d3f6a4639c62e3"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "wasmtime-internal-core",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12874,9 +13270,22 @@ checksum = "4e748c970993865d9bf474465c3f10f96e541c472bc8f7ec0b031779f4ac29c6"
 dependencies = [
  "anyhow",
  "cfg-if 1.0.4",
- "cranelift-codegen",
+ "cranelift-codegen 0.123.8",
  "log",
- "object",
+ "object 0.37.3",
+]
+
+[[package]]
+name = "wasmtime-internal-unwinder"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a62ad422ee3cbf1e87c2242dc0717a01c7a5878fbc3a68abc4b4d2fff3e85e1"
+dependencies = [
+ "cfg-if 1.0.4",
+ "cranelift-codegen 0.132.0",
+ "log",
+ "object 0.39.1",
+ "wasmtime-environ 45.0.0",
 ]
 
 [[package]]
@@ -12888,6 +13297,34 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "wasmtime-internal-versioned-export-macros"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c660c5b091648cffdd84a34dc24ffcdb9d027f9048fe7bd5e01896adbd0935f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "wasmtime-internal-winch"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2aceb92b48b6e3a5cc2a05ab7a2dcb565eaf86fb870d04664b7f12cf9bba39a"
+dependencies = [
+ "cranelift-codegen 0.132.0",
+ "gimli 0.33.0",
+ "log",
+ "object 0.39.1",
+ "target-lexicon 0.13.5",
+ "wasmparser 0.248.0",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-cranelift 45.0.0",
+ "winch-codegen",
 ]
 
 [[package]]
@@ -12989,12 +13426,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 
 [[package]]
-name = "wildmatch"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29333c3ea1ba8b17211763463ff24ee84e41c78224c16b001cd907e663a38c68"
-
-[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13024,6 +13455,25 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winch-codegen"
+version = "45.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3128bd53313b132e8737d7d318edbc438bab1abe525ac037bbf9857839e717e2"
+dependencies = [
+ "cranelift-assembler-x64 0.132.0",
+ "cranelift-codegen 0.132.0",
+ "gimli 0.33.0",
+ "regalloc2 0.15.1",
+ "smallvec",
+ "target-lexicon 0.13.5",
+ "thiserror 2.0.18",
+ "wasmparser 0.248.0",
+ "wasmtime-environ 45.0.0",
+ "wasmtime-internal-core",
+ "wasmtime-internal-cranelift 45.0.0",
+]
 
 [[package]]
 name = "windows"
@@ -13135,15 +13585,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -13195,21 +13636,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -13249,12 +13675,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -13273,12 +13693,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -13294,12 +13708,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -13333,12 +13741,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -13354,12 +13756,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -13381,12 +13777,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -13402,12 +13792,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -13437,16 +13821,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if 1.0.4",
- "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -13483,7 +13857,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "prettyplease 0.2.37",
  "syn 2.0.117",
  "wasm-metadata",
@@ -13514,7 +13888,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -13533,7 +13907,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "log",
  "semver 1.0.27",
  "serde",
@@ -13602,12 +13976,6 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
 ]
-
-[[package]]
-name = "xml-rs"
-version = "0.8.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xz2"
@@ -13766,7 +14134,7 @@ dependencies = [
  "arbitrary",
  "crc32fast",
  "flate2",
- "indexmap 2.13.0",
+ "indexmap 2.14.0",
  "memchr",
  "zopfli",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ hkdf = "0.12.4"
 http = "1.4.0"
 humantime = "2.3.0"
 # TODO(#1299): updating this brings considerable breaking changes
-hyper = { version = "0.14.32", features = ["server", "http1", "tcp", "stream"] }
+hyper = { version = "0.14.32", features = ["client", "server", "http1", "tcp", "stream"] }
 inferno = "0.12"
 insta = { version = "1.46.3", features = ["json", "redactions"] }
 itertools = "0.14.0"
@@ -251,16 +251,16 @@ zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zstd = "0.13.3"
 
 # NEAR CORE DEPENDENCIES:
-near-async = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-store = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
-nearcore = { git = "https://github.com/near/nearcore", tag = "2.11.1" }
+near-async = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-store = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
+nearcore = { git = "https://github.com/near/nearcore", tag = "2.12.0-rc.1" }
 
 ## Outdated dependencies we cannot upgrade ##
 # Version 0.8.3 requires rustc 1.88

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -169,9 +169,12 @@ args = [
 [tasks.build-mpc-contract-optimized]
 description = "Build the mpc-contract WASM used by the E2E tests"
 condition = { env_not_set = ["E2E_SKIP_BUILD"] }
+# `--enable-bulk-memory` and `--enable-nontrapping-float-to-int` mirror what
+# `cargo near build` passes to wasm-opt; rustc >= 1.87 emits both feature
+# sets by default, so wasm-opt must accept them to validate the input.
 script = [
   "cargo build -p mpc-contract --target=wasm32-unknown-unknown --profile=release-contract --locked",
-  "wasm-opt -Oz target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm -o target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm",
+  "wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm -o target/wasm32-unknown-unknown/release-contract/mpc_contract.wasm",
 ]
 
 [tasks.build-test-parallel-contract-optimized]
@@ -179,7 +182,7 @@ description = "Build the test-parallel-contract WASM used by the E2E tests"
 condition = { env_not_set = ["E2E_SKIP_BUILD"] }
 script = [
   "cargo build -p test-parallel-contract --target=wasm32-unknown-unknown --profile=release-contract --locked",
-  "wasm-opt -Oz target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm -o target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm",
+  "wasm-opt -Oz --enable-bulk-memory --enable-nontrapping-float-to-int target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm -o target/wasm32-unknown-unknown/release-contract/test_parallel_contract.wasm",
 ]
 
 [tasks.build-backup-cli]

--- a/clippy.toml
+++ b/clippy.toml
@@ -2,12 +2,15 @@ disallowed-types = [
     { path = "near_crypto::ED25519PublicKey", reason = "Use `near_sdk::PublicKey` instead for types that directly interact with the MPC contract. For more context see https://github.com/near/mpc/issues/880" },
     { path = "near_crypto::Secp256K1PublicKey", reason = "Use `near_sdk::PublicKey` instead for types that directly interact with the MPC contract. For more context see https://github.com/near/mpc/issues/880" },
     { path = "near_crypto::PublicKey", reason = "Use `near_sdk::PublicKey` instead for types that directly interact with the MPC contract. For more context see https://github.com/near/mpc/issues/880" },
-    { path = "near_crypto::PrivateKey", reason = "Use the crates `secp256k1` or `ed25519_dalek` instead for private keys. This type provides no functionality benefit for the MPC project. For more context see https://github.com/near/mpc/issues/880" },
+    { path = "near_crypto::SecretKey", reason = "Use the crates `secp256k1` or `ed25519_dalek` instead for private keys. This type provides no functionality benefit for the MPC project. For more context see https://github.com/near/mpc/issues/880" },
 ]
 
 disallowed-methods = [
-    { path = "near_crypto::ED25519PublicKey", reason = "Use `near_sdk::PublicKey` instead for types that directly interact with the MPC contract. For more context see https://github.com/near/mpc/issues/880" },
-    { path = "near_crypto::Secp256K1PublicKey", reason = "Use `near_sdk::PublicKey` instead for types that directly interact with the MPC contract. For more context see https://github.com/near/mpc/issues/880" },
+    # The two tuple-struct entries below ban constructor calls (e.g. `ED25519PublicKey(bytes)`).
+    # `allow-invalid = true` silences clippy's config-time warning that the path resolves to a
+    # struct rather than a function — the lint still fires correctly at constructor call sites.
+    { path = "near_crypto::ED25519PublicKey", reason = "Use `near_sdk::PublicKey` instead for types that directly interact with the MPC contract. For more context see https://github.com/near/mpc/issues/880", allow-invalid = true },
+    { path = "near_crypto::Secp256K1PublicKey", reason = "Use `near_sdk::PublicKey` instead for types that directly interact with the MPC contract. For more context see https://github.com/near/mpc/issues/880", allow-invalid = true },
     { path = "near_o11y::testonly::init_integration_logger", reason = "we are in the process of removing nearcore dependencies. Use the `#[test_log::test]` macro instead" },
     { path = "near_o11y::metrics::try_create_histogram", reason = "we are in the process of removing nearcore dependencies. Use the prometheus crate directly instead with `prometheus::register_histogram!` macro" },
 ]

--- a/crates/chain-gateway/src/primitives.rs
+++ b/crates/chain-gateway/src/primitives.rs
@@ -25,7 +25,7 @@ pub(crate) trait IsSyncing: Send + Sync + 'static {
                 match self.is_syncing().await {
                     Ok(false) => return,
                     Ok(true) => {
-                        if attempt % 120 == 0 {
+                        if attempt.is_multiple_of(120) {
                             tracing::info!("has been syncing for: {} seconds", attempt / 2);
                         }
                         attempt += 1;

--- a/crates/contract/src/primitives/votes.rs
+++ b/crates/contract/src/primitives/votes.rs
@@ -199,6 +199,10 @@ mod tests {
 
     #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, BorshDeserialize, BorshSerialize)]
     struct TestVoter(String);
+    #[expect(
+        dead_code,
+        reason = "constructed in tests via Borsh deserialization, which the dead-code analyzer doesn't see."
+    )]
     #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, BorshDeserialize, BorshSerialize)]
     struct TestProposal(String);
 

--- a/crates/contract/tests/abi.rs
+++ b/crates/contract/tests/abi.rs
@@ -10,6 +10,11 @@ fn compile_project() -> (Vec<u8>, serde_json::Value) {
         out_dir: Some(to_utf8(out_dir.clone())),
         features: Some("abi".to_string()),
         profile: Some("release-contract".to_string()),
+        // See `test_utils::contract_build` for the rationale; cargo-near's
+        // rustc >= 1.87 refusal is obsolete and the field-based bypass
+        // doesn't reach the `cargo-near` subprocess, so we inject the flag
+        // via the command prefix.
+        cli_description: test_utils::contract_build::skip_rust_version_check_cli_description(),
         ..Default::default()
     };
 
@@ -47,6 +52,7 @@ fn test_abi_has_not_changed() {
     insta::assert_json_snapshot!(abi,
         {
         ".metadata.wasm_hash" => "[WASM_HASH]",
-        ".metadata.build.builder" => "[CARGO_NEAR_BUILD_VERSION]"
+        ".metadata.build.builder" => "[CARGO_NEAR_BUILD_VERSION]",
+        ".metadata.build.compiler" => "[RUSTC_VERSION]"
     });
 }

--- a/crates/contract/tests/inprocess/attestation_submission.rs
+++ b/crates/contract/tests/inprocess/attestation_submission.rs
@@ -366,7 +366,6 @@ fn clean_tee_status__should_not_touch_attestations() {
         .participants_list
         .iter()
         .take(PARTICIPANT_COUNT)
-        .cloned()
         .map(|(account_id, _, participant_info)| NodeId {
             account_id: account_id.clone(),
             tls_public_key: participant_info.tls_public_key.clone(),

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -8,7 +8,7 @@ expression: abi
     "name": "mpc-contract",
     "version": "3.10.0",
     "build": {
-      "compiler": "rustc 1.86.0",
+      "compiler": "[RUSTC_VERSION]",
       "builder": "[CARGO_NEAR_BUILD_VERSION]"
     },
     "wasm_hash": "[WASM_HASH]"

--- a/crates/contract/tests/test.rs
+++ b/crates/contract/tests/test.rs
@@ -1,6 +1,2 @@
-#![expect(
-    clippy::mod_module_files,
-    reason = "each file in /tests is compiled as a separate crate, thus mod.rs files are needed for common helper crate"
-)]
 pub mod inprocess;
 pub mod sandbox;

--- a/crates/devnet/src/account.rs
+++ b/crates/devnet/src/account.rs
@@ -12,6 +12,10 @@
 //! because we need a mutable reference to it to add access keys to our local state. On the other
 //! hand, sending an arbitrary transfer of NEAR tokens is in OperatingAccessKey, since no local
 //! state needs changing (other than updating the nonce, which is per access key).
+#![expect(
+    clippy::disallowed_types,
+    reason = "devnet tooling uses `near_crypto::SecretKey` to build signed transactions via the legacy `near_jsonrpc_client` API."
+)]
 use crate::contracts::ActionCall;
 use crate::queries;
 use crate::rpc::NearRpcClients;
@@ -596,7 +600,7 @@ impl OperatingAccounts {
 
     /// Get the balance of a single account.
     pub async fn get_account_balance(&self, account_id: &AccountId) -> u128 {
-        self.get_account_balances(&[account_id.clone()])
+        self.get_account_balances(std::slice::from_ref(account_id))
             .await
             .remove(account_id)
             .unwrap()

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -1291,7 +1291,7 @@ async fn create_user_accounts(
         let key = generate_deterministic_key(200 + i);
         let account: AccountId = format!("user{i}.{SANDBOX_ROOT_ACCOUNT}").parse()?;
         blockchain
-            .create_account_with_keys(account.as_ref(), 100, &[key.clone()])
+            .create_account_with_keys(account.as_ref(), 100, std::slice::from_ref(&key))
             .await?;
         map.insert(account, key);
     }

--- a/crates/near-mpc-bounded-collections/src/bounded_vec.rs
+++ b/crates/near-mpc-bounded-collections/src/bounded_vec.rs
@@ -223,12 +223,12 @@ impl<T, const L: usize, const U: usize, W> BoundedVec<T, L, U, W> {
     }
 
     /// Returns an iterator
-    pub fn iter(&self) -> Iter<T> {
+    pub fn iter(&self) -> Iter<'_, T> {
         self.inner.iter()
     }
 
     /// Returns an iterator that allows to modify each value
-    pub fn iter_mut(&mut self) -> IterMut<T> {
+    pub fn iter_mut(&mut self) -> IterMut<'_, T> {
         self.inner.iter_mut()
     }
 }
@@ -687,11 +687,11 @@ mod serde_impl {
                 generator: &mut schemars::r#gen::SchemaGenerator,
             ) -> schemars::schema::Schema {
                 let mut schema = <Vec<T>>::json_schema(generator);
-                if let schemars::schema::Schema::Object(ref mut obj) = schema {
-                    if let Some(ref mut array) = obj.array {
-                        array.min_items = u32::try_from(L).ok();
-                        array.max_items = u32::try_from(U).ok();
-                    }
+                if let schemars::schema::Schema::Object(ref mut obj) = schema
+                    && let Some(ref mut array) = obj.array
+                {
+                    array.min_items = u32::try_from(L).ok();
+                    array.max_items = u32::try_from(U).ok();
                 }
                 schema
             }

--- a/crates/near-mpc-bounded-collections/src/btreemap.rs
+++ b/crates/near-mpc-bounded-collections/src/btreemap.rs
@@ -144,10 +144,10 @@ impl<K: Ord + schemars::JsonSchema, V: schemars::JsonSchema> schemars::JsonSchem
     fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         // Reuse BTreeMap's schema with minProperties: 1
         let mut schema = <BTreeMap<K, V>>::json_schema(generator);
-        if let schemars::schema::Schema::Object(ref mut obj) = schema {
-            if let Some(ref mut object) = obj.object {
-                object.min_properties = Some(1);
-            }
+        if let schemars::schema::Schema::Object(ref mut obj) = schema
+            && let Some(ref mut object) = obj.object
+        {
+            object.min_properties = Some(1);
         }
         schema
     }

--- a/crates/near-mpc-bounded-collections/src/btreeset.rs
+++ b/crates/near-mpc-bounded-collections/src/btreeset.rs
@@ -116,10 +116,10 @@ impl<T: Ord + schemars::JsonSchema> schemars::JsonSchema for NonEmptyBTreeSet<T>
     fn json_schema(generator: &mut schemars::r#gen::SchemaGenerator) -> schemars::schema::Schema {
         // Reuse BTreeSet's schema with minItems: 1
         let mut schema = <BTreeSet<T>>::json_schema(generator);
-        if let schemars::schema::Schema::Object(ref mut obj) = schema {
-            if let Some(ref mut array) = obj.array {
-                array.min_items = Some(1);
-            }
+        if let schemars::schema::Schema::Object(ref mut obj) = schema
+            && let Some(ref mut array) = obj.array
+        {
+            array.min_items = Some(1);
         }
         schema
     }

--- a/crates/node/src/db.rs
+++ b/crates/node/src/db.rs
@@ -104,7 +104,7 @@ impl SecretDB {
         Ok(Self { db, cipher }.into())
     }
 
-    fn cf_handle(&self, cf: DBCol) -> rocksdb::ColumnFamilyRef {
+    fn cf_handle(&self, cf: DBCol) -> rocksdb::ColumnFamilyRef<'_> {
         self.db.cf_handle(cf.as_str()).unwrap()
     }
 

--- a/crates/node/src/indexer/stats.rs
+++ b/crates/node/src/indexer/stats.rs
@@ -40,11 +40,9 @@ pub(crate) async fn indexer_logger(indexer_state: Arc<IndexerState>) {
                 .await
                 .map(|block| block.header.height)
             {
-                let blocks_behind = if block_height > stats_copy.last_processed_block_height {
-                    block_height - stats_copy.last_processed_block_height
-                } else {
-                    0 // We're ahead of the chain tip, no catching up needed
-                };
+                // 0 when we're ahead of the chain tip — no catching up needed.
+                let blocks_behind =
+                    block_height.saturating_sub(stats_copy.last_processed_block_height);
 
                 Some(std::time::Duration::from_millis(
                     ((blocks_behind as f64 / block_processing_speed) * 1000f64) as u64,

--- a/crates/node/src/indexer/types.rs
+++ b/crates/node/src/indexer/types.rs
@@ -28,16 +28,6 @@ use near_mpc_contract_interface::method_names::REGISTER_FOREIGN_CHAIN_CONFIG;
 
 const MAX_GAS: Gas = Gas::from_teragas(300);
 
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
-pub struct SerializableScalar {
-    pub scalar: Scalar,
-}
-
-#[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Clone, Copy)]
-struct SerializableAffinePoint {
-    pub affine_point: AffinePoint,
-}
-
 /* The format in which the chain signatures contract expects
  * to receive the details of the original request. `epsilon`
  * is used to refer to the (serializable) tweak derived from the caller's

--- a/crates/node/src/keyshare.rs
+++ b/crates/node/src/keyshare.rs
@@ -510,6 +510,10 @@ pub async fn generate_key_storage() -> (KeyshareStorage, tempfile::TempDir) {
 }
 
 #[cfg(test)]
+#[expect(
+    clippy::cloned_ref_to_slice_refs,
+    reason = "tests build single-element keyshare slices; clarity beats `slice::from_ref` here."
+)]
 pub mod tests {
     use mpc_primitives::domain::DomainId;
     use mpc_primitives::{AttemptId, EpochId, KeyEventId};

--- a/crates/node/src/tee/allowed_image_hashes_watcher.rs
+++ b/crates/node/src/tee/allowed_image_hashes_watcher.rs
@@ -52,13 +52,12 @@ impl AllowedImageHashesStorage for AllowedImageHashesFile {
 
             tokio::task::spawn_blocking(move || {
                 let file = std::fs::File::create(&tmp_path)?;
-                serde_json::to_writer_pretty(&file, &approved_hashes)
-                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                serde_json::to_writer_pretty(&file, &approved_hashes).map_err(io::Error::other)?;
 
                 file.sync_all()
             })
             .await
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, "writing to disk task failed"))??;
+            .map_err(|_| io::Error::other("writing to disk task failed"))??;
         }
         // Atomic replace: POSIX rename() ensures that either the old file or the new file exists.
         // The final file is never left in a partially-written state.
@@ -193,7 +192,7 @@ mod tests {
     use assert_matches::assert_matches;
     use mockall::predicate;
     use rstest::rstest;
-    use std::{io::ErrorKind, sync::Arc, time::Duration};
+    use std::{sync::Arc, time::Duration};
     use tokio::sync::{mpsc::error::TryRecvError, Notify};
     use tokio_util::time::FutureExt;
 
@@ -279,9 +278,9 @@ mod tests {
     ) {
         let mut mock = MockAllowedImageHashesStorage::new();
 
-        mock.expect_set().once().returning(|_| {
-            Box::pin(async { Err(io::Error::new(ErrorKind::Other, "Expected test error.")) })
-        });
+        mock.expect_set()
+            .once()
+            .returning(|_| Box::pin(async { Err(io::Error::other("Expected test error.")) }));
 
         let cancellation_token = CancellationToken::new();
         let (_sender, receiver) = watch::channel(allowed_images);

--- a/crates/test-utils/src/contract_build.rs
+++ b/crates/test-utils/src/contract_build.rs
@@ -5,6 +5,24 @@ fn workspace_root() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
 
+/// `CliDescription` whose command prefix passes `--skip-rust-version-check` to the
+/// `cargo-near` subprocess invoked by `build_with_cli`.
+// TODO(#3363): drop this helper and the `cli_description` override once
+// cargo-near-build ships near/cargo-near#420, then set
+// `BuildOpts::skip_rust_version_check: true` instead.
+pub fn skip_rust_version_check_cli_description() -> cargo_near_build::CliDescription {
+    cargo_near_build::CliDescription {
+        cli_name_abi: "cargo-near".into(),
+        cli_command_prefix: vec![
+            "cargo".into(),
+            "near".into(),
+            "build".into(),
+            "non-reproducible-wasm".into(),
+            "--skip-rust-version-check".into(),
+        ],
+    }
+}
+
 /// Builds a contract and returns the path to the compiled WASM artifact.
 ///
 /// Uses `cargo near build non-reproducible-wasm` under the hood. The caller
@@ -86,6 +104,16 @@ impl ContractBuilder {
             } else {
                 Some(self.features.join(","))
             },
+            // Bypass cargo-near's rustc >= 1.87 refusal: the historical bulk-memory
+            // incompatibility with the nearcore contract VM has been resolved
+            // upstream, so the check is now obsolete and would otherwise block
+            // contract builds with the workspace's current toolchain.
+            //
+            // `BuildOpts::skip_rust_version_check` is honored only by the
+            // in-process build path; `build_with_cli` invokes a separate
+            // `cargo-near` process whose CLI doesn't read that field. We inject
+            // `--skip-rust-version-check` into the prefix so the subprocess sees it.
+            cli_description: skip_rust_version_check_cli_description(),
             ..Default::default()
         };
 

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,4 +6,4 @@ pub mod contract_types;
 /// Single source of truth shared by the e2e-tests crate and the contract test crates.
 /// `scripts/check-sandbox-image-version.sh` enforces that this stays in lockstep with
 /// the workspace's nearcore tag.
-pub const DEFAULT_SANDBOX_VERSION: &str = "2.11.1";
+pub const DEFAULT_SANDBOX_VERSION: &str = "2.12.0-rc.1";

--- a/crates/threshold-signatures/src/confidential_key_derivation/scalar_wrapper.rs
+++ b/crates/threshold-signatures/src/confidential_key_derivation/scalar_wrapper.rs
@@ -18,6 +18,12 @@ impl Zeroize for ScalarWrapper {
     /// See <https://docs.rs/zeroize/latest/zeroize/#what-guarantees-does-this-crate-provide>
     /// for more details
     /// TODO(#238): push this feature upstream
+    // Clippy 1.93's `volatile_composites` / `borrow_as_ptr` lints flag the
+    // composite `write_volatile` and the implicit borrow respectively. The
+    // existing approach is a known best-effort pattern (see issue #238)
+    // pending an upstream fix in `zeroize`; don't change the zeroization
+    // behavior in a routine version bump.
+    #[allow(clippy::volatile_composites, clippy::borrow_as_ptr)]
     fn zeroize(&mut self) {
         unsafe {
             ptr::write_volatile(&mut self.0, blstrs::Scalar::default());

--- a/crates/threshold-signatures/src/crypto/polynomials.rs
+++ b/crates/threshold-signatures/src/crypto/polynomials.rs
@@ -175,7 +175,7 @@ where
         // Batch invert points_set to get 1 / x_i
         let inv_xis = batch_invert::<C>(points_set)?;
         // Return the proper numerator based on the number of elements
-        (if n % 2 == 0 { minus_p } else { p }, inv_xis)
+        (if n.is_multiple_of(2) { minus_p } else { p }, inv_xis)
     } else {
         // General case: x != 0
         let mut full_numerator = <C::Group as Group>::Field::one();

--- a/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/triples/bits.rs
+++ b/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/triples/bits.rs
@@ -234,7 +234,7 @@ impl BitMatrix {
     ///
     /// Each chunk will have a security parameter's worth of rows.
     pub fn random(rng: &mut impl CryptoRngCore, height: usize) -> Result<Self, ProtocolError> {
-        if height % SECURITY_PARAMETER != 0 {
+        if !height.is_multiple_of(SECURITY_PARAMETER) {
             return Err(ProtocolError::InvalidInput(format!(
                 "height {height} must be a multiple of SECURITY_PARAMETER ({SECURITY_PARAMETER})"
             )));
@@ -329,7 +329,7 @@ impl SquareBitMatrix {
     /// Expand transpose expands each row to contain `chunks * SECURITY_PARAMETER` bits, and then transposes
     /// the resulting matrix.
     pub fn expand_transpose(&self, sid: &[u8], rows: usize) -> Result<BitMatrix, ProtocolError> {
-        if rows % SECURITY_PARAMETER != 0 {
+        if !rows.is_multiple_of(SECURITY_PARAMETER) {
             return Err(ProtocolError::InvalidInput(format!(
                 "rows {rows} must be a multiple of SECURITY_PARAMETER ({SECURITY_PARAMETER})"
             )));
@@ -382,7 +382,7 @@ impl_secret_debug!(ChoiceVector);
 impl ChoiceVector {
     /// Generate a random vector with a certain number of bits.
     pub fn random(rng: &mut impl CryptoRngCore, size: usize) -> Result<Self, ProtocolError> {
-        if size == 0 || size % SECURITY_PARAMETER != 0 {
+        if size == 0 || !size.is_multiple_of(SECURITY_PARAMETER) {
             return Err(ProtocolError::InvalidInput(format!(
                 "size {size} must be a positive multiple of SECURITY_PARAMETER ({SECURITY_PARAMETER})"
             )));

--- a/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/triples/generation.rs
+++ b/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/triples/generation.rs
@@ -56,6 +56,8 @@ pub type TripleGenerationOutput = (TripleShare, TriplePub);
 pub type TripleGenerationOutputMany = Vec<(TripleShare, TriplePub)>;
 type C = Secp256K1Sha256;
 
+#[allow(dead_code)]
+// superseded by `PolynomialCommitmentsMessageMany`; kept as the single-instance wire-format reference.
 #[derive(Serialize, Deserialize)]
 struct PolynomialCommitmentsMessage {
     big_e: PolynomialCommitment,
@@ -869,7 +871,7 @@ mod test {
         let triple_pub = result[2].1 .1.clone();
 
         let participants = vec![result[0].0, result[1].0, result[2].0];
-        let triple_shares = vec![
+        let triple_shares = [
             result[0].1 .0.clone(),
             result[1].1 .0.clone(),
             result[2].1 .0.clone(),
@@ -923,7 +925,7 @@ mod test {
         let triple_pub = result[2].1[0].1.clone();
 
         let participants = vec![result[0].0, result[1].0, result[2].0];
-        let triple_shares = vec![
+        let triple_shares = [
             result[0].1[0].0.clone(),
             result[1].1[0].0.clone(),
             result[2].1[0].0.clone(),

--- a/crates/threshold-signatures/src/ecdsa/robust_ecdsa/test.rs
+++ b/crates/threshold-signatures/src/ecdsa/robust_ecdsa/test.rs
@@ -363,7 +363,7 @@ fn test_e2e_random_identifiers_with_rerandomization() -> Result<(), Box<dyn Erro
 }
 
 #[test]
-#[ignore] // this test is ignored because our scheme is not yet robust due to split-view attacks
+#[ignore = "scheme is not yet robust due to split-view attacks"]
 fn test_robustness_without_rerandomization() {
     let mut rng = MockCryptoRng::seed_from_u64(42);
     // Without robustness, the signature verification would fail
@@ -372,7 +372,7 @@ fn test_robustness_without_rerandomization() {
 }
 
 #[test]
-#[ignore] // this test is ignored because our scheme is not yet robust due to split-view attacks
+#[ignore = "scheme is not yet robust due to split-view attacks"]
 fn test_robustness_with_rerandomization() {
     let mut rng = MockCryptoRng::seed_from_u64(42);
     // Without robustness, the signature verification would fail

--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767926800,
-        "narHash": "sha256-x0n73J6ufD/EhDlVdcoAmF0OQHZ+b0a2cKDc8RZyt+o=",
+        "lastModified": 1779333539,
+        "narHash": "sha256-lpmN2lrBDZDPjov2cbD3bOOJsI0fkKolKXasYPCqSys=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "499e9eed88ff9494b6604205b42847e847dfeb91",
+        "rev": "672fa5fc5608d5cd82286a6f69aaf84a40b4fe41",
         "type": "github"
       },
       "original": {

--- a/nix/cargo-near.nix
+++ b/nix/cargo-near.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-near";
-  version = "0.19.1";
+  version = "0.20.1";
 
   src = fetchFromGitHub {
     owner = "near";
     repo = "cargo-near";
     rev = "cargo-near-v${version}";
-    hash = "sha256-D+z2zKE2Vbzj3A6KuR8FGwY2KqRZJJpIeD1GZEZGmeY=";
+    hash = "sha256-f/XgtrYnr9ISvdHXRduUmzyO8QG5ZWFNBBcldNrAUIc=";
   };
 
-  cargoHash = "sha256-m1EloFOJDDkK35V4tAmhtkVexO2J8dnYmah2DjOE4DQ=";
+  cargoHash = "sha256-5fiWcjxoxJZ5ZSrWy6K30JmDR8MpIK1j3FZTXKSzpjs=";
 
   nativeBuildInputs = [
     pkg-config

--- a/nix/mpc-contract.nix
+++ b/nix/mpc-contract.nix
@@ -64,8 +64,16 @@ let
   # The Nix sandbox provides the hermetic environment (toolchain, vendored
   # registry, fixed SOURCE_DATE_EPOCH), and cargo-near drives the build —
   # `non-reproducible-wasm` inside a hermetic environment becomes reproducible.
+  # Bypass cargo-near's rustc >= 1.87 refusal: the bulk-memory
+  # incompatibility with the nearcore contract VM it guards against has been
+  # resolved upstream, so the check is now obsolete and would otherwise block
+  # the build with the workspace's current toolchain. Mirrors the matching
+  # workaround in crates/test-utils/src/contract_build.rs.
+  # TODO(#3363): drop `--skip-rust-version-check` once cargo-near removes the
+  # obsolete check.
   cargoNearArgs = [
     "non-reproducible-wasm"
+    "--skip-rust-version-check"
     "--locked"
     "--profile=release-contract"
     "--features"

--- a/nix/mpc-node.nix
+++ b/nix/mpc-node.nix
@@ -71,15 +71,11 @@ let
   };
 
   # Vendor the cargo lockfile via nixpkgs' importCargoLock instead of crane's
-  # default `cargo package`-based vendoring. Two reasons:
-  #
-  #   1. `cargo package --exclude-lockfile` (used by recent crane) requires
-  #      cargo >= 1.88, but rust-toolchain.toml pins 1.86.0.
-  #   2. `cargo package` only ships files inside a crate's own directory.
-  #      Some git deps (e.g. nearcore's `near-jsonrpc`) pull files from
-  #      sibling directories via `include_bytes!("../../../...")`; those get
-  #      stripped by cargo's packaging rules. `fetchgit` copies the entire
-  #      git checkout, preserving siblings.
+  # default `cargo package`-based vendoring. Reason: `cargo package` only ships
+  # files inside a crate's own directory. Some git deps (e.g. nearcore's
+  # `near-jsonrpc`) pull files from sibling directories via
+  # `include_bytes!("../../../...")`; those get stripped by cargo's packaging
+  # rules. `fetchgit` copies the entire git checkout, preserving siblings.
   #
   # `allowBuiltinFetchGit = true` uses `builtins.fetchGit`, which is
   # reproducible: the revision fully determines content, no `sha256` needed.
@@ -103,7 +99,7 @@ let
   #
   #   $out/                           ← cargoVendorDir (3 ups from src/lib.rs)
   #   ├── vendor/                     ← config.toml's `directory = "..."`
-  #   │   ├── near-jsonrpc-2.11.1 ──┐ relative symlink (stays inside $out)
+  #   │   ├── near-jsonrpc-X.Y.Z  ──┐ relative symlink (stays inside $out)
   #   │   └── (other crates as symlinks into importedVendorDir)
   #   ├── chain/jsonrpc/  ←──────────┘ real copy of the near-jsonrpc tree
   #   │   ├── src/lib.rs

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # This needs to be at least as high as the nearcore's toolchain version.
-channel = "1.86.0"
+channel = "1.93.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
Closes #3282 and #972
