### PR TITLE
chore: Add new foreign chain support methods to access keys

### DIFF
--- a/docs/localnet/localnet.md
+++ b/docs/localnet/localnet.md
@@ -235,7 +235,7 @@ export SAM_RESPONDER_KEY=$(curl -s localhost:8082/public_data | jq -r ".near_res
 Now we can add these keys to the appropriate NEAR accounts with the NEAR CLI.
 
 ```shell
-NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
+NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_support,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
 
 near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_PUBKEY" network-config mpc-localnet sign-with-keychain send
 near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send

--- a/docs/localnet/tee-localnet.md
+++ b/docs/localnet/tee-localnet.md
@@ -215,7 +215,7 @@ export MPC_HOST=$MACHINE_IP
 Now, add these keys to the appropriate NEAR accounts using the NEAR CLI:
 
 ```bash
-NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
+NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_support,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
 
 near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_PUBKEY" network-config mpc-localnet sign-with-keychain send
 near account add-key frodo.test.near grant-function-call-access --allowance unlimited --contract-account-id mpc-contract.test.near --function-names "$NODE_METHODS" use-manually-provided-public-key "$FRODO_RESPONDER_KEY" network-config mpc-localnet sign-with-keychain send

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1089,7 +1089,7 @@ This section shows how to add the MPC node's public key (from the previous secti
 * **`METHOD_NAMES`** → The list of contract methods the MPC node is allowed to call:
 
   ```txt
-  respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,vote_foreign_chain_policy,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration
+  respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_support,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration
   ```
 
   > **Note:** This must be a single comma-separated string with no spaces or newlines.
@@ -1129,7 +1129,7 @@ ALLOWANCE="unlimited"
 NETWORK="testnet"   # or "mainnet"
 
 # Methods the MPC node is allowed to call
-METHOD_NAMES="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,vote_foreign_chain_policy,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
+METHOD_NAMES="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_support,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
 
 # === Add Access Key ===
 near account add-key $ACCOUNT_ID \

--- a/docs/testnet/setup-guide-for-testnet-with-tee-support.md
+++ b/docs/testnet/setup-guide-for-testnet-with-tee-support.md
@@ -257,7 +257,7 @@ export SAM_P2P_KEY=$(curl -s http://$SERVER_IP_2:18082/public_data | jq -r '.nea
 Add keys to each NEAR account:
 
 ```bash
-NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
+NODE_METHODS="respond,respond_ckd,respond_verify_foreign_tx,vote_pk,start_keygen_instance,vote_reshared,register_foreign_chain_support,register_foreign_chain_config,start_reshare_instance,vote_abort_key_event_instance,verify_tee,submit_participant_info,conclude_node_migration"
 
 near account add-key $FRODO_ACCOUNT grant-function-call-access \
   --allowance unlimited --contract-account-id $MPC_CONTRACT_ACCOUNT --function-names "$NODE_METHODS" \


### PR DESCRIPTION
closes #3430 

This PR also cleans up the old unused `vote_foreign_chain_policy` methods from the access keys. We should still consider changing this to full access keys but that's a discussion for https://github.com/near/mpc/issues/3429