### PR TITLE
chore(tee/localnet): unify port_override with cvm-deployment + add migration smoke test (#3238)

### DIFF
--- a/localnet/tee/scripts/rust-launcher/README.md
+++ b/localnet/tee/scripts/rust-launcher/README.md
@@ -20,6 +20,8 @@ Scripts for deploying and testing MPC nodes with the launcher on localnet (TDX C
 | `node.conf.localnet.toml.tpl` / `node.conf.testnet.toml.tpl` | TOML config templates rendered by the deploy scripts via `envsubst` (one per `MODE`). |
 | `test-verify-and-upgrade.sh` | Cluster verification and rolling upgrade test (localnet). |
 | `test-hash-override.sh` | Test `mpc_hash_override` TOML config parameter (positive and negative cases). |
+| `test-migration.sh` | End-to-end `backup-cli` node-migration test (A→B forward, B→A back) on real-TDX localnet. Brings up a third CVM that shares the source's NEAR account but has its own P2P key; drives the migration handshake in both directions with ECDSA sign verification each direction. |
+| `common.sh` | **Sourced, not executed.** Shared helpers used by the test scripts: coloured logging (`log`/`warn`/`err`/`pass`/`fatal`), `HOST_PROFILE` → IP layout (alice / bob), `ip_for_i`, `ports_to_toml`, `$CLI` for the dstack vmm-cli, and `near_call_ro`/`near_call_tx` + `extract_json_ro`/`extract_json_tx` wrappers. |
 | `create-and-sweep-to-treasury.sh` | **(testnet only)** Faucet a fresh account and sweep it to a treasury. Useful before a `MODE=testnet` deploy when your `FUNDER_ACCOUNT` is short on NEAR (faucet caps at ~10 NEAR per account). |
 
 ## Quick Start
@@ -55,6 +57,9 @@ bash localnet/tee/scripts/rust-launcher/test-hash-override.sh override <64-hex-h
 
 # Test override rejection (unapproved hash — launcher should exit with error)
 bash localnet/tee/scripts/rust-launcher/test-hash-override.sh override-reject
+
+# End-to-end backup-cli migration (A → B forward, B → A back, with ECDSA sign each direction)
+bash localnet/tee/scripts/rust-launcher/test-migration.sh both
 ```
 
 ## Collecting Test Assets

--- a/localnet/tee/scripts/rust-launcher/common.sh
+++ b/localnet/tee/scripts/rust-launcher/common.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Shared helpers for localnet/tee/scripts/rust-launcher/ scripts.
+# =============================================================================
+#
+# Source this from a script as:
+#
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/common.sh"
+#
+# This file is NOT meant to be executed directly. It defines:
+#
+#   - Coloured logging: log / warn / err / pass / fatal
+#   - HOST_PROFILE → IP_PREFIX / IP_START_OCTET (alice + bob)
+#   - ip_for_i              — per-index CVM IP
+#   - ports_to_toml         — convert "host:container,…" to launcher TOML rows
+#   - $CLI                  — wrapper for the dstack vmm-cli (requires BASE_PATH)
+#   - near_call_ro / _tx    — concise wrappers around `near contract call-function`
+#   - extract_json_ro / _tx — strip ANSI banners from near CLI output
+#
+# Callers are expected to have already set BASE_PATH, VMM_RPC,
+# MPC_CONTRACT_ACCOUNT, and NEAR_NETWORK_CONFIG before invoking the
+# near_call_* or $CLI plumbing. The HOST_PROFILE block runs at source-time
+# and exits the caller with an error on an unknown profile.
+# =============================================================================
+
+# Refuse to be executed (only sourced).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  echo "common.sh is meant to be sourced, not executed." >&2
+  exit 1
+fi
+
+# ---- Logging --------------------------------------------------------------
+# Errors go to stderr so they don't mix with stdout JSON captures.
+log()   { echo -e "\033[1;34m[INFO]\033[0m $*"; }
+warn()  { echo -e "\033[1;33m[WARN]\033[0m $*"; }
+err()   { echo -e "\033[1;31m[ERROR]\033[0m $*" >&2; }
+pass()  { echo -e "\033[1;32m[PASS]\033[0m $*"; }
+fatal() { err "$*"; exit 1; }
+
+# ---- Host profile → IP layout --------------------------------------------
+# Sets IP_PREFIX and IP_START_OCTET. Bob's numbers match
+# deploy-tee-cluster.sh's canonical values (5.196.36.<113+i>); the older
+# test scripts used to disagree on bob, which is why this lives here now.
+HOST_PROFILE="${HOST_PROFILE:-alice}"
+case "$HOST_PROFILE" in
+  alice) IP_PREFIX="51.68.219."; IP_START_OCTET=1   ;;
+  bob)   IP_PREFIX="5.196.36." ; IP_START_OCTET=113 ;;
+  *)
+    echo "[ERROR] Unknown HOST_PROFILE=$HOST_PROFILE (supported: alice | bob)" >&2
+    exit 1
+    ;;
+esac
+
+# ---- Per-index IP helper -------------------------------------------------
+ip_for_i() { echo "${IP_PREFIX}$((IP_START_OCTET + $1))"; }
+
+# ---- ports_to_toml -------------------------------------------------------
+# Convert a "host:container[,host:container]*" string into launcher TOML
+# `port_mappings` rows. "host" in this TOML means the CVM-side port (the
+# launcher's POV inside the CVM), NOT the QEMU host port — that mapping is
+# done separately by deploy-launcher.sh's `--port` args.
+ports_to_toml() {
+  local ports="$1" result=""
+  IFS=',' read -ra pairs <<< "$ports"
+  for pair in "${pairs[@]}"; do
+    local host_port="${pair%%:*}"
+    local container_port="${pair##*:}"
+    result+="    { host =$host_port, container =$container_port },
+"
+  done
+  echo -n "$result"
+}
+
+# ---- dstack vmm-cli wrapper ----------------------------------------------
+# Constructed lazily so callers that don't need vmm-cli can skip BASE_PATH.
+if [ -n "${BASE_PATH:-}" ]; then
+  CLI="python3 $BASE_PATH/vmm/src/vmm-cli.py --url ${VMM_RPC:-http://127.0.0.1:10000}"
+fi
+
+# ---- NEAR CLI wrappers ---------------------------------------------------
+# Require MPC_CONTRACT_ACCOUNT and NEAR_NETWORK_CONFIG in the calling env.
+# Output goes to stdout+stderr merged so callers can grep it; pair with
+# extract_json_* below when only the JSON return value is wanted.
+near_call_ro() {
+  local method="$1" args="$2"
+  near contract call-function as-read-only "$MPC_CONTRACT_ACCOUNT" "$method" \
+    json-args "$args" network-config "$NEAR_NETWORK_CONFIG" now 2>&1
+}
+near_call_tx() {
+  local method="$1" args="$2" signer="$3"
+  near contract call-function as-transaction "$MPC_CONTRACT_ACCOUNT" "$method" \
+    json-args "$args" prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' \
+    sign-as "$signer" network-config "$NEAR_NETWORK_CONFIG" sign-with-keychain send 2>&1
+}
+
+# ---- JSON extraction from `near contract call-function` output -----------
+# `near` writes JSON return values to stdout and ANSI banners to stderr; the
+# `2>&1` in the wrappers above means both end up in the same stream, so we
+# need to strip the banner lines to get parseable JSON.
+extract_json_tx() {
+  sed -n '/^Function execution return value/,/^$/{ /^Function/d; /^$/d; p }' \
+    | sed '/^Here is your console/,$d' \
+    | sed 's/^│[[:space:]]*//' \
+    | sed '/^$/d'
+}
+extract_json_ro() {
+  sed -n '/^Function execution return value/,/^Here is your console/{
+    /^Function/d
+    /^Here is your console/d
+    p
+  }'
+}

--- a/localnet/tee/scripts/rust-launcher/common.sh
+++ b/localnet/tee/scripts/rust-launcher/common.sh
@@ -73,7 +73,11 @@ ports_to_toml() {
 }
 
 # ---- dstack vmm-cli wrapper ----------------------------------------------
-# Constructed lazily so callers that don't need vmm-cli can skip BASE_PATH.
+# $CLI is resolved at source-time, so callers that intend to use it MUST set
+# BASE_PATH (and optionally VMM_RPC) BEFORE sourcing common.sh. Callers that
+# don't need vmm-cli (e.g. single-node.sh, which uses inline python3
+# invocations) can source common.sh before BASE_PATH is set — $CLI just
+# stays unset, and any later use will trip `set -u` with a clear message.
 if [ -n "${BASE_PATH:-}" ]; then
   CLI="python3 $BASE_PATH/vmm/src/vmm-cli.py --url ${VMM_RPC:-http://127.0.0.1:10000}"
 fi

--- a/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
@@ -156,20 +156,16 @@ LOCAL_DEBUG_BASE=3031
 
 STATE_SYNC_PORT=24567
 MAIN_PORT=80
-# Per-node base port. In cvm-deployment (testnet/mainnet) the same
-# EXTERNAL_MPC_MIGRATION_PORT slot carries the migration HTTP endpoint on
-# :8079; here in the localnet rust-launcher path it is repurposed as the
-# per-node TLS/P2P forward — the contract's participant URLs point to
-# https://<ip>:$(migration_port_for_i $i), so the MPC node's TLS listener
-# binds on this port (not on $MAIN_PORT=80).
-MIGRATION_BASE_PORT="${MIGRATION_BASE_PORT:-13001}"
-migration_port_for_i() { echo $((MIGRATION_BASE_PORT + $1)); }
+# Migration HTTP endpoint that backup-cli connects to for get/put-keyshares.
+# Container-side this matches `migration_web_ui` in node.conf.*.toml.tpl.
+# Uniform across all CVMs — per-IP isolation keeps them from colliding.
+MIGRATION_PORT=8079
 
 INTERNAL_PUBLIC_DEBUG_PORT=8080
 INTERNAL_LOCAL_DEBUG_PORT=3030
 INTERNAL_STATE_SYNC_PORT=24567
 INTERNAL_MAIN_PORT=80
-INTERNAL_MIGRATION_PORT=13001
+INTERNAL_MIGRATION_PORT=8079
 
 OS_IMAGE="${OS_IMAGE:-dstack-dev-0.5.8}"
 SEALING_KEY_TYPE="${SEALING_KEY_TYPE:-SGX}"
@@ -731,7 +727,7 @@ preflight() {
   }
 
   log "Using IP range: ${IP_PREFIX}${IP_START_OCTET} .. ${IP_PREFIX}$((IP_START_OCTET + N - 1))"
-  log "Ports per node: main=$MAIN_PORT migration_base=$MIGRATION_BASE_PORT (per-node) state_sync=$STATE_SYNC_PORT public_data_base=$PUBLIC_DATA_BASE"
+  log "Ports per node: main=$MAIN_PORT migration=$MIGRATION_PORT state_sync=$STATE_SYNC_PORT public_data_base=$PUBLIC_DATA_BASE"
   log "Localhost per node: ssh_base=$SSH_BASE agent_base=$AGENT_BASE local_debug_base=$LOCAL_DEBUG_BASE"
 
   local any_fail=0
@@ -752,9 +748,8 @@ preflight() {
     p_ssh="$(ssh_port_for_i "$i")"
     p_agent="$(agent_port_for_i "$i")"
     p_ld="$(local_dbg_port_for_i "$i")"
-    p_migration="$(migration_port_for_i "$i")"
 
-    for port in "$MAIN_PORT" "$STATE_SYNC_PORT" "$p_pub" "$p_migration"; do
+    for port in "$MAIN_PORT" "$STATE_SYNC_PORT" "$p_pub" "$MIGRATION_PORT"; do
       if port_free "$ip" "$port"; then
         echo "  ✅ free $ip:$port"
       else
@@ -834,16 +829,13 @@ render_node_files_range() {
         export TIER3_PUBLIC_ADDR="${ip}:${STATE_SYNC_PORT}"
         export EXTERNAL_STORAGE_FALLBACK_THRESHOLD="${EXTERNAL_STORAGE_FALLBACK_THRESHOLD:-100}"
     fi
-    local migration_port
-    migration_port="$(migration_port_for_i "$i")"
-
-    export EXTERNAL_MPC_MIGRATION_PORT="${ip}:${migration_port}"
+    export EXTERNAL_MPC_MIGRATION_PORT="${ip}:${MIGRATION_PORT}"
 
     export INTERNAL_MPC_PUBLIC_DEBUG_PORT="$INTERNAL_PUBLIC_DEBUG_PORT"
     export INTERNAL_MPC_LOCAL_DEBUG_PORT="$INTERNAL_LOCAL_DEBUG_PORT"
     export INTERNAL_MPC_DECENTRALIZED_STATE_SYNC="$INTERNAL_STATE_SYNC_PORT"
     export INTERNAL_MPC_MAIN_PORT="$INTERNAL_MAIN_PORT"
-    export INTERNAL_MPC_MIGRATION_PORT="${migration_port}"
+    export INTERNAL_MPC_MIGRATION_PORT="$INTERNAL_MIGRATION_PORT"
 
     export MPC_ENV
 
@@ -855,10 +847,13 @@ render_node_files_range() {
       # 24566 forwards the CVM's outbound to the host's localnet neard via the
       # QEMU slirp gateway (10.0.2.2). On testnet we don't run a host neard;
       # the CVM's indexer talks to real testnet peers on 24567 directly.
-      export PORTS="8080:8080,24566:24566,${migration_port}:${migration_port}"
+      # `port_override = 80` in the toml makes the MPC node bind P2P on
+      # container:80 regardless of the contract URL port, so we forward
+      # main(80) here for P2P and 8079 for the migration endpoint.
+      export PORTS="${MAIN_PORT}:${INTERNAL_MAIN_PORT},8080:8080,24566:24566,${MIGRATION_PORT}:${INTERNAL_MIGRATION_PORT}"
       export NEAR_BOOT_NODES="ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
     else
-      export PORTS="8080:8080,${STATE_SYNC_PORT}:${STATE_SYNC_PORT},${migration_port}:${migration_port}"
+      export PORTS="${MAIN_PORT}:${INTERNAL_MAIN_PORT},8080:8080,${STATE_SYNC_PORT}:${STATE_SYNC_PORT},${MIGRATION_PORT}:${INTERNAL_MIGRATION_PORT}"
       export NEAR_BOOT_NODES="$bootnodes"
     fi
     export PORTS_TOML
@@ -1080,13 +1075,15 @@ threshold = int("${threshold}")
 
 parts = []
 for k in keys:
-    url_port = 13001 + int(k["i"])
     parts.append([
         k["account"],
         k["i"],
         {
             "tls_public_key": k["tls_pk"],
-            "url": f"https://{k['ip']}:{url_port}",
+            # P2P/TLS listens on $MAIN_PORT(=80) inside the CVM. The toml
+            # sets `port_override = 80` so the node ignores the URL port
+            # and uses 80; we publish 80 here for clarity.
+            "url": f"https://{k['ip']}:80",
         },
     ])
 
@@ -1407,8 +1404,9 @@ for k in new_keys:
     acct=k["account"]
     ip=k["ip"]
     tls_pk=k["tls_pk"]  # P2P key == tls_public_key
-    url_port = 13001 + int(k["i"])
-    new_parts.append([acct, next_id, {"tls_public_key": tls_pk, "url": f"https://127.0.0.1:{url_port}"}])
+    # `port_override = 80` in the toml makes the node bind P2P on 80
+    # regardless of this URL port; publish 80 explicitly.
+    new_parts.append([acct, next_id, {"tls_public_key": tls_pk, "url": f"https://{ip}:80"}])
     next_id += 1
 
 out={

--- a/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
+++ b/localnet/tee/scripts/rust-launcher/deploy-tee-cluster.sh
@@ -850,10 +850,14 @@ render_node_files_range() {
       # `port_override = 80` in the toml makes the MPC node bind P2P on
       # container:80 regardless of the contract URL port, so we forward
       # main(80) here for P2P and 8079 for the migration endpoint.
-      export PORTS="${MAIN_PORT}:${INTERNAL_MAIN_PORT},8080:8080,24566:24566,${MIGRATION_PORT}:${INTERNAL_MIGRATION_PORT}"
+      # PORTS is CVM-side:container-side (the launcher's port_mappings),
+      # NOT host:CVM — host:CVM forwarding is set up separately via the
+      # EXTERNAL_* env vars in deploy-launcher.sh. Both sides should use
+      # the CVM/container-internal port values.
+      export PORTS="${INTERNAL_MAIN_PORT}:${INTERNAL_MAIN_PORT},8080:8080,24566:24566,${INTERNAL_MIGRATION_PORT}:${INTERNAL_MIGRATION_PORT}"
       export NEAR_BOOT_NODES="ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
     else
-      export PORTS="${MAIN_PORT}:${INTERNAL_MAIN_PORT},8080:8080,${STATE_SYNC_PORT}:${STATE_SYNC_PORT},${MIGRATION_PORT}:${INTERNAL_MIGRATION_PORT}"
+      export PORTS="${INTERNAL_MAIN_PORT}:${INTERNAL_MAIN_PORT},8080:8080,${STATE_SYNC_PORT}:${STATE_SYNC_PORT},${INTERNAL_MIGRATION_PORT}:${INTERNAL_MIGRATION_PORT}"
       export NEAR_BOOT_NODES="$bootnodes"
     fi
     export PORTS_TOML

--- a/localnet/tee/scripts/rust-launcher/how-to-run-deploy-tee-cluster.md
+++ b/localnet/tee/scripts/rust-launcher/how-to-run-deploy-tee-cluster.md
@@ -381,8 +381,12 @@ verification uses the per-step `near` commands above.)
 ## Notes
 
 - All nodes vote for **add-domain**
-- Node-to-node ports are per-node (`13001+i`)
-- Telemetry uses port `18082` with per-node IPs
+- Node-to-node P2P/TLS binds container port `80` on every CVM (the templates
+  set `port_override = 80`, so the MPC node ignores the contract URL port and
+  always uses 80). CVMs are distinguished by IP (`<ip-i>:80`).
+- Migration HTTP (`migration_web_ui`) is uniform at container port `8079`,
+  reachable at `<ip-i>:8079`.
+- Telemetry / `/public_data` / `/debug/*` uses port `18082` with per-node IPs.
 - Script is designed for iterative debugging and safe restarts
 - The launcher uses TOML config
 - MPC node image must support `start-with-config-file` (commit `9515e18` or later)

--- a/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl
@@ -28,7 +28,7 @@ my_near_account_id = "${MPC_ACCOUNT_ID}"
 near_responder_account_id = "${MPC_ACCOUNT_ID}"
 number_of_responder_keys = 1
 web_ui = "0.0.0.0:8080"
-migration_web_ui = "0.0.0.0:8078"
+migration_web_ui = "0.0.0.0:8079"
 cores = 4
 
 [mpc_node_config.node.indexer]
@@ -37,6 +37,11 @@ sync_mode = "Latest"
 concurrency = 1
 mpc_contract_id = "${MPC_CONTRACT_ID}"
 finality = "optimistic"
+# Force the P2P/TLS listener onto port 80 regardless of the port written in
+# the contract participant URL. This matches `deployment/cvm-deployment/`
+# and `deployment/testnet/{frodo,sam}.toml`. With per-CVM IPs, host:<ip>:80
+# is unique per node so there's no collision.
+port_override = 80
 
 [mpc_node_config.node.triple]
 concurrency = 2

--- a/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
+++ b/localnet/tee/scripts/rust-launcher/node.conf.testnet.toml.tpl
@@ -30,7 +30,7 @@ my_near_account_id = "${MPC_ACCOUNT_ID}"
 near_responder_account_id = "${MPC_ACCOUNT_ID}"
 number_of_responder_keys = 1
 web_ui = "0.0.0.0:8080"
-migration_web_ui = "0.0.0.0:8078"
+migration_web_ui = "0.0.0.0:8079"
 cores = 4
 
 [mpc_node_config.node.indexer]
@@ -39,6 +39,9 @@ sync_mode = "Latest"
 concurrency = 1
 mpc_contract_id = "${MPC_CONTRACT_ID}"
 finality = "optimistic"
+# Mirrors production: contract participant URLs may publish any port, but
+# the P2P/TLS listener always binds 80 inside the CVM.
+port_override = 80
 
 [mpc_node_config.node.triple]
 concurrency = 2

--- a/localnet/tee/scripts/rust-launcher/set-localnet-env.sh
+++ b/localnet/tee/scripts/rust-launcher/set-localnet-env.sh
@@ -16,7 +16,7 @@ export MPC_IMAGE=nearone/mpc-node
 # Manifest digest of the MPC node image (filled into the launcher compose
 # template and voted in as the allowed code hash).
 # Get with: docker pull nearone/mpc-node:<tag> 2>&1 | grep Digest
-export MPC_MANIFEST_DIGEST=sha256:eb4e3b75d439b77689534df6a69b542e779989f10b681ac43787a58e7c4aefdb
+export MPC_MANIFEST_DIGEST=sha256:2d399b135910f1c92696c7675d7e95c02e0da3766b39a1943087757e73386a61
 
 # Manifest digest of the launcher image (filled into the launcher compose
 # template and voted in as the allowed launcher hash).
@@ -31,6 +31,12 @@ export FUNDER_ACCOUNT=test.near
 export FUNDER_PRIVATE_KEY="$(jq -r '.secret_key' ~/.near/mpc-localnet/validator_key.json)"
 
 export MAX_NODES_TO_FUND=2
+
+# Migration test drives a lot of operator txns (add-key x2 for the target,
+# register_backup_service, start_node_migration) — 1 NEAR per node runs
+# out. Give each node 10 NEAR and the root enough to cover.
+export NODE_INITIAL_BALANCE="10 NEAR"
+export ROOT_INITIAL_BALANCE="45 NEAR"
 
 export NEAR_TX_SLEEP_SEC=1
 export NEAR_RETRY_SLEEP_SEC=2

--- a/localnet/tee/scripts/rust-launcher/set-testnet-env.sh
+++ b/localnet/tee/scripts/rust-launcher/set-testnet-env.sh
@@ -51,6 +51,16 @@ export VMM_RPC=http://127.0.0.1:10000
 export ROOT_INITIAL_BALANCE="20 NEAR"
 # (CONTRACT_INITIAL_BALANCE and NODE_INITIAL_BALANCE use the script's
 # defaults — 16 NEAR contract, 1 NEAR per node.)
+#
+# If you plan to run `test-migration.sh both` against this cluster, bump:
+#   export NODE_INITIAL_BALANCE="10 NEAR"     # was 1 NEAR by default
+#   export ROOT_INITIAL_BALANCE="45 NEAR"     # 16 contract + 2*10 nodes + buffer
+# Migration drives ~5 operator txns per node (add-key x2 for the target,
+# register_backup_service, start_node_migration, plus retries), and 1 NEAR
+# runs out mid-test. Cost note for testnet: real NEAR, not free —
+# expect ~25–30 NEAR per full prepare + forward + back cycle. The faucet
+# caps at ~10 NEAR per account, so you'll need to top up `$FUNDER_ACCOUNT`
+# via `create-and-sweep-to-treasury.sh` a few times before starting.
 
 # --- Image reference (no tag — manifest digest is voted in separately) ---
 

--- a/localnet/tee/scripts/rust-launcher/single-node.sh
+++ b/localnet/tee/scripts/rust-launcher/single-node.sh
@@ -2,8 +2,11 @@
 set -euo pipefail
 export NEAR_CLI_DISABLE_SPINNER=1
 
-log(){ echo -e "\033[1;34m[INFO]\033[0m $*"; }
-err(){ echo -e "\033[1;31m[ERROR]\033[0m $*"; }
+# Shared helpers: log/err/pass/warn/fatal, ports_to_toml.
+# Sourced early — $CLI definition is guarded, so it's safe even before
+# BASE_PATH is set (this script defines its own vmm-cli invocations inline).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/common.sh"
 
 find_free_port() {
   python3 -c '
@@ -134,19 +137,6 @@ REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
 TEE_LAUNCHER_DIR="$REPO_ROOT/deployment/cvm-deployment"
 ENV_TPL="${ENV_TPL:-$REPO_ROOT/localnet/tee/scripts/node.env.tpl}"
 CONF_TPL="${CONF_TPL:-$REPO_ROOT/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl}"
-
-# Convert comma-separated "host:container" port string to TOML inline table array entries.
-ports_to_toml() {
-  local ports="$1" result=""
-  IFS=',' read -ra pairs <<< "$ports"
-  for pair in "${pairs[@]}"; do
-    local host_port="${pair%%:*}"
-    local container_port="${pair##*:}"
-    result+="    { host =$host_port, container =$container_port },
-"
-  done
-  echo -n "$result"
-}
 
 WORKDIR="${WORKDIR:-$(mktemp -d /tmp/mpc_localnet_one_node.XXXXXX)}"
 mkdir -p "$WORKDIR"

--- a/localnet/tee/scripts/rust-launcher/single-node.sh
+++ b/localnet/tee/scripts/rust-launcher/single-node.sh
@@ -199,7 +199,9 @@ render_env_and_conf() {
   export INTERNAL_MPC_PUBLIC_DEBUG_PORT="${INTERNAL_PUBLIC_DEBUG_PORT:-8080}"
   export INTERNAL_MPC_DECENTRALIZED_STATE_SYNC="${INTERNAL_STATE_SYNC_PORT:-24567}"
   export INTERNAL_MPC_MAIN_PORT="${INTERNAL_MAIN_PORT:-80}"
-  export INTERNAL_MPC_MIGRATION_PORT="${INTERNAL_MIGRATION_PORT:-13001}"
+  # Container-side migration HTTP port — must match `migration_web_ui` in
+  # node.conf.localnet.toml.tpl (8079).
+  export INTERNAL_MPC_MIGRATION_PORT="${INTERNAL_MIGRATION_PORT:-8079}"
 
   export MPC_ENV="${MPC_ENV:-mpc-localnet}"
   export MPC_IMAGE="nearone/mpc-node"
@@ -209,9 +211,9 @@ render_env_and_conf() {
   # The launcher PORTS map is CVM->container. vmm-cli (in deploy-launcher.sh)
   # forwards host:$MIGRATION_PORT -> CVM:$INTERNAL_MIGRATION_PORT, so the
   # launcher must publish container:$INTERNAL_MIGRATION_PORT on the same CVM
-  # port. Mapping ${MIGRATION_PORT}:${MIGRATION_PORT} would land on a closed
-  # container port when the two differ.
-  export PORTS="${PORTS:-8080:8080,24566:24566,${INTERNAL_MIGRATION_PORT:-13001}:${INTERNAL_MIGRATION_PORT:-13001}}"
+  # port. We also forward host:$MAIN_PORT -> CVM:$INTERNAL_MAIN_PORT(=80)
+  # so the P2P/TLS listener (`port_override = 80`) is reachable.
+  export PORTS="${PORTS:-${INTERNAL_MAIN_PORT:-80}:${INTERNAL_MAIN_PORT:-80},8080:8080,24566:24566,${INTERNAL_MIGRATION_PORT:-8079}:${INTERNAL_MIGRATION_PORT:-8079}}"
   export PORTS_TOML
   PORTS_TOML="$(ports_to_toml "$PORTS")"
 

--- a/localnet/tee/scripts/rust-launcher/test-hash-override.sh
+++ b/localnet/tee/scripts/rust-launcher/test-hash-override.sh
@@ -33,46 +33,22 @@ ROOT_ACCOUNT="${MPC_NETWORK_NAME}${ACCOUNT_SUFFIX}"
 MPC_CONTRACT_ACCOUNT="${MPC_CONTRACT_ACCOUNT:-mpc.${ROOT_ACCOUNT}}"
 VMM_RPC="${VMM_RPC:-http://127.0.0.1:10000}"
 BASE_PATH="${BASE_PATH:?Must set BASE_PATH}"
-CLI="python3 $BASE_PATH/vmm/src/vmm-cli.py --url $VMM_RPC"
+# Shared helpers: $CLI, logging, HOST_PROFILE → IP_PREFIX/IP_START_OCTET,
+# ip_for_i, near_call_*, extract_json_*.
+source "$SCRIPT_DIR/common.sh"
 
 WORKDIR="/tmp/${USER}/mpc_testnet_scale/${MPC_NETWORK_NAME}"
 
-HOST_PROFILE="${HOST_PROFILE:-alice}"
-case "$HOST_PROFILE" in
-  alice) IP_PREFIX="51.68.219."; IP_START_OCTET=1 ;;
-  bob)   IP_PREFIX="51.68.219."; IP_START_OCTET=11 ;;
-  *)     echo "Unknown HOST_PROFILE=$HOST_PROFILE"; exit 1 ;;
-esac
-
 AGENT_BASE="${AGENT_BASE:-18090}"
 
-# ---------- logging ----------
-log()  { echo -e "\033[1;34m[INFO]\033[0m $*"; }
-warn() { echo -e "\033[1;33m[WARN]\033[0m $*"; }
-err()  { echo -e "\033[1;31m[ERROR]\033[0m $*"; }
-pass() { echo -e "\033[1;32m[PASS]\033[0m $*"; }
-fail() { echo -e "\033[1;31m[FAIL]\033[0m $*"; FAILURES=$((FAILURES + 1)); }
-
+# Test-local: non-fatal failure counter; common.sh's `fatal` exits, this
+# script wants to keep going and report at the end.
 FAILURES=0
+fail() { echo -e "\033[1;31m[FAIL]\033[0m $*" >&2; FAILURES=$((FAILURES + 1)); }
 
-# ---------- helpers ----------
+# ---------- script-local helpers ----------
 node_account() { echo "node$1.${ROOT_ACCOUNT}"; }
-ip_for_i()     { echo "${IP_PREFIX}$((IP_START_OCTET + $1))"; }
 agent_port()   { echo $((AGENT_BASE + $1)); }
-
-near_call_ro() {
-  local method="$1" args="$2"
-  near contract call-function as-read-only "$MPC_CONTRACT_ACCOUNT" "$method" \
-    json-args "$args" network-config "$NEAR_NETWORK_CONFIG" now 2>&1
-}
-
-extract_json_ro() {
-  sed -n '/^Function execution return value/,/^Here is your console/{
-    /^Function/d
-    /^Here is your console/d
-    p
-  }'
-}
 
 # =============================================================================
 # POSITIVE TEST: override forces launcher to use a specific approved hash

--- a/localnet/tee/scripts/rust-launcher/test-migration.sh
+++ b/localnet/tee/scripts/rust-launcher/test-migration.sh
@@ -1,0 +1,751 @@
+#!/usr/bin/env bash
+# =============================================================================
+# MPC Localnet TEE — backup-cli migration test
+# =============================================================================
+#
+# Drives a full node-migration cycle on a 2-node localnet TEE cluster:
+#
+#   prepare       -> bring up A0 + A1 via deploy-tee-cluster.sh (clean deploy)
+#   deploy-target -> bring up B0 (third CVM, sharing A0's NEAR account)
+#   forward       -> register backup-cli + GET keyshares from A0 +
+#                    start_node_migration + PUT keyshares to B0 + verify
+#   back          -> stop & restart A0's CVM, then GET from B0 + PUT to A0
+#                    (this is the empirical reproduction attempt for #2121)
+#   both          -> forward + back
+#   status        -> dump migration_info, get_tee_accounts, state
+#   cleanup       -> remove B0's CVM and the local backup tmp dir
+#
+# Caveat: localnet TDX provides REAL Dstack attestation, so this exercises
+# the real-attestation path the Rust E2E harness mocks. It does NOT
+# naturally produce a stale on-chain attestation (TDX collateral TTL is
+# ~7 days). A happy back-migration result here pushes the bug specifically
+# toward "stale collateral", not "any real attestation".
+#
+# Prereqs:
+#   - dstack VMM running at $VMM_RPC
+#   - $BASE_PATH points at the dstack base dir (contains vmm/src/vmm-cli.py)
+#   - 51.68.219.{1,2,3} configured on the host (alice profile)
+#   - `near` CLI in PATH, mpc-localnet keychain configured
+#   - `jq`, `envsubst`, `python3`, `curl` available
+#
+# Usage:
+#   source localnet/tee/scripts/rust-launcher/set-localnet-env.sh
+#   export MPC_NETWORK_BASE_NAME=mpc-local   # match deploy-tee-cluster.sh
+#   bash localnet/tee/scripts/rust-launcher/test-migration.sh both
+#
+# =============================================================================
+set -euo pipefail
+export NEAR_CLI_DISABLE_SPINNER=1
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../../.." && pwd)"
+DEPLOY_SCRIPT="$SCRIPT_DIR/deploy-tee-cluster.sh"
+LAUNCHER_DIR="$REPO_ROOT/deployment/cvm-deployment"
+ENV_TPL="$REPO_ROOT/localnet/tee/scripts/node.env.tpl"
+CONF_TPL="$REPO_ROOT/localnet/tee/scripts/rust-launcher/node.conf.localnet.toml.tpl"
+
+# ---------- env defaults (kept in sync with deploy-tee-cluster.sh) ----------
+NEAR_NETWORK_CONFIG="${NEAR_NETWORK_CONFIG:-mpc-localnet}"
+N="${N:-2}"
+ACCOUNT_SUFFIX="${ACCOUNT_SUFFIX:-.test.near}"
+MPC_NETWORK_BASE_NAME="${MPC_NETWORK_BASE_NAME:?Must set MPC_NETWORK_BASE_NAME (e.g. mpc-local)}"
+MPC_NETWORK_NAME="${REUSE_NETWORK_NAME:-${MPC_NETWORK_BASE_NAME}}"
+ROOT_ACCOUNT="${MPC_NETWORK_NAME}${ACCOUNT_SUFFIX}"
+MPC_CONTRACT_ACCOUNT="${MPC_CONTRACT_ACCOUNT:-mpc.${ROOT_ACCOUNT}}"
+VMM_RPC="${VMM_RPC:-http://127.0.0.1:10000}"
+BASE_PATH="${BASE_PATH:?Must set BASE_PATH}"
+CLI="python3 $BASE_PATH/vmm/src/vmm-cli.py --url $VMM_RPC"
+OS_IMAGE="${OS_IMAGE:-dstack-dev-0.5.8}"
+SEALING_KEY_TYPE="${SEALING_KEY_TYPE:-SGX}"
+DISK="${DISK:-500G}"
+
+# Manifest digests (from set-localnet-env.sh or operator override)
+: "${MPC_MANIFEST_DIGEST:?Must export MPC_MANIFEST_DIGEST (sha256:...)}"
+: "${LAUNCHER_MANIFEST_DIGEST:?Must export LAUNCHER_MANIFEST_DIGEST (sha256:...)}"
+
+# Workdir matches deploy-tee-cluster.sh — we read its rendered node0.env etc.
+WORKDIR="/tmp/${USER}/mpc_testnet_scale/${MPC_NETWORK_NAME}"
+mkdir -p "$WORKDIR"
+
+# Host profile / IPs / ports — keep aligned with deploy-tee-cluster.sh defaults
+HOST_PROFILE="${HOST_PROFILE:-alice}"
+case "$HOST_PROFILE" in
+  alice) IP_PREFIX="51.68.219."; IP_START_OCTET=1 ;;
+  bob)   IP_PREFIX="5.196.36.";  IP_START_OCTET=113 ;;
+  *) echo "Unknown HOST_PROFILE=$HOST_PROFILE"; exit 1 ;;
+esac
+
+MAIN_PORT="${MAIN_PORT:-80}"                   # P2P/TLS — `port_override=80` makes the node bind here
+PUBLIC_DATA_BASE="${PUBLIC_DATA_BASE:-18082}"  # public_data is fixed at 18082 per port handler
+MIGRATION_PORT="${MIGRATION_PORT:-8079}"       # migration HTTP — uniform across CVMs, per-IP isolation
+STATE_SYNC_PORT="${STATE_SYNC_PORT:-24567}"
+SSH_BASE="${SSH_BASE:-22220}"
+AGENT_BASE="${AGENT_BASE:-18090}"
+LOCAL_DEBUG_BASE="${LOCAL_DEBUG_BASE:-3030}"  # uses random offset per node
+
+# Migration target params (B0)
+B_INDEX="${B_INDEX:-2}"
+B_SOURCE_INDEX="${B_SOURCE_INDEX:-0}"   # which node B0 is migrating from
+# Distinct secret_store_key from A0 ("00…00") and A1 ("00…01")
+B_SECRET_STORE_KEY="${B_SECRET_STORE_KEY:-$(printf '%032x' 99)}"
+
+# Backup-cli / migration test config
+BACKUP_HOME_DIR="${BACKUP_HOME_DIR:-/tmp/${USER}/mpc-migration-backup}"
+BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}"
+BACKUP_CLI="${BACKUP_CLI:-$REPO_ROOT/target/release/backup-cli}"
+
+# ---------- logging ----------
+log()  { echo -e "\033[1;34m[INFO]\033[0m $*"; }
+warn() { echo -e "\033[1;33m[WARN]\033[0m $*"; }
+err()  { echo -e "\033[1;31m[ERROR]\033[0m $*" >&2; }
+pass() { echo -e "\033[1;32m[PASS]\033[0m $*"; }
+fatal(){ err "$*"; exit 1; }
+
+# ---------- helpers ----------
+node_account_for_i() {
+  # The migration target B0 (index B_INDEX) shares its NEAR account with the
+  # source node it migrates from (B_SOURCE_INDEX). All other indices map
+  # directly. This is what makes migration on-chain a "TLS-key swap" rather
+  # than a participant set change.
+  if [ "$1" = "$B_INDEX" ]; then
+    echo "node${B_SOURCE_INDEX}.${ROOT_ACCOUNT}"
+  else
+    echo "node$1.${ROOT_ACCOUNT}"
+  fi
+}
+ip_for_i()           { echo "${IP_PREFIX}$((IP_START_OCTET + $1))"; }
+migration_port_for_i() { echo "$MIGRATION_PORT"; }  # same on every CVM; per-IP isolation
+agent_port_for_i()   { echo $((AGENT_BASE + $1)); }
+ssh_port_for_i()     { echo $((SSH_BASE + $1)); }
+local_dbg_port_for_i() { echo $((LOCAL_DEBUG_BASE + $1 + 100)); }  # offset to dodge neard's 3030
+public_port_for_i()  { echo "$PUBLIC_DATA_BASE"; }
+b_app_name()         { echo "${MPC_NETWORK_NAME}-node${B_INDEX}-migration-tee"; }
+
+near_call_ro() {
+  local method="$1" args="$2"
+  near contract call-function as-read-only "$MPC_CONTRACT_ACCOUNT" "$method" \
+    json-args "$args" network-config "$NEAR_NETWORK_CONFIG" now 2>&1
+}
+near_call_tx() {
+  local method="$1" args="$2" signer="$3"
+  near contract call-function as-transaction "$MPC_CONTRACT_ACCOUNT" "$method" \
+    json-args "$args" prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' \
+    sign-as "$signer" network-config "$NEAR_NETWORK_CONFIG" sign-with-keychain send 2>&1
+}
+# Extract the JSON return value of a near call. Two variants because read-only
+# and as-transaction output differs (mirrors test-verify-and-upgrade.sh).
+extract_json_tx() {
+  sed -n '/^Function execution return value/,/^$/{ /^Function/d; /^$/d; p }' \
+    | sed '/^Here is your console/,$d' \
+    | sed 's/^│[[:space:]]*//' \
+    | sed '/^$/d'
+}
+extract_json_ro() {
+  sed -n '/^Function execution return value/,/^Here is your console/{
+    /^Function/d; /^Here is your console/d; p
+  }'
+}
+
+# ---------- backup-cli plumbing ----------
+ensure_backup_cli() {
+  if [ ! -x "$BACKUP_CLI" ]; then
+    log "Building backup-cli (release)"
+    (cd "$REPO_ROOT" && cargo build --release -p backup-cli --locked)
+  fi
+  [ -x "$BACKUP_CLI" ] || fatal "backup-cli not built at $BACKUP_CLI"
+}
+
+ensure_backup_keys() {
+  if [ -f "$BACKUP_HOME_DIR/secrets.json" ]; then
+    log "Reusing backup-cli keys at $BACKUP_HOME_DIR"
+    return 0
+  fi
+  mkdir -p "$BACKUP_HOME_DIR"
+  log "Generating backup-cli keys at $BACKUP_HOME_DIR"
+  "$BACKUP_CLI" --home-dir "$BACKUP_HOME_DIR" generate-keys
+}
+
+# Extract the public_key the backup-cli would register with, by parsing the
+# `register` subcommand's near CLI output.
+backup_cli_pubkey() {
+  "$BACKUP_CLI" --home-dir "$BACKUP_HOME_DIR" register \
+    --mpc-contract-account-id "$MPC_CONTRACT_ACCOUNT" \
+    --near-network "$NEAR_NETWORK_CONFIG" \
+    --signer-account-id "$(node_account_for_i "$B_SOURCE_INDEX")" 2>&1 \
+    | grep -oE 'ed25519:[1-9A-HJ-NP-Za-km-z]+' | head -1
+}
+
+# Register the backup-cli's public key on the contract under the source account.
+# Idempotent — re-running just refreshes the entry. Waits for the source node's
+# indexer to catch up to the new registration (else GET keyshares races the
+# indexer and the node closes the TLS connection before authorizing).
+register_backup_service() {
+  ensure_backup_cli
+  ensure_backup_keys
+  local pk acct
+  pk="$(backup_cli_pubkey)"
+  acct="$(node_account_for_i "$B_SOURCE_INDEX")"
+  [ -n "$pk" ] || fatal "could not derive backup-cli public key"
+  log "Registering backup-cli pk=$pk for account=$acct"
+  near_call_tx register_backup_service \
+    "{\"backup_service_info\":{\"public_key\":\"$pk\"}}" "$acct" \
+    | tail -5
+
+  wait_for_source_indexer_backup_service "$B_SOURCE_INDEX" "$pk"
+}
+
+# Poll the source node's /debug/migrations until backup_service.public_key
+# matches `expected_pk`. The source MPC node uses its own indexer view to
+# authorize backup-cli, so we must wait for the indexer to ingest the
+# register_backup_service tx before issuing GET keyshares.
+wait_for_source_indexer_backup_service() {
+  local source_idx="$1" expected_pk="$2"
+  local ip; ip="$(ip_for_i "$source_idx")"
+  local acct; acct="$(node_account_for_i "$source_idx")"
+  log "Waiting for node$source_idx indexer to see backup_service=$expected_pk"
+  for attempt in $(seq 1 60); do
+    local actual
+    actual="$(curl -sf "http://${ip}:18082/debug/migrations" 2>/dev/null \
+              | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)[1].get('$acct', [None, None])[0] or {}
+    print(d.get('public_key',''))
+except Exception:
+    print('')
+" 2>/dev/null)"
+    if [ "$actual" = "$expected_pk" ]; then
+      pass "Source node indexer caught up"
+      return 0
+    fi
+    sleep 2
+  done
+  fatal "source node indexer did not register backup_service within 120s (last seen: $actual)"
+}
+
+# Poll the target node's /debug/migrations until destination_node_info.tls_public_key
+# matches expected — the target's indexer must see the start_node_migration tx
+# before backup-cli's PUT lands (otherwise mid-PUT the active_migration flip
+# trips the migration web server's cancellation token and tears down TLS).
+wait_for_target_indexer_destination() {
+  local source_idx="$1" target_tls="$2"
+  local ip; ip="$(ip_for_i "$source_idx")"  # debug endpoint is on the SOURCE (it owns the migration)
+  local acct; acct="$(node_account_for_i "$source_idx")"
+  log "Waiting for source-node indexer to see destination tls=$target_tls"
+  for attempt in $(seq 1 60); do
+    local actual
+    actual="$(curl -sf "http://${ip}:18082/debug/migrations" 2>/dev/null \
+              | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)[1].get('$acct', [None, None])[1] or {}
+    info = d.get('destination_node_info', {})
+    print(info.get('tls_public_key',''))
+except Exception:
+    print('')
+" 2>/dev/null)"
+    if [ "$actual" = "$target_tls" ]; then
+      pass "Source node indexer saw destination"
+      return 0
+    fi
+    sleep 2
+  done
+  fatal "source node indexer did not register destination within 120s (last seen: $actual)"
+}
+
+# Save current contract state into BACKUP_HOME_DIR/contract_state.json
+# (backup-cli reads this to know the current epoch/keyset before GET/PUT).
+save_contract_state() {
+  local out="$BACKUP_HOME_DIR/contract_state.json"
+  log "Saving contract state to $out"
+  # near CLI emits ANSI/formatting on stderr and the raw JSON return value
+  # on stdout — redirect stderr away so the file is clean JSON for backup-cli.
+  near contract call-function as-read-only "$MPC_CONTRACT_ACCOUNT" state \
+    json-args {} network-config "$NEAR_NETWORK_CONFIG" now > "$out" 2>/dev/null
+  [ -s "$out" ] || fatal "contract_state.json is empty"
+  # Sanity-check parseable JSON
+  python3 -c "import json,sys; json.load(open('$out'))" 2>/dev/null \
+    || fatal "contract_state.json is not valid JSON; head: $(head -1 "$out")"
+}
+
+# Fetch tls_public_key + near_signer_public_key for a given index from its
+# CVM's /public_data endpoint.
+fetch_node_keys() {
+  local i="$1" out="$2"
+  local ip url
+  ip="$(ip_for_i "$i")"
+  url="http://${ip}:$(public_port_for_i "$i")/public_data"
+  log "Fetching keys for node$i from $url"
+  for attempt in $(seq 1 120); do
+    if curl -fsS "$url" > "$out" 2>/dev/null; then
+      [ -s "$out" ] && return 0
+    fi
+    sleep 2
+  done
+  fatal "node$i: /public_data never responded at $url"
+}
+
+# ---------- migration target deployment ----------
+render_target_files() {
+  local target_idx="$B_INDEX"
+  local source_idx="$B_SOURCE_INDEX"
+  local ip; ip="$(ip_for_i "$target_idx")"
+  local account; account="$(node_account_for_i "$source_idx")"  # SAME as A0
+  local app_name; app_name="$(b_app_name)"
+  local migration_port; migration_port="$(migration_port_for_i "$target_idx")"  # always 8079
+  local agent_port; agent_port="$(agent_port_for_i "$target_idx")"
+  local ssh_port; ssh_port="$(ssh_port_for_i "$target_idx")"
+  local pub_port; pub_port="$(public_port_for_i "$target_idx")"
+  local local_dbg_port; local_dbg_port="$(local_dbg_port_for_i "$target_idx")"
+
+  export APP_NAME="$app_name"
+  export VMM_RPC SEALING_KEY_TYPE OS_IMAGE DISK
+  export LAUNCHER_MANIFEST_DIGEST MPC_MANIFEST_DIGEST
+
+  export EXTERNAL_DSTACK_AGENT_PORT="127.0.0.1:${agent_port}"
+  export EXTERNAL_SSH_PORT="127.0.0.1:${ssh_port}"
+  export EXTERNAL_MPC_PUBLIC_DEBUG_PORT="${ip}:${pub_port}"
+  export EXTERNAL_MPC_LOCAL_DEBUG_PORT="127.0.0.1:${local_dbg_port}"
+  export EXTERNAL_MPC_DECENTRALIZED_STATE_SYNC="${ip}:${STATE_SYNC_PORT}"
+  export EXTERNAL_MPC_MAIN_PORT="${ip}:${MAIN_PORT}"               # P2P/TLS (port_override=80)
+  export EXTERNAL_MPC_MIGRATION_PORT="${ip}:${migration_port}"     # migration HTTP (8079)
+
+  export INTERNAL_MPC_PUBLIC_DEBUG_PORT=8080
+  export INTERNAL_MPC_LOCAL_DEBUG_PORT=3030
+  export INTERNAL_MPC_DECENTRALIZED_STATE_SYNC=24567
+  export INTERNAL_MPC_MAIN_PORT=80
+  export INTERNAL_MPC_MIGRATION_PORT="${migration_port}"           # 8079, container's migration_web_ui
+
+  export MPC_ENV="$NEAR_NETWORK_CONFIG"
+  export MPC_IMAGE="nearone/mpc-node"
+  export MPC_ACCOUNT_ID="$account"             # KEY OVERRIDE: same as A0
+  export MPC_SECRET_STORE_KEY="$B_SECRET_STORE_KEY"  # distinct from A0
+  export MPC_CONTRACT_ID="$MPC_CONTRACT_ACCOUNT"
+
+  # Localnet: route CVM outbound to host neard via the QEMU slirp gateway.
+  # Forward MAIN(80) for P2P/TLS, 8080 for /public_data, 24566 for neard, 8079 for migration.
+  export PORTS="${MAIN_PORT}:${INTERNAL_MPC_MAIN_PORT},8080:8080,24566:24566,${migration_port}:${migration_port}"
+  export NEAR_BOOT_NODES="ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
+
+  # PORTS_TOML transformation (same shape as deploy-tee-cluster.sh).
+  local PORTS_TOML="" pair host_port container_port
+  IFS=',' read -ra pairs <<< "$PORTS"
+  for pair in "${pairs[@]}"; do
+    host_port="${pair%%:*}"
+    container_port="${pair##*:}"
+    PORTS_TOML+="    { host =${host_port}, container =${container_port} },
+"
+  done
+  export PORTS_TOML
+
+  local env_out="$WORKDIR/node${target_idx}.env"
+  local conf_out="$WORKDIR/node${target_idx}.toml"
+  export USER_CONFIG_FILE_PATH="$conf_out"
+
+  log "Rendering target env -> $env_out"
+  envsubst <"$ENV_TPL" >"$env_out"
+  log "Rendering target conf -> $conf_out"
+  envsubst <"$CONF_TPL" >"$conf_out"
+}
+
+deploy_target() {
+  # Idempotency: skip if a VM with the migration app name is already running.
+  local app; app="$(b_app_name)"
+  if $CLI lsvm 2>/dev/null | grep -q "$app.*running"; then
+    log "Migration target VM '$app' already running — skipping deploy"
+    return 0
+  fi
+
+  render_target_files
+
+  local ip; ip="$(ip_for_i "$B_INDEX")"
+  log "Deploying migration target B0 (app=$app, ip=$ip, idx=$B_INDEX, account=$(node_account_for_i "$B_SOURCE_INDEX"))"
+
+  (cd "$LAUNCHER_DIR" \
+    && ./deploy-launcher.sh --yes \
+        --env-file "$WORKDIR/node${B_INDEX}.env" \
+        --base-path "$BASE_PATH" \
+        --python-exec python)
+
+  # Wait for /public_data to respond — confirms launcher + MPC node are up.
+  local pub_port; pub_port="$(public_port_for_i "$B_INDEX")"
+  local url="http://${ip}:${pub_port}/public_data"
+  log "Waiting for $url ..."
+  for attempt in $(seq 1 180); do
+    curl -fsS "$url" >/dev/null 2>&1 && { pass "Migration target online"; return 0; }
+    sleep 2
+  done
+  fatal "Migration target did not come online within 6 min"
+}
+
+# Add B0's near_signer_public_key as a function-call access key on A0's account
+# so B0 can call node-facing methods (conclude_node_migration etc).
+add_target_signer_key() {
+  local keys_json="$WORKDIR/node${B_INDEX}.keys.json"
+  fetch_node_keys "$B_INDEX" "$keys_json"
+  local signer responder acct
+  signer="$(jq -r '.near_signer_public_key' "$keys_json")"
+  responder="$(jq -r '.near_responder_public_keys[0]' "$keys_json")"
+  acct="$(node_account_for_i "$B_SOURCE_INDEX")"
+  [ -n "$signer" ] && [ "$signer" != "null" ] || fatal "missing near_signer_public_key for B0"
+  log "Adding B0's signer key ($signer) to $acct as restricted FC-access key"
+
+  local node_methods="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
+
+  set +e
+  near account add-key "$acct" grant-function-call-access \
+    --allowance unlimited \
+    --contract-account-id "$MPC_CONTRACT_ACCOUNT" \
+    --function-names "$node_methods" \
+    use-manually-provided-public-key "$signer" \
+    network-config "$NEAR_NETWORK_CONFIG" sign-with-keychain send 2>&1 | tail -3
+  local rc=$?
+  set -e
+
+  if [ -n "$responder" ] && [ "$responder" != "null" ]; then
+    log "Adding B0's responder key ($responder) to $acct"
+    set +e
+    near account add-key "$acct" grant-function-call-access \
+      --allowance unlimited \
+      --contract-account-id "$MPC_CONTRACT_ACCOUNT" \
+      --function-names "$node_methods" \
+      use-manually-provided-public-key "$responder" \
+      network-config "$NEAR_NETWORK_CONFIG" sign-with-keychain send 2>&1 | tail -3
+    set -e
+  fi
+
+  if [ $rc -ne 0 ]; then
+    warn "add-key returned non-zero — may just mean the key already exists"
+  fi
+
+  # Sanity: wait until contract sees B0's attestation
+  log "Waiting for contract to register B0's TEE attestation..."
+  for attempt in $(seq 1 60); do
+    local tee_out tee_json count
+    tee_out="$(near_call_tx get_tee_accounts '{}' "$acct" 2>&1)"
+    tee_json="$(echo "$tee_out" | extract_json_tx)"
+    count="$(echo "$tee_json" | jq "[.[] | select(.account_id==\"$acct\")] | length" 2>/dev/null || echo 0)"
+    if [ "${count:-0}" -ge 2 ]; then
+      pass "Contract shows 2 TEE attestations for $acct (A0 + B0)"
+      return 0
+    fi
+    sleep 5
+  done
+  fatal "Contract never registered B0's attestation under $acct"
+}
+
+# ---------- migration flow ----------
+
+# GET keyshares from `source_idx` -> $BACKUP_HOME_DIR/permanent_keys/
+do_get_keyshares() {
+  local source_idx="$1"
+  local ip mport tls_key keys_json
+  ip="$(ip_for_i "$source_idx")"
+  mport="$(migration_port_for_i "$source_idx")"
+  keys_json="$WORKDIR/node${source_idx}.keys.json"
+  fetch_node_keys "$source_idx" "$keys_json"
+  tls_key="$(jq -r '.near_p2p_public_key' "$keys_json")"
+
+  save_contract_state
+
+  log "GET keyshares from node$source_idx at ${ip}:${mport} (tls=$tls_key)"
+  "$BACKUP_CLI" --home-dir "$BACKUP_HOME_DIR" get-keyshares \
+    --mpc-node-address "${ip}:${mport}" \
+    --mpc-node-p2p-key "$tls_key" \
+    --backup-encryption-key-hex "$BACKUP_ENCRYPTION_KEY"
+  pass "GET keyshares completed (saved under $BACKUP_HOME_DIR/permanent_keys/)"
+}
+
+# Tell contract to migrate from source -> target. Source account is the
+# operator's; target params come from the target's /public_data.
+#
+# The URL we publish here becomes the contract participant URL after
+# conclude_node_migration. With `port_override = 80` in the toml, the MPC
+# node ignores the URL port and binds P2P on 80 regardless — we publish 80
+# explicitly for clarity and to match init_args.
+do_start_node_migration() {
+  local source_idx="$1" target_idx="$2"
+  local source_acct ip keys_json signer_pk tls_pk
+  source_acct="$(node_account_for_i "$source_idx")"
+  ip="$(ip_for_i "$target_idx")"
+  keys_json="$WORKDIR/node${target_idx}.keys.json"
+  fetch_node_keys "$target_idx" "$keys_json"
+  signer_pk="$(jq -r '.near_signer_public_key' "$keys_json")"
+  tls_pk="$(jq -r '.near_p2p_public_key' "$keys_json")"
+
+  local url="https://${ip}:${MAIN_PORT}"
+  log "start_node_migration: source=$source_acct -> target_tls=$tls_pk url=$url"
+
+  local args
+  args="$(jq -nc \
+    --arg pk "$signer_pk" --arg url "$url" --arg tls "$tls_pk" \
+    '{destination_node_info: {signer_account_pk:$pk, destination_node_info: {url:$url, tls_public_key:$tls}}}')"
+  near_call_tx start_node_migration "$args" "$source_acct" | tail -5
+
+  # Wait for the source node's indexer to see the active_migration entry —
+  # backup-cli's PUT relies on it (else mid-PUT the destination_node_info
+  # flip trips the migration server's cancellation token).
+  wait_for_target_indexer_destination "$source_idx" "$tls_pk"
+}
+
+# PUT keyshares to target_idx via the backup-cli.
+do_put_keyshares() {
+  local target_idx="$1"
+  local ip mport keys_json tls_key
+  ip="$(ip_for_i "$target_idx")"
+  mport="$(migration_port_for_i "$target_idx")"
+  keys_json="$WORKDIR/node${target_idx}.keys.json"
+  fetch_node_keys "$target_idx" "$keys_json"
+  tls_key="$(jq -r '.near_p2p_public_key' "$keys_json")"
+
+  save_contract_state
+
+  log "PUT keyshares to node$target_idx at ${ip}:${mport} (tls=$tls_key)"
+  "$BACKUP_CLI" --home-dir "$BACKUP_HOME_DIR" put-keyshares \
+    --mpc-node-address "${ip}:${mport}" \
+    --mpc-node-p2p-key "$tls_key" \
+    --backup-encryption-key-hex "$BACKUP_ENCRYPTION_KEY"
+  pass "PUT keyshares completed"
+}
+
+# Poll until contract.migration_info[source] has no destination AND
+# contract.state shows target's tls_public_key as the participant for source's account.
+wait_for_migration_completion() {
+  local source_idx="$1" target_idx="$2"
+  local source_acct target_tls
+  source_acct="$(node_account_for_i "$source_idx")"
+  target_tls="$(jq -r '.near_p2p_public_key' "$WORKDIR/node${target_idx}.keys.json")"
+
+  log "Waiting for contract to finalize $source_acct -> tls=$target_tls (up to 120s)"
+  for attempt in $(seq 1 60); do
+    local mi state mi_json state_json
+    mi="$(near_call_ro migration_info '{}')"
+    mi_json="$(echo "$mi" | extract_json_ro)"
+    local dest
+    dest="$(echo "$mi_json" | jq -r --arg a "$source_acct" '.[$a][1]' 2>/dev/null || echo "null")"
+
+    state="$(near_call_ro state '{}')"
+    state_json="$(echo "$state" | extract_json_ro)"
+    local found_tls
+    found_tls="$(echo "$state_json" | jq -r --arg a "$source_acct" '
+      .Running.parameters.participants.participants[]
+      | select(.[0]==$a) | .[2].tls_public_key' 2>/dev/null | head -1)"
+
+    if [ "$dest" = "null" ] && [ "$found_tls" = "$target_tls" ]; then
+      pass "Migration finalized: migration_info clear and participant TLS == target"
+      return 0
+    fi
+    sleep 2
+  done
+
+  err "Migration did NOT finalize. Last state:"
+  echo "  migration_info[$source_acct].destination = $dest"
+  echo "  participants[$source_acct].tls_public_key = ${found_tls:-<unknown>}"
+  echo "  expected target_tls = $target_tls"
+  return 1
+}
+
+verify_signing() {
+  log "Verifying signature generation works"
+  local sign_ok=0
+  for attempt in 1 2 3 4; do
+    local out
+    out="$(near contract call-function as-transaction "$MPC_CONTRACT_ACCOUNT" sign \
+      file-args "$REPO_ROOT/docs/localnet/args/sign_ecdsa.json" \
+      prepaid-gas '300.0 Tgas' attached-deposit '100 yoctoNEAR' \
+      sign-as "$(node_account_for_i 0)" network-config "$NEAR_NETWORK_CONFIG" \
+      sign-with-keychain send 2>&1)"
+    if echo "$out" | grep -q '"big_r"'; then
+      pass "ECDSA signature succeeded"
+      sign_ok=1
+      break
+    fi
+    [ $attempt -lt 4 ] && { warn "sign attempt $attempt failed, retry in 30s"; sleep 30; }
+  done
+  [ $sign_ok -eq 1 ] || fatal "ECDSA signing failed after 4 attempts"
+}
+
+# Find the VM id for node `i`. Matches by app name pattern used at deploy.
+vm_id_for() {
+  local i="$1" app
+  if [ "$i" = "$B_INDEX" ]; then
+    app="$(b_app_name)"
+  else
+    app="${MPC_NETWORK_NAME}-node${i}-testnet-tee"
+  fi
+  $CLI lsvm 2>/dev/null | grep "$app" | awk '{print $2}' | tail -1
+}
+
+# Stop + start A0's CVM (state preserved). This is what makes back-migration
+# meaningful: A0's keyshares are still on disk on restart — the exact
+# precondition for the P1 early-return.
+restart_source_node() {
+  local i="$B_SOURCE_INDEX"
+  local vm; vm="$(vm_id_for "$i")"
+  [ -n "$vm" ] || fatal "could not find VM for node$i"
+  log "Stopping A0 (node$i, vm=$vm) ..."
+  $CLI stop -f "$vm" 2>/dev/null || true
+  sleep 5
+  log "Starting A0 (node$i, vm=$vm) ..."
+  $CLI start "$vm" 2>/dev/null
+  local ip; ip="$(ip_for_i "$i")"
+  local url="http://${ip}:$(public_port_for_i "$i")/public_data"
+  log "Waiting for A0 /public_data ($url) ..."
+  for attempt in $(seq 1 120); do
+    curl -fsS "$url" >/dev/null 2>&1 && { pass "A0 back online"; return 0; }
+    sleep 2
+  done
+  fatal "A0 did not come back online"
+}
+
+# ---------- subcommands ----------
+cmd_prepare() {
+  log "Tearing down any existing CVMs matching mpc-local-*"
+  $CLI lsvm 2>/dev/null | awk '/mpc-local-/ {print $2}' | while read -r vm; do
+    [ -n "$vm" ] || continue
+    log "  stop+remove $vm"
+    $CLI stop -f "$vm" 2>/dev/null || true
+  done
+  sleep 5
+  $CLI lsvm 2>/dev/null | awk '/mpc-local-/ {print $2}' | while read -r vm; do
+    [ -n "$vm" ] || continue
+    $CLI remove "$vm" 2>/dev/null || true
+  done
+
+  log "Resetting localnet neard"
+  pkill -9 neard 2>/dev/null || true
+  sleep 1
+  rm -rf "$HOME/.near/mpc-localnet"
+  neard --home "$HOME/.near/mpc-localnet" init --chain-id mpc-localnet >/dev/null 2>&1
+  cp -rf "$REPO_ROOT/deployment/localnet/." "$HOME/.near/mpc-localnet/"
+  NEAR_ENV=mpc-localnet nohup neard --home "$HOME/.near/mpc-localnet" run >/tmp/neard.log 2>&1 &
+  for attempt in 1 2 3 4 5 6 7 8; do
+    if curl -sf http://127.0.0.1:3030/status 2>/dev/null | grep -q mpc-localnet; then
+      pass "neard ready"
+      break
+    fi
+    sleep 1
+  done
+
+  log "Delegating clean cluster deploy to $DEPLOY_SCRIPT (N=$N)"
+  NO_PAUSE=1 FORCE_RECOLLECT=1 FORCE_REINIT_ARGS=1 \
+    MPC_CONTRACT_ACCOUNT="$MPC_CONTRACT_ACCOUNT" \
+    START_FROM_PHASE=preflight RESUME=0 \
+    bash "$DEPLOY_SCRIPT"
+  pass "Base cluster prepared (A0 + A1)"
+}
+
+cmd_status() {
+  log "migration_info:"
+  near_call_ro migration_info '{}' | extract_json_ro | jq . || true
+  log "get_tee_accounts:"
+  near_call_tx get_tee_accounts '{}' "$(node_account_for_i 0)" | extract_json_tx | jq . || true
+  log "state (truncated):"
+  near_call_ro state '{}' | extract_json_ro | jq '{state_keys: keys, participants: .Running.parameters.participants.participants}' || true
+}
+
+cmd_deploy_target() {
+  deploy_target
+  add_target_signer_key
+  pass "Migration target ready"
+}
+
+cmd_forward() {
+  cmd_deploy_target
+  ensure_backup_cli
+  ensure_backup_keys
+  register_backup_service
+  do_get_keyshares "$B_SOURCE_INDEX"
+  do_start_node_migration "$B_SOURCE_INDEX" "$B_INDEX"
+  do_put_keyshares "$B_INDEX"
+  wait_for_migration_completion "$B_SOURCE_INDEX" "$B_INDEX" || fatal "forward did NOT complete"
+  verify_signing
+  pass "Forward migration A0 -> B0 succeeded"
+}
+
+cmd_back() {
+  # Pre-condition: forward completed (B0 is the participant, A0 is dormant).
+  restart_source_node
+  ensure_backup_cli
+  ensure_backup_keys
+  register_backup_service
+
+  # Clear backup-cli's cached keyshares from the forward run. Without this,
+  # backup-cli refuses GET with: "Refusing to overwrite existing permanent
+  # keyshares of epoch 0 with new permanent keyshares of same epoch ...".
+  # Note: LocalPermanentKeyStorageBackend reads from $home_dir/key (top-level
+  # file), not from permanent_keys/ — must remove both. Preserve secrets.json
+  # (the backup-cli identity).
+  log "Clearing cached permanent keyshares at $BACKUP_HOME_DIR"
+  rm -rf "$BACKUP_HOME_DIR/permanent_keys" "$BACKUP_HOME_DIR/key"
+
+  do_get_keyshares "$B_INDEX"             # source is now B0
+  do_start_node_migration "$B_INDEX" "$B_SOURCE_INDEX"   # B -> A
+  do_put_keyshares "$B_SOURCE_INDEX"
+  if wait_for_migration_completion "$B_INDEX" "$B_SOURCE_INDEX"; then
+    verify_signing
+    pass "Back-migration B0 -> A0 succeeded (bug NOT reproduced on real-TDX localnet)"
+  else
+    err "Back-migration did not finalize"
+    err "This is the empirical signal for near/mpc#2121 on real-TDX."
+    cmd_status || true
+    exit 1
+  fi
+}
+
+cmd_both() {
+  cmd_forward
+  cmd_back
+}
+
+cmd_cleanup() {
+  local vm; vm="$(vm_id_for "$B_INDEX" || true)"
+  if [ -n "$vm" ]; then
+    log "Removing migration target VM $vm"
+    $CLI stop -f "$vm" 2>/dev/null || true
+    sleep 2
+    $CLI remove "$vm" 2>/dev/null || true
+  else
+    log "No migration target VM to remove"
+  fi
+  rm -rf "$BACKUP_HOME_DIR"
+  rm -f "$WORKDIR/node${B_INDEX}.env" "$WORKDIR/node${B_INDEX}.toml" "$WORKDIR/node${B_INDEX}.keys.json"
+  pass "Cleanup complete"
+}
+
+usage() {
+  cat <<EOF
+Usage: $0 <command>
+
+Commands:
+  prepare        Deploy a clean 2-node A0+A1 cluster via deploy-tee-cluster.sh
+  deploy-target  Bring up B0 (third CVM sharing A0's account)
+  forward        A0 -> B0 (deploys B0 if missing)
+  back           B0 -> A0 (restarts A0 first)
+  both           forward + back
+  status         Dump migration_info + tee_accounts + participant set
+  cleanup        Remove B0's CVM and tmp state
+
+Env (required): MPC_NETWORK_BASE_NAME BASE_PATH
+                MPC_MANIFEST_DIGEST LAUNCHER_MANIFEST_DIGEST
+                (source set-localnet-env.sh first)
+
+Env (optional): NEAR_NETWORK_CONFIG (=mpc-localnet)
+                MPC_CONTRACT_ACCOUNT
+                HOST_PROFILE (alice|bob)
+                B_INDEX (=2), B_SOURCE_INDEX (=0)
+                BACKUP_HOME_DIR, BACKUP_CLI
+EOF
+}
+
+case "${1:-}" in
+  prepare)        cmd_prepare ;;
+  deploy-target)  cmd_deploy_target ;;
+  forward)        cmd_forward ;;
+  back)           cmd_back ;;
+  both)           cmd_both ;;
+  status)         cmd_status ;;
+  cleanup)        cmd_cleanup ;;
+  ""|-h|--help)   usage ;;
+  *)              usage; exit 1 ;;
+esac

--- a/localnet/tee/scripts/rust-launcher/test-migration.sh
+++ b/localnet/tee/scripts/rust-launcher/test-migration.sh
@@ -24,7 +24,9 @@
 # Prereqs:
 #   - dstack VMM running at $VMM_RPC
 #   - $BASE_PATH points at the dstack base dir (contains vmm/src/vmm-cli.py)
-#   - 51.68.219.{1,2,3} configured on the host (alice profile)
+#   - Three CVM IPs configured on the host:
+#       alice profile (default): 51.68.219.{1,2,3}
+#       bob profile (HOST_PROFILE=bob): 5.196.36.{113,114,115}
 #   - `near` CLI in PATH, mpc-localnet keychain configured
 #   - `jq`, `envsubst`, `python3`, `curl` available
 #
@@ -324,7 +326,10 @@ render_target_files() {
 
   # Localnet: route CVM outbound to host neard via the QEMU slirp gateway.
   # Forward MAIN(80) for P2P/TLS, 8080 for /public_data, 24566 for neard, 8079 for migration.
-  export PORTS="${MAIN_PORT}:${INTERNAL_MPC_MAIN_PORT},8080:8080,24566:24566,${migration_port}:${migration_port}"
+  # PORTS is CVM-side:container-side (the launcher's port_mappings); both
+  # sides use CVM/container-internal port values. host:CVM forwarding is
+  # handled separately by deploy-launcher.sh's EXTERNAL_* --port args.
+  export PORTS="${INTERNAL_MPC_MAIN_PORT}:${INTERNAL_MPC_MAIN_PORT},8080:8080,24566:24566,${migration_port}:${migration_port}"
   export NEAR_BOOT_NODES="ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
 
   # PORTS_TOML transformation (same shape as deploy-tee-cluster.sh).
@@ -612,6 +617,7 @@ cmd_prepare() {
     $CLI remove "$vm" 2>/dev/null || true
   done
 
+  warn "About to SIGKILL any running 'neard' processes and wipe \$HOME/.near/mpc-localnet — localnet-only, but destructive on a shared host."
   log "Resetting localnet neard"
   pkill -9 neard 2>/dev/null || true
   sleep 1

--- a/localnet/tee/scripts/rust-launcher/test-migration.sh
+++ b/localnet/tee/scripts/rust-launcher/test-migration.sh
@@ -650,11 +650,25 @@ cmd_deploy_target() {
   pass "Migration target ready"
 }
 
+# Clear backup-cli's cached keyshares (from a prior forward/back run). The
+# `Refusing to overwrite existing permanent keyshares ...` safety check in
+# `mpc-node`'s PermanentKeyStorage will trip otherwise. Preserve
+# secrets.json (the backup-cli identity). Note:
+# LocalPermanentKeyStorageBackend reads from $home_dir/key (top-level file),
+# not from permanent_keys/ — must remove both.
+clear_keyshare_cache() {
+  if [ -e "$BACKUP_HOME_DIR/key" ] || [ -d "$BACKUP_HOME_DIR/permanent_keys" ]; then
+    log "Clearing cached permanent keyshares at $BACKUP_HOME_DIR"
+    rm -rf "$BACKUP_HOME_DIR/permanent_keys" "$BACKUP_HOME_DIR/key"
+  fi
+}
+
 cmd_forward() {
   cmd_deploy_target
   ensure_backup_cli
   ensure_backup_keys
   register_backup_service
+  clear_keyshare_cache
   do_get_keyshares "$B_SOURCE_INDEX"
   do_start_node_migration "$B_SOURCE_INDEX" "$B_INDEX"
   do_put_keyshares "$B_INDEX"
@@ -669,16 +683,7 @@ cmd_back() {
   ensure_backup_cli
   ensure_backup_keys
   register_backup_service
-
-  # Clear backup-cli's cached keyshares from the forward run. Without this,
-  # backup-cli refuses GET with: "Refusing to overwrite existing permanent
-  # keyshares of epoch 0 with new permanent keyshares of same epoch ...".
-  # Note: LocalPermanentKeyStorageBackend reads from $home_dir/key (top-level
-  # file), not from permanent_keys/ — must remove both. Preserve secrets.json
-  # (the backup-cli identity).
-  log "Clearing cached permanent keyshares at $BACKUP_HOME_DIR"
-  rm -rf "$BACKUP_HOME_DIR/permanent_keys" "$BACKUP_HOME_DIR/key"
-
+  clear_keyshare_cache
   do_get_keyshares "$B_INDEX"             # source is now B0
   do_start_node_migration "$B_INDEX" "$B_SOURCE_INDEX"   # B -> A
   do_put_keyshares "$B_SOURCE_INDEX"

--- a/localnet/tee/scripts/rust-launcher/test-migration.sh
+++ b/localnet/tee/scripts/rust-launcher/test-migration.sh
@@ -56,7 +56,9 @@ ROOT_ACCOUNT="${MPC_NETWORK_NAME}${ACCOUNT_SUFFIX}"
 MPC_CONTRACT_ACCOUNT="${MPC_CONTRACT_ACCOUNT:-mpc.${ROOT_ACCOUNT}}"
 VMM_RPC="${VMM_RPC:-http://127.0.0.1:10000}"
 BASE_PATH="${BASE_PATH:?Must set BASE_PATH}"
-CLI="python3 $BASE_PATH/vmm/src/vmm-cli.py --url $VMM_RPC"
+# Shared helpers: $CLI, logging, HOST_PROFILE → IP_PREFIX/IP_START_OCTET,
+# ip_for_i, ports_to_toml, near_call_*, extract_json_*.
+source "$SCRIPT_DIR/common.sh"
 OS_IMAGE="${OS_IMAGE:-dstack-dev-0.5.8}"
 SEALING_KEY_TYPE="${SEALING_KEY_TYPE:-SGX}"
 DISK="${DISK:-500G}"
@@ -68,14 +70,6 @@ DISK="${DISK:-500G}"
 # Workdir matches deploy-tee-cluster.sh — we read its rendered node0.env etc.
 WORKDIR="/tmp/${USER}/mpc_testnet_scale/${MPC_NETWORK_NAME}"
 mkdir -p "$WORKDIR"
-
-# Host profile / IPs / ports — keep aligned with deploy-tee-cluster.sh defaults
-HOST_PROFILE="${HOST_PROFILE:-alice}"
-case "$HOST_PROFILE" in
-  alice) IP_PREFIX="51.68.219."; IP_START_OCTET=1 ;;
-  bob)   IP_PREFIX="5.196.36.";  IP_START_OCTET=113 ;;
-  *) echo "Unknown HOST_PROFILE=$HOST_PROFILE"; exit 1 ;;
-esac
 
 MAIN_PORT="${MAIN_PORT:-80}"                   # P2P/TLS — `port_override=80` makes the node bind here
 PUBLIC_DATA_BASE="${PUBLIC_DATA_BASE:-18082}"  # public_data is fixed at 18082 per port handler
@@ -96,57 +90,24 @@ BACKUP_HOME_DIR="${BACKUP_HOME_DIR:-/tmp/${USER}/mpc-migration-backup}"
 BACKUP_ENCRYPTION_KEY="${BACKUP_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}"
 BACKUP_CLI="${BACKUP_CLI:-$REPO_ROOT/target/release/backup-cli}"
 
-# ---------- logging ----------
-log()  { echo -e "\033[1;34m[INFO]\033[0m $*"; }
-warn() { echo -e "\033[1;33m[WARN]\033[0m $*"; }
-err()  { echo -e "\033[1;31m[ERROR]\033[0m $*" >&2; }
-pass() { echo -e "\033[1;32m[PASS]\033[0m $*"; }
-fatal(){ err "$*"; exit 1; }
-
-# ---------- helpers ----------
+# ---------- script-specific helpers ----------
+# Migration-aware account map: the target B0 (index B_INDEX) shares its NEAR
+# account with the source it migrates from (B_SOURCE_INDEX). All other
+# indices map directly. This is what makes migration on-chain a "TLS-key
+# swap" rather than a participant set change.
 node_account_for_i() {
-  # The migration target B0 (index B_INDEX) shares its NEAR account with the
-  # source node it migrates from (B_SOURCE_INDEX). All other indices map
-  # directly. This is what makes migration on-chain a "TLS-key swap" rather
-  # than a participant set change.
   if [ "$1" = "$B_INDEX" ]; then
     echo "node${B_SOURCE_INDEX}.${ROOT_ACCOUNT}"
   else
     echo "node$1.${ROOT_ACCOUNT}"
   fi
 }
-ip_for_i()           { echo "${IP_PREFIX}$((IP_START_OCTET + $1))"; }
 migration_port_for_i() { echo "$MIGRATION_PORT"; }  # same on every CVM; per-IP isolation
-agent_port_for_i()   { echo $((AGENT_BASE + $1)); }
-ssh_port_for_i()     { echo $((SSH_BASE + $1)); }
+agent_port_for_i()     { echo $((AGENT_BASE + $1)); }
+ssh_port_for_i()       { echo $((SSH_BASE + $1)); }
 local_dbg_port_for_i() { echo $((LOCAL_DEBUG_BASE + $1 + 100)); }  # offset to dodge neard's 3030
-public_port_for_i()  { echo "$PUBLIC_DATA_BASE"; }
-b_app_name()         { echo "${MPC_NETWORK_NAME}-node${B_INDEX}-migration-tee"; }
-
-near_call_ro() {
-  local method="$1" args="$2"
-  near contract call-function as-read-only "$MPC_CONTRACT_ACCOUNT" "$method" \
-    json-args "$args" network-config "$NEAR_NETWORK_CONFIG" now 2>&1
-}
-near_call_tx() {
-  local method="$1" args="$2" signer="$3"
-  near contract call-function as-transaction "$MPC_CONTRACT_ACCOUNT" "$method" \
-    json-args "$args" prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' \
-    sign-as "$signer" network-config "$NEAR_NETWORK_CONFIG" sign-with-keychain send 2>&1
-}
-# Extract the JSON return value of a near call. Two variants because read-only
-# and as-transaction output differs (mirrors test-verify-and-upgrade.sh).
-extract_json_tx() {
-  sed -n '/^Function execution return value/,/^$/{ /^Function/d; /^$/d; p }' \
-    | sed '/^Here is your console/,$d' \
-    | sed 's/^│[[:space:]]*//' \
-    | sed '/^$/d'
-}
-extract_json_ro() {
-  sed -n '/^Function execution return value/,/^Here is your console/{
-    /^Function/d; /^Here is your console/d; p
-  }'
-}
+public_port_for_i()    { echo "$PUBLIC_DATA_BASE"; }
+b_app_name()           { echo "${MPC_NETWORK_NAME}-node${B_INDEX}-migration-tee"; }
 
 # ---------- backup-cli plumbing ----------
 ensure_backup_cli() {

--- a/localnet/tee/scripts/rust-launcher/test-migration.sh
+++ b/localnet/tee/scripts/rust-launcher/test-migration.sh
@@ -294,14 +294,7 @@ render_target_files() {
   export NEAR_BOOT_NODES="ed25519:BGa4WiBj43Mr66f9Ehf6swKtR6wZmWuwCsV3s4PSR3nx@10.0.2.2:24566"
 
   # PORTS_TOML transformation (same shape as deploy-tee-cluster.sh).
-  local PORTS_TOML="" pair host_port container_port
-  IFS=',' read -ra pairs <<< "$PORTS"
-  for pair in "${pairs[@]}"; do
-    host_port="${pair%%:*}"
-    container_port="${pair##*:}"
-    PORTS_TOML+="    { host =${host_port}, container =${container_port} },
-"
-  done
+  PORTS_TOML="$(ports_to_toml "$PORTS")"
   export PORTS_TOML
 
   local env_out="$WORKDIR/node${target_idx}.env"

--- a/localnet/tee/scripts/rust-launcher/test-migration.sh
+++ b/localnet/tee/scripts/rust-launcher/test-migration.sh
@@ -419,9 +419,12 @@ do_get_keyshares() {
 # operator's; target params come from the target's /public_data.
 #
 # The URL we publish here becomes the contract participant URL after
-# conclude_node_migration. With `port_override = 80` in the toml, the MPC
-# node ignores the URL port and binds P2P on 80 regardless — we publish 80
-# explicitly for clarity and to match init_args.
+# conclude_node_migration. With `port_override = 80` in the toml (see
+# `node.conf.localnet.toml.tpl` under `[mpc_node_config.node.indexer]`),
+# the MPC node ignores the URL port and binds P2P on 80 regardless — we
+# publish 80 explicitly for clarity and to match `init_args` in
+# `deploy-tee-cluster.sh`. If `port_override` is ever changed in the
+# toml, the literal `${MAIN_PORT}` below must move with it.
 do_start_node_migration() {
   local source_idx="$1" target_idx="$2"
   local source_acct ip keys_json signer_pk tls_pk
@@ -599,7 +602,7 @@ cmd_status() {
   log "migration_info:"
   near_call_ro migration_info '{}' | extract_json_ro | jq . || true
   log "get_tee_accounts:"
-  near_call_tx get_tee_accounts '{}' "$(node_account_for_i 0)" | extract_json_tx | jq . || true
+  near_call_ro get_tee_accounts '{}' | extract_json_ro | jq . || true
   log "state (truncated):"
   near_call_ro state '{}' | extract_json_ro | jq '{state_keys: keys, participants: .Running.parameters.participants.participants}' || true
 }

--- a/localnet/tee/scripts/rust-launcher/test-verify-and-upgrade.sh
+++ b/localnet/tee/scripts/rust-launcher/test-verify-and-upgrade.sh
@@ -41,65 +41,23 @@ ROOT_ACCOUNT="${MPC_NETWORK_NAME}${ACCOUNT_SUFFIX}"
 MPC_CONTRACT_ACCOUNT="${MPC_CONTRACT_ACCOUNT:-mpc.${ROOT_ACCOUNT}}"
 VMM_RPC="${VMM_RPC:-http://127.0.0.1:10000}"
 BASE_PATH="${BASE_PATH:?Must set BASE_PATH}"
-CLI="python3 $BASE_PATH/vmm/src/vmm-cli.py --url $VMM_RPC"
+# Shared helpers: $CLI, logging, HOST_PROFILE → IP_PREFIX/IP_START_OCTET,
+# ip_for_i, near_call_*, extract_json_*.
+source "$SCRIPT_DIR/common.sh"
 
 WORKDIR="/tmp/${USER}/mpc_testnet_scale/${MPC_NETWORK_NAME}"
 
-# Host profile for IP computation
-HOST_PROFILE="${HOST_PROFILE:-alice}"
-case "$HOST_PROFILE" in
-  alice) IP_PREFIX="51.68.219."; IP_START_OCTET=1 ;;
-  bob)   IP_PREFIX="51.68.219."; IP_START_OCTET=11 ;;
-  *)     echo "Unknown HOST_PROFILE=$HOST_PROFILE"; exit 1 ;;
-esac
-
 AGENT_BASE="${AGENT_BASE:-18090}"
 
-# ---------- logging ----------
-log()  { echo -e "\033[1;34m[INFO]\033[0m $*"; }
-warn() { echo -e "\033[1;33m[WARN]\033[0m $*"; }
-err()  { echo -e "\033[1;31m[ERROR]\033[0m $*"; }
-pass() { echo -e "\033[1;32m[PASS]\033[0m $*"; }
-fail() { echo -e "\033[1;31m[FAIL]\033[0m $*"; FAILURES=$((FAILURES + 1)); }
-
+# Test-local: count non-fatal failures so the script reports a summary at the
+# end instead of bailing on the first issue. (common.sh provides fatal/err
+# that exit/print but not this counter pattern.)
 FAILURES=0
+fail() { echo -e "\033[1;31m[FAIL]\033[0m $*" >&2; FAILURES=$((FAILURES + 1)); }
 
-# ---------- helpers ----------
+# ---------- script-local helpers ----------
 node_account() { echo "node$1.${ROOT_ACCOUNT}"; }
-ip_for_i()     { echo "${IP_PREFIX}$((IP_START_OCTET + $1))"; }
 agent_port()   { echo $((AGENT_BASE + $1)); }
-
-near_call_ro() {
-  local method="$1" args="$2"
-  near contract call-function as-read-only "$MPC_CONTRACT_ACCOUNT" "$method" \
-    json-args "$args" network-config "$NEAR_NETWORK_CONFIG" now 2>&1
-}
-
-near_call_tx() {
-  local method="$1" args="$2" signer="$3"
-  near contract call-function as-transaction "$MPC_CONTRACT_ACCOUNT" "$method" \
-    json-args "$args" prepaid-gas '300.0 Tgas' attached-deposit '0 NEAR' \
-    sign-as "$signer" network-config "$NEAR_NETWORK_CONFIG" sign-with-keychain send 2>&1
-}
-
-# Get the JSON "Function execution return value" from near CLI output.
-# near CLI prints structured output; the JSON payload is between the
-# "return value" banner and the next "Here is your console command" line.
-extract_json() {
-  sed -n '/^Function execution return value/,/^$/{ /^Function/d; /^$/d; p }' \
-    | sed '/^Here is your console/,$d' \
-    | sed 's/^│[[:space:]]*//' \
-    | sed '/^$/d'
-}
-
-# Extract JSON from read-only call (slightly different output format)
-extract_json_ro() {
-  sed -n '/^Function execution return value/,/^Here is your console/{
-    /^Function/d
-    /^Here is your console/d
-    p
-  }'
-}
 
 # =============================================================================
 # SCENARIO 1: VERIFY
@@ -125,7 +83,7 @@ verify_cluster() {
   local tee_output
   tee_output="$(near_call_tx get_tee_accounts '{}' "${ROOT_ACCOUNT}")"
   local tee_json
-  tee_json="$(echo "$tee_output" | extract_json)"
+  tee_json="$(echo "$tee_output" | extract_json_tx)"
   local tee_count
   tee_count="$(echo "$tee_json" | jq 'length')"
   if [ "$tee_count" -eq "$N" ]; then
@@ -150,7 +108,7 @@ verify_cluster() {
     att_output="$(near_call_ro get_attestation "{\"tls_public_key\": \"${tls_keys[$i]}\"}")"
     if echo "$att_output" | grep -q '"Dstack"'; then
       local mpc_hash
-      mpc_hash="$(echo "$att_output" | extract_json_ro | jq -r '.Dstack.mpc_image_hash')"
+      mpc_hash="$(echo "$att_output" | extract_json_tx_ro | jq -r '.Dstack.mpc_image_hash')"
       pass "node$i attestation: Dstack (mpc_hash=${mpc_hash:0:16}...)"
     elif echo "$att_output" | grep -q '"Mock"'; then
       fail "node$i attestation: Mock (expected Dstack)"
@@ -174,7 +132,7 @@ verify_cluster() {
       sign-with-keychain send 2>&1)"
     if echo "$sign_output" | grep -q '"big_r"'; then
       local sig_r
-      sig_r="$(echo "$sign_output" | extract_json | jq -r '.big_r.affine_point')"
+      sig_r="$(echo "$sign_output" | extract_json_tx | jq -r '.big_r.affine_point')"
       pass "ECDSA signature generated (big_r=${sig_r:0:20}...)"
       sign_ok=1
       break
@@ -193,7 +151,7 @@ verify_cluster() {
   local hashes_output
   hashes_output="$(near_call_ro allowed_docker_image_hashes '{}')"
   local hashes_json
-  hashes_json="$(echo "$hashes_output" | extract_json_ro)"
+  hashes_json="$(echo "$hashes_output" | extract_json_tx_ro)"
   local hash_count
   hash_count="$(echo "$hashes_json" | jq 'length')"
   pass "Allowed MPC image hashes: $hash_count"
@@ -241,7 +199,7 @@ upgrade_cluster() {
 
   # Check if already approved
   local current_hashes
-  current_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_ro)"
+  current_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_tx_ro)"
   if echo "$current_hashes" | jq -e --arg h "$new_hash" '.[] | select(. == $h)' >/dev/null 2>&1; then
     warn "Hash $new_hash is already approved — skipping vote"
   else
@@ -269,7 +227,7 @@ upgrade_cluster() {
 
     # Verify vote succeeded
     local updated_hashes
-    updated_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_ro)"
+    updated_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_tx_ro)"
     if echo "$updated_hashes" | jq -e --arg h "$new_hash" '.[] | select(. == $h)' >/dev/null 2>&1; then
       pass "New hash approved on-chain: $new_hash"
     else
@@ -375,7 +333,7 @@ upgrade_cluster() {
   local tee_output
   tee_output="$(near_call_tx get_tee_accounts '{}' "${ROOT_ACCOUNT}")"
   local tee_json
-  tee_json="$(echo "$tee_output" | extract_json)"
+  tee_json="$(echo "$tee_output" | extract_json_tx)"
 
   for i in $(seq 0 $((N - 1))); do
     local key
@@ -383,7 +341,7 @@ upgrade_cluster() {
     local att_output
     att_output="$(near_call_ro get_attestation "{\"tls_public_key\": \"$key\"}")"
     local mpc_hash
-    mpc_hash="$(echo "$att_output" | extract_json_ro | jq -r '.Dstack.mpc_image_hash // empty')"
+    mpc_hash="$(echo "$att_output" | extract_json_tx_ro | jq -r '.Dstack.mpc_image_hash // empty')"
     if [ "$mpc_hash" = "$new_hash" ]; then
       pass "node$i attestation confirms new image hash"
     else

--- a/localnet/tee/scripts/rust-launcher/test-verify-and-upgrade.sh
+++ b/localnet/tee/scripts/rust-launcher/test-verify-and-upgrade.sh
@@ -108,7 +108,7 @@ verify_cluster() {
     att_output="$(near_call_ro get_attestation "{\"tls_public_key\": \"${tls_keys[$i]}\"}")"
     if echo "$att_output" | grep -q '"Dstack"'; then
       local mpc_hash
-      mpc_hash="$(echo "$att_output" | extract_json_tx_ro | jq -r '.Dstack.mpc_image_hash')"
+      mpc_hash="$(echo "$att_output" | extract_json_ro | jq -r '.Dstack.mpc_image_hash')"
       pass "node$i attestation: Dstack (mpc_hash=${mpc_hash:0:16}...)"
     elif echo "$att_output" | grep -q '"Mock"'; then
       fail "node$i attestation: Mock (expected Dstack)"
@@ -151,7 +151,7 @@ verify_cluster() {
   local hashes_output
   hashes_output="$(near_call_ro allowed_docker_image_hashes '{}')"
   local hashes_json
-  hashes_json="$(echo "$hashes_output" | extract_json_tx_ro)"
+  hashes_json="$(echo "$hashes_output" | extract_json_ro)"
   local hash_count
   hash_count="$(echo "$hashes_json" | jq 'length')"
   pass "Allowed MPC image hashes: $hash_count"
@@ -199,7 +199,7 @@ upgrade_cluster() {
 
   # Check if already approved
   local current_hashes
-  current_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_tx_ro)"
+  current_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_ro)"
   if echo "$current_hashes" | jq -e --arg h "$new_hash" '.[] | select(. == $h)' >/dev/null 2>&1; then
     warn "Hash $new_hash is already approved — skipping vote"
   else
@@ -227,7 +227,7 @@ upgrade_cluster() {
 
     # Verify vote succeeded
     local updated_hashes
-    updated_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_tx_ro)"
+    updated_hashes="$(near_call_ro allowed_docker_image_hashes '{}' | extract_json_ro)"
     if echo "$updated_hashes" | jq -e --arg h "$new_hash" '.[] | select(. == $h)' >/dev/null 2>&1; then
       pass "New hash approved on-chain: $new_hash"
     else
@@ -341,7 +341,7 @@ upgrade_cluster() {
     local att_output
     att_output="$(near_call_ro get_attestation "{\"tls_public_key\": \"$key\"}")"
     local mpc_hash
-    mpc_hash="$(echo "$att_output" | extract_json_tx_ro | jq -r '.Dstack.mpc_image_hash // empty')"
+    mpc_hash="$(echo "$att_output" | extract_json_ro | jq -r '.Dstack.mpc_image_hash // empty')"
     if [ "$mpc_hash" = "$new_hash" ]; then
       pass "node$i attestation confirms new image hash"
     else


### PR DESCRIPTION
## Summary

Closes #3238 by unifying the rust-launcher localnet/testnet path with `deployment/cvm-deployment/`'s `port_override = 80` model, plus adds the localnet TEE migration test driver that validates it end-to-end.

After this PR:

- **P2P/TLS** binds container `:80` everywhere (`port_override = 80` forces it). Reached at `<ip>:80` per-CVM, distinguished by IP.
- **Migration HTTP** (`migration_web_ui`) binds container `:8079` everywhere. Reached at `<ip>:8079`. `EXTERNAL_MPC_MIGRATION_PORT` carries this consistently — no more dual meaning.
- The localnet-specific `MIGRATION_BASE_PORT` / `migration_port_for_i` / `13001+i` repurposing of the migration slot for P2P is gone.

Before this change, the migration HTTP service in the rust-launcher localnet path was never reachable end-to-end — `migration_web_ui = 8078` was bound inside the container but only port `13001+i` was forwarded, and that slot was carrying P2P. See #3238 for the full investigation and #2121 for the empirical reproduction.

## Diff overview

| File | Change |
|---|---|
| `node.conf.localnet.toml.tpl` | Add `port_override = 80`; change `migration_web_ui` 8078 → 8079 |
| `node.conf.testnet.toml.tpl` | Add `port_override = 80`; change `migration_web_ui` 8078 → 8079 |
| `deploy-tee-cluster.sh` | Drop `MIGRATION_BASE_PORT` / `migration_port_for_i`. `MIGRATION_PORT=8079` (constant). `PORTS` now also forwards `${MAIN_PORT}:${INTERNAL_MAIN_PORT}` so the P2P listener on container:80 is reachable. Both `init_args` Python blocks publish `https://<ip>:80` instead of `https://<ip>:(13001+i)` |
| `single-node.sh` | Default `INTERNAL_MIGRATION_PORT=8079` (was 13001); include `MAIN_PORT:INTERNAL_MAIN_PORT` in `PORTS` for the P2P forward |
| `test-migration.sh` **(new)** | Self-contained driver: `prepare`, `deploy-target`, `forward`, `back`, `both`, `status`, `cleanup`. Brings up a third CVM (B0) sharing A0's NEAR account but with a distinct P2P key, then drives backup-cli through the full A→B→A migration cycle with ECDSA sign verification each direction |
| `set-localnet-env.sh` | Bump `MPC_MANIFEST_DIGEST` to a post-#3260 image (older images can't deserialize the current contract schema). Bump `NODE_INITIAL_BALANCE` 1 → 10 NEAR + new `ROOT_INITIAL_BALANCE=45 NEAR` (migration drives ~5 operator txns per node) |

## Drive-by fix

The resharing-flow `init_args` generator at `deploy-tee-cluster.sh:1405` hardcoded `https://127.0.0.1:<port>` for new participants — that would break cross-IP resharing (the participants' actual IPs were thrown away). Changed to `https://<ip>:80` to use the participant's real IP.

## Test plan

- [x] `bash -n` parses all five modified scripts.
- [x] `test-migration.sh both` on real-TDX localnet (forward A→B then back B→A) completes end-to-end with ECDSA sign verification each direction. Output:
  ```
  [PASS] Forward migration A0 -> B0 succeeded
  [PASS] Back-migration B0 -> A0 succeeded
  ```
  Final contract state: both participant URLs on `:80`, `migration_info.destination_node_info: null`. Real Dstack attestation throughout (not Mock).
- [ ] Real testnet smoke deploy — confirm a 2-node `deploy-tee-cluster.sh MODE=testnet` deploy still reaches `Running` with sign requests succeeding (no functional change expected; `port_override=80` already matched the production tomls, this just brings the rust-launcher's test-deploy template into line).

## Related

- Issue: #3238
- Originating PR (cvm-deployment migration-port fix): #3234
- Empirical reproduction & validation: [#2121 comment](https://github.com/near/mpc/issues/2121#issuecomment-4529634993)