### PR TITLE
docs(operator-guide): require empty Pre-launch Script and Init Script on manual deploy

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -842,7 +842,7 @@ Use the following custom settings for MPC:
 1. Launcher docker compose file - provided above.
 2. VM HW setting (use exactly those settings, since vCPU/Memory are measured):
     vCPU number=8, Memory = 64GB, disk = 500 GB
-3. Pre script - empty.
+3. Pre-launch Script **and** Init Script - both must be left **empty**. The WebUI may pre-fill the Pre-launch Script with a dstack launch-token check; delete it. Any script content changes the measured app configuration, and the MPC attestation verifier requires `pre_launch_script` to be absent — a node deployed with a non-empty script will fail attestation and be rejected by the other participants and the contract.
 4. user-config - provided above
 5. Toggles:
    - KMS = disable


### PR DESCRIPTION
## What

Clarifies the **Web interface (manual)** deploy steps in the operator guide: both the **Pre-launch Script** and **Init Script** fields must be left empty, and explains why.

The dstack-vmm WebUI pre-fills the Pre-launch Script with a default launch-token check. The MPC attestation verifier binds the whole `app-compose.json` into RTMR3 and requires `pre_launch_script` to be absent (`validate_app_compose_config` → `pre_launch_script.is_none()`), so a node deployed with the pre-filled script fails attestation and is rejected by peers and the contract.

## Change

One line in `docs/running-an-mpc-node-in-tdx-external-guide.md` (step 3 of the Web-interface deploy settings), expanded from "Pre script - empty." to name both fields and state the consequence.

Closes #3411

🤖 Generated with [Claude Code](https://claude.com/claude-code)
