### PR TITLE
chore: delete triple migration steps from 3.11, clean legacy triples column

### DIFF
--- a/crates/contract/src/state/running.rs
+++ b/crates/contract/src/state/running.rs
@@ -186,12 +186,13 @@ impl RunningContractState {
             crate::primitives::domain::validate_domain_purpose(domain)?;
             crate::primitives::domain::validate_domain_threshold(domain, num_participants)?;
         }
-        // 3.11-transition lock: all CaitSith domains (ForeignTx included) must
-        // share one `reconstruction_threshold` so the legacy unprefixed
-        // `DBCol::Triple` mirror (#3292) can't collide. If no CaitSith
-        // domain exists yet the first one is free to pick any valid `t`;
-        // any later CaitSith — in the same proposal or in future calls —
-        // must match it. Remove once #3298 drops the mirror.
+        // TODO(#3164): remove this single-threshold lock once each domain can
+        // carry its own `t`. All CaitSith domains (ForeignTx included) must
+        // share one `reconstruction_threshold` today, because the node only
+        // runs background triple generation for a single `t`. If no CaitSith
+        // domain exists yet the first one is free to pick any valid `t`; any
+        // later CaitSith — in the same proposal or in future calls — must
+        // match it.
         let mut expected_caitsith_t = self
             .domains
             .domains()

--- a/crates/e2e-tests/tests/key_resharing.rs
+++ b/crates/e2e-tests/tests/key_resharing.rs
@@ -174,9 +174,9 @@ async fn test_multi_domain() {
     // when: start keygen for a new domain (ID 7), kill the leader to stall it,
     // then vote to cancel from the 3 remaining participants. Reuse the
     // existing CaitSith `t = 2` so the #3304 lock accepts the proposal.
-    // TODO(#3298): once the legacy `DBCol::Triple` mirror is gone and the
-    // #3304 lock is removed, restore `reconstruction_threshold = 3` to
-    // match the post-reshare cluster threshold.
+    // TODO(#3164): once the single-threshold #3304 lock is removed, restore
+    // `reconstruction_threshold = 3` to match the post-reshare cluster
+    // threshold.
     cluster
         .start_add_domains(vec![DomainConfig {
             id: DomainId(7),

--- a/crates/node/src/assets.rs
+++ b/crates/node/src/assets.rs
@@ -352,13 +352,6 @@ where
     /// no prefix (i.e. the original layout where keys were just
     /// `borsh(UniqueId)`).
     prefix: Vec<u8>,
-    /// Optional companion column mirrored on every write/delete. Keys in
-    /// `legacy_col` are written WITHOUT the `prefix` (just `borsh(UniqueId)`).
-    /// Used during the per-`t` triple migration so a downgrade can still read
-    /// triples this binary wrote.
-    /// TODO(#3298): drop together with the legacy `DBCol::Triple` once 3.11 is
-    /// out across the network.
-    legacy_col: Option<DBCol>,
     my_participant_id: ParticipantId,
     owned_queue: DoubleQueue<T, Vec<ParticipantId>>,
     last_id: Mutex<Option<UniqueId>>,
@@ -374,8 +367,9 @@ where
 /// for `is_subset_of_active_participants(persistent_participants)`.
 ///
 /// The caller is responsible for committing `update_writer`. Sharing a writer
-/// across multiple calls lets a single cleanup pass (legacy + per-`t` +
-/// per-domain columns + epoch marker) be committed as one atomic batch.
+/// across multiple calls lets a single cleanup pass (per-`t` triple columns +
+/// per-domain presignature columns + epoch marker) be committed as one atomic
+/// batch.
 pub fn clean_db<T>(
     db: &Arc<SecretDB>,
     update_writer: &mut SecretDBUpdate,
@@ -403,13 +397,11 @@ impl<T> DistributedAssetStorage<T>
 where
     T: Serialize + DeserializeOwned + Send + 'static,
 {
-    #[expect(clippy::too_many_arguments)]
     pub fn new(
         clock: Clock,
         db: Arc<SecretDB>,
         col: DBCol,
         prefix: Vec<u8>,
-        legacy_col: Option<DBCol>,
         my_participant_id: ParticipantId,
         condition: fn(&Vec<ParticipantId>, &T) -> bool,
         alive_participant_ids_query: Arc<dyn Fn() -> Vec<ParticipantId> + Send + Sync>,
@@ -433,7 +425,6 @@ where
             db,
             col,
             prefix,
-            legacy_col,
             my_participant_id,
             owned_queue,
             last_id: Mutex::new(last_id),
@@ -455,11 +446,6 @@ where
         let mut key = self.prefix.clone();
         key.extend_from_slice(&borsh::to_vec(&id).unwrap());
         key
-    }
-
-    /// Key under the optional legacy mirror column: never prefixed.
-    fn make_legacy_key(id: UniqueId) -> Vec<u8> {
-        borsh::to_vec(&id).unwrap()
     }
 
     fn decode_key(key: &[u8], prefix_len: usize) -> anyhow::Result<UniqueId> {
@@ -512,9 +498,6 @@ where
         let (id, asset) = self.owned_queue.take_owned().await;
         let mut update = self.db.update();
         update.delete(self.col, &self.make_key(id));
-        if let Some(legacy_col) = self.legacy_col {
-            update.delete(legacy_col, &Self::make_legacy_key(id));
-        }
         update
             .commit()
             .expect("Unrecoverable error writing to database");
@@ -527,9 +510,6 @@ where
         let value_ser = serde_json::to_vec(&value).unwrap();
         let mut update = self.db.update();
         update.put(self.col, &key, &value_ser);
-        if let Some(legacy_col) = self.legacy_col {
-            update.put(legacy_col, &Self::make_legacy_key(id), &value_ser);
-        }
         update
             .commit()
             .expect("Unrecoverable error writing to database");
@@ -549,9 +529,6 @@ where
             let mut update = self.db.update();
             for id in removed_cold_ids {
                 update.delete(self.col, &self.make_key(id));
-                if let Some(legacy_col) = self.legacy_col {
-                    update.delete(legacy_col, &Self::make_legacy_key(id));
-                }
             }
             update
                 .commit()
@@ -565,9 +542,6 @@ where
         let value_ser = serde_json::to_vec(&value).unwrap();
         let mut update = self.db.update();
         update.put(self.col, &key, &value_ser);
-        if let Some(legacy_col) = self.legacy_col {
-            update.put(legacy_col, &Self::make_legacy_key(id), &value_ser);
-        }
         update
             .commit()
             .expect("Unrecoverable error writing to database");
@@ -602,9 +576,6 @@ where
         })?;
         let mut update = self.db.update();
         update.delete(self.col, &key);
-        if let Some(legacy_col) = self.legacy_col {
-            update.delete(legacy_col, &Self::make_legacy_key(id));
-        }
         update
             .commit()
             .expect("Unrecoverable error writing to database");
@@ -877,9 +848,8 @@ mod tests {
         let store = DistributedAssetStorage::<ParticipantsWithI32>::new(
             clock.clock(),
             db,
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             ParticipantId::from_raw(42),
             |cond, val| val.is_subset_of_active_participants(cond),
             {
@@ -1013,9 +983,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1061,9 +1030,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db.clone(),
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1112,9 +1080,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1131,9 +1098,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             ParticipantId::from_raw(42),
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1173,9 +1139,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db.clone(),
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             myself,
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1198,9 +1163,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             myself,
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1233,9 +1197,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db.clone(),
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             myself,
             |_, x| *x != 1,
             Arc::new(Vec::new),
@@ -1255,9 +1218,8 @@ mod tests {
         let store = DistributedAssetStorage::<u32>::new(
             FakeClock::default().clock(),
             db,
-            crate::db::DBCol::Triple,
+            crate::db::DBCol::TripleV2,
             Vec::new(),
-            None,
             myself,
             |_, _| true,
             Arc::new(std::vec::Vec::new),
@@ -1281,7 +1243,6 @@ mod tests {
                 db.clone(),
                 crate::db::DBCol::Presignature,
                 domain_id_to_prefix(domain_id),
-                None,
                 myself,
                 |_, _| true,
                 Arc::new(std::vec::Vec::new),
@@ -1315,7 +1276,6 @@ mod tests {
                 db.clone(),
                 crate::db::DBCol::Presignature,
                 domain_id_to_prefix(domain_id),
-                None,
                 myself,
                 |_, _| true,
                 Arc::new(std::vec::Vec::new),
@@ -1369,7 +1329,6 @@ mod tests {
                 db.clone(),
                 db_col,
                 domain_id_to_prefix(domain_id),
-                None,
                 my_participant_id,
                 |cond, val| val.is_subset_of_active_participants(cond),
                 {
@@ -1384,7 +1343,7 @@ mod tests {
             assert_eq!(store.num_owned(), expected);
         };
         for domain_id in [None, Some(DomainId(0)), Some(DomainId(1))] {
-            for db_col in [crate::db::DBCol::Presignature, crate::db::DBCol::Triple] {
+            for db_col in [crate::db::DBCol::Presignature, crate::db::DBCol::TripleV2] {
                 assert_db_num_owned(db_col, domain_id, 0);
                 {
                     // populate the database

--- a/crates/node/src/assets/cleanup.rs
+++ b/crates/node/src/assets/cleanup.rs
@@ -47,21 +47,10 @@ pub fn delete_stale_triples_and_presignatures(
         AssetCleanup::Keep => {}
         AssetCleanup::DeleteAll => {
             update_writer.delete_all(DBCol::Presignature)?;
-            update_writer.delete_all(DBCol::Triple)?;
             update_writer.delete_all(DBCol::TripleV2)?;
         }
         AssetCleanup::KeepOnly(persitent_participants) => {
-            // Triples — both columns, since they are dual-written during the
-            // rollout window. Legacy `Triple` uses an empty prefix; new
-            // `TripleV2` uses a `[t as u64 BE]` prefix per store.
-            clean_db::<PairedTriple>(
-                db,
-                &mut update_writer,
-                DBCol::Triple,
-                &persitent_participants,
-                my_participant_id,
-                &[],
-            )?;
+            // Triples — `TripleV2` uses a `[t as u64 BE]` prefix per store.
             for t in &triple_thresholds {
                 clean_db::<PairedTriple>(
                     db,
@@ -186,7 +175,6 @@ mod tests {
     use crate::assets::test_utils;
     use crate::assets::test_utils::TestContext;
     use crate::assets::test_utils::get_participant_ids;
-    use crate::assets::test_utils::legacy_triple_key;
     use crate::assets::test_utils::make_triple;
     use crate::assets::test_utils::random_verifying_key;
     use crate::assets::test_utils::triple_v2_key;
@@ -272,16 +260,14 @@ mod tests {
         assert_epoch_data_in_db_matches(&ctx, &end_data);
     }
 
-    /// End-to-end check that a dual-written triple (via `TripleStorage::add_owned`,
-    /// which writes to both `DBCol::TripleV2` under `[t]` and `DBCol::Triple` with
-    /// no prefix) is removed from BOTH columns when the participant set changes.
-    /// The other cleanup tests populate `TripleV2` only via a local helper that
-    /// bypasses the dual-write, so this is the only one that exercises the
-    /// realistic post-`add_owned` state.
+    /// End-to-end check that a triple written via `TripleStorage::add_owned`
+    /// (into `DBCol::TripleV2` under `[t]`) is removed when the participant set
+    /// changes. The other cleanup tests populate `TripleV2` via a local helper;
+    /// this one exercises the realistic post-`add_owned` state.
     #[test]
     #[expect(non_snake_case)]
-    fn delete_stale_triples_and_presignatures__should_clean_dual_written_triples_in_both_columns() {
-        // Given a node has dual-written a stale triple via TripleStorage.
+    fn delete_stale_triples_and_presignatures__should_clean_stale_triple_in_v2_column() {
+        // Given a node has written a stale triple via TripleStorage.
         let (mut start_data, my_participant_id, threshold) = test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
         let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
@@ -301,10 +287,8 @@ mod tests {
         let id = triple_store.generate_and_reserve_id();
         triple_store.add_owned(id, make_triple(&all_participants));
         let v2_key = triple_v2_key(threshold, id);
-        let legacy_key = legacy_triple_key(id);
-        // Sanity: the row really is in both columns.
+        // Sanity: the row really is in the TripleV2 column.
         assert!(db.get(DBCol::TripleV2, &v2_key).unwrap().is_some());
-        assert!(db.get(DBCol::Triple, &legacy_key).unwrap().is_some());
 
         // Seed the persisted epoch_data so the next call enters the
         // `KeepOnly` branch (same epoch_id, persistent set shrinks).
@@ -317,7 +301,6 @@ mod tests {
         )
         .unwrap();
         assert!(db.get(DBCol::TripleV2, &v2_key).unwrap().is_some());
-        assert!(db.get(DBCol::Triple, &legacy_key).unwrap().is_some());
 
         // When one participant's TLS key changes — the triple's participant
         // set is no longer fully persistent.
@@ -337,17 +320,15 @@ mod tests {
         )
         .unwrap();
 
-        // Then the dual-written row is gone from both columns.
+        // Then the row is gone from the TripleV2 column.
         assert!(db.get(DBCol::TripleV2, &v2_key).unwrap().is_none());
-        assert!(db.get(DBCol::Triple, &legacy_key).unwrap().is_none());
     }
 
-    /// Counterpart to the stale-cleaned test: a dual-written triple whose
-    /// participants are all in the persistent set must survive the cleanup in
-    /// both columns.
+    /// Counterpart to the stale-cleaned test: a triple whose participants are
+    /// all in the persistent set must survive the cleanup.
     #[test]
     #[expect(non_snake_case)]
-    fn delete_stale_triples_and_presignatures__should_keep_dual_written_active_triple() {
+    fn delete_stale_triples_and_presignatures__should_keep_active_triple() {
         let (mut start_data, my_participant_id, threshold) = test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
         // Triple uses everyone EXCEPT the last participant (whose TLS we'll change
@@ -374,7 +355,6 @@ mod tests {
         let id = triple_store.generate_and_reserve_id();
         triple_store.add_owned(id, make_triple(&active_subset));
         let v2_key = triple_v2_key(threshold, id);
-        let legacy_key = legacy_triple_key(id);
 
         // Seed epoch_data, then run cleanup with one participant's TLS rotated
         // (the one our triple does not depend on).
@@ -402,15 +382,14 @@ mod tests {
         .unwrap();
 
         assert!(db.get(DBCol::TripleV2, &v2_key).unwrap().is_some());
-        assert!(db.get(DBCol::Triple, &legacy_key).unwrap().is_some());
     }
 
-    /// A dual-written triple authored by a peer (received locally via
-    /// `add_unowned`) must not be touched by *our* cleanup — each node only
-    /// cleans the triples it owns.
+    /// A triple authored by a peer (received locally via `add_unowned`) must
+    /// not be touched by *our* cleanup — each node only cleans the triples it
+    /// owns.
     #[test]
     #[expect(non_snake_case)]
-    fn delete_stale_triples_and_presignatures__should_keep_peer_owned_dual_written_triple() {
+    fn delete_stale_triples_and_presignatures__should_keep_peer_owned_triple() {
         let (mut start_data, my_participant_id, threshold) = test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
         let peer = *all_participants
@@ -436,7 +415,6 @@ mod tests {
         let peer_id = UniqueId::new(peer, 100, 0);
         triple_store.add_unowned(peer_id, make_triple(&all_participants));
         let v2_key = triple_v2_key(threshold, peer_id);
-        let legacy_key = legacy_triple_key(peer_id);
 
         delete_stale_triples_and_presignatures(
             &db,
@@ -462,6 +440,5 @@ mod tests {
         .unwrap();
 
         assert!(db.get(DBCol::TripleV2, &v2_key).unwrap().is_some());
-        assert!(db.get(DBCol::Triple, &legacy_key).unwrap().is_some());
     }
 }

--- a/crates/node/src/assets/test_utils.rs
+++ b/crates/node/src/assets/test_utils.rs
@@ -42,11 +42,6 @@ pub fn triple_v2_key(t: ReconstructionThreshold, id: UniqueId) -> Vec<u8> {
     key
 }
 
-/// On-disk key for a `DBCol::Triple` (legacy) entry: just `borsh(UniqueId)`.
-pub fn legacy_triple_key(id: UniqueId) -> Vec<u8> {
-    borsh::to_vec(&id).unwrap()
-}
-
 /// Generates a 4-participant test fixture with threshold 3. Returns the epoch
 /// data, the local participant's ID, and the threshold so callers don't have
 /// to restate the magic number alongside the fixture.
@@ -80,6 +75,9 @@ pub struct TestContext {
     pub my_participant_id: ParticipantId,
     pub alive_participants: Arc<Mutex<Vec<ParticipantId>>>,
     pub presign_domain_ids: Vec<DomainId>,
+    /// Threshold whose `TripleV2` prefix `populate`/`assert_owned` operate on;
+    /// matches the fixture from [`gen_four_participants`].
+    pub triple_threshold: ReconstructionThreshold,
 }
 
 pub fn make_triple(participants: &[ParticipantId]) -> PairedTriple {
@@ -133,7 +131,12 @@ impl TestContext {
             my_participant_id,
             alive_participants,
             presign_domain_ids: [DomainId(0), DomainId(1)].to_vec(),
+            triple_threshold: ReconstructionThreshold::new(3),
         }
+    }
+
+    fn triple_prefix(&self) -> Vec<u8> {
+        self.triple_threshold.inner().to_be_bytes().to_vec()
     }
 
     pub fn new_store<T>(&self, db_col: DBCol, prefix: Vec<u8>) -> DistributedAssetStorage<T>
@@ -145,7 +148,6 @@ impl TestContext {
             self.db.clone(),
             db_col,
             prefix,
-            None,
             self.my_participant_id,
             |cond, val| val.is_subset_of_active_participants(cond),
             {
@@ -157,8 +159,8 @@ impl TestContext {
     }
 
     pub fn populate(&self, participants: &[ParticipantId]) {
-        // Mirror cleanup's view of triples: legacy column has no prefix.
-        let store = self.new_store::<PairedTriple>(DBCol::Triple, Vec::new());
+        // Mirror cleanup's view of triples: per-`t` TripleV2 column.
+        let store = self.new_store::<PairedTriple>(DBCol::TripleV2, self.triple_prefix());
         let id = store.generate_and_reserve_id();
         store.add_owned(id, make_triple(participants));
 
@@ -173,7 +175,7 @@ impl TestContext {
     }
 
     pub fn assert_owned(&self, expected: usize) {
-        let store = self.new_store::<PairedTriple>(DBCol::Triple, Vec::new());
+        let store = self.new_store::<PairedTriple>(DBCol::TripleV2, self.triple_prefix());
         assert_eq!(store.num_owned(), expected);
 
         for &d in &self.presign_domain_ids {

--- a/crates/node/src/db.rs
+++ b/crates/node/src/db.rs
@@ -24,11 +24,6 @@ impl std::fmt::Debug for SecretDB {
 /// Each DBCol corresponds to a column family.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DBCol {
-    /// Legacy triple column: keys are `borsh(UniqueId)` with no prefix.
-    /// Kept alongside `TripleV2` during the rollout so that a downgrade can
-    /// still find triples this binary wrote.
-    /// TODO(#3298): remove once all production nodes have upgraded past 3.11.
-    Triple,
     /// Per-`t` triple column: keys are `[t as u64 BE][borsh(UniqueId)]`. A
     /// triple is stored under the threshold it was generated with so that
     /// presign can draw from a store of matching `t`.
@@ -43,7 +38,6 @@ pub enum DBCol {
 impl DBCol {
     fn as_str(&self) -> &'static str {
         match self {
-            DBCol::Triple => "triple",
             DBCol::TripleV2 => "triple_v2",
             DBCol::Presignature => "presignature",
             DBCol::SignRequest => "sign_request",
@@ -53,9 +47,8 @@ impl DBCol {
         }
     }
 
-    fn all() -> [DBCol; 7] {
+    fn all() -> [DBCol; 6] {
         [
-            DBCol::Triple,
             DBCol::TripleV2,
             DBCol::Presignature,
             DBCol::SignRequest,
@@ -110,7 +103,21 @@ impl SecretDB {
             .into_iter()
             .collect();
         let all_cfs: Vec<&String> = known_cfs.union(&on_disk_cfs).collect();
-        let db = rocksdb::DB::open_cf(&options, path, &all_cfs)?;
+        let mut db = rocksdb::DB::open_cf(&options, path, &all_cfs)?;
+
+        // One-time cleanup: drop the legacy unprefixed triple column family
+        // (former `DBCol::Triple`) if a pre-3.12 binary left it on disk. Its
+        // contents are dead — every triple now lives in the per-`t`
+        // `DBCol::TripleV2`. Dropping reclaims the SST files rather than leaving
+        // tombstones behind.
+        // TODO(#3456): remove this cleanup once 3.12 has rolled out to all
+        // nodes, so no node still carries the column on disk.
+        let legacy_triple = "triple";
+        if on_disk_cfs.contains(legacy_triple) {
+            db.drop_cf(legacy_triple)?;
+            tracing::info!("Dropped legacy '{legacy_triple}' column family on startup");
+        }
+
         Ok(Self { db, cipher }.into())
     }
 
@@ -145,24 +152,6 @@ impl SecretDB {
         let iter = self
             .db
             .iterator_cf_opt(&self.cf_handle(col), iter_opt, iter_mode);
-        iter.map(move |result| {
-            let (key, value) = result?;
-            let value = decrypt(&self.cipher, &value)?;
-            anyhow::Ok((key, value))
-        })
-    }
-
-    /// Iterates every key/value in the column with no upper bound. Use this
-    /// instead of `iter_range(col, &[], &[0xFF; N])` whenever a full-column
-    /// scan is intended — the latter silently skips rows whose keys are ≥ the
-    /// sentinel, which is fragile against future key-schema growth.
-    pub fn iter_all(
-        &self,
-        col: DBCol,
-    ) -> impl Iterator<Item = anyhow::Result<(Box<[u8]>, Vec<u8>)>> + '_ {
-        let iter = self
-            .db
-            .iterator_cf(self.cf_handle(col), IteratorMode::Start);
         iter.map(move |result| {
             let (key, value) = result?;
             let value = decrypt(&self.cipher, &value)?;
@@ -267,23 +256,23 @@ mod tests {
         let db = SecretDB::new(dir.path(), [1; 16])?;
         let mut update = db.update();
         update.put(DBCol::Presignature, b"key", b"value");
-        update.put(DBCol::Triple, b"triple1", b"tripledata");
+        update.put(DBCol::TripleV2, b"triple1", b"tripledata");
         update.put(
-            DBCol::Triple,
+            DBCol::TripleV2,
             b"triple2",
             b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
         );
-        update.put(DBCol::Triple, b"triple3", b"");
+        update.put(DBCol::TripleV2, b"triple3", b"");
         update.commit()?;
         assert_eq!(db.get(DBCol::Presignature, b"key")?.unwrap(), b"value");
-        assert_eq!(db.get(DBCol::Triple, b"triple1")?.unwrap(), b"tripledata");
+        assert_eq!(db.get(DBCol::TripleV2, b"triple1")?.unwrap(), b"tripledata");
         assert_eq!(
-            db.get(DBCol::Triple, b"triple2")?.unwrap(),
+            db.get(DBCol::TripleV2, b"triple2")?.unwrap(),
             b"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
         );
-        assert_eq!(db.get(DBCol::Triple, b"triple3")?.unwrap(), b"");
+        assert_eq!(db.get(DBCol::TripleV2, b"triple3")?.unwrap(), b"");
 
-        let mut iter = db.iter_range(DBCol::Triple, b"triple1", b"triple3");
+        let mut iter = db.iter_range(DBCol::TripleV2, b"triple1", b"triple3");
         assert_eq!(
             iter.next().unwrap().unwrap(),
             (
@@ -299,19 +288,48 @@ mod tests {
             )
         );
         let mut update = db.update();
-        update.delete(DBCol::Triple, b"triple1");
+        update.delete(DBCol::TripleV2, b"triple1");
         update.commit()?;
-        assert_eq!(db.get(DBCol::Triple, b"triple1")?, None);
+        assert_eq!(db.get(DBCol::TripleV2, b"triple1")?, None);
 
         // Sanity check that the DB does encrypt the value.
         assert!(
-            !db.get_ciphertext(DBCol::Triple, b"triple2")
+            !db.get_ciphertext(DBCol::TripleV2, b"triple2")
                 .unwrap()
                 .unwrap()
                 .is_ascii()
         );
 
         Ok(())
+    }
+
+    #[test]
+    #[expect(non_snake_case)]
+    fn secret_db_new__should_drop_legacy_triple_column_family_on_startup() {
+        // Given a DB that still carries the populated legacy "triple" column
+        // family on disk (as a pre-3.12 binary would have left it).
+        let dir = tempfile::tempdir().expect("tempdir should be created");
+        let key = [1; 16];
+        let legacy_triple = "triple";
+        {
+            let mut options = rocksdb::Options::default();
+            options.create_if_missing(true);
+            options.create_missing_column_families(true);
+            let cfs = [legacy_triple, "triple_v2", "presignature"];
+            let db = rocksdb::DB::open_cf(&options, dir.path(), cfs).expect("db should open");
+            let cf = db.cf_handle(legacy_triple).unwrap();
+            db.put_cf(&cf, b"key", b"value").unwrap();
+        }
+
+        // When the DB is opened through SecretDB and then closed.
+        {
+            let _db = SecretDB::new(dir.path(), key).expect("SecretDB should open");
+        }
+
+        // Then the legacy column family is gone from disk.
+        let options = rocksdb::Options::default();
+        let on_disk = rocksdb::DB::list_cf(&options, dir.path()).expect("list_cf should succeed");
+        assert!(!on_disk.contains(&legacy_triple.to_string()));
     }
 
     #[test]

--- a/crates/node/src/providers/ecdsa/presign.rs
+++ b/crates/node/src/providers/ecdsa/presign.rs
@@ -44,7 +44,6 @@ impl PresignatureStorage {
             db,
             crate::db::DBCol::Presignature,
             domain_id.0.to_be_bytes().to_vec(),
-            None,
             my_participant_id,
             |participants, presignature| {
                 presignature.is_subset_of_active_participants(participants)

--- a/crates/node/src/providers/ecdsa/snapshots/mpc_node__providers__ecdsa__triple__tests__db_key_layout__is_stable.snap
+++ b/crates/node/src/providers/ecdsa/snapshots/mpc_node__providers__ecdsa__triple__tests__db_key_layout__is_stable.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/node/src/providers/ecdsa/triple.rs
-expression: "format!(\"v2_key:     {}\\nlegacy_key: {}\", hex::encode(&v2_key),\nhex::encode(&legacy_key),)"
+expression: "format!(\"v2_key: {}\", hex::encode(&v2_key))"
 ---
-v2_key:     0102030405060708aabbccdd1122334455667788deadbeef
-legacy_key: aabbccdd1122334455667788deadbeef
+v2_key: 0102030405060708aabbccdd1122334455667788deadbeef

--- a/crates/node/src/providers/ecdsa/triple.rs
+++ b/crates/node/src/providers/ecdsa/triple.rs
@@ -27,12 +27,7 @@ use threshold_signatures::participants::Participant;
 /// participant count and the Shamir degree `t − 1` are equivalent
 /// identifiers).
 ///
-/// Backed by [`DBCol::TripleV2`] under prefix `t.inner().to_be_bytes()` (8 BE),
-/// with dual-write to [`DBCol::Triple`] (no prefix) so that a node downgraded
-/// to the previous binary can still consume triples this binary wrote. The
-/// mirror is intended to be dropped in a follow-up release once the rollout
-/// is complete. See [`TripleStorage::new`] for how the mirror is wired through
-/// [`DistributedAssetStorage::new`]'s `legacy_col` parameter.
+/// Backed by [`DBCol::TripleV2`] under prefix `t.inner().to_be_bytes()` (8 BE).
 pub struct TripleStorage(DistributedAssetStorage<PairedTriple>);
 
 impl TripleStorage {
@@ -48,7 +43,6 @@ impl TripleStorage {
             db,
             DBCol::TripleV2,
             threshold.inner().to_be_bytes().to_vec(),
-            Some(DBCol::Triple),
             my_participant_id,
             |participants, pair| pair.is_subset_of_active_participants(participants),
             alive_participant_ids_query,
@@ -62,67 +56,6 @@ impl Deref for TripleStorage {
     fn deref(&self) -> &Self::Target {
         &self.0
     }
-}
-
-/// Rebuild [`DBCol::TripleV2`] from the legacy [`DBCol::Triple`] column.
-///
-/// `Triple` is the source of truth: the new binary mirrors every write/delete
-/// to it via dual-write, and the old binary only knows about that column. So
-/// at process startup we wipe `TripleV2` and re-populate it from whatever is
-/// currently in `Triple`, bucketed under `[t as u64 BE]` prefixes derived from
-/// each triple's own threshold. Legacy entries are left in place — a downgrade
-/// to the previous binary still needs to see them.
-///
-/// Rebuilding (rather than incrementally migrating) is what keeps re-upgrade
-/// after a downgrade safe: if the downgraded binary consumed triples — deleting
-/// them from `Triple` but not `TripleV2` — naive incremental migration would
-/// leave those stale entries in `TripleV2`, and the new binary would re-use
-/// them in presign. With ECDSA that is a nonce-reuse hazard that leaks the
-/// private key. Wiping `TripleV2` first drops any such orphans.
-///
-/// The whole rebuild commits in one atomic batch.
-///
-/// SAFETY: must be called before any [`TripleStorage`] is constructed for this
-/// DB, and exactly once per process. The unconditional [`DBCol::TripleV2`]
-/// wipe would race with a live `TripleStorage` (vending the same `UniqueId`
-/// to two consumers across the wipe) — so this is invoked from `run.rs` right
-/// after [`crate::db::SecretDB::new`], before the coordinator can construct
-/// any provider. Do not call it from `EcdsaSignatureProvider::new` or any
-/// other path that may run multiple times per process (e.g., across
-/// coordinator Running ↔ Resharing transitions).
-///
-/// TODO(#3298): delete after 3.11 is out across the network.
-pub fn migrate_legacy_triples_to_v2(db: &Arc<SecretDB>) -> anyhow::Result<usize> {
-    let mut migrated = 0usize;
-    let mut update = db.update();
-    update.delete_all(DBCol::TripleV2)?;
-    for item in db.iter_all(DBCol::Triple) {
-        let (legacy_key, value_ser) = item?;
-        let triple: PairedTriple = match serde_json::from_slice(&value_ser) {
-            Ok(t) => t,
-            Err(err) => {
-                tracing::warn!(
-                    ?err,
-                    "Skipping unparseable legacy triple row during migration"
-                );
-                continue;
-            }
-        };
-        // Both halves of a cait-sith paired triple are generated with the same
-        // participant set, so either one yields the correct `t`.
-        let threshold: u64 = triple.0.1.participants.len().try_into()?;
-        let mut new_key = Vec::with_capacity(std::mem::size_of::<u64>() + legacy_key.len());
-        new_key.extend_from_slice(&threshold.to_be_bytes());
-        new_key.extend_from_slice(&legacy_key);
-        update.put(DBCol::TripleV2, &new_key, &value_ser);
-        migrated += 1;
-    }
-    update.commit()?;
-    tracing::info!(
-        migrated,
-        "Rebuilt TripleV2 from legacy Triple column on startup"
-    );
-    Ok(migrated)
 }
 
 pub const SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE: usize = 64;
@@ -402,9 +335,8 @@ pub fn participants_from_triples(
 mod tests {
     use super::{
         ManyTripleGenerationComputation, PairedTriple, ReconstructionThreshold, TripleStorage,
-        migrate_legacy_triples_to_v2,
     };
-    use crate::assets::test_utils::{legacy_triple_key, make_triple, triple_v2_key};
+    use crate::assets::test_utils::{make_triple, triple_v2_key};
     use crate::db::{DBCol, SecretDB};
     use crate::network::computation::MpcLeaderCentricComputation;
     use crate::network::testing::run_test_clients;
@@ -553,13 +485,6 @@ mod tests {
             .collect())
     }
 
-    fn write_legacy_triple(db: &Arc<SecretDB>, id: UniqueId, triple: &PairedTriple) {
-        let value = serde_json::to_vec(triple).unwrap();
-        let mut update = db.update();
-        update.put(DBCol::Triple, &legacy_triple_key(id), &value);
-        update.commit().unwrap();
-    }
-
     fn new_triple_store(
         db: Arc<SecretDB>,
         my_participant_id: ParticipantId,
@@ -576,18 +501,11 @@ mod tests {
         .unwrap()
     }
 
-    /// Returns the `t` (Shamir degree + 1) baked into a triple's public part.
-    fn triple_threshold(triple: &PairedTriple) -> ReconstructionThreshold {
-        ReconstructionThreshold::new(triple.0.1.participants.len() as u64)
-    }
-
-    /// Snapshot test pinning the on-disk DB key layout for the triple stores.
+    /// Snapshot test pinning the on-disk DB key layout for the triple store.
     ///
-    /// The exact byte layout is load-bearing for the dual-write / migration
-    /// dance (#3298): the new binary writes both columns, and a downgraded
-    /// binary must be able to read what we wrote. Any drift in how
-    /// `ReconstructionThreshold` or `UniqueId` serialize would silently break
-    /// that compatibility. The snapshot makes the layout an explicit, reviewed
+    /// The exact byte layout is load-bearing: any drift in how
+    /// `ReconstructionThreshold` or `UniqueId` serialize would silently change
+    /// the on-disk format. The snapshot makes the layout an explicit, reviewed
     /// artifact — if it diffs, you're changing on-disk format and must think
     /// about migration.
     #[test]
@@ -600,124 +518,8 @@ mod tests {
         let id = UniqueId::new(participant, 0x1122_3344_5566_7788, 0xDEAD_BEEF);
 
         let v2_key = triple_v2_key(t, id);
-        let legacy_key = legacy_triple_key(id);
 
-        insta::assert_snapshot!(format!(
-            "v2_key:     {}\nlegacy_key: {}",
-            hex::encode(&v2_key),
-            hex::encode(&legacy_key),
-        ));
-    }
-
-    #[test]
-    #[expect(non_snake_case)]
-    fn migrate_legacy_triples_to_v2__should_bucket_legacy_entries_by_t() {
-        // Given a DB with two legacy triples, each carrying a different `t`.
-        let dir = tempfile::tempdir().unwrap();
-        let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
-        let me = ParticipantId::from_raw(42);
-        let participants_3 = vec![me, ParticipantId::from_raw(1), ParticipantId::from_raw(2)];
-        let participants_4 = vec![
-            me,
-            ParticipantId::from_raw(1),
-            ParticipantId::from_raw(2),
-            ParticipantId::from_raw(3),
-        ];
-        let id_a = UniqueId::new(me, 100, 0);
-        let id_b = UniqueId::new(me, 100, 1);
-        let t3 = ReconstructionThreshold::new(3);
-        let t4 = ReconstructionThreshold::new(4);
-        let triple_t3 = make_triple(&participants_3);
-        let triple_t4 = make_triple(&participants_4);
-        assert_eq!(triple_threshold(&triple_t3), t3);
-        assert_eq!(triple_threshold(&triple_t4), t4);
-        write_legacy_triple(&db, id_a, &triple_t3);
-        write_legacy_triple(&db, id_b, &triple_t4);
-
-        // When the migration runs.
-        let migrated = migrate_legacy_triples_to_v2(&db).unwrap();
-
-        // Then each legacy entry appears in TripleV2 under its `t` prefix, and
-        // the legacy entries are still present (downgrade-safe).
-        assert_eq!(migrated, 2);
-        assert!(
-            db.get(DBCol::TripleV2, &triple_v2_key(t3, id_a))
-                .unwrap()
-                .is_some()
-        );
-        assert!(
-            db.get(DBCol::TripleV2, &triple_v2_key(t4, id_b))
-                .unwrap()
-                .is_some()
-        );
-        assert!(
-            db.get(DBCol::Triple, &legacy_triple_key(id_a))
-                .unwrap()
-                .is_some()
-        );
-        assert!(
-            db.get(DBCol::Triple, &legacy_triple_key(id_b))
-                .unwrap()
-                .is_some()
-        );
-
-        // And the per-`t` store surfaces only the matching triples.
-        let store_t3 = new_triple_store(db.clone(), me, t3, participants_3.clone());
-        let store_t4 = new_triple_store(db.clone(), me, t4, participants_4.clone());
-        assert_eq!(store_t3.num_owned(), 1);
-        assert_eq!(store_t4.num_owned(), 1);
-    }
-
-    #[test]
-    #[expect(non_snake_case)]
-    fn migrate_legacy_triples_to_v2__should_be_idempotent_with_no_legacy_entries() {
-        // Given a DB with only new-format (per-`t`) triple rows.
-        let dir = tempfile::tempdir().unwrap();
-        let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
-        let me = ParticipantId::from_raw(42);
-        let participants = vec![me];
-        let t1 = ReconstructionThreshold::new(1);
-        let store = new_triple_store(db.clone(), me, t1, participants.clone());
-        store.add_owned(store.generate_and_reserve_id(), make_triple(&participants));
-        // `store.add_owned` also dual-writes to DBCol::Triple. The migration
-        // will rewrite that row idempotently.
-        let migrated_count = migrate_legacy_triples_to_v2(&db).unwrap();
-
-        // When/Then: the migration is harmless and the store still has its one triple.
-        assert_eq!(migrated_count, 1);
-        let store = new_triple_store(db, me, t1, participants);
-        assert_eq!(store.num_owned(), 1);
-    }
-
-    #[test]
-    #[expect(non_snake_case)]
-    fn migrate_legacy_triples_to_v2__should_drop_orphans_left_by_downgrade() {
-        // Given a DB where `TripleV2` carries an entry that `Triple` no longer
-        // has — the exact shape a downgraded binary would leave behind after
-        // consuming a triple (deleting from `Triple`, unaware of `TripleV2`).
-        // Reusing that triple post re-upgrade would be a nonce-reuse hazard.
-        let dir = tempfile::tempdir().unwrap();
-        let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
-        let me = ParticipantId::from_raw(42);
-        let participants = vec![me, ParticipantId::from_raw(1), ParticipantId::from_raw(2)];
-        let stale_id = UniqueId::new(me, 100, 0);
-        let stale_triple = make_triple(&participants);
-        let mut update = db.update();
-        update.put(
-            DBCol::TripleV2,
-            &triple_v2_key(triple_threshold(&stale_triple), stale_id),
-            &serde_json::to_vec(&stale_triple).unwrap(),
-        );
-        update.commit().unwrap();
-
-        // When the migration runs.
-        let migrated = migrate_legacy_triples_to_v2(&db).unwrap();
-
-        // Then `TripleV2` is rebuilt from `Triple` (empty), and the orphan is
-        // gone — the per-`t` store surfaces nothing.
-        assert_eq!(migrated, 0);
-        let store = new_triple_store(db, me, triple_threshold(&stale_triple), participants);
-        assert_eq!(store.num_owned(), 0);
+        insta::assert_snapshot!(format!("v2_key: {}", hex::encode(&v2_key)));
     }
 
     #[test]
@@ -757,8 +559,8 @@ mod tests {
 
     #[test]
     #[expect(non_snake_case)]
-    fn triple_storage_add_owned__should_dual_write_to_legacy_column() {
-        // Given a TripleStorage configured with legacy mirroring.
+    fn triple_storage_add_owned__should_write_to_triple_v2_column() {
+        // Given a TripleStorage for `t = 3`.
         let dir = tempfile::tempdir().unwrap();
         let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
         let me = ParticipantId::from_raw(42);
@@ -770,18 +572,18 @@ mod tests {
         // When adding an owned triple.
         store.add_owned(id, make_triple(&participants));
 
-        // Then both columns contain the same value.
-        let v2 = db.get(DBCol::TripleV2, &triple_v2_key(t, id)).unwrap();
-        let legacy = db.get(DBCol::Triple, &legacy_triple_key(id)).unwrap();
-        assert!(v2.is_some());
-        assert!(legacy.is_some());
-        assert_eq!(v2, legacy);
+        // Then it is persisted under the per-`t` TripleV2 key.
+        assert!(
+            db.get(DBCol::TripleV2, &triple_v2_key(t, id))
+                .unwrap()
+                .is_some()
+        );
     }
 
     #[test]
     #[expect(non_snake_case)]
-    fn triple_storage_take_owned__should_delete_from_both_columns() {
-        // Given a triple present in both columns via dual-write.
+    fn triple_storage_take_owned__should_delete_from_triple_v2_column() {
+        // Given a triple present in the per-`t` TripleV2 column.
         let dir = tempfile::tempdir().unwrap();
         let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
         let me = ParticipantId::from_raw(42);
@@ -794,14 +596,9 @@ mod tests {
         // When the triple is consumed.
         let _ = store.take_owned().now_or_never().unwrap();
 
-        // Then it is gone from both columns.
+        // Then it is gone from the TripleV2 column.
         assert!(
             db.get(DBCol::TripleV2, &triple_v2_key(t, id))
-                .unwrap()
-                .is_none()
-        );
-        assert!(
-            db.get(DBCol::Triple, &legacy_triple_key(id))
                 .unwrap()
                 .is_none()
         );

--- a/crates/node/src/providers/robust_ecdsa/presign.rs
+++ b/crates/node/src/providers/robust_ecdsa/presign.rs
@@ -47,7 +47,6 @@ impl PresignatureStorage {
             db,
             crate::db::DBCol::Presignature,
             domain_id.0.to_be_bytes().to_vec(),
-            None,
             my_participant_id,
             |participants, presignature| {
                 presignature.is_subset_of_active_participants(participants)

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -12,7 +12,6 @@ use crate::{
     keyshare::{GcpPermanentKeyStorageConfig, KeyStorageConfig, KeyshareStorage},
     migration_service::spawn_recovery_server_and_run_onboarding,
     profiler,
-    providers::ecdsa::triple::migrate_legacy_triples_to_v2,
     tracing::init_logging,
     tracking::{self, start_root_task},
     web::{DebugRequest, start_web_server, static_web_data},
@@ -261,11 +260,6 @@ where
         Ed25519PublicKey::from(&secrets.persistent_secrets.near_signer_key.verifying_key());
 
     let secret_db = SecretDB::new(&home_dir.join("assets"), secrets.local_storage_aes_key)?;
-
-    // One-shot at process startup, before any TripleStorage is constructed
-    // for this DB. See `migrate_legacy_triples_to_v2`'s SAFETY note for why
-    // this can't run on every coordinator state transition.
-    migrate_legacy_triples_to_v2(&secret_db)?;
 
     let key_storage_config = KeyStorageConfig {
         home_dir: home_dir.clone(),


### PR DESCRIPTION
Closes #3298