### PR TITLE
fix(attestation): reject non-empty app-compose init_script

### DIFF
--- a/crates/attestation/src/app_compose.rs
+++ b/crates/attestation/src/app_compose.rs
@@ -24,6 +24,11 @@ pub struct AppCompose {
     pub no_instance_id: bool,
     pub secure_time: Option<bool>,
     pub pre_launch_script: Option<String>,
+    /// Bash script that dstack (>= 0.5.5) executes as root, before the docker
+    /// daemon starts. Like `pre_launch_script`, it is arbitrary pre-workload
+    /// code, so we model it explicitly and require it to be absent during
+    /// verification (see `validate_app_compose_config`).
+    pub init_script: Option<String>,
     // The following fields that don't have any security implication are omitted:
     //
     // - docker_config: JsonValue,

--- a/crates/attestation/src/app_compose.rs
+++ b/crates/attestation/src/app_compose.rs
@@ -24,10 +24,6 @@ pub struct AppCompose {
     pub no_instance_id: bool,
     pub secure_time: Option<bool>,
     pub pre_launch_script: Option<String>,
-    /// Bash script that dstack (>= 0.5.5) executes as root, before the docker
-    /// daemon starts. Like `pre_launch_script`, it is arbitrary pre-workload
-    /// code, so we model it explicitly and require it to be absent during
-    /// verification (see `validate_app_compose_config`).
     pub init_script: Option<String>,
     // The following fields that don't have any security implication are omitted:
     //

--- a/crates/attestation/src/attestation.rs
+++ b/crates/attestation/src/attestation.rs
@@ -388,6 +388,7 @@ impl DstackAttestation {
             && app_compose.allowed_envs.is_empty()
             && app_compose.no_instance_id
             && app_compose.pre_launch_script.is_none()
+            && app_compose.init_script.is_none()
     }
 
     /// Verifies local key-provider event digest matches the expected digest.
@@ -588,6 +589,38 @@ mod tests {
     }
 
     #[test]
+    fn validate_app_compose_config__rejects_non_empty_pre_launch_script() {
+        // Given
+        let app_compose = AppCompose {
+            pre_launch_script: Some("echo pwn".to_string()),
+            ..valid_app_compose()
+        };
+        // When
+        let result = DstackAttestation::validate_app_compose_config(&app_compose);
+
+        // Then
+        assert!(!result)
+    }
+
+    #[test]
+    fn validate_app_compose_config__rejects_non_empty_init_script() {
+        // `init_script` is arbitrary root code run before dockerd. It is
+        // measured into the compose hash but not pinned to any allowed value,
+        // so verification must reject it outright.
+
+        // Given
+        let app_compose = AppCompose {
+            init_script: Some("echo pwn".to_string()),
+            ..valid_app_compose()
+        };
+        // When
+        let result = DstackAttestation::validate_app_compose_config(&app_compose);
+
+        // Then
+        assert!(!result)
+    }
+
+    #[test]
     fn validate_app_compose_config__allows_insecure_time() {
         // Given
         let app_compose = AppCompose {
@@ -618,6 +651,7 @@ mod tests {
             no_instance_id: true,
             secure_time: None,
             pre_launch_script: None,
+            init_script: None,
         }
     }
 }

--- a/crates/attestation/src/attestation.rs
+++ b/crates/attestation/src/attestation.rs
@@ -589,7 +589,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_app_compose_config__rejects_non_empty_pre_launch_script() {
+    fn validate_app_compose_config__rejects_present_pre_launch_script() {
         // Given
         let app_compose = AppCompose {
             pre_launch_script: Some("echo pwn".to_string()),
@@ -603,7 +603,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_app_compose_config__rejects_non_empty_init_script() {
+    fn validate_app_compose_config__rejects_present_init_script() {
         // `init_script` is arbitrary root code run before dockerd. It is
         // measured into the compose hash but not pinned to any allowed value,
         // so verification must reject it outright.

--- a/crates/near-mpc-contract-interface/src/types/attestation.rs
+++ b/crates/near-mpc-contract-interface/src/types/attestation.rs
@@ -273,6 +273,7 @@ pub struct AppCompose {
     pub no_instance_id: bool,
     pub secure_time: Option<bool>,
     pub pre_launch_script: Option<String>,
+    pub init_script: Option<String>,
 }
 
 /// Trusted Computing Base information structure

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -842,7 +842,7 @@ Use the following custom settings for MPC:
 1. Launcher docker compose file - provided above.
 2. VM HW setting (use exactly those settings, since vCPU/Memory are measured):
     vCPU number=8, Memory = 64GB, disk = 500 GB
-3. Pre script - empty.
+3. Pre-launch Script and Init Script - both must be empty (a non-empty script fails attestation).
 4. user-config - provided above
 5. Toggles:
    - KMS = disable

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -842,7 +842,7 @@ Use the following custom settings for MPC:
 1. Launcher docker compose file - provided above.
 2. VM HW setting (use exactly those settings, since vCPU/Memory are measured):
     vCPU number=8, Memory = 64GB, disk = 500 GB
-3. Pre-launch Script and Init Script - both must be empty (a non-empty script fails attestation).
+3. Pre-launch Script and Init Script - both must be empty (a non-empty script fails attestation). Caution: the Pre-launch Script may not be empty by default - clear it before deploying.
 4. user-config - provided above
 5. Toggles:
    - KMS = disable


### PR DESCRIPTION
## What

Verification rejected a non-empty `pre_launch_script` but ignored dstack's `init_script` (added in 0.5.5), a bash script run as **root before dockerd**. It was measured into the compose hash but never pinned or validated, so a CVM with an arbitrary `init_script` passed attestation — arbitrary root code in the enclave before the MPC node.

## Change

- `AppCompose` (`crates/attestation/src/app_compose.rs`) now models `init_script: Option<String>`.
- `validate_app_compose_config` requires `init_script.is_none()`, mirroring `pre_launch_script`.
- Added rejection tests for both `init_script` and `pre_launch_script`; existing real-fixture deserialization tests still pass (the field is optional → missing parses as `None`).
- Operator guide (`docs/running-an-mpc-node-in-tdx-external-guide.md`): one-line note that both the Pre-launch Script and Init Script fields must be empty on the manual/WebUI deploy path (folds in the superseded #3412).

## Notes / follow-up

- The launcher-compose allow-list only covers `sha256(docker_compose_file)` and the measurements allow-list does not pin RTMR3, which is why an unvalidated app-compose field could slip through. Whether to add `#[serde(deny_unknown_fields)]` so future dstack-added executable fields fail closed is tracked in #3415.
- There is a parallel, currently-unused DTO `AppCompose` in `crates/near-mpc-contract-interface` that also lacks the field; left untouched here.

Closes #3413