### PR TITLE
feat(foreign-chain-inspector): canonical-chain check for Bitcoin and Starknet

### DIFF
--- a/crates/e2e-tests/src/foreign_chain_mock.rs
+++ b/crates/e2e-tests/src/foreign_chain_mock.rs
@@ -10,6 +10,7 @@ use httpmock::{HttpMockRequest, HttpMockResponse};
 pub const MOCK_BLOCK_HASH: &str =
     "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 pub const MOCK_TX_ID: &str = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+pub const MOCK_BLOCK_HEIGHT: u64 = 800_000;
 
 fn jsonrpc_error(id: serde_json::Value, method: &str) -> HttpMockResponse {
     let response_body = serde_json::json!({
@@ -33,16 +34,22 @@ pub fn setup_bitcoin_mock(server: &MockServer) {
             let id = body["id"].clone();
             let method = body["method"].as_str().expect("method field");
 
-            if method != "getrawtransaction" {
-                return jsonrpc_error(id, method);
-            }
+            let result = match method {
+                "getrawtransaction" => serde_json::json!({
+                    "blockhash": MOCK_BLOCK_HASH,
+                    "confirmations": 10,
+                }),
+                "getblock" => serde_json::json!({
+                    "hash": MOCK_BLOCK_HASH,
+                    "height": MOCK_BLOCK_HEIGHT,
+                }),
+                "getblockhash" => serde_json::Value::String(MOCK_BLOCK_HASH.to_string()),
+                other => return jsonrpc_error(id, other),
+            };
 
             let response_body = serde_json::json!({
                 "jsonrpc": "2.0",
-                "result": {
-                    "blockhash": MOCK_BLOCK_HASH,
-                    "confirmations": 10,
-                },
+                "result": result,
                 "id": id,
             });
 
@@ -135,12 +142,32 @@ pub fn setup_starknet_mock(server: &MockServer) {
             let id = body["id"].clone();
             let method = body["method"].as_str().expect("method field");
 
-            if method != "starknet_getTransactionReceipt" {
-                return jsonrpc_error(id, method);
-            }
+            let result = match method {
+                "starknet_getTransactionReceipt" => starknet_receipt_result(),
+                "starknet_getBlockWithTxHashes" => serde_json::json!({
+                    "block_hash": format!("0x{MOCK_BLOCK_HASH}"),
+                    "block_number": 6868546,
+                }),
+                other => return jsonrpc_error(id, other),
+            };
 
             let response_body = serde_json::json!({
-                "result": {
+                "result": result,
+                "jsonrpc": "2.0",
+                "id": id,
+            });
+
+            HttpMockResponse::builder()
+                .status(200)
+                .header("content-type", "application/json")
+                .body(serde_json::to_string(&response_body).unwrap())
+                .build()
+        });
+    });
+}
+
+fn starknet_receipt_result() -> serde_json::Value {
+    serde_json::json!({
                     "type": "INVOKE",
                     "transaction_hash": "0x52a6c2b9d1d1b77dbc322b298fd91f39e3cca9bf1db4a7aa79f14a90efa633e",
                     "actual_fee": { "amount": "0xe97d3e61059940", "unit": "FRI" },
@@ -206,16 +233,5 @@ pub fn setup_starknet_mock(server: &MockServer) {
                         "l2_gas": 3159360,
                         "l1_data_gas": 512,
                     },
-                },
-                "jsonrpc": "2.0",
-                "id": id,
-            });
-
-            HttpMockResponse::builder()
-                .status(200)
-                .header("content-type", "application/json")
-                .body(serde_json::to_string(&response_body).unwrap())
-                .build()
-        });
-    });
+    })
 }

--- a/crates/foreign-chain-inspector/src/bitcoin/inspector.rs
+++ b/crates/foreign-chain-inspector/src/bitcoin/inspector.rs
@@ -3,12 +3,19 @@ use jsonrpsee::core::client::ClientT;
 use crate::bitcoin::{BitcoinExtractedValue, BitcoinTransactionHash};
 use crate::{BlockConfirmations, ForeignChainInspectionError, ForeignChainInspector};
 use foreign_chain_rpc_interfaces::bitcoin::{
-    GetRawTransactionArgs, GetRawTransactionVerboseResponse, TransportBitcoinTransactionHash,
+    GET_BLOCK_VERBOSITY_HEADER_AND_TXIDS, GetBlockArgs, GetBlockHashArgs, GetBlockResponse,
+    GetRawTransactionArgs, GetRawTransactionVerboseResponse, TransportBitcoinBlockHash,
+    TransportBitcoinTransactionHash,
 };
 
 /// https://developer.bitcoin.org/reference/rpc/getrawtransaction.html
 const GET_RAW_TRANSACTION_METHOD: &str = "getrawtransaction";
 const VERBOSE_RESPONSE: bool = true;
+
+/// https://developer.bitcoin.org/reference/rpc/getblock.html
+const GET_BLOCK_METHOD: &str = "getblock";
+/// https://developer.bitcoin.org/reference/rpc/getblockhash.html
+const GET_BLOCK_HASH_METHOD: &str = "getblockhash";
 
 pub struct BitcoinInspector<Client> {
     client: Client,
@@ -51,6 +58,9 @@ where
             });
         }
 
+        self.verify_block_is_canonical(rpc_response.blockhash)
+            .await?;
+
         let extracted_values = extractors
             .iter()
             .map(|extractor| extractor.extract_value(&rpc_response))
@@ -66,6 +76,42 @@ where
 {
     pub fn new(client: Client) -> Self {
         Self { client }
+    }
+
+    /// Checks that the receipt's block is on the canonical chain by resolving its height via
+    /// `getblock` and then asking the RPC for the canonical hash at that height via
+    /// `getblockhash`. `getblockhash` only ever returns canonical blocks, so a mismatch means
+    /// the `getrawtransaction` response was anchored to a side block (stale tx index,
+    /// partially-applied reorg, divergent RPC backend, etc.).
+    async fn verify_block_is_canonical(
+        &self,
+        receipt_blockhash: TransportBitcoinBlockHash,
+    ) -> Result<(), ForeignChainInspectionError> {
+        let get_block_args = GetBlockArgs {
+            blockhash: receipt_blockhash,
+            verbosity: GET_BLOCK_VERBOSITY_HEADER_AND_TXIDS,
+        };
+        let block: GetBlockResponse = self
+            .client
+            .request(GET_BLOCK_METHOD, &get_block_args)
+            .await?;
+
+        let get_block_hash_args = GetBlockHashArgs {
+            height: block.height,
+        };
+        let canonical_blockhash: TransportBitcoinBlockHash = self
+            .client
+            .request(GET_BLOCK_HASH_METHOD, &get_block_hash_args)
+            .await?;
+
+        if canonical_blockhash != receipt_blockhash {
+            return Err(ForeignChainInspectionError::NonCanonicalBlock {
+                block_number: block.height,
+                receipt_hash: (*receipt_blockhash).to_vec(),
+                canonical_hash: (*canonical_blockhash).to_vec(),
+            });
+        }
+        Ok(())
     }
 }
 

--- a/crates/foreign-chain-inspector/src/evm/inspector.rs
+++ b/crates/foreign-chain-inspector/src/evm/inspector.rs
@@ -136,9 +136,9 @@ where
 
         if canonical.hash != receipt_block_hash {
             return Err(ForeignChainInspectionError::NonCanonicalBlock {
-                block_number: receipt_block_number,
-                receipt_hash: receipt_block_hash,
-                canonical_hash: canonical.hash,
+                block_number: receipt_block_number.as_u64(),
+                receipt_hash: receipt_block_hash.as_bytes().to_vec(),
+                canonical_hash: canonical.hash.as_bytes().to_vec(),
             });
         }
         Ok(())

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -1,5 +1,4 @@
 use derive_more::{Deref, Display, From};
-use ethereum_types::{H256, U64};
 use http::{HeaderMap, HeaderName, HeaderValue};
 use jsonrpsee::http_client::{HttpClient, HttpClientBuilder};
 use thiserror::Error;
@@ -72,9 +71,9 @@ pub enum ForeignChainInspectionError {
         "transaction receipt's block_hash does not match the canonical chain at block {block_number}: receipt_hash={receipt_hash:?}, canonical_hash={canonical_hash:?}"
     )]
     NonCanonicalBlock {
-        block_number: U64,
-        receipt_hash: H256,
-        canonical_hash: H256,
+        block_number: u64,
+        receipt_hash: Vec<u8>,
+        canonical_hash: Vec<u8>,
     },
     #[error("The transaction's status was not success")]
     TransactionFailed,

--- a/crates/foreign-chain-inspector/src/starknet/inspector.rs
+++ b/crates/foreign-chain-inspector/src/starknet/inspector.rs
@@ -1,13 +1,14 @@
 use crate::starknet::{StarknetExtractedValue, StarknetTransactionHash};
 use crate::{ForeignChainInspectionError, ForeignChainInspector};
 use foreign_chain_rpc_interfaces::starknet::{
-    GetTransactionReceiptArgs, GetTransactionReceiptResponse, H256, StarknetExecutionStatus,
-    StarknetFinalityStatus,
+    BlockId, GetBlockWithTxHashesArgs, GetBlockWithTxHashesResponse, GetTransactionReceiptArgs,
+    GetTransactionReceiptResponse, H256, StarknetExecutionStatus, StarknetFinalityStatus,
 };
 use jsonrpsee::core::client::ClientT;
 use near_mpc_contract_interface::types::{StarknetFelt, StarknetLog};
 
 const GET_TRANSACTION_RECEIPT_METHOD: &str = "starknet_getTransactionReceipt";
+const GET_BLOCK_WITH_TX_HASHES_METHOD: &str = "starknet_getBlockWithTxHashes";
 
 pub struct StarknetInspector<Client> {
     client: Client,
@@ -58,6 +59,9 @@ where
             return Err(ForeignChainInspectionError::NotFinalized);
         }
 
+        self.verify_block_is_canonical(rpc_response.block_number, rpc_response.block_hash)
+            .await?;
+
         let extracted_values = extractors
             .iter()
             .map(|extractor| extractor.extract_value(&rpc_response))
@@ -73,6 +77,36 @@ where
 {
     pub fn new(client: Client) -> Self {
         Self { client }
+    }
+
+    /// Checks that the receipt's block is on the canonical chain by re-fetching the canonical
+    /// block at `receipt_block_number` and comparing hashes. `starknet_getBlockWithTxHashes`
+    /// only ever resolves to a canonical block, so a mismatch means the receipt was indexed
+    /// against a side block (stale tx index, partially-applied reorg, divergent RPC backend,
+    /// etc.).
+    async fn verify_block_is_canonical(
+        &self,
+        receipt_block_number: u64,
+        receipt_block_hash: H256,
+    ) -> Result<(), ForeignChainInspectionError> {
+        let args = GetBlockWithTxHashesArgs {
+            block_id: BlockId::Number {
+                block_number: receipt_block_number,
+            },
+        };
+        let canonical: GetBlockWithTxHashesResponse = self
+            .client
+            .request(GET_BLOCK_WITH_TX_HASHES_METHOD, &args)
+            .await?;
+
+        if canonical.block_hash != receipt_block_hash {
+            return Err(ForeignChainInspectionError::NonCanonicalBlock {
+                block_number: receipt_block_number,
+                receipt_hash: receipt_block_hash.as_bytes().to_vec(),
+                canonical_hash: canonical.block_hash.as_bytes().to_vec(),
+            });
+        }
+        Ok(())
     }
 }
 

--- a/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
@@ -1,6 +1,10 @@
+#![allow(non_snake_case)]
+
 pub mod common;
 
-use crate::common::{FixedResponseRpcClient, JsonRpcResponse, mock_client_from_fixed_response};
+use crate::common::{
+    FixedResponseRpcClient, SequentialResponseMockClientBuilder, mock_client_from_fixed_response,
+};
 
 use foreign_chain_inspector::{
     BlockConfirmations, ForeignChainInspectionError, ForeignChainInspector, RpcAuthentication,
@@ -13,11 +17,14 @@ use foreign_chain_inspector::{
 
 use assert_matches::assert_matches;
 use foreign_chain_rpc_interfaces::bitcoin::{
-    GetRawTransactionVerboseResponse, TransportBitcoinBlockHash,
+    GetBlockResponse, GetRawTransactionVerboseResponse, TransportBitcoinBlockHash,
 };
 use httpmock::prelude::*;
+use httpmock::{HttpMockRequest, HttpMockResponse};
 use jsonrpsee::core::client::error::Error as RpcClientError;
 use rstest::rstest;
+
+const TEST_BLOCK_HEIGHT: u64 = 800_000;
 
 #[rstest]
 #[tokio::test]
@@ -33,14 +40,22 @@ async fn extract_returns_block_hash_when_confirmations_sufficient(
     // given
     let tx_id = BitcoinTransactionHash::from([3; 32]);
     let expected_block_hash = BitcoinBlockHash::from([4; 32]);
+    let transport_block_hash = TransportBitcoinBlockHash::from(*expected_block_hash);
 
-    // Mock the JSON-RPC response
-    let mock_response = GetRawTransactionVerboseResponse {
-        blockhash: TransportBitcoinBlockHash::from(*expected_block_hash),
+    let tx_response = GetRawTransactionVerboseResponse {
+        blockhash: transport_block_hash,
         confirmations: *confirmations,
     };
+    let block_response = GetBlockResponse {
+        hash: transport_block_hash,
+        height: TEST_BLOCK_HEIGHT,
+    };
 
-    let mock_client = mock_client_from_fixed_response(mock_response);
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(tx_response)
+        .with_response(block_response)
+        .with_response(transport_block_hash)
+        .build();
     let inspector = BitcoinInspector::new(mock_client);
 
     // when
@@ -94,13 +109,22 @@ async fn extract_returns_empty_when_no_extractors_provided() {
 
     let confirmations = BlockConfirmations::from(9u64);
     let threshold = BlockConfirmations::from(6u64);
+    let transport_block_hash = TransportBitcoinBlockHash::from(*expected_block_hash);
 
-    let mock_response = GetRawTransactionVerboseResponse {
-        blockhash: TransportBitcoinBlockHash::from(*expected_block_hash),
+    let tx_response = GetRawTransactionVerboseResponse {
+        blockhash: transport_block_hash,
         confirmations: *confirmations,
     };
+    let block_response = GetBlockResponse {
+        hash: transport_block_hash,
+        height: TEST_BLOCK_HEIGHT,
+    };
 
-    let mock_client = mock_client_from_fixed_response(mock_response);
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(tx_response)
+        .with_response(block_response)
+        .with_response(transport_block_hash)
+        .build();
     let inspector = BitcoinInspector::new(mock_client);
 
     // when
@@ -138,30 +162,155 @@ async fn extract_propagates_rpc_client_errors() {
 }
 
 #[tokio::test]
+async fn extract__should_return_non_canonical_block_when_receipt_blockhash_differs_from_canonical()
+{
+    // given: the receipt's blockhash exists (getblock resolves its height) but the canonical hash
+    // at that height differs, simulating an RPC that returned a receipt for a side block.
+    let tx_id = BitcoinTransactionHash::from([1; 32]);
+    let threshold = BlockConfirmations::from(1u64);
+    let receipt_blockhash = TransportBitcoinBlockHash::from([0xbb; 32]);
+    let canonical_blockhash = TransportBitcoinBlockHash::from([0xcc; 32]);
+
+    let tx_response = GetRawTransactionVerboseResponse {
+        blockhash: receipt_blockhash,
+        confirmations: 10,
+    };
+    let block_response = GetBlockResponse {
+        hash: receipt_blockhash,
+        height: TEST_BLOCK_HEIGHT,
+    };
+
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(tx_response)
+        .with_response(block_response)
+        .with_response(canonical_blockhash)
+        .build();
+    let inspector = BitcoinInspector::new(mock_client);
+
+    // when
+    let response = inspector
+        .extract(tx_id, threshold, vec![BitcoinExtractor::BlockHash])
+        .await;
+
+    // then
+    assert_matches!(
+        response,
+        Err(ForeignChainInspectionError::NonCanonicalBlock {
+            block_number,
+            receipt_hash,
+            canonical_hash,
+        }) if block_number == TEST_BLOCK_HEIGHT
+            && receipt_hash == vec![0xbb; 32]
+            && canonical_hash == vec![0xcc; 32]
+    );
+}
+
+#[tokio::test]
+async fn extract__should_propagate_getblock_rpc_error() {
+    // given: getrawtransaction succeeds; getblock returns a payload that fails to deserialize.
+    let tx_id = BitcoinTransactionHash::from([1; 32]);
+    let threshold = BlockConfirmations::from(1u64);
+    let receipt_blockhash = TransportBitcoinBlockHash::from([0xbb; 32]);
+
+    let tx_response = GetRawTransactionVerboseResponse {
+        blockhash: receipt_blockhash,
+        confirmations: 10,
+    };
+
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(tx_response)
+        .with_response(serde_json::json!({ "unexpected": "shape" }))
+        .build();
+    let inspector = BitcoinInspector::new(mock_client);
+
+    // when
+    let response = inspector
+        .extract(tx_id, threshold, vec![BitcoinExtractor::BlockHash])
+        .await;
+
+    // then
+    assert_matches!(response, Err(ForeignChainInspectionError::ClientError(_)));
+}
+
+#[tokio::test]
+async fn extract__should_propagate_getblockhash_rpc_error() {
+    // given: getrawtransaction and getblock succeed; getblockhash returns an invalid payload.
+    let tx_id = BitcoinTransactionHash::from([1; 32]);
+    let threshold = BlockConfirmations::from(1u64);
+    let receipt_blockhash = TransportBitcoinBlockHash::from([0xbb; 32]);
+
+    let tx_response = GetRawTransactionVerboseResponse {
+        blockhash: receipt_blockhash,
+        confirmations: 10,
+    };
+    let block_response = GetBlockResponse {
+        hash: receipt_blockhash,
+        height: TEST_BLOCK_HEIGHT,
+    };
+
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(tx_response)
+        .with_response(block_response)
+        .with_response(serde_json::json!(42))
+        .build();
+    let inspector = BitcoinInspector::new(mock_client);
+
+    // when
+    let response = inspector
+        .extract(tx_id, threshold, vec![BitcoinExtractor::BlockHash])
+        .await;
+
+    // then
+    assert_matches!(response, Err(ForeignChainInspectionError::ClientError(_)));
+}
+
+#[tokio::test]
 async fn inspector_extracts_block_hash_via_http_rpc_client() {
     // given
     let server = MockServer::start();
 
     let tx_id = BitcoinTransactionHash::from([9; 32]);
     let expected_block_hash = BitcoinBlockHash::from([5; 32]);
+    let transport_block_hash = TransportBitcoinBlockHash::from(*expected_block_hash);
     let confirmations = 10u64;
     let threshold = BlockConfirmations::from(6u64);
 
+    let tx_response = GetRawTransactionVerboseResponse {
+        blockhash: transport_block_hash,
+        confirmations,
+    };
+    let block_response = GetBlockResponse {
+        hash: transport_block_hash,
+        height: TEST_BLOCK_HEIGHT,
+    };
+
     server.mock(|when, then| {
         when.method(POST).path("/");
+        then.respond_with(move |req: &HttpMockRequest| {
+            let body: serde_json::Value =
+                serde_json::from_slice(req.body().as_ref()).expect("valid json-rpc request");
+            let id = body["id"].clone();
+            let method = body["method"].as_str().expect("method field");
 
-        let response = JsonRpcResponse {
-            jsonrpc: "2.0".to_string(),
-            result: GetRawTransactionVerboseResponse {
-                blockhash: TransportBitcoinBlockHash::from(*expected_block_hash),
-                confirmations,
-            },
-            id: 0,
-        };
+            let result = match method {
+                "getrawtransaction" => serde_json::to_value(&tx_response).unwrap(),
+                "getblock" => serde_json::to_value(&block_response).unwrap(),
+                "getblockhash" => serde_json::to_value(transport_block_hash).unwrap(),
+                other => panic!("unexpected RPC method: {other}"),
+            };
 
-        then.status(200)
-            .header("content-type", "application/json")
-            .json_body(serde_json::to_value(&response).unwrap());
+            let response_body = serde_json::json!({
+                "jsonrpc": "2.0",
+                "result": result,
+                "id": id,
+            });
+
+            HttpMockResponse::builder()
+                .status(200)
+                .header("content-type", "application/json")
+                .body(serde_json::to_string(&response_body).unwrap())
+                .build()
+        });
     });
 
     let client = build_http_client(server.url("/"), RpcAuthentication::KeyInUrl).unwrap();

--- a/crates/foreign-chain-inspector/tests/evm_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/evm_inspector.rs
@@ -545,9 +545,9 @@ macro_rules! evm_inspector_tests {
                         block_number,
                         receipt_hash,
                         canonical_hash,
-                    }) if block_number == U64::from(90)
-                        && receipt_hash == H256::from([0xbb; 32])
-                        && canonical_hash == H256::from([0xcc; 32])
+                    }) if block_number == 90
+                        && receipt_hash == vec![0xbb; 32]
+                        && canonical_hash == vec![0xcc; 32]
                 );
             }
         }

--- a/crates/foreign-chain-inspector/tests/starknet_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/starknet_inspector.rs
@@ -2,7 +2,9 @@
 
 pub mod common;
 
-use crate::common::{FixedResponseRpcClient, mock_client_from_fixed_response};
+use crate::common::{
+    FixedResponseRpcClient, SequentialResponseMockClientBuilder, mock_client_from_fixed_response,
+};
 
 use foreign_chain_inspector::{
     ForeignChainInspectionError, ForeignChainInspector, RpcAuthentication, build_http_client,
@@ -14,8 +16,8 @@ use foreign_chain_inspector::{
 
 use assert_matches::assert_matches;
 use foreign_chain_rpc_interfaces::starknet::{
-    GetTransactionReceiptResponse, H256, StarknetEvent, StarknetExecutionStatus,
-    StarknetFinalityStatus,
+    GetBlockWithTxHashesResponse, GetTransactionReceiptResponse, H256, StarknetEvent,
+    StarknetExecutionStatus, StarknetFinalityStatus,
 };
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse};
@@ -37,6 +39,13 @@ fn mock_receipt(
         }],
         finality_status,
         execution_status,
+    }
+}
+
+fn canonical_block_for(receipt: &GetTransactionReceiptResponse) -> GetBlockWithTxHashesResponse {
+    GetBlockWithTxHashesResponse {
+        block_hash: receipt.block_hash,
+        block_number: receipt.block_number,
     }
 }
 
@@ -62,7 +71,11 @@ async fn extract__should_return_block_hash_when_finality_is_sufficient(
     let tx_id = StarknetTransactionHash::from([3; 32]);
 
     let receipt = mock_receipt(actual_finality_status, StarknetExecutionStatus::Succeeded);
-    let mock_client = mock_client_from_fixed_response(receipt);
+    let canonical_block = canonical_block_for(&receipt);
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(&receipt)
+        .with_response(&canonical_block)
+        .build();
     let inspector = StarknetInspector::new(mock_client);
 
     // when
@@ -168,7 +181,11 @@ async fn extract__should_return_empty_when_no_extractors_are_requested() {
         StarknetFinalityStatus::AcceptedOnL1,
         StarknetExecutionStatus::Succeeded,
     );
-    let mock_client = mock_client_from_fixed_response(receipt);
+    let canonical_block = canonical_block_for(&receipt);
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(&receipt)
+        .with_response(&canonical_block)
+        .build();
     let inspector = StarknetInspector::new(mock_client);
 
     // when
@@ -217,7 +234,11 @@ async fn extract__should_return_error_when_log_index_out_of_bounds() {
         StarknetFinalityStatus::AcceptedOnL1,
         StarknetExecutionStatus::Succeeded,
     );
-    let mock_client = mock_client_from_fixed_response(receipt);
+    let canonical_block = canonical_block_for(&receipt);
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(&receipt)
+        .with_response(&canonical_block)
+        .build();
     let inspector = StarknetInspector::new(mock_client);
 
     // when
@@ -259,7 +280,11 @@ async fn extract__should_return_correct_log_for_specific_index() {
         finality_status: StarknetFinalityStatus::AcceptedOnL1,
         execution_status: StarknetExecutionStatus::Succeeded,
     };
-    let mock_client = mock_client_from_fixed_response(receipt);
+    let canonical_block = canonical_block_for(&receipt);
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(&receipt)
+        .with_response(&canonical_block)
+        .build();
     let inspector = StarknetInspector::new(mock_client);
 
     // when
@@ -303,6 +328,7 @@ fn test_receipt() -> GetTransactionReceiptResponse {
 
 fn setup_starknet_rpc_mock(server: &MockServer) {
     let receipt = test_receipt();
+    let canonical_block = canonical_block_for(&receipt);
     server.mock(|when, then| {
         when.method(POST).path("/");
         then.respond_with(move |req: &HttpMockRequest| {
@@ -311,9 +337,11 @@ fn setup_starknet_rpc_mock(server: &MockServer) {
             let id = body["id"].clone();
             let method = body["method"].as_str().expect("method field");
 
-            assert_eq!(method, "starknet_getTransactionReceipt");
-
-            let result = serde_json::to_value(&receipt).unwrap();
+            let result = match method {
+                "starknet_getTransactionReceipt" => serde_json::to_value(&receipt).unwrap(),
+                "starknet_getBlockWithTxHashes" => serde_json::to_value(&canonical_block).unwrap(),
+                other => panic!("unexpected RPC method: {other}"),
+            };
 
             let response_body = serde_json::json!({
                 "jsonrpc": "2.0",
@@ -359,6 +387,83 @@ async fn extract__should_return_block_hash_via_http_rpc_client() {
         ))],
         extracted_values,
     );
+}
+
+#[tokio::test]
+async fn extract__should_return_non_canonical_block_when_receipt_block_hash_differs_from_canonical()
+{
+    // given: the receipt is fully finalized but the canonical block at its height has a
+    // different hash, simulating an RPC that served a side-block receipt for a finalized block.
+    let tx_id = StarknetTransactionHash::from([1; 32]);
+
+    let receipt = GetTransactionReceiptResponse {
+        block_hash: H256::from([0xbb; 32]),
+        block_number: 842_750,
+        events: vec![],
+        finality_status: StarknetFinalityStatus::AcceptedOnL1,
+        execution_status: StarknetExecutionStatus::Succeeded,
+    };
+    let canonical_block = GetBlockWithTxHashesResponse {
+        block_hash: H256::from([0xcc; 32]),
+        block_number: 842_750,
+    };
+
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(&receipt)
+        .with_response(&canonical_block)
+        .build();
+    let inspector = StarknetInspector::new(mock_client);
+
+    // when
+    let response = inspector
+        .extract(
+            tx_id,
+            StarknetFinality::AcceptedOnL1,
+            vec![StarknetExtractor::BlockHash],
+        )
+        .await;
+
+    // then
+    assert_matches!(
+        response,
+        Err(ForeignChainInspectionError::NonCanonicalBlock {
+            block_number,
+            receipt_hash,
+            canonical_hash,
+        }) if block_number == 842_750
+            && receipt_hash == vec![0xbb; 32]
+            && canonical_hash == vec![0xcc; 32]
+    );
+}
+
+#[tokio::test]
+async fn extract__should_propagate_get_block_with_tx_hashes_rpc_error() {
+    // given: starknet_getTransactionReceipt succeeds; starknet_getBlockWithTxHashes returns
+    // a payload that fails to deserialize as GetBlockWithTxHashesResponse.
+    let tx_id = StarknetTransactionHash::from([1; 32]);
+
+    let receipt = mock_receipt(
+        StarknetFinalityStatus::AcceptedOnL1,
+        StarknetExecutionStatus::Succeeded,
+    );
+
+    let mock_client = SequentialResponseMockClientBuilder::new()
+        .with_response(receipt)
+        .with_response(serde_json::json!({ "unexpected": "shape" }))
+        .build();
+    let inspector = StarknetInspector::new(mock_client);
+
+    // when
+    let response = inspector
+        .extract(
+            tx_id,
+            StarknetFinality::AcceptedOnL1,
+            vec![StarknetExtractor::BlockHash],
+        )
+        .await;
+
+    // then
+    assert_matches!(response, Err(ForeignChainInspectionError::ClientError(_)));
 }
 
 #[tokio::test]

--- a/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
@@ -40,3 +40,59 @@ impl Serialize for GetRawTransactionArgs {
 impl ToRpcParams for &GetRawTransactionArgs {
     to_rpc_params_impl!();
 }
+
+/// Verbosity level for `getblock` that returns a decoded JSON header (with `height` and `hash`)
+/// plus a list of txids. Lower levels return hex-encoded raw bytes which we'd have to parse.
+pub const GET_BLOCK_VERBOSITY_HEADER_AND_TXIDS: u8 = 1;
+
+/// Partial RPC response for `getblock`. See link below for full spec;
+/// <https://developer.bitcoin.org/reference/rpc/getblock.html>
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct GetBlockResponse {
+    pub hash: TransportBitcoinBlockHash,
+    pub height: u64,
+}
+
+/// Request args for `getblock`.
+pub struct GetBlockArgs {
+    pub blockhash: TransportBitcoinBlockHash,
+    pub verbosity: u8,
+}
+
+impl Serialize for GetBlockArgs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // `getblock` expects a positional list https://developer.bitcoin.org/reference/rpc/getblock.html#argument-1-blockhash
+        // 1. blockhash
+        // 2. verbosity
+        let request_parameters = (&self.blockhash, &self.verbosity);
+
+        request_parameters.serialize(serializer)
+    }
+}
+
+impl ToRpcParams for &GetBlockArgs {
+    to_rpc_params_impl!();
+}
+
+/// Request args for `getblockhash`.
+/// <https://developer.bitcoin.org/reference/rpc/getblockhash.html>
+pub struct GetBlockHashArgs {
+    pub height: u64,
+}
+
+impl Serialize for GetBlockHashArgs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let request_parameters = [self.height];
+        request_parameters.serialize(serializer)
+    }
+}
+
+impl ToRpcParams for &GetBlockHashArgs {
+    to_rpc_params_impl!();
+}

--- a/crates/foreign-chain-rpc-interfaces/src/starknet.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/starknet.rs
@@ -62,6 +62,62 @@ impl ToRpcParams for &GetTransactionReceiptArgs {
     to_rpc_params_impl!();
 }
 
+/// Block identifier accepted by Starknet block-lookup RPCs. Only the `Number` variant is used
+/// by the inspector's canonical-chain check; the others are modeled for completeness.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BlockId {
+    Number {
+        block_number: u64,
+    },
+    Hash {
+        #[serde(serialize_with = "serialize_starknet_felt")]
+        #[serde(deserialize_with = "deserialize_starknet_felt")]
+        block_hash: H256,
+    },
+}
+
+/// Partial RPC response for `starknet_getBlockWithTxHashes`.
+/// <https://www.alchemy.com/docs/chains/starknet/starknet-api-endpoints/starknet-get-block-with-tx-hashes>
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub struct GetBlockWithTxHashesResponse {
+    #[serde(deserialize_with = "deserialize_starknet_felt")]
+    pub block_hash: H256,
+    pub block_number: u64,
+}
+
+/// Request args for `starknet_getBlockWithTxHashes`.
+pub struct GetBlockWithTxHashesArgs {
+    pub block_id: BlockId,
+}
+
+impl Serialize for GetBlockWithTxHashesArgs {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        // `starknet_getBlockWithTxHashes` expects a single-element array: [block_id]
+        let request_parameters = [&self.block_id];
+        request_parameters.serialize(serializer)
+    }
+}
+
+impl ToRpcParams for &GetBlockWithTxHashesArgs {
+    to_rpc_params_impl!();
+}
+
+fn serialize_starknet_felt<S>(value: &H256, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    let mut hex = String::with_capacity(2 + 64);
+    hex.push_str("0x");
+    for byte in value.as_bytes() {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    serializer.serialize_str(&hex)
+}
+
 /// Starknet felt values use `0x`-prefixed hex like Ethereum, but may omit leading
 /// zeros (e.g. `"0x5"` instead of `"0x0000…0005"`). This function zero-pads
 /// short representations so they can be parsed as an [`H256`].
@@ -99,6 +155,7 @@ where
 #[expect(non_snake_case)]
 mod tests {
     use super::{
+        BlockId, GetBlockWithTxHashesArgs, GetBlockWithTxHashesResponse,
         GetTransactionReceiptResponse, H256, StarknetExecutionStatus, StarknetFinalityStatus,
         parse_felt,
     };
@@ -159,6 +216,47 @@ mod tests {
                 parse_felt("0x4322cec55a56b85793864e0cfd27a563849ac9209d4307621d65bcd616c1dd8")
                     .unwrap(),
             ]
+        );
+    }
+
+    #[test]
+    fn serialize_get_block_with_tx_hashes_args__should_wrap_block_id_in_array() {
+        // given
+        let args = GetBlockWithTxHashesArgs {
+            block_id: BlockId::Number {
+                block_number: 842_750,
+            },
+        };
+
+        // when
+        let serialized = serde_json::to_value(&args).unwrap();
+
+        // then
+        assert_eq!(serialized, serde_json::json!([{ "block_number": 842_750 }]));
+    }
+
+    #[test]
+    fn deserialize_get_block_with_tx_hashes_response__should_accept_short_hex_block_hash() {
+        let json = r#"
+        {
+            "block_hash": "0x5",
+            "block_number": 842750
+        }
+        "#;
+
+        let response: GetBlockWithTxHashesResponse = serde_json::from_str(json).unwrap();
+
+        let expected_bytes = {
+            let mut bytes = [0u8; 32];
+            bytes[31] = 5;
+            bytes
+        };
+        assert_eq!(
+            response,
+            GetBlockWithTxHashesResponse {
+                block_hash: H256::from(expected_bytes),
+                block_number: 842_750,
+            }
         );
     }
 }

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -36,8 +36,9 @@ Not all extractors can be satisfied by a single RPC method call.
 * **Provider selection**: The request does **not** specify an RPC URL. Nodes deterministically select an allowed provider from the on-chain foreign-chain configurations.
 * **Extractor-driven calls**: Each extractor implicitly defines which RPC method(s) it requires. Some extractors require more than one call. For the initial set:
 
-  * **BlockHash (Ethereum)**: `eth_getTransactionReceipt` for `blockHash`.
-  * **BlockHash (Bitcoin)**: `getrawtransaction` (with verbose) to get the containing `blockhash` (and `getblock` if needed).
+  * **BlockHash (Ethereum)**: `eth_getTransactionReceipt` for `blockHash`, plus `eth_getBlockByNumber` for the finality-head and canonical-chain checks.
+  * **BlockHash (Bitcoin)**: `getrawtransaction` (verbose) for the containing `blockhash` and confirmation count, then `getblock` + `getblockhash` for the canonical-chain defense-in-depth check.
+  * **BlockHash (Starknet)**: `starknet_getTransactionReceipt` for `block_hash` + `finality_status`, then `starknet_getBlockWithTxHashes` for the canonical-chain defense-in-depth check.
   * **SolanaProgramIdIndex / SolanaDataHash**: `getTransaction` to access `transaction.message` + `meta` and instruction data.
 * **Shared fetches**: When multiple extractors require the same underlying data, nodes may perform the RPC call once and share the result across extractors.
 


### PR DESCRIPTION
## Summary

Closes #3335.

The EVM inspector already protects against an RPC returning a transaction receipt anchored to a *side block* by re-fetching the canonical block at the receipt's height and comparing hashes (added in #3091). This PR applies the same defense-in-depth check to the Bitcoin and Starknet inspectors, which previously relied on the RPC honoring "no receipt for non-canonical txs" as a security property.

## Approach

- **Bitcoin**: two-step lookup — `getblock(receipt.blockhash) → height`, then `getblockhash(height) → canonical_hash`, compare to `receipt.blockhash`. Mirrors the EVM pattern closely.
- **Starknet**: single extra RPC — `starknet_getBlockWithTxHashes({block_number: receipt.block_number}) → canonical_hash`, compare to `receipt.block_hash`. The receipt already exposes the block number, so no second lookup is needed.
- **Error variant**: generalized `ForeignChainInspectionError::NonCanonicalBlock` to chain-agnostic primitive types (`u64` + `Vec<u8>`) so Bitcoin's 32-byte `TransportBitcoinBlockHash` newtype can populate it without coercion. EVM call site and EVM test updated accordingly.
- **Docs**: `docs/foreign-chain-transactions.md` updated to describe the new RPC call plan for all three inspectors.
- **e2e mocks**: `crates/e2e-tests/src/foreign_chain_mock.rs` dispatches on method and handles the new `getblock`/`getblockhash`/`starknet_getBlockWithTxHashes` calls.

## Verification

- `cargo nextest run -p foreign-chain-rpc-interfaces -p foreign-chain-inspector` — 118 tests pass
- `cargo clippy --all-targets -D warnings` clean on changed crates
- `cargo fmt -- --check` clean
- e2e foreign-chain validation suite still needs a manual run on CI