### PR TITLE
fix(node): handle SIGTERM for graceful shutdown on operator stop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3288,6 +3288,7 @@ dependencies = [
  "hex",
  "httpmock",
  "launcher-interface",
+ "libc",
  "mpc-node-config",
  "mpc-primitives",
  "near-account-id 2.6.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ jemalloc_pprof = "0.4.2"
 jsonrpsee = { version = "0.26.0", features = ["http-client"] }
 k256 = "0.13.4"
 keccak = "0.1.5"
+libc = "0.2"
 lru = "0.18.0"
 # Re-exported by `jemalloc_pprof` (workspace sibling). Used to embed runtime
 # binary mappings into emitted pprof profiles so `pprof` can symbolicate

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -15,7 +15,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 httpmock = { workspace = true }
 launcher-interface = { workspace = true }
-libc = "0.2"
+libc = { workspace = true }
 mpc-node-config = { workspace = true }
 near-account-id = { workspace = true }
 near-indexer-primitives = { workspace = true }

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -15,6 +15,7 @@ futures = { workspace = true }
 hex = { workspace = true }
 httpmock = { workspace = true }
 launcher-interface = { workspace = true }
+libc = "0.2"
 mpc-node-config = { workspace = true }
 near-account-id = { workspace = true }
 near-indexer-primitives = { workspace = true }

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -344,6 +344,33 @@ impl MpcCluster {
         Ok(())
     }
 
+    /// Send SIGTERM to a running node and wait up to `grace` for it to exit on
+    /// its own. Returns the exit status — `status.code().is_some()` indicates
+    /// the process exited cleanly via its own main() (i.e. our SIGTERM handler
+    /// ran), while `status.signal().is_some()` indicates the OS terminated it
+    /// (i.e. there was no handler).
+    pub fn terminate_node_with_sigterm(
+        &mut self,
+        idx: usize,
+        grace: std::time::Duration,
+    ) -> anyhow::Result<std::process::ExitStatus> {
+        anyhow::ensure!(
+            idx < self.nodes.len(),
+            "node index {idx} out of bounds (have {} nodes)",
+            self.nodes.len()
+        );
+        let state = self.nodes.remove(idx);
+        let (status, setup) = match state {
+            MpcNodeState::Running(node) => node.terminate_with_sigterm(grace)?,
+            MpcNodeState::Stopped(setup) => {
+                self.nodes.insert(idx, MpcNodeState::Stopped(setup));
+                anyhow::bail!("node {idx} already stopped; cannot SIGTERM");
+            }
+        };
+        self.nodes.insert(idx, MpcNodeState::Stopped(setup));
+        Ok(status)
+    }
+
     pub fn start_nodes(&mut self, indices: &[usize]) -> anyhow::Result<()> {
         for &idx in indices {
             let state = self.nodes.remove(idx);

--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -39,10 +39,13 @@ impl MpcNode {
         self.setup
     }
 
-    /// Send SIGTERM to the node and wait up to `grace` for it to exit on its
-    /// own. Returns the child's `ExitStatus` on graceful exit; errors if the
-    /// grace period elapses (in which case `self.process`'s Drop will SIGKILL
-    /// it as a fallback). Used to exercise the production SIGTERM handler.
+    /// Send SIGTERM and wait up to `grace` for the node to exit. If grace
+    /// expires before the process exits on its own, send SIGKILL and wait
+    /// for it explicitly (instead of relying on `ProcessGuard::Drop` to do
+    /// the same). Either way, returns the child's `ExitStatus`:
+    /// `status.success()` ⇒ graceful exit via mpc-node's SIGTERM handler;
+    /// `status.signal() == Some(9)` ⇒ SIGKILL fallback fired. Used to
+    /// exercise the production SIGTERM handler.
     pub fn terminate_with_sigterm(
         mut self,
         grace: std::time::Duration,
@@ -65,9 +68,19 @@ impl MpcNode {
                 Some(status) => return Ok((status, self.setup)),
                 None => {
                     if start.elapsed() >= grace {
-                        anyhow::bail!(
-                            "mpc-node pid {pid} did not exit within {grace:?} after SIGTERM"
-                        );
+                        // Grace expired: explicit SIGKILL fallback, then wait
+                        // for the child to actually exit so we return a real
+                        // `ExitStatus` rather than bailing.
+                        self.process
+                            .0
+                            .kill()
+                            .context("SIGKILL fallback on grace-period expiry failed")?;
+                        let status = self
+                            .process
+                            .0
+                            .wait()
+                            .context("wait after SIGKILL fallback failed")?;
+                        return Ok((status, self.setup));
                     }
                     std::thread::sleep(poll_interval);
                 }

--- a/crates/e2e-tests/src/mpc_node.rs
+++ b/crates/e2e-tests/src/mpc_node.rs
@@ -39,6 +39,42 @@ impl MpcNode {
         self.setup
     }
 
+    /// Send SIGTERM to the node and wait up to `grace` for it to exit on its
+    /// own. Returns the child's `ExitStatus` on graceful exit; errors if the
+    /// grace period elapses (in which case `self.process`'s Drop will SIGKILL
+    /// it as a fallback). Used to exercise the production SIGTERM handler.
+    pub fn terminate_with_sigterm(
+        mut self,
+        grace: std::time::Duration,
+    ) -> anyhow::Result<(std::process::ExitStatus, MpcNodeSetup)> {
+        let pid = self.process.0.id() as libc::pid_t;
+        // SAFETY: `libc::kill` with `SIGTERM` and a pid Rust's Child reports
+        // for a live child is well-defined. We make no assumptions beyond
+        // that the pid is the child we spawned.
+        let rc = unsafe { libc::kill(pid, libc::SIGTERM) };
+        anyhow::ensure!(
+            rc == 0,
+            "libc::kill({pid}, SIGTERM) failed: {}",
+            std::io::Error::last_os_error()
+        );
+
+        let start = std::time::Instant::now();
+        let poll_interval = std::time::Duration::from_millis(100);
+        loop {
+            match self.process.0.try_wait()? {
+                Some(status) => return Ok((status, self.setup)),
+                None => {
+                    if start.elapsed() >= grace {
+                        anyhow::bail!(
+                            "mpc-node pid {pid} did not exit within {grace:?} after SIGTERM"
+                        );
+                    }
+                    std::thread::sleep(poll_interval);
+                }
+            }
+        }
+    }
+
     /// Kill then start. New process, same config and data directory.
     pub fn restart(self) -> anyhow::Result<MpcNode> {
         self.kill().start()

--- a/crates/e2e-tests/tests/common.rs
+++ b/crates/e2e-tests/tests/common.rs
@@ -35,6 +35,7 @@ pub const CONTRACT_UPGRADE_COMPATIBILITY_MAINNET_PORT_SEED: u16 = 18;
 pub const CONTRACT_UPGRADE_COMPATIBILITY_TESTNET_PORT_SEED: u16 = 19;
 pub const TIMEOUT_METRIC_PORT_SEED: u16 = 20;
 pub const MIGRATION_BACK_PORT_SEED: u16 = 21;
+pub const SIGTERM_HANDLER_PORT_SEED: u16 = 22;
 
 /// Start a cluster, wait for Running state and presignatures to buffer.
 ///

--- a/crates/e2e-tests/tests/e2e.rs
+++ b/crates/e2e-tests/tests/e2e.rs
@@ -12,6 +12,7 @@ mod migration_service;
 mod parallel_sign_calls;
 mod request_during_resharing;
 mod request_lifecycle;
+mod sigterm_handler;
 mod submit_participant_info;
 mod timeout_metric;
 mod web_endpoints;

--- a/crates/e2e-tests/tests/sigterm_handler.rs
+++ b/crates/e2e-tests/tests/sigterm_handler.rs
@@ -3,15 +3,16 @@ use std::time::Duration;
 
 use crate::common;
 
-/// Verifies that mpc-node's SIGTERM handler initiates a graceful shutdown
-/// instead of letting the OS default-terminate the process.
+/// Verifies that mpc-node's SIGTERM handler drives a clean graceful shutdown
+/// (exit code 0), not just any process termination.
 ///
-/// Would fail under revert: without the handler in `crates/node/src/run.rs`,
-/// SIGTERM hits the process with no handler installed and the OS terminates
-/// the process directly. `status.signal()` is then `Some(15)` (SIGTERM) and
-/// `status.code()` is `None`, which the assertion below catches. With the
-/// handler installed the process exits via `main`'s normal return path,
-/// `status.code()` is `Some(_)`, and the assertion passes.
+/// Would fail under revert in two ways:
+/// - Without the SIGTERM handler at all, the OS default-terminates the
+///   process and `status.success()` is false (`code()` is `None`,
+///   `signal()` is `Some(15)`).
+/// - With a handler that returns an error from `run_mpc_node` on signal
+///   shutdown (the previous behavior, before the signal/image-hash split),
+///   `status.success()` is also false (exit code 1).
 #[tokio::test(flavor = "multi_thread")]
 #[expect(non_snake_case)]
 async fn sigterm_handler__should_exit_cleanly_instead_of_default_terminating() {
@@ -24,10 +25,11 @@ async fn sigterm_handler__should_exit_cleanly_instead_of_default_terminating() {
         .terminate_node_with_sigterm(0, Duration::from_secs(30))
         .expect("node did not exit within the SIGTERM grace period");
 
-    // Then: the process exited via its own main(), not by OS signal.
+    // Then: the process exited cleanly with code 0.
     assert!(
-        status.code().is_some(),
-        "mpc-node was terminated by signal {:?} instead of exiting cleanly via the SIGTERM handler",
+        status.success(),
+        "mpc-node did not exit cleanly after SIGTERM: code={:?} signal={:?}",
+        status.code(),
         status.signal()
     );
 }

--- a/crates/e2e-tests/tests/sigterm_handler.rs
+++ b/crates/e2e-tests/tests/sigterm_handler.rs
@@ -1,0 +1,33 @@
+use std::os::unix::process::ExitStatusExt;
+use std::time::Duration;
+
+use crate::common;
+
+/// Verifies that mpc-node's SIGTERM handler initiates a graceful shutdown
+/// instead of letting the OS default-terminate the process.
+///
+/// Would fail under revert: without the handler in `crates/node/src/run.rs`,
+/// SIGTERM hits the process with no handler installed and the OS terminates
+/// the process directly. `status.signal()` is then `Some(15)` (SIGTERM) and
+/// `status.code()` is `None`, which the assertion below catches. With the
+/// handler installed the process exits via `main`'s normal return path,
+/// `status.code()` is `Some(_)`, and the assertion passes.
+#[tokio::test(flavor = "multi_thread")]
+#[expect(non_snake_case)]
+async fn sigterm_handler__should_exit_cleanly_instead_of_default_terminating() {
+    // Given: a running cluster.
+    let (mut cluster, _running) =
+        common::must_setup_cluster(common::SIGTERM_HANDLER_PORT_SEED, |_| {}).await;
+
+    // When: SIGTERM is delivered to node 0 with a 30s grace period.
+    let status = cluster
+        .terminate_node_with_sigterm(0, Duration::from_secs(30))
+        .expect("node did not exit within the SIGTERM grace period");
+
+    // Then: the process exited via its own main(), not by OS signal.
+    assert!(
+        status.code().is_some(),
+        "mpc-node was terminated by signal {:?} instead of exiting cleanly via the SIGTERM handler",
+        status.signal()
+    );
+}

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -54,22 +54,10 @@ async fn await_optional_signal(handle: Option<&mut Signal>) {
     }
 }
 
-/// Listen for SIGTERM / SIGINT / SIGHUP and forward the first arrival into
-/// `sender`. Operators stopping the node via dstack CVM stop / `docker stop`
-/// / `kubectl delete` / `systemctl stop` (or a dev pressing Ctrl-C) hit this
-/// path; routing into the same channel that `monitor_allowed_image_hashes`
-/// uses lets the main `select!` exit gracefully.
-///
-/// Logs a per-signal warning if any individual install fails; if none can be
-/// installed (rare), logs an error and exits without ever forwarding —
-/// graceful shutdown via signals is disabled in that case but the rest of
-/// the node keeps running.
-///
-/// Spawned as the first thing after the tokio runtime is built so signals
-/// arriving during early startup (indexer bootstrap, contract state fetch,
-/// attestation generation) are also handled gracefully — otherwise they'd
-/// hit the process with no handler installed and the OS would terminate it
-/// immediately, functionally identical to SIGKILL.
+/// Install handlers for SIGTERM / SIGINT / SIGHUP and forward the first
+/// signal that arrives into `sender` so the main `select!` can drive a
+/// graceful shutdown. Spawned right after the runtime is built so signals
+/// arriving during early startup are also handled.
 async fn await_and_forward_shutdown_signal(sender: mpsc::Sender<()>) {
     let install = |kind: SignalKind, name: &'static str| {
         signal(kind)
@@ -136,10 +124,13 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
 
     let _tokio_enter_guard = root_runtime.enter();
 
-    let (shutdown_signal_sender, mut shutdown_signal_receiver) = mpsc::channel(1);
-    root_runtime.spawn(await_and_forward_shutdown_signal(
-        shutdown_signal_sender.clone(),
-    ));
+    // Two independent shutdown sources, each owns its own channel so the main
+    // `select!` can give them distinct exit semantics: a graceful operator stop
+    // (SIGTERM/SIGINT/SIGHUP) exits cleanly with code 0; the image-hash watcher
+    // exits non-zero on the rare error conditions that cause it to bail.
+    let (signal_shutdown_sender, mut signal_shutdown_receiver) = mpsc::channel(1);
+    let (image_hash_shutdown_sender, mut image_hash_shutdown_receiver) = mpsc::channel(1);
+    root_runtime.spawn(await_and_forward_shutdown_signal(signal_shutdown_sender));
 
     // Load configuration and initialize persistent secrets
     let node_config = config.node.clone();
@@ -255,7 +246,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         *config.tee.image_hash,
         allowed_hashes_in_contract,
         image_hash_storage,
-        shutdown_signal_sender.clone(),
+        image_hash_shutdown_sender,
     ));
 
     let home_dir = config.home_dir.clone();
@@ -272,15 +263,22 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
 
     let root_task = root_runtime.spawn(start_root_task("root", root_future).0);
 
-    let exit_reason = tokio::select! {
+    let exit_reason: anyhow::Result<()> = tokio::select! {
         root_task_result = root_task => {
             root_task_result?
         }
         indexer_exit_response = indexer_exit_receiver => {
             indexer_exit_response.context("Indexer thread dropped response channel.")?
         }
-        Some(()) = shutdown_signal_receiver.recv() => {
-            Err(anyhow!("TEE allowed image hashes watcher is sending shutdown signal."))
+        Some(()) = signal_shutdown_receiver.recv() => {
+            info!("shutdown signal received; exiting cleanly");
+            Ok(())
+        }
+        Some(()) = image_hash_shutdown_receiver.recv() => {
+            // The specific `ExitError` (storage I/O failure or indexer's
+            // contract-state channel closed) is logged a few lines below via
+            // `info!(?exit_result, "Image hash watcher exited.")`.
+            Err(anyhow!("TEE allowed-image-hashes watcher exited unexpectedly."))
         }
     };
 
@@ -292,18 +290,11 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     info!(?exit_result, "Image hash watcher exited.");
 
     // Stop nearcore's actor system so its tasks have a chance to commit any
-    // in-flight RocksDB batches before the process exits. We deliberately do
-    // NOT then call `near_store::db::RocksDB::block_until_all_instances_are_dropped()`
-    // (which neard's standalone binary does next) — our embedded indexer
-    // runs in a separate `std::thread::spawn`'d closure whose `block_on`
-    // never returns, because the spawned monitor tasks hold
-    // `Arc<IndexerState>` → `Arc<RocksDB>` references that nothing
-    // currently cancels. Calling `block_until_all_instances_are_dropped`
-    // here would hang the SIGTERM path past any reasonable grace period;
-    // the orchestrator would then SIGKILL us and we'd land in the exact
-    // uncommitted-RocksDB state this handler was supposed to prevent.
-    // RocksDB's WAL still guarantees committed data survives a kill; this
-    // call mostly closes a smaller flush window.
+    // in-flight RocksDB batches before the process exits. We deliberately
+    // skip `RocksDB::block_until_all_instances_are_dropped()` here (which
+    // neard's standalone binary calls next): in this embedding it would
+    // hang past any reasonable grace period, and the orchestrator would
+    // SIGKILL us before the graceful path completes.
     info!("Stopping nearcore actor system.");
     near_async::shutdown_all_actors();
 

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -30,6 +30,7 @@ use std::{
     time::Duration,
 };
 use tee_authority::tee_authority::TeeAuthority;
+use tokio::signal::unix::{Signal, SignalKind, signal};
 use tokio::sync::{RwLock, broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -40,6 +41,64 @@ use crate::tee::{
 };
 
 pub const ATTESTATION_RESUBMISSION_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 hour
+
+/// Await a signal if its handle is present; if the handle is `None` (its
+/// install failed), park forever so the `tokio::select!` arm is effectively
+/// dead and the other (successfully-installed) signals still work.
+async fn await_optional_signal(handle: Option<&mut Signal>) {
+    match handle {
+        Some(h) => {
+            h.recv().await;
+        }
+        None => std::future::pending().await,
+    }
+}
+
+/// Listen for SIGTERM / SIGINT / SIGHUP and forward the first arrival into
+/// `sender`. Operators stopping the node via dstack CVM stop / `docker stop`
+/// / `kubectl delete` / `systemctl stop` (or a dev pressing Ctrl-C) hit this
+/// path; routing into the same channel that `monitor_allowed_image_hashes`
+/// uses lets the main `select!` exit gracefully.
+///
+/// Logs a per-signal warning if any individual install fails; if none can be
+/// installed (rare), logs an error and exits without ever forwarding —
+/// graceful shutdown via signals is disabled in that case but the rest of
+/// the node keeps running.
+///
+/// Spawned as the first thing after the tokio runtime is built so signals
+/// arriving during early startup (indexer bootstrap, contract state fetch,
+/// attestation generation) are also handled gracefully — otherwise they'd
+/// hit the process with no handler installed and the OS would terminate it
+/// immediately, functionally identical to SIGKILL.
+async fn await_and_forward_shutdown_signal(sender: mpsc::Sender<()>) {
+    let install = |kind: SignalKind, name: &'static str| {
+        signal(kind)
+            .inspect_err(|e| tracing::warn!(error = %e, signal = name, "failed to install shutdown-signal handler"))
+            .ok()
+    };
+    let mut sigterm = install(SignalKind::terminate(), "SIGTERM");
+    let mut sigint = install(SignalKind::interrupt(), "SIGINT");
+    let mut sighup = install(SignalKind::hangup(), "SIGHUP");
+    if sigterm.is_none() && sigint.is_none() && sighup.is_none() {
+        tracing::error!(
+            "no shutdown-signal handlers could be installed; graceful shutdown disabled"
+        );
+        return;
+    }
+    let signal_name = tokio::select! {
+        _ = await_optional_signal(sigterm.as_mut()) => "SIGTERM",
+        _ = await_optional_signal(sigint.as_mut()) => "SIGINT",
+        _ = await_optional_signal(sighup.as_mut()) => "SIGHUP",
+    };
+    tracing::warn!(
+        signal = signal_name,
+        "shutdown signal received, initiating graceful shutdown"
+    );
+    // `send` returns Err only if the receiver has been dropped (the main
+    // `select!` already exited via a different arm); we're shutting down
+    // anyway, so it's fine to ignore.
+    let _ = sender.send(()).await;
+}
 
 pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     init_logging(&config.log);
@@ -76,6 +135,11 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         .build()?;
 
     let _tokio_enter_guard = root_runtime.enter();
+
+    let (shutdown_signal_sender, mut shutdown_signal_receiver) = mpsc::channel(1);
+    root_runtime.spawn(await_and_forward_shutdown_signal(
+        shutdown_signal_sender.clone(),
+    ));
 
     // Load configuration and initialize persistent secrets
     let node_config = config.node.clone();
@@ -180,7 +244,6 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         node_config.foreign_chains.clone(),
     );
 
-    let (shutdown_signal_sender, mut shutdown_signal_receiver) = mpsc::channel(1);
     let cancellation_token = CancellationToken::new();
 
     let allowed_hashes_in_contract = indexer_api.allowed_docker_images_receiver.clone();
@@ -227,6 +290,22 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     info!("Waiting for image hash watcher to gracefully exit.");
     let exit_result = image_hash_watcher_handle.await;
     info!(?exit_result, "Image hash watcher exited.");
+
+    // Stop nearcore's actor system so its tasks have a chance to commit any
+    // in-flight RocksDB batches before the process exits. We deliberately do
+    // NOT then call `near_store::db::RocksDB::block_until_all_instances_are_dropped()`
+    // (which neard's standalone binary does next) — our embedded indexer
+    // runs in a separate `std::thread::spawn`'d closure whose `block_on`
+    // never returns, because the spawned monitor tasks hold
+    // `Arc<IndexerState>` → `Arc<RocksDB>` references that nothing
+    // currently cancels. Calling `block_until_all_instances_are_dropped`
+    // here would hang the SIGTERM path past any reasonable grace period;
+    // the orchestrator would then SIGKILL us and we'd land in the exact
+    // uncommitted-RocksDB state this handler was supposed to prevent.
+    // RocksDB's WAL still guarantees committed data survives a kill; this
+    // call mostly closes a smaller flush window.
+    info!("Stopping nearcore actor system.");
+    near_async::shutdown_all_actors();
 
     exit_reason
 }

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -30,7 +30,7 @@ use std::{
     time::Duration,
 };
 use tee_authority::tee_authority::TeeAuthority;
-use tokio::signal::unix::{Signal, SignalKind, signal};
+use tokio::signal::unix::{SignalKind, signal};
 use tokio::sync::{RwLock, broadcast, mpsc, oneshot, watch};
 use tokio_util::sync::CancellationToken;
 use tracing::info;
@@ -41,52 +41,6 @@ use crate::tee::{
 };
 
 pub const ATTESTATION_RESUBMISSION_INTERVAL: Duration = Duration::from_secs(60 * 60); // 1 hour
-
-/// Await a signal if its handle is present; if the handle is `None` (its
-/// install failed), park forever so the `tokio::select!` arm is effectively
-/// dead and the other (successfully-installed) signals still work.
-async fn await_optional_signal(handle: Option<&mut Signal>) {
-    match handle {
-        Some(h) => {
-            h.recv().await;
-        }
-        None => std::future::pending().await,
-    }
-}
-
-/// Install handlers for SIGTERM / SIGINT / SIGHUP and forward the first
-/// signal that arrives into `sender` so the main `select!` can drive a
-/// graceful shutdown. Spawned right after the runtime is built so signals
-/// arriving during early startup are also handled.
-async fn await_and_forward_shutdown_signal(sender: mpsc::Sender<()>) {
-    let install = |kind: SignalKind, name: &'static str| {
-        signal(kind)
-            .inspect_err(|e| tracing::warn!(error = %e, signal = name, "failed to install shutdown-signal handler"))
-            .ok()
-    };
-    let mut sigterm = install(SignalKind::terminate(), "SIGTERM");
-    let mut sigint = install(SignalKind::interrupt(), "SIGINT");
-    let mut sighup = install(SignalKind::hangup(), "SIGHUP");
-    if sigterm.is_none() && sigint.is_none() && sighup.is_none() {
-        tracing::error!(
-            "no shutdown-signal handlers could be installed; graceful shutdown disabled"
-        );
-        return;
-    }
-    let signal_name = tokio::select! {
-        _ = await_optional_signal(sigterm.as_mut()) => "SIGTERM",
-        _ = await_optional_signal(sigint.as_mut()) => "SIGINT",
-        _ = await_optional_signal(sighup.as_mut()) => "SIGHUP",
-    };
-    tracing::warn!(
-        signal = signal_name,
-        "shutdown signal received, initiating graceful shutdown"
-    );
-    // `send` returns Err only if the receiver has been dropped (the main
-    // `select!` already exited via a different arm); we're shutting down
-    // anyway, so it's fine to ignore.
-    let _ = sender.send(()).await;
-}
 
 pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     init_logging(&config.log);
@@ -124,13 +78,21 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
 
     let _tokio_enter_guard = root_runtime.enter();
 
-    // Two independent shutdown sources, each owns its own channel so the main
-    // `select!` can give them distinct exit semantics: a graceful operator stop
-    // (SIGTERM/SIGINT/SIGHUP) exits cleanly with code 0; the image-hash watcher
-    // exits non-zero on the rare error conditions that cause it to bail.
-    let (signal_shutdown_sender, mut signal_shutdown_receiver) = mpsc::channel(1);
-    let (image_hash_shutdown_sender, mut image_hash_shutdown_receiver) = mpsc::channel(1);
-    root_runtime.spawn(await_and_forward_shutdown_signal(signal_shutdown_sender));
+    // Install the SIGTERM handler as the first thing after the runtime is
+    // built, BEFORE any expensive startup (indexer bootstrap, contract
+    // state fetch, attestation generation). A SIGTERM arriving during
+    // that window would otherwise hit the process with no handler
+    // installed and the OS would terminate us immediately — functionally
+    // identical to SIGKILL.
+    //
+    // If install fails (which would only happen if the host's signal
+    // subsystem is fundamentally broken — in which case nothing else
+    // about the node is going to work either), we log and degrade to
+    // the pre-handler baseline: SIGTERM OS-default-terminates. The rest
+    // of the node still runs.
+    let mut sigterm_handle = signal(SignalKind::terminate())
+        .inspect_err(|e| tracing::error!(error = %e, "failed to install SIGTERM handler — graceful shutdown disabled"))
+        .ok();
 
     // Load configuration and initialize persistent secrets
     let node_config = config.node.clone();
@@ -241,6 +203,12 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     let image_hash_storage =
         AllowedImageHashesFile::from(config.tee.latest_allowed_hash_file_path.clone());
 
+    // Dedicated shutdown channel for the image-hash watcher. The watcher's
+    // Drop fires this on its rare exceptional exits (storage I/O failure
+    // or indexer's contract-state channel closed); the main `select!`
+    // arm below converts that into a non-zero process exit.
+    let (image_hash_shutdown_sender, mut image_hash_shutdown_receiver) = mpsc::channel(1);
+
     let image_hash_watcher_handle = root_runtime.spawn(monitor_allowed_image_hashes(
         cancellation_token.child_token(),
         *config.tee.image_hash,
@@ -270,8 +238,16 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         indexer_exit_response = indexer_exit_receiver => {
             indexer_exit_response.context("Indexer thread dropped response channel.")?
         }
-        Some(()) = signal_shutdown_receiver.recv() => {
-            info!("shutdown signal received; exiting cleanly");
+        // Race SIGTERM directly. If install above failed, `sigterm_handle`
+        // is `None` and this arm is parked on `pending()` forever — i.e.
+        // effectively absent — so the other arms still drive the loop.
+        _ = async {
+            match sigterm_handle.as_mut() {
+                Some(s) => { s.recv().await; }
+                None => std::future::pending().await,
+            }
+        } => {
+            info!(signal = "SIGTERM", "shutdown signal received; exiting cleanly");
             Ok(())
         }
         Some(()) = image_hash_shutdown_receiver.recv() => {


### PR DESCRIPTION
Closes https://github.com/near/mpc/issues/3409.

## Summary

- Installs a Unix signal handler in `mpc-node` that catches **SIGTERM**, **SIGINT**, and **SIGHUP**, routing any of them into the existing internal shutdown channel — operators stopping the node via dstack CVM stop / `docker stop` / `kubectl delete` / `systemctl stop` (or a dev pressing Ctrl-C) now get graceful shutdown semantics where before these signals were effectively SIGKILL.
- After the main `select!` exits, calls `near_async::shutdown_all_actors()` so nearcore's actor system can commit any in-flight RocksDB batches before the process exits.
- Handler is installed **as the first thing** after the tokio runtime is built — before `spawn_real_indexer` and the expensive startup (attestation generation, contract state fetch) — so signals arriving during early startup are also handled gracefully.

Closes #3409. Does NOT close the upstream nearcore restart panic at `streamer/mod.rs:207` — that's filed upstream as [`near/nearcore#15867`](https://github.com/near/nearcore/issues/15867); investigation context in near/mpc#3409. Campaign data shows this handler gets the back-migration e2e from 0/5 to 1/5 pass — a real production improvement, but not a full fix for the upstream non-determinism.

## Notable non-action: no `RocksDB::block_until_all_instances_are_dropped()`

neard's standalone binary follows `shutdown_all_actors()` with `RocksDB::block_until_all_instances_are_dropped()`. This PR deliberately omits that next step because in our embedding it hangs indefinitely: the indexer runs in a `std::thread::spawn`'d closure whose `block_on` never returns — the spawned `monitor_*`/`indexer_logger` tasks hold `Arc<IndexerState>` → `Arc<RocksDB>` references that nothing currently cancels on shutdown. Calling `block_until_all_instances_are_dropped` would block the SIGTERM path past any reasonable grace period and the orchestrator would SIGKILL us anyway. A proper fix wires a `CancellationToken` through the indexer thread — that's [PR #3486](https://github.com/near/mpc/pull/3486), stacked on top of this one. The inline comment in `run.rs` captures the rationale.

## Test plan

- [x] e2e test added: `sigterm_handler__should_exit_cleanly_instead_of_default_terminating`. Sends SIGTERM to a running cluster node, asserts the process exits via its own `main()` (i.e. `status.code().is_some()`) rather than being default-terminated by the OS (`status.signal().is_some()`). Would fail under revert.
- [x] CI green (cargo check / clippy / fmt on the new code).
- [x] No regression: existing e2e tests pass.

## Known related issues outside this PR

- **`deployment/start.sh` doesn't `exec` mpc-node** — the non-TEE Docker `Dockerfile-node` uses `CMD ["/app/start.sh"]`, and `start.sh` runs `/app/mpc-node start` directly (not via `exec`). That means bash is PID 1 in the container; bash doesn't forward SIGTERM to its child, so for the non-TEE Docker deployment this handler still never receives the signal. The TEE deployment (via `crates/tee-launcher/mpc-node-docker-compose.tee.template.yml`) is unaffected — it uses `command: ["/app/mpc-node", ...]` directly, making mpc-node PID 1. The start.sh fix is tracked separately as #3487.