### PR TITLE
docs: set `KillMode=process` on the dstack-vmm systemd unit

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -235,6 +235,12 @@ Restart=on-failure
 RestartSec=5
 User=mpc
 Group=mpc
+# Only stop the dstack-vmm process itself — not the qemu CVMs it supervises.
+# Without this, systemd's default KillMode=control-group sends SIGTERM to every
+# process in the unit's cgroup (i.e. all CVMs) whenever dstack-vmm is restarted —
+# for example when an OS package upgrade triggers `needrestart` — taking every
+# node on the host down at once.
+KillMode=process
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Closes #3462

Draft — do not merge until `KillMode=process` is verified on a test host to leave running CVMs alive and let the restarted daemon re-adopt them (see #3462 acceptance criteria).