### PR TITLE
refactor: drop `Result` from `RecentBlocksTracker::add_block`

### DIFF
--- a/crates/node/src/requests/queue.rs
+++ b/crates/node/src/requests/queue.rs
@@ -3,7 +3,7 @@ use super::recent_blocks_tracker::AtomicBlockStatus;
 use crate::indexer::types::ChainRespondArgs;
 use crate::primitives::ParticipantId;
 use crate::requests::metrics;
-use crate::requests::recent_blocks_tracker::RecentBlocksTracker;
+use crate::requests::recent_blocks_tracker::{AddBlockResult, RecentBlocksTracker};
 use crate::types::{self, Request, RequestId, RequestsUpdate};
 use k256::sha2::Sha256;
 use near_indexer_primitives::CryptoHash;
@@ -510,14 +510,8 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
             requests,
             completed_requests,
         } = requests;
-        let block_ref = match self.recent_blocks.add_block(&block) {
-            Ok(add_result) => add_result.block_ref,
-            Err(err) => {
-                // block already exists.
-                tracing::warn!(target: "request", "Ignoring block {:?} at height {}: {:?}", block.hash, block.height, err);
-                return;
-            }
-        };
+
+        let AddBlockResult { block_ref } = self.recent_blocks.add_block(&block);
 
         // TODO(#3316): remove this per-queue counter when the tracker is shared across queues.
         mpc_pending_queue_blocks_indexed.inc();

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -319,9 +319,12 @@ impl RecentBlocksTracker {
 
     /// Adds a block to the tracker. This is expected to be called for EVERY block given by the
     /// indexer (whether or not it is interesting).
-    pub fn add_block(&mut self, block: &BlockViewLite) -> anyhow::Result<AddBlockResult> {
-        if self.hash_to_node.contains_key(&block.hash) {
-            anyhow::bail!("Block already exists in the tracker");
+    pub fn add_block(&mut self, block: &BlockViewLite) -> AddBlockResult {
+        if let Some(block) = self.hash_to_node.get(&block.hash) {
+            tracing::error!(target: "recent blocks tracker", "Block {:?} at height {} already exists", block.hash, block.height);
+            return AddBlockResult {
+                block_ref: Arc::downgrade(&block.status),
+            };
         }
         let status = Arc::new(AtomicBlockStatus(AtomicU8::new(u8::from(
             BlockStatus::OptimisticButNotCanonical,
@@ -368,7 +371,7 @@ impl RecentBlocksTracker {
             self.maximum_height_available = block.height;
         }
         self.prune_old_blocks();
-        Ok(AddBlockResult { block_ref })
+        AddBlockResult { block_ref }
     }
 
     /// Advance the final head, mark its ancestors as final, and drop every
@@ -771,7 +774,7 @@ pub mod tests {
                 !self.parents_of_added_blocks.contains(&block.hash),
                 "Cannot retroactively add the parent of an already added block"
             );
-            let result = self.tracker.add_block(&block.to_block_view()).unwrap();
+            let result = self.tracker.add_block(&block.to_block_view());
             if let Some(parent) = block.parent.clone() {
                 self.parents_of_added_blocks.insert(parent.hash);
             }


### PR DESCRIPTION
resolves #3450

### Previous behavior

Note that before, when receiving a new block, the queue returned early in case the block was already known to the tracker, as it indicated that the requests and responses from that block had already been handled by the queue.

#### Why we change it
This is technically correct behavior, but it is leaking `RecentBlocksTracker` internals into the queue. Once we move `RecentBlocksTracker` to the chain gateway, the queue will no longer have the luxury of knowing whether a block has already been indexed or not, but needs to handle whatever data it receives from the `BlockEventSubscriber`. As such, while unexpected, it must be able to handle duplicate events.

Hence, removing the early return and having the queue handle any duplicates is in line with where future refactors will take us.

### New behavior

The queue still handles duplicates correctly: for requests, it is a no-op. A request that has already been seen won't be added twice to the queue. For responses, it's not a no-op, but the code is duplicate-tolerant (the `IndexedRespondTxs::status()` reducer is _"is any entry final?"_, which is invariant to duplicates).
The only impact duplicates would have is on the metrics `mpc_pending_queue_matching_responses_indexed` and `mpc_pending_queue_responses_indexed`. Specifically, we would double-count a response if the indexer sends the same block twice. We do accept this double count, for the following reasons:

- the indexer is not supposed to do that, so we don't expect this to actually occur in practice;
- even if it occurs, the impact is minor (falsely incrementing a metric, that metric on its own is not an indicator for anything meaningful about our system health). The event is accompanied by an "error" log, which will help us be aware of what is happening;
- removing the double count would require us to compromise on performance in more relevant production logic: Instead of storing a `Vec<IndexedRespondTx>`, we would need to store it in a map `BTreeMap<BlockHash, IndexedRespondTx>`, which is an unjustified overhead, given the limited impact of everything outlined above.


Note that until #3316 is resolved, we will also be double-counting indexed blocks (in case they get sent twice by the indexer). Impact is again limited and we expect #3316 to be resolved imminently, at which point, we won't be double counting indexed blocks anymore.

