### PR TITLE
fix(attestation): fail closed on unknown app-compose fields; reject tproxy_enabled

### DIFF
--- a/crates/attestation/src/app_compose.rs
+++ b/crates/attestation/src/app_compose.rs
@@ -49,19 +49,20 @@ pub struct AppCompose {
     pub bash_script: Option<String>,
     // The fields below are absorbed only to satisfy `deny_unknown_fields`; they are never read, so
     // they deserialize as `IgnoredAny` to avoid allocating attacker-controlled JSON from the
-    // untrusted app-compose. `key_provider` integrity is pinned by the measured `key-provider`
-    // event digest (`verify_key_provider_digest`), not this field. `port_policy` is a dstack 0.5.11
-    // gateway field (0.5.8 never emits it), inert while the gateway is disabled.
+    // untrusted app-compose.
     #[serde(default)]
     pub features: Option<IgnoredAny>,
     #[serde(default)]
     pub public_tcbinfo: Option<bool>,
+    // Key-provider integrity is pinned by the measured `key-provider` event digest
+    // (`verify_key_provider_digest`), not this field.
     #[serde(default)]
     pub key_provider: Option<IgnoredAny>,
     #[serde(default)]
     pub storage_fs: Option<String>,
     #[serde(default)]
     pub swap_size: Option<IgnoredAny>,
+    // dstack 0.5.11 gateway field (0.5.8 never emits it); inert while the gateway is disabled.
     #[serde(default)]
     pub port_policy: Option<IgnoredAny>,
     #[serde(default)]

--- a/crates/attestation/src/app_compose.rs
+++ b/crates/attestation/src/app_compose.rs
@@ -1,8 +1,7 @@
 use alloc::{string::String, vec::Vec};
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{Deref, From};
-use serde::{Deserialize, Serialize};
-use serde_json::Value;
+use serde::{Deserialize, Serialize, de::IgnoredAny};
 
 /// Helper struct to deserialize the `app_compose` JSON from TCB info. This is a workaround due to
 /// current limitations in the Dstack SDK.
@@ -15,7 +14,7 @@ use serde_json::Value;
 /// dstack's `AppCompose` (`dstack-types/src/lib.rs`) plus the script keys read directly via `jq`
 /// during boot (`pre_launch_script`, `init_script`, `bash_script`). Fields without a security
 /// implication are modeled only to absorb their key; they are not validated.
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct AppCompose {
     pub manifest_version: u32,
@@ -48,23 +47,25 @@ pub struct AppCompose {
     pub init_script: Option<String>,
     #[serde(default)]
     pub bash_script: Option<String>,
-    // Modeled to absorb the key under `deny_unknown_fields`; not validated.
+    // The fields below are absorbed only to satisfy `deny_unknown_fields`; they are never read, so
+    // they deserialize as `IgnoredAny` to avoid allocating attacker-controlled JSON from the
+    // untrusted app-compose. `key_provider` integrity is pinned by the measured `key-provider`
+    // event digest (`verify_key_provider_digest`), not this field. `port_policy` is a dstack 0.5.11
+    // gateway field (0.5.8 never emits it), inert while the gateway is disabled.
     #[serde(default)]
-    pub features: Vec<String>,
+    pub features: Option<IgnoredAny>,
     #[serde(default)]
     pub public_tcbinfo: Option<bool>,
     #[serde(default)]
-    pub key_provider: Option<Value>,
+    pub key_provider: Option<IgnoredAny>,
     #[serde(default)]
     pub storage_fs: Option<String>,
     #[serde(default)]
-    pub swap_size: Option<Value>,
-    // Added in dstack 0.5.11 (0.5.8 never emits it); pre-modeled for future 0.5.11 support. Gateway
-    // port config, inert while the gateway is disabled, so no security implication.
+    pub swap_size: Option<IgnoredAny>,
     #[serde(default)]
-    pub port_policy: Option<Value>,
+    pub port_policy: Option<IgnoredAny>,
     #[serde(default)]
-    pub docker_config: Option<Value>,
+    pub docker_config: Option<IgnoredAny>,
 }
 
 /// A type that contains a docker compose the contents of a docker compose file as

--- a/crates/attestation/src/app_compose.rs
+++ b/crates/attestation/src/app_compose.rs
@@ -2,33 +2,69 @@ use alloc::{string::String, vec::Vec};
 use borsh::{BorshDeserialize, BorshSerialize};
 use derive_more::{Deref, From};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 /// Helper struct to deserialize the `app_compose` JSON from TCB info. This is a workaround due to
 /// current limitations in the Dstack SDK.
 ///
 /// See: <https://github.com/Dstack-TEE/dstack/issues/267>
-#[derive(Debug, Deserialize, Serialize, BorshSerialize, BorshDeserialize)]
+///
+/// `deny_unknown_fields` makes verification fail closed: every key dstack can emit into
+/// `app-compose.json` must be modeled here, so a field added by a future dstack version is rejected
+/// until it is reviewed and modeled, rather than silently ignored. Fields are mirrored from
+/// dstack's `AppCompose` (`dstack-types/src/lib.rs`) plus the script keys read directly via `jq`
+/// during boot (`pre_launch_script`, `init_script`, `bash_script`). Fields without a security
+/// implication are modeled only to absorb their key; they are not validated.
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
 pub struct AppCompose {
     pub manifest_version: u32,
     pub name: String,
     pub runner: String,
     pub docker_compose_file: DockerComposeString,
+    #[serde(default)]
     pub kms_enabled: bool,
+    #[serde(default)]
     pub tproxy_enabled: Option<bool>,
+    #[serde(default)]
     pub gateway_enabled: Option<bool>,
+    #[serde(default)]
     pub public_logs: bool,
+    #[serde(default)]
     pub public_sysinfo: bool,
+    #[serde(default)]
     pub local_key_provider_enabled: bool,
+    #[serde(default)]
     pub key_provider_id: Option<String>,
+    #[serde(default)]
     pub allowed_envs: Vec<String>,
+    #[serde(default)]
     pub no_instance_id: bool,
+    #[serde(default)]
     pub secure_time: Option<bool>,
+    #[serde(default)]
     pub pre_launch_script: Option<String>,
+    #[serde(default)]
     pub init_script: Option<String>,
-    // The following fields that don't have any security implication are omitted:
-    //
-    // - docker_config: JsonValue,
-    // - public_tcbinfo: bool,
+    #[serde(default)]
+    pub bash_script: Option<String>,
+    // Modeled to absorb the key under `deny_unknown_fields`; not validated.
+    #[serde(default)]
+    pub features: Vec<String>,
+    #[serde(default)]
+    pub public_tcbinfo: Option<bool>,
+    #[serde(default)]
+    pub key_provider: Option<Value>,
+    #[serde(default)]
+    pub storage_fs: Option<String>,
+    #[serde(default)]
+    pub swap_size: Option<Value>,
+    // Added in dstack 0.5.11 (0.5.8 never emits it); pre-modeled for future 0.5.11 support. Gateway
+    // port config, inert while the gateway is disabled, so no security implication.
+    #[serde(default)]
+    pub port_policy: Option<Value>,
+    #[serde(default)]
+    pub docker_config: Option<Value>,
 }
 
 /// A type that contains a docker compose the contents of a docker compose file as

--- a/crates/attestation/src/app_compose.rs
+++ b/crates/attestation/src/app_compose.rs
@@ -23,49 +23,36 @@ pub struct AppCompose {
     pub docker_compose_file: DockerComposeString,
     #[serde(default)]
     pub kms_enabled: bool,
-    #[serde(default)]
     pub tproxy_enabled: Option<bool>,
-    #[serde(default)]
     pub gateway_enabled: Option<bool>,
-    #[serde(default)]
+    // public_logs / public_sysinfo / local_key_provider_enabled / no_instance_id must be `true`, so
+    // they carry no `serde(default)` — a missing one fails to parse. No security gap either way: a
+    // defaulted `false` is rejected by `validate_app_compose_config`; dropping it is just clearer.
+    // (kms_enabled / allowed_envs keep a default because their default *is* the safe value.)
     pub public_logs: bool,
-    #[serde(default)]
     pub public_sysinfo: bool,
-    #[serde(default)]
     pub local_key_provider_enabled: bool,
-    #[serde(default)]
     pub key_provider_id: Option<String>,
     #[serde(default)]
     pub allowed_envs: Vec<String>,
-    #[serde(default)]
     pub no_instance_id: bool,
-    #[serde(default)]
     pub secure_time: Option<bool>,
-    #[serde(default)]
     pub pre_launch_script: Option<String>,
-    #[serde(default)]
     pub init_script: Option<String>,
-    #[serde(default)]
     pub bash_script: Option<String>,
-    // The fields below are absorbed only to satisfy `deny_unknown_fields`; they are never read, so
-    // they deserialize as `IgnoredAny` to avoid allocating attacker-controlled JSON from the
-    // untrusted app-compose.
-    #[serde(default)]
+    // The fields below are absorbed only to satisfy `deny_unknown_fields`; they are never read. The
+    // structured ones use `IgnoredAny` to avoid allocating attacker-controlled JSON from the
+    // untrusted app-compose. (`serde(default)` is omitted on every `Option<_>` field above and
+    // below — serde already treats those as optional.)
     pub features: Option<IgnoredAny>,
-    #[serde(default)]
     pub public_tcbinfo: Option<bool>,
     // Key-provider integrity is pinned by the measured `key-provider` event digest
     // (`verify_key_provider_digest`), not this field.
-    #[serde(default)]
     pub key_provider: Option<IgnoredAny>,
-    #[serde(default)]
-    pub storage_fs: Option<String>,
-    #[serde(default)]
+    pub storage_fs: Option<IgnoredAny>,
     pub swap_size: Option<IgnoredAny>,
     // dstack 0.5.11 gateway field (0.5.8 never emits it); inert while the gateway is disabled.
-    #[serde(default)]
     pub port_policy: Option<IgnoredAny>,
-    #[serde(default)]
     pub docker_config: Option<IgnoredAny>,
 }
 

--- a/crates/attestation/src/attestation.rs
+++ b/crates/attestation/src/attestation.rs
@@ -676,10 +676,13 @@ mod tests {
             "some_future_dstack_field": "whatever"
         }"#;
         // When
-        let result = serde_json::from_str::<AppCompose>(app_compose_json);
+        let err = serde_json::from_str::<AppCompose>(app_compose_json).unwrap_err();
 
         // Then
-        result.unwrap_err();
+        assert!(
+            err.to_string().contains("unknown field"),
+            "expected an unknown-field error, got: {err}"
+        );
     }
 
     #[test]
@@ -715,7 +718,7 @@ mod tests {
             pre_launch_script: None,
             init_script: None,
             bash_script: None,
-            features: Vec::new(),
+            features: None,
             public_tcbinfo: None,
             key_provider: None,
             storage_fs: None,

--- a/crates/attestation/src/attestation.rs
+++ b/crates/attestation/src/attestation.rs
@@ -381,14 +381,22 @@ impl DstackAttestation {
         app_compose.manifest_version == 2
             && app_compose.runner == "docker-compose"
             && !app_compose.kms_enabled
+            // dstack enables the gateway when `gateway_enabled || tproxy_enabled` (the latter is the
+            // legacy alias), so both must be disabled.
             && app_compose.gateway_enabled == Some(false)
+            && app_compose.tproxy_enabled != Some(true)
             && app_compose.public_logs
             && app_compose.public_sysinfo
             && app_compose.local_key_provider_enabled
             && app_compose.allowed_envs.is_empty()
             && app_compose.no_instance_id
+            // Reject all three arbitrary-root-code fields. `pre_launch_script` and `init_script` run
+            // unconditionally; `bash_script` only runs when `runner == "bash"` (so the runner pin
+            // above already neutralizes it), but we reject it explicitly so the guarantee does not
+            // silently depend on that pin.
             && app_compose.pre_launch_script.is_none()
             && app_compose.init_script.is_none()
+            && app_compose.bash_script.is_none()
     }
 
     /// Verifies local key-provider event digest matches the expected digest.
@@ -621,6 +629,60 @@ mod tests {
     }
 
     #[test]
+    fn validate_app_compose_config__rejects_present_bash_script() {
+        // `bash_script` is arbitrary root code; dstack only runs it when `runner == "bash"`, but we
+        // reject it explicitly rather than relying solely on the runner pin.
+
+        // Given
+        let app_compose = AppCompose {
+            bash_script: Some("echo pwn".to_string()),
+            ..valid_app_compose()
+        };
+        // When
+        let result = DstackAttestation::validate_app_compose_config(&app_compose);
+
+        // Then
+        assert!(!result)
+    }
+
+    #[test]
+    fn validate_app_compose_config__rejects_tproxy_enabled() {
+        // dstack enables the gateway on `gateway_enabled || tproxy_enabled`, so a `tproxy_enabled`
+        // set via the legacy alias must be rejected even when `gateway_enabled` is false.
+
+        // Given
+        let app_compose = AppCompose {
+            tproxy_enabled: Some(true),
+            ..valid_app_compose()
+        };
+        // When
+        let result = DstackAttestation::validate_app_compose_config(&app_compose);
+
+        // Then
+        assert!(!result)
+    }
+
+    #[test]
+    fn app_compose__rejects_unknown_field() {
+        // `deny_unknown_fields` must make a key dstack might add in the future fail to parse, so it
+        // halts verification rather than being silently ignored.
+
+        // Given
+        let app_compose_json = r#"{
+            "manifest_version": 2,
+            "name": "",
+            "runner": "docker-compose",
+            "docker_compose_file": "",
+            "some_future_dstack_field": "whatever"
+        }"#;
+        // When
+        let result = serde_json::from_str::<AppCompose>(app_compose_json);
+
+        // Then
+        result.unwrap_err();
+    }
+
+    #[test]
     fn validate_app_compose_config__allows_insecure_time() {
         // Given
         let app_compose = AppCompose {
@@ -652,6 +714,14 @@ mod tests {
             secure_time: None,
             pre_launch_script: None,
             init_script: None,
+            bash_script: None,
+            features: Vec::new(),
+            public_tcbinfo: None,
+            key_provider: None,
+            storage_fs: None,
+            swap_size: None,
+            port_policy: None,
+            docker_config: None,
         }
     }
 }

--- a/crates/near-mpc-contract-interface/src/types/attestation.rs
+++ b/crates/near-mpc-contract-interface/src/types/attestation.rs
@@ -278,6 +278,7 @@ pub struct AppCompose {
     pub secure_time: Option<bool>,
     pub pre_launch_script: Option<String>,
     pub init_script: Option<String>,
+    pub bash_script: Option<String>,
 }
 
 /// Trusted Computing Base information structure

--- a/crates/near-mpc-contract-interface/src/types/attestation.rs
+++ b/crates/near-mpc-contract-interface/src/types/attestation.rs
@@ -253,6 +253,10 @@ impl fmt::Debug for DstackAttestation {
     BorshSerialize,
     BorshDeserialize,
 )]
+// NOTE: this is a hand-maintained mirror of the verified `attestation::AppCompose`. It is the
+// security-relevant subset and is NOT the type used during attestation verification. Keep its
+// security fields in sync with the verified struct, or it can drift (see #3425). Deduping the two
+// is pending a team decision.
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)

--- a/crates/near-mpc-contract-interface/src/types/attestation.rs
+++ b/crates/near-mpc-contract-interface/src/types/attestation.rs
@@ -253,10 +253,10 @@ impl fmt::Debug for DstackAttestation {
     BorshSerialize,
     BorshDeserialize,
 )]
-// NOTE: this is a hand-maintained mirror of the verified `attestation::AppCompose`. It is the
-// security-relevant subset and is NOT the type used during attestation verification. Keep its
-// security fields in sync with the verified struct, or it can drift (see #3425). Deduping the two
-// is pending a team decision.
+// This is a hand-maintained mirror of the verified `attestation::AppCompose` — the
+// security-relevant subset, NOT the type used during attestation verification. Keep its security
+// fields in sync with the verified struct, or it can drift.
+// TODO(#3425): dedupe with `attestation::AppCompose` (single source of truth) — pending team decision.
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)


### PR DESCRIPTION
Closes https://github.com/near/mpc/issues/3415

follow up for #3414 
## What

Makes app-compose verification fail closed, and closes a second bypass of the `init_script` class.

- `#[serde(deny_unknown_fields)]` on `AppCompose` + the full dstack field set modeled, so a field added by a future dstack version halts verification instead of being silently ignored.
- Reject `tproxy_enabled == Some(true)` (legacy gateway alias — dstack enables the gateway on `gateway_enabled || tproxy_enabled`) and `bash_script`, alongside the existing `pre_launch_script`/`init_script` checks.
- Sync `init_script` onto the public `AppCompose` DTO in `near-mpc-contract-interface` (dedupe tracked in #3425).
- Drop unused Borsh derives on `AppCompose`.

Verified end-to-end on a real-TDX localnet: a real dstack 0.5.8 CVM attestation is accepted by the hardened contract (Running 2-node cluster, ECDSA sign).
