### PR TITLE
test(e2e): wait for indexer progress in back-migration restart (fix flaky test)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,5 +18,13 @@ max-threads = 4
 filter = 'package(e2e-tests)'
 test-group = 'e2e'
 
+# Surface tracing output on passing migration_service tests so the
+# new wait_for_node_indexer_height_above log line (added in PR #3365)
+# is visible in CI logs without having to wait for a failure. Scoped to
+# this one test family to keep the rest of the e2e output quiet.
+[[profile.ci-e2e.overrides]]
+filter = 'package(e2e-tests) and test(/migration_service/)'
+success-output = 'immediate'
+
 [profile.ci-other]
 default-filter = 'not package(mpc-node) and not package(mpc-contract) and not package(e2e-tests) and not package(contract-history) and not test(=tee_authority::tests::test_fetch_collateral_from_pccs) and not (test(/^registry::integration_tests::/) and package(tee-launcher))'

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -18,13 +18,5 @@ max-threads = 4
 filter = 'package(e2e-tests)'
 test-group = 'e2e'
 
-# Surface tracing output on passing migration_service tests so the
-# new wait_for_node_indexer_height_above log line (added in PR #3365)
-# is visible in CI logs without having to wait for a failure. Scoped to
-# this one test family to keep the rest of the e2e output quiet.
-[[profile.ci-e2e.overrides]]
-filter = 'package(e2e-tests) and test(/migration_service/)'
-success-output = 'immediate'
-
 [profile.ci-other]
 default-filter = 'not package(mpc-node) and not package(mpc-contract) and not package(e2e-tests) and not package(contract-history) and not test(=tee_authority::tests::test_fetch_collateral_from_pccs) and not (test(/^registry::integration_tests::/) and package(tee-launcher))'

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -399,6 +399,10 @@ impl MpcCluster {
 
     /// Wait until the node at `idx` responds with HTTP 200 on its `/health` endpoint.
     /// Returns an error if the node is not running or does not become healthy within 120 seconds.
+    ///
+    /// Only verifies the web server is bound; for full readiness (e.g. after
+    /// kill+restart), pair with `common::wait_for_node_indexer_height_above`.
+    /// See issue #3366.
     pub async fn wait_for_node_healthy(&self, idx: usize) -> anyhow::Result<()> {
         let node = match &self.nodes[idx] {
             MpcNodeState::Running(n) => n,

--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -219,8 +219,9 @@ pub async fn wait_for_node_indexer_height_above(
     Ok(())
 }
 
-/// Read node `idx`'s current indexer block height. Returns `None` if the
-/// node is not running or the metric scrape fails (process down).
+/// Read node `idx`'s current indexer block height. Returns `Ok(None)` if
+/// the node is not running or the HTTP scrape can't connect (process
+/// down); returns `Err` if a metrics body read fails partway through.
 pub async fn current_node_indexer_height(
     cluster: &MpcCluster,
     idx: usize,

--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -187,7 +187,16 @@ pub async fn wait_for_node_indexer_height_above(
     timeout: Duration,
 ) -> anyhow::Result<()> {
     let max_times = (timeout.as_millis() / POLL_INTERVAL.as_millis()) as usize;
-    (|| async {
+    let start = std::time::Instant::now();
+    tracing::info!(
+        node = idx,
+        min_height,
+        timeout_ms = timeout.as_millis() as u64,
+        "waiting for indexer to advance past pre-kill height"
+    );
+    let attempts = std::sync::atomic::AtomicU32::new(0);
+    let result = (|| async {
+        attempts.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
         let heights = cluster
             .get_metric_all_nodes(metrics::INDEXER_LATEST_BLOCK_HEIGHT)
             .await
@@ -200,7 +209,7 @@ pub async fn wait_for_node_indexer_height_above(
             h > min_height,
             "node {idx} indexer height {h} has not advanced past {min_height} yet"
         );
-        Ok(())
+        Ok(h)
     })
     .retry(
         ConstantBuilder::default()
@@ -210,7 +219,17 @@ pub async fn wait_for_node_indexer_height_above(
     .await
     .with_context(|| {
         format!("node {idx} indexer did not advance past height {min_height} within {timeout:?}")
-    })
+    })?;
+    let elapsed = start.elapsed();
+    tracing::info!(
+        node = idx,
+        min_height,
+        reached_height = result,
+        attempts = attempts.load(std::sync::atomic::Ordering::Relaxed),
+        elapsed_ms = elapsed.as_millis() as u64,
+        "indexer advanced past pre-kill height"
+    );
+    Ok(())
 }
 
 /// Read node `idx`'s current indexer block height. Returns `None` if the

--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -164,22 +164,9 @@ pub async fn wait_metric_on_nodes(
     .await
 }
 
-/// Wait until node `idx`'s indexer block-height metric reports a value
-/// strictly greater than `min_height`.
-///
-/// Use this after `MpcCluster::start_nodes` + `wait_for_node_healthy` to
-/// confirm the node's *indexer* (not just the web server) is alive and
-/// progressing. `/health` returns 200 the moment the web server binds —
-/// which happens early in node startup, before the indexer is started
-/// (see `crates/node/src/web.rs`). If the indexer subsequently fails or
-/// the whole process crashes during catch-up, the test would otherwise
-/// march on with a node that's actually dead and only discover it via
-/// "Connection refused" 30s later in some downstream polling loop.
-///
-/// Returns an error if the indexer doesn't advance within `timeout` —
-/// for restarted nodes the caller should pass the height observed
-/// *before* the kill, so this proves the indexer caught up and made
-/// forward progress (not just resumed at the persisted height).
+/// Wait until node `idx`'s indexer block-height metric exceeds `min_height`.
+/// Stronger readiness check than `wait_for_node_healthy`, which only verifies
+/// the web server is up (see #3366).
 pub async fn wait_for_node_indexer_height_above(
     cluster: &MpcCluster,
     idx: usize,

--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -164,6 +164,67 @@ pub async fn wait_metric_on_nodes(
     .await
 }
 
+/// Wait until node `idx`'s indexer block-height metric reports a value
+/// strictly greater than `min_height`.
+///
+/// Use this after `MpcCluster::start_nodes` + `wait_for_node_healthy` to
+/// confirm the node's *indexer* (not just the web server) is alive and
+/// progressing. `/health` returns 200 the moment the web server binds —
+/// which happens early in node startup, before the indexer is started
+/// (see `crates/node/src/web.rs`). If the indexer subsequently fails or
+/// the whole process crashes during catch-up, the test would otherwise
+/// march on with a node that's actually dead and only discover it via
+/// "Connection refused" 30s later in some downstream polling loop.
+///
+/// Returns an error if the indexer doesn't advance within `timeout` —
+/// for restarted nodes the caller should pass the height observed
+/// *before* the kill, so this proves the indexer caught up and made
+/// forward progress (not just resumed at the persisted height).
+pub async fn wait_for_node_indexer_height_above(
+    cluster: &MpcCluster,
+    idx: usize,
+    min_height: i64,
+    timeout: Duration,
+) -> anyhow::Result<()> {
+    let max_times = (timeout.as_millis() / POLL_INTERVAL.as_millis()) as usize;
+    (|| async {
+        let heights = cluster
+            .get_metric_all_nodes(metrics::INDEXER_LATEST_BLOCK_HEIGHT)
+            .await
+            .context("failed to scrape indexer block-height metric")?;
+        let h = heights
+            .get(idx)
+            .and_then(|h| *h)
+            .context("indexer block-height metric not available — node may have exited")?;
+        anyhow::ensure!(
+            h > min_height,
+            "node {idx} indexer height {h} has not advanced past {min_height} yet"
+        );
+        Ok(())
+    })
+    .retry(
+        ConstantBuilder::default()
+            .with_delay(POLL_INTERVAL)
+            .with_max_times(max_times),
+    )
+    .await
+    .with_context(|| {
+        format!("node {idx} indexer did not advance past height {min_height} within {timeout:?}")
+    })
+}
+
+/// Read node `idx`'s current indexer block height. Returns `None` if the
+/// node is not running or the metric scrape fails (process down).
+pub async fn current_node_indexer_height(
+    cluster: &MpcCluster,
+    idx: usize,
+) -> anyhow::Result<Option<i64>> {
+    let heights = cluster
+        .get_metric_all_nodes(metrics::INDEXER_LATEST_BLOCK_HEIGHT)
+        .await?;
+    Ok(heights.get(idx).copied().flatten())
+}
+
 /// Wait until every node in `alive_nodes` is at least `min_height_diff` blocks
 /// ahead of `faulty_node` according to the indexer block-height metric.
 ///

--- a/crates/e2e-tests/tests/migration_service.rs
+++ b/crates/e2e-tests/tests/migration_service.rs
@@ -732,15 +732,8 @@ async fn migration_service__should_handle_back_migration_a_to_b_to_a() {
         .wait_for_node_healthy(a_idx)
         .await
         .expect("A0 did not become healthy after restart");
-    // `/health` returns 200 the moment the web server binds, which
-    // happens before the indexer is started (see
-    // crates/node/src/web.rs). Without an additional wait, the test
-    // can march into back-migration while A0's indexer is still
-    // initializing — and if A0's process then crashes during catch-up,
-    // the downstream `start_migration_and_wait` polling loop just
-    // hits "Connection refused" against a dead node for 30s.
-    // Wait for the indexer to actually advance past where it was before
-    // the kill (CI run 26451546911 attempt 1 hit this race).
+    // `wait_for_node_healthy` only checks the web port; wait for the
+    // indexer to actually resume before back-migration (see #3366).
     common::wait_for_node_indexer_height_above(
         &cluster,
         a_idx,

--- a/crates/e2e-tests/tests/migration_service.rs
+++ b/crates/e2e-tests/tests/migration_service.rs
@@ -715,6 +715,13 @@ async fn migration_service__should_handle_back_migration_a_to_b_to_a() {
         "A0's permanent_keys/ is empty before kill — test setup did not produce keyshares, \
          so the back-migration P1 precondition can't be modeled"
     );
+    // Snapshot A0's indexer height before the kill so the post-restart
+    // readiness check (below) can prove the indexer has resumed and
+    // advanced past where it was — not just bound the web port.
+    let a0_indexer_height_before_kill = common::current_node_indexer_height(&cluster, a_idx)
+        .await
+        .expect("failed to read A0's indexer height before kill")
+        .expect("A0's indexer should be reporting a block height before the kill");
     cluster
         .kill_nodes(&[a_idx])
         .expect("failed to kill A0 before back-migration");
@@ -725,6 +732,23 @@ async fn migration_service__should_handle_back_migration_a_to_b_to_a() {
         .wait_for_node_healthy(a_idx)
         .await
         .expect("A0 did not become healthy after restart");
+    // `/health` returns 200 the moment the web server binds, which
+    // happens before the indexer is started (see
+    // crates/node/src/web.rs). Without an additional wait, the test
+    // can march into back-migration while A0's indexer is still
+    // initializing — and if A0's process then crashes during catch-up,
+    // the downstream `start_migration_and_wait` polling loop just
+    // hits "Connection refused" against a dead node for 30s.
+    // Wait for the indexer to actually advance past where it was before
+    // the kill (CI run 26451546911 attempt 1 hit this race).
+    common::wait_for_node_indexer_height_above(
+        &cluster,
+        a_idx,
+        a0_indexer_height_before_kill,
+        Duration::from_secs(60),
+    )
+    .await
+    .expect("A0's indexer did not resume + advance within 60s after restart");
     // Validate the assumption the test rests on: A0's keyshares are
     // still on disk after the restart. If they're missing or different,
     // the test no longer models production's back-migration scenario


### PR DESCRIPTION
Closes #3366.

## Summary

A **diagnostic + readability improvement** for the `migration_service__should_handle_back_migration_a_to_b_to_a` test. When that test does flake during A0's restart, the failure mode goes from a 30 s silent `Connection refused` against a closed socket to a labeled `"indexer block-height metric not available — node may have exited"` error pointing at the actual root cause. I am **not** claiming this PR prevents the underlying flake — see [Honest caveats](#honest-caveats). It's still worth merging on the diagnostic value alone.

Originally observed in PR #3346's CI run [26451546911](https://github.com/near/mpc/actions/runs/26451546911/job/77873914394) attempt 1, with two further reproductions on PR #3362 ([job 77946818099](https://github.com/near/mpc/actions/runs/26471648821/job/77946818099) and [job 77952041274](https://github.com/near/mpc/actions/runs/26473240463/job/77952041274)).

### Observed failure

```
back: start_migration_and_wait failed: timed out waiting for target node to index node migration

Caused by:
    0: error sending request for url (http://127.0.0.1:21725/debug/migrations)
    3: Connection refused (os error 111)
```

`Connection refused` is a kernel-level error — **nothing was listening on port 21725** by the time the test polled. That's softer than "process exited" (the listener could also go away via a panic in the web-server task alone, or a controlled shutdown), but it's stronger than "indexer slow" — a slow-but-alive indexer would return HTTP 200 with stale data, not refuse connections.

### Readiness gap

After the forward migration the test does:
```rust
cluster.kill_nodes(&[a_idx])
cluster.start_nodes(&[a_idx])
cluster.wait_for_node_healthy(a_idx)
```

`wait_for_node_healthy` only checks that `/health` returns 200. `/health` is literally:

```rust
.route("/health", axum::routing::get(|| async { "OK" }))
```
(`crates/node/src/web.rs`). The web server binds early in node startup — well **before** the indexer is started. Observed restart-to-"healthy" times in the three failing runs: ~509 ms, ~512 ms, **~16 ms** — that last one is the time to spawn the binary and bind a socket, nothing more.

### What this PR adds

After `wait_for_node_healthy`, also wait for A0's indexer to advance **past** the height it had pre-kill. Two helpers added to `common.rs`:

- `current_node_indexer_height(cluster, idx)` — single-shot read of one node's `mpc_indexer_latest_block_height`. Used to capture the baseline before the kill.
- `wait_for_node_indexer_height_above(cluster, idx, min_height, timeout)` — polls until the metric exceeds a baseline. If A0's process exits during catch-up, `MpcNode::get_metric` returns `Ok(None)` on connect failure, so the retry loop runs the full 60 s budget; on timeout the error chain ends with `indexer block-height metric not available — node may have exited` as a chained cause, instead of the silent 30 s `Connection refused` from the downstream polling loop. Same total wait if A0 really did die, but the diagnostic points at the right thing.
- The helper emits `tracing::info!` on entry and exit (attempts, elapsed_ms, reached_height).

Called from `migration_service__should_handle_back_migration_a_to_b_to_a` between the restart and the back-migration round. Targeted at the only test that kill+restarts a participant; other callers of `wait_for_node_healthy` are unchanged on purpose.

### Diagnostic value demonstrated in practice

After this fix was rebased into PR #3362, that test failed again — but now with the new error chain:

```
A0's indexer did not resume + advance within 60s after restart:
node 0 indexer did not advance past height 301 within 60s

Caused by:
    indexer block-height metric not available — node may have exited
```

That's the exact before/after this PR is designed to produce: silent 30 s `Connection refused` → labeled `"node may have exited"`. It immediately pointed at A0's process being dead on PR #3362's branch (likely caused by `9df5e1fd fix(node): refresh attestation…`, not by anything in the test infra) — without this fix we'd have needed forensics on a TCP-level error to reach the same conclusion.

## Empirical evidence

Ran 15 CI runs on this branch via `workflow_dispatch` to validate. **All 15 passed.** The last 7 used the logged version of the helper, giving wait metrics per run:

| Run | pre-kill height | reached height | attempts | elapsed |
|---|---|---|---|---|
| [26473939908](https://github.com/near/mpc/actions/runs/26473939908) | 223 | 226 | 4 | 1.60s |
| [26474390449](https://github.com/near/mpc/actions/runs/26474390449) | 215 | 222 | 6 | 2.60s |
| [26474967584](https://github.com/near/mpc/actions/runs/26474967584) | 230 | 232 | 4 | 1.54s |
| [26475368365](https://github.com/near/mpc/actions/runs/26475368365) | 238 | **260** | 5 | 2.07s |
| [26475788260](https://github.com/near/mpc/actions/runs/26475788260) | 227 | 229 | 4 | 1.54s |
| [26476134304](https://github.com/near/mpc/actions/runs/26476134304) | 242 | 243 | 5 | 2.08s |
| [26476483277](https://github.com/near/mpc/actions/runs/26476483277) | 221 | **236** | 5 | 2.06s |

In every logged run the helper actually waited (≥4 attempts, never resolved on attempt 1); A0 stayed alive throughout (`heights[idx]` was always `Some(n)`, never `None`). A subsequent 5-run + ongoing 10-run extension on the same branch continued to pass.

## Honest caveats

What we can claim with confidence:

- **The new wait is engaged.** Every logged run took 1.5–2.6 s in the helper; the original `wait_for_node_healthy` would have returned the test into back-migration with the indexer not yet past the pre-kill height.
- **The diagnostic is genuinely better** when the failure does fire — the error chain ends with `indexer block-height metric not available — node may have exited`, not a silent 30 s `Connection refused` against a closed socket. This was demonstrated in practice on PR #3362 after rebase.

What we *cannot* prove:

- **That this fix prevents the original flake.** In all the logged runs on this branch, A0 stayed alive, so the catastrophic "listener disappeared" path didn't fire. Without my fix, those same runs would likely have absorbed the same indexer-catch-up time inside `start_migration_and_wait`'s own retry loop (which has a 30 s budget on `/debug/migrations`) and still passed — i.e. the fix may have shifted ~2 s of waiting from one place to another without changing the outcome.
- **That a flake exists on plain main.** The three documented failures are all on branches with additional code on top of main (PR #3346 had its own additions; PR #3362 has the `fix(node): refresh attestation` change). It is possible the failures are branch-specific rather than a main-branch flake, in which case this PR is purely a diagnostic improvement on main. A parallel 20-run main-baseline experiment is currently running; results will be added if they show anything informative either way.
- **What kills the listener on the failing branches.** Most likely a panic in A0's indexer/coordinator (possibly fragile state seen during catch-up after the forward migration's identity swap), but without `stderr.log` capture from a failing run we can't confirm. A future follow-up to dump per-node `stderr.log` to the test output on failure would close that diagnostic loop.

Net: this PR is a structural improvement to the readiness check and, more importantly, a diagnostic improvement. Whether it also prevents flakes in practice depends on conditions we haven't been able to reproduce on plain main. I'm not claiming a behavioural fix; I'm claiming the next time this test fails, the failure will be self-explanatory instead of mysterious — and the value of that has already been demonstrated once on PR #3362.

## Test plan

- [x] `cargo check --tests -p e2e-tests` clean
- [x] 15 + 5 + 10 CI runs on this branch (`workflow_dispatch`, `cancel-in-progress` enforces sequencing) — all passed at time of writing; final tallies will be updated when the in-flight runs finish
- [x] Logging metrics confirm the new wait runs ~2 s per call, never resolves on attempt 1
- [x] Diagnostic improvement confirmed in practice on PR #3362 (rebased): failure now surfaces `"node may have exited"` instead of `Connection refused`
- [ ] Parallel 20-run baseline on a clean main snapshot to check whether the original flake exists on main without other code changes (in progress)
