### PR TITLE
refactor: wrap `BlockStatus` in handle

### DIFF
--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -235,11 +235,11 @@ where
 
                     self.client.update_indexer_height(block_update.block.height);
 
-                    let AddBlockResult{ block_ref } = recent_blocks.add_block(&block_update.block);
+                    let AddBlockResult{ block_status } = recent_blocks.add_block(&block_update.block);
 
                     let signature_requests : RequestsUpdate<SignatureRequest> = RequestsUpdate::from_chain(
                         &block_update.block,
-                        block_ref.clone(),
+                        block_status.clone(),
                         block_update.signature_requests,
                         block_update.completed_signatures,
                     );
@@ -254,7 +254,7 @@ where
 
                     let ckd_requests: RequestsUpdate<CKDRequest> = RequestsUpdate::from_chain(
                         &block_update.block,
-                        block_ref.clone(),
+                        block_status.clone(),
                         block_update.ckd_requests,
                         block_update.completed_ckds
                     );
@@ -266,7 +266,7 @@ where
 
                     let verify_foreign_tx_requests : RequestsUpdate<VerifyForeignTxRequest> = RequestsUpdate::from_chain(
                         &block_update.block,
-                        block_ref,
+                        block_status,
                         block_update.verify_foreign_tx_requests,
                         block_update.completed_verify_foreign_txs
                     );

--- a/crates/node/src/requests/queue.rs
+++ b/crates/node/src/requests/queue.rs
@@ -1,5 +1,5 @@
 use super::debug::{CompletedRequest, CompletedRequests};
-use super::recent_blocks_tracker::AtomicBlockStatus;
+use super::recent_blocks_tracker::BlockStatusGuard;
 use crate::indexer::types::ChainRespondArgs;
 use crate::primitives::ParticipantId;
 use crate::requests::metrics;
@@ -79,12 +79,11 @@ struct IndexedRespondTxs(Vec<IndexedRespondTx>);
 /// An on-chain `respond` transaction observed in an indexed block.
 #[derive(Clone)]
 struct IndexedRespondTx {
-    /// Weak ref to the block's atomic status; lets us observe canonical/final changes the
-    /// tracker makes after we recorded the response.
-    block_status: Weak<AtomicBlockStatus>,
+    /// The finality status of the block this transaction was observed in.
+    block_status: BlockStatusGuard,
     /// Wall-clock time at which our node observed the block containing the response.
     received_at: near_time::Instant,
-    // TODO(#3318): We could share the `block_height` through the same weak pointer as
+    // TODO(#3318): We could share the `block_height` through the same guard as
     // `block_status`, however, that's a larger refactor and this change will only truly make sense
     // once we start improving the metrics with #3318, so we defer it to later and accept to hold a
     // u64 for each response.
@@ -99,16 +98,22 @@ impl Default for IndexedRespondTxs {
 
 impl IndexedRespondTxs {
     fn status(&self) -> AggregateResponseStatus {
-        for (status, received_at, block_height) in self.0.iter().filter_map(|tx| {
-            Weak::upgrade(&tx.block_status).map(|status| (status, tx.received_at, tx.block_height))
-        }) {
-            if status.is_final() {
+        for respond_tx in &self.0 {
+            let Some((is_final, is_canonical)) = respond_tx
+                .block_status
+                .try_with(|s| (s.is_final(), s.is_canonical()))
+            else {
+                // the block this response was included in was dropped by the tracker
+                continue;
+            };
+
+            if is_final {
                 return AggregateResponseStatus::Resolved {
-                    received_at,
-                    block_height,
+                    received_at: respond_tx.received_at,
+                    block_height: respond_tx.block_height,
                 };
             }
-            if status.is_canonical() {
+            if is_canonical {
                 // We return early if the response is on the canonical chain.
                 // This is appropriate, because it is not possible to have, simultaneously:
                 // - a response that is final
@@ -151,7 +156,7 @@ pub(super) struct QueuedRequest<RequestType: Request, ChainRespondArgsType: Chai
     pub request: RequestType,
 
     /// Finality status of the block the request was included in.
-    status: Weak<AtomicBlockStatus>,
+    status: BlockStatusGuard,
     /// Respond transactions for this request observed in indexed blocks.
     indexed_respond_txs: IndexedRespondTxs,
 
@@ -251,7 +256,7 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs>
         clock: &near_time::Clock,
         request: RequestType,
         block_height: u64,
-        status: Weak<AtomicBlockStatus>,
+        status: BlockStatusGuard,
         all_participants: &[ParticipantId],
         time_indexed: near_time::Instant,
     ) -> Self {
@@ -376,10 +381,10 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
             // This request is definitely not useful anymore, so discard it.
             return RequestStatus::Drop(DropReason::RequestTimedOut);
         }
-        let Some(status) = self.status.upgrade() else {
+        let Some(is_canonical) = self.status.try_with(|s| s.is_canonical()) else {
             return RequestStatus::Drop(DropReason::BlockNotFound);
         };
-        if !status.is_canonical() {
+        if !is_canonical {
             return RequestStatus::Wait("request is not on canonical chain");
         }
         let Some(leader) = self.current_leader(eligible_leaders) else {
@@ -486,7 +491,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
         let RequestsUpdate::<RequestType> {
             requests,
             completed_requests,
-            block_ref,
+            block_status,
             block_height,
         } = update;
 
@@ -499,14 +504,14 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                     &self.clock,
                     request.clone(),
                     block_height,
-                    block_ref.clone(),
+                    block_status.clone(),
                     &self.all_participants,
                     now,
                 ));
         }
         mpc_pending_queue_responses_indexed.inc_by(completed_requests.len() as u64);
         let indexed_respond_tx = IndexedRespondTx {
-            block_status: block_ref.clone(),
+            block_status: block_status.clone(),
             received_at: now,
             block_height,
         };
@@ -795,8 +800,8 @@ mod tests {
         responses_to_submit: Vec<CryptoHash>,
         rng: rand::rngs::StdRng,
         /// Test-side counterpart to the shared tracker that mpc_client owns in production.
-        /// Each `update*` adds a block to it; the resulting `Weak<AtomicBlockStatus>` ends
-        /// up inside the returned `RequestsUpdate`.
+        /// Each `update*` adds a block to it; the resulting `BlockStatusGuard` ends up
+        /// inside the returned `RequestsUpdate`.
         tracker: RecentBlocksTracker,
     }
 
@@ -888,12 +893,15 @@ mod tests {
         ) -> u64 {
             let new_height = self.max_known_height() + 1;
             let new_block = self.head.descendant(new_height);
-            let block_ref = self.tracker.add_block(&new_block.to_block_view()).block_ref;
+            let block_status = self
+                .tracker
+                .add_block(&new_block.to_block_view())
+                .block_status;
             let update = RequestsUpdate {
                 requests: self.requests_to_submit.clone(),
                 completed_requests: self.responses_to_submit.clone(),
                 block_height: new_height,
-                block_ref,
+                block_status,
             };
             self.requests_to_submit = Vec::new();
             self.responses_to_submit = Vec::new();
@@ -912,12 +920,15 @@ mod tests {
                 self.fork = self.head.parent.clone();
             }
             let new_block = self.fork.as_ref().unwrap().descendant(new_height);
-            let block_ref = self.tracker.add_block(&new_block.to_block_view()).block_ref;
+            let block_status = self
+                .tracker
+                .add_block(&new_block.to_block_view())
+                .block_status;
             let update = RequestsUpdate {
                 requests: self.requests_to_submit.clone(),
                 completed_requests: self.responses_to_submit.clone(),
                 block_height: new_height,
-                block_ref,
+                block_status,
             };
             self.requests_to_submit = Vec::new();
             self.responses_to_submit = Vec::new();

--- a/crates/node/src/requests/queue.rs
+++ b/crates/node/src/requests/queue.rs
@@ -1,5 +1,5 @@
 use super::debug::{CompletedRequest, CompletedRequests};
-use super::recent_blocks_tracker::BlockStatusGuard;
+use super::recent_blocks_tracker::BlockStatusHandle;
 use crate::indexer::types::ChainRespondArgs;
 use crate::primitives::ParticipantId;
 use crate::requests::metrics;
@@ -79,8 +79,8 @@ struct IndexedRespondTxs(Vec<IndexedRespondTx>);
 /// An on-chain `respond` transaction observed in an indexed block.
 #[derive(Clone)]
 struct IndexedRespondTx {
-    /// The finality status of the block this transaction was observed in.
-    block_status: BlockStatusGuard,
+    /// Live view of the finality status of the block this transaction was observed in.
+    block_status: BlockStatusHandle,
     /// Wall-clock time at which our node observed the block containing the response.
     received_at: near_time::Instant,
     // TODO(#3318): We could share the `block_height` through the same guard as
@@ -99,21 +99,18 @@ impl Default for IndexedRespondTxs {
 impl IndexedRespondTxs {
     fn status(&self) -> AggregateResponseStatus {
         for respond_tx in &self.0 {
-            let Some((is_final, is_canonical)) = respond_tx
-                .block_status
-                .try_with(|s| (s.is_final(), s.is_canonical()))
-            else {
+            match respond_tx.block_status.is_final() {
                 // the block this response was included in was dropped by the tracker
-                continue;
-            };
-
-            if is_final {
-                return AggregateResponseStatus::Resolved {
-                    received_at: respond_tx.received_at,
-                    block_height: respond_tx.block_height,
-                };
+                None => continue,
+                Some(true) => {
+                    return AggregateResponseStatus::Resolved {
+                        received_at: respond_tx.received_at,
+                        block_height: respond_tx.block_height,
+                    };
+                }
+                Some(false) => {}
             }
-            if is_canonical {
+            if respond_tx.block_status.is_canonical() == Some(true) {
                 // We return early if the response is on the canonical chain.
                 // This is appropriate, because it is not possible to have, simultaneously:
                 // - a response that is final
@@ -156,7 +153,7 @@ pub(super) struct QueuedRequest<RequestType: Request, ChainRespondArgsType: Chai
     pub request: RequestType,
 
     /// Finality status of the block the request was included in.
-    status: BlockStatusGuard,
+    status: BlockStatusHandle,
     /// Respond transactions for this request observed in indexed blocks.
     indexed_respond_txs: IndexedRespondTxs,
 
@@ -256,7 +253,7 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs>
         clock: &near_time::Clock,
         request: RequestType,
         block_height: u64,
-        status: BlockStatusGuard,
+        status: BlockStatusHandle,
         all_participants: &[ParticipantId],
         time_indexed: near_time::Instant,
     ) -> Self {
@@ -381,7 +378,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
             // This request is definitely not useful anymore, so discard it.
             return RequestStatus::Drop(DropReason::RequestTimedOut);
         }
-        let Some(is_canonical) = self.status.try_with(|s| s.is_canonical()) else {
+        let Some(is_canonical) = self.status.is_canonical() else {
             return RequestStatus::Drop(DropReason::BlockNotFound);
         };
         if !is_canonical {
@@ -800,7 +797,7 @@ mod tests {
         responses_to_submit: Vec<CryptoHash>,
         rng: rand::rngs::StdRng,
         /// Test-side counterpart to the shared tracker that mpc_client owns in production.
-        /// Each `update*` adds a block to it; the resulting `BlockStatusGuard` ends up
+        /// Each `update*` adds a block to it; the resulting `BlockStatusHandle` ends up
         /// inside the returned `RequestsUpdate`.
         tracker: RecentBlocksTracker,
     }

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -14,7 +14,7 @@ use super::metrics::{MPC_BLOCKS_INDEXED, MPC_FINALIZED_BLOCKS_INDEXED};
 /// This class provides two important functionalities:
 ///  - Converts a stream of optimistic blocks from the indexer into a stream of finalized
 ///    blocks.
-///  - For each block added via `add_block`, it returns a `BlockStatusGuard` that can be
+///  - For each block added via `add_block`, it returns a `BlockStatusHandle` that can be
 ///    used to observe that block's current `BlockStatus` (non-canonical, canonical or final).
 ///
 /// This class provides the following invariants (provided the requirements listed below are met):
@@ -137,14 +137,14 @@ impl From<BlockStatus> for u8 {
     }
 }
 
-pub struct AtomicBlockStatus(AtomicU8);
+struct AtomicBlockStatus(AtomicU8);
 
 impl AtomicBlockStatus {
-    pub fn is_final(&self) -> bool {
+    fn is_final(&self) -> bool {
         self.0.load(Ordering::Relaxed) == u8::from(BlockStatus::Final)
     }
 
-    pub fn is_canonical(&self) -> bool {
+    fn is_canonical(&self) -> bool {
         let status = self.0.load(Ordering::Relaxed);
         status == u8::from(BlockStatus::OptimisticAndCanonical)
             || status == u8::from(BlockStatus::Final)
@@ -181,24 +181,28 @@ impl AtomicBlockStatus {
     }
 }
 
-/// Guards a `Weak` to an [`AtomicBlockStatus`].
+/// A handle to a block's status held by the [`RecentBlocksTracker`].
 ///
-/// Consumers can read the current status, but cannot hold a strong reference to it.
-/// This is to ensure pruning the block from the tracker results in a ref count of zero.
+/// Consumers can read the current finality status but cannot hold a strong
+/// reference to the underlying atomic. Pruning a block from the tracker
+/// drops its ref count to zero.
 #[derive(Clone)]
-pub struct BlockStatusGuard(Weak<AtomicBlockStatus>);
+pub struct BlockStatusHandle(Weak<AtomicBlockStatus>);
 
-impl BlockStatusGuard {
-    /// Observes the underlying status under a single short-lived upgrade.
-    ///
-    /// Returns `None` if the block has been pruned, otherwise calls `f`.
-    pub fn try_with<R>(&self, f: impl FnOnce(&AtomicBlockStatus) -> R) -> Option<R> {
-        self.0.upgrade().as_deref().map(f)
+impl BlockStatusHandle {
+    /// `None` if the block has been pruned from the tracker.
+    pub fn is_final(&self) -> Option<bool> {
+        self.0.upgrade().map(|s| s.is_final())
+    }
+
+    /// `None` if the block has been pruned from the tracker.
+    pub fn is_canonical(&self) -> Option<bool> {
+        self.0.upgrade().map(|s| s.is_canonical())
     }
 }
 
 pub struct AddBlockResult {
-    pub block_status: BlockStatusGuard,
+    pub block_status: BlockStatusHandle,
 }
 
 /// Represents a block in the recent blockchain.
@@ -206,8 +210,8 @@ struct BlockNode {
     hash: CryptoHash,
     height: u64,
     /// Indicates the finality status of this block. Held as `Arc`.
-    /// A [`BlockStatusGuard`] is handed out via [`AddBlockResult::block_status`] to consmers,
-    /// allowing to observe status changes and detect pruning.
+    /// A [`BlockStatusHandle`] is handed out via [`AddBlockResult::block_status`] to consumers,
+    /// allowing them to observe status changes and detect pruning.
     status: Arc<AtomicBlockStatus>,
     /// The parent block, if we're aware of it. This may be None if we have never
     /// heard of the parent.
@@ -223,8 +227,8 @@ impl BlockNode {
         self.parent.as_ref().and_then(Weak::upgrade)
     }
 
-    fn status_guard(&self) -> BlockStatusGuard {
-        BlockStatusGuard(Arc::downgrade(&self.status))
+    fn status_handle(&self) -> BlockStatusHandle {
+        BlockStatusHandle(Arc::downgrade(&self.status))
     }
 
     fn keep_only_child(
@@ -341,7 +345,7 @@ impl RecentBlocksTracker {
                 block.height,
             );
             return AddBlockResult {
-                block_status: node.status_guard(),
+                block_status: node.status_handle(),
             };
         }
         MPC_BLOCKS_INDEXED.inc();
@@ -355,7 +359,7 @@ impl RecentBlocksTracker {
             parent: parent.as_ref().map(Arc::downgrade),
             children: Mutex::new(Vec::new()),
         });
-        let block_status = node.status_guard();
+        let block_status = node.status_handle();
         self.hash_to_node.insert(block.hash, node.clone());
         if let Some(parent) = parent {
             parent.children.lock().unwrap().push(node.clone());
@@ -590,7 +594,7 @@ impl Debug for RecentBlocksTracker {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::requests::recent_blocks_tracker::{AtomicBlockStatus, BlockStatusGuard};
+    use crate::requests::recent_blocks_tracker::{AtomicBlockStatus, BlockStatusHandle};
 
     use super::{BlockEntropy, BlockStatus, BlockViewLite, RecentBlocksTracker};
     use near_indexer::near_primitives::hash::hash;
@@ -775,11 +779,14 @@ pub mod tests {
             self.maker.block(height)
         }
 
-        pub fn check(&self, guard: &BlockStatusGuard) -> Option<BlockStatus> {
-            guard.try_with(|s| BlockStatus::from(s.0.load(Ordering::Relaxed)))
+        pub fn check(&self, handle: &BlockStatusHandle) -> Option<BlockStatus> {
+            handle
+                .0
+                .upgrade()
+                .map(|s| BlockStatus::from(s.0.load(Ordering::Relaxed)))
         }
 
-        pub fn add(&mut self, block: &Arc<TestBlock>) -> BlockStatusGuard {
+        pub fn add(&mut self, block: &Arc<TestBlock>) -> BlockStatusHandle {
             assert!(
                 !self.parents_of_added_blocks.contains(&block.hash),
                 "Cannot retroactively add the parent of an already added block"
@@ -1108,12 +1115,12 @@ pub mod tests {
 
     #[test]
     #[expect(non_snake_case)]
-    fn test__weak_ref_is_in_sync_with_tracker() {
-        // Regression guard: the `BlockStatusGuard` returned by `Tester::add`
+    fn block_status_handle__should_observe_same_atomic_as_tracker() {
+        // Regression guard: the `BlockStatusHandle` returned by `Tester::add`
         // must observe the same atomic the tracker mutates on the BlockNode.
-        // A refactor that wires the returned guard to a separate Arc would silently
-        // break finality observation for QueuedRequest. We exercise all four
-        // outcomes through the returned guard:
+        // A refactor that wires the returned handle to a separate Arc would
+        // silently break finality observation for QueuedRequest. We exercise
+        // all four outcomes through the returned handle:
         //  - OptimisticAndCanonical (canonical-head update on add),
         //  - OptimisticButNotCanonical (sibling root losing canonical race),
         //  - Final (last_final_block advance during a 3-block chain),
@@ -1140,14 +1147,14 @@ pub mod tests {
         tester.add(&b2);
         tester.add(&b3);
         // add(b3) advances last_final_block to b1 (3 consecutive heights b1-b2-b3),
-        // promoting b1 to Final. The Weak from add(b1) must observe this.
+        // promoting b1 to Final. The handle from add(b1) must observe this.
         assert_eq!(tester.check(&s1), Some(BlockStatus::Final));
 
         tester.add(&b4);
         tester.add(&b5);
         // After add(b5): max=5, window=3, final_head=b3 (h=3), min_keep=3.
-        // b1 (h=1) falls below the recency window → BlockNode dropped → Weak
-        // can no longer upgrade.
+        // b1 (h=1) falls below the recency window → BlockNode dropped → handle
+        // can no longer observe the status.
         assert_eq!(tester.check(&s1), None);
     }
 }

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -14,7 +14,7 @@ use super::metrics::{MPC_BLOCKS_INDEXED, MPC_FINALIZED_BLOCKS_INDEXED};
 /// This class provides two important functionalities:
 ///  - Converts a stream of optimistic blocks from the indexer into a stream of finalized
 ///    blocks.
-///  - For each block added via `add_block`, it returns a `Weak<AtomicBlockStatus>` that can be
+///  - For each block added via `add_block`, it returns a `BlockStatusGuard` that can be
 ///    used to observe that block's current `BlockStatus` (non-canonical, canonical or final).
 ///
 /// This class provides the following invariants (provided the requirements listed below are met):
@@ -181,17 +181,33 @@ impl AtomicBlockStatus {
     }
 }
 
+/// Guards a `Weak` to an [`AtomicBlockStatus`].
+///
+/// Consumers can read the current status, but cannot hold a strong reference to it.
+/// This is to ensure pruning the block from the tracker results in a ref count of zero.
+#[derive(Clone)]
+pub struct BlockStatusGuard(Weak<AtomicBlockStatus>);
+
+impl BlockStatusGuard {
+    /// Observes the underlying status under a single short-lived upgrade.
+    ///
+    /// Returns `None` if the block has been pruned, otherwise calls `f`.
+    pub fn try_with<R>(&self, f: impl FnOnce(&AtomicBlockStatus) -> R) -> Option<R> {
+        self.0.upgrade().as_deref().map(f)
+    }
+}
+
 pub struct AddBlockResult {
-    pub block_ref: Weak<AtomicBlockStatus>,
+    pub block_status: BlockStatusGuard,
 }
 
 /// Represents a block in the recent blockchain.
 struct BlockNode {
     hash: CryptoHash,
     height: u64,
-    /// Indicates the finality status of this block. Held as `Arc` so that a `Weak` reference
-    /// can be handed out (via `AddBlockResult::block_ref`) to consumers like `QueuedRequest`,
-    /// which observe status changes and detect pruning when the upgrade fails.
+    /// Indicates the finality status of this block. Held as `Arc`.
+    /// A [`BlockStatusGuard`] is handed out via [`AddBlockResult::block_status`] to consmers,
+    /// allowing to observe status changes and detect pruning.
     status: Arc<AtomicBlockStatus>,
     /// The parent block, if we're aware of it. This may be None if we have never
     /// heard of the parent.
@@ -205,6 +221,10 @@ struct BlockNode {
 impl BlockNode {
     fn get_parent(&self) -> Option<Arc<BlockNode>> {
         self.parent.as_ref().and_then(Weak::upgrade)
+    }
+
+    fn status_guard(&self) -> BlockStatusGuard {
+        BlockStatusGuard(Arc::downgrade(&self.status))
     }
 
     fn keep_only_child(
@@ -321,22 +341,21 @@ impl RecentBlocksTracker {
                 block.height,
             );
             return AddBlockResult {
-                block_ref: Arc::downgrade(&node.status),
+                block_status: node.status_guard(),
             };
         }
         MPC_BLOCKS_INDEXED.inc();
-        let status = Arc::new(AtomicBlockStatus(AtomicU8::new(u8::from(
-            BlockStatus::OptimisticButNotCanonical,
-        ))));
-        let block_ref = Arc::downgrade(&status);
         let parent = self.hash_to_node.get(&block.prev_hash).cloned();
         let node = Arc::new(BlockNode {
             hash: block.hash,
             height: block.height,
-            status,
+            status: Arc::new(AtomicBlockStatus(AtomicU8::new(u8::from(
+                BlockStatus::OptimisticButNotCanonical,
+            )))),
             parent: parent.as_ref().map(Arc::downgrade),
             children: Mutex::new(Vec::new()),
         });
+        let block_status = node.status_guard();
         self.hash_to_node.insert(block.hash, node.clone());
         if let Some(parent) = parent {
             parent.children.lock().unwrap().push(node.clone());
@@ -368,7 +387,7 @@ impl RecentBlocksTracker {
             self.maximum_height_available = block.height;
         }
         self.prune_old_blocks();
-        AddBlockResult { block_ref }
+        AddBlockResult { block_status }
     }
 
     /// Advance the final head, mark its ancestors as final, and drop every
@@ -571,7 +590,7 @@ impl Debug for RecentBlocksTracker {
 
 #[cfg(test)]
 pub mod tests {
-    use crate::requests::recent_blocks_tracker::AtomicBlockStatus;
+    use crate::requests::recent_blocks_tracker::{AtomicBlockStatus, BlockStatusGuard};
 
     use super::{BlockEntropy, BlockStatus, BlockViewLite, RecentBlocksTracker};
     use near_indexer::near_primitives::hash::hash;
@@ -579,7 +598,7 @@ pub mod tests {
     use std::collections::HashSet;
     use std::fmt::Write;
     use std::sync::atomic::{AtomicU8, AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex, Weak};
+    use std::sync::{Arc, Mutex};
 
     pub struct TestBlock {
         hash: CryptoHash,
@@ -756,12 +775,11 @@ pub mod tests {
             self.maker.block(height)
         }
 
-        pub fn check(&self, weak: &Weak<AtomicBlockStatus>) -> Option<BlockStatus> {
-            weak.upgrade()
-                .map(|s| BlockStatus::from(s.0.load(Ordering::Relaxed)))
+        pub fn check(&self, guard: &BlockStatusGuard) -> Option<BlockStatus> {
+            guard.try_with(|s| BlockStatus::from(s.0.load(Ordering::Relaxed)))
         }
 
-        pub fn add(&mut self, block: &Arc<TestBlock>) -> Weak<AtomicBlockStatus> {
+        pub fn add(&mut self, block: &Arc<TestBlock>) -> BlockStatusGuard {
             assert!(
                 !self.parents_of_added_blocks.contains(&block.hash),
                 "Cannot retroactively add the parent of an already added block"
@@ -778,7 +796,7 @@ pub mod tests {
                 self.tracker
             )
             .unwrap();
-            result.block_ref
+            result.block_status
         }
     }
 
@@ -1091,11 +1109,11 @@ pub mod tests {
     #[test]
     #[expect(non_snake_case)]
     fn test__weak_ref_is_in_sync_with_tracker() {
-        // Regression guard: the `Weak<AtomicBlockStatus>` returned by `Tester::add`
-        // must upgrade to the same atomic the tracker mutates on the BlockNode.
-        // A refactor that wires the returned Weak to a separate Arc would silently
+        // Regression guard: the `BlockStatusGuard` returned by `Tester::add`
+        // must observe the same atomic the tracker mutates on the BlockNode.
+        // A refactor that wires the returned guard to a separate Arc would silently
         // break finality observation for QueuedRequest. We exercise all four
-        // outcomes through the returned Weak:
+        // outcomes through the returned guard:
         //  - OptimisticAndCanonical (canonical-head update on add),
         //  - OptimisticButNotCanonical (sibling root losing canonical race),
         //  - Final (last_final_block advance during a 3-block chain),

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -12,20 +12,20 @@ use crate::{
     indexer::handler::{
         CKDRequestFromChain, SignatureRequestFromChain, VerifyForeignTxRequestFromChain,
     },
-    requests::recent_blocks_tracker::{BlockStatusGuard, BlockViewLite},
+    requests::recent_blocks_tracker::{BlockStatusHandle, BlockViewLite},
 };
 
 pub(crate) struct RequestsUpdate<T> {
     pub(crate) requests: Vec<T>,
     pub(crate) completed_requests: Vec<RequestId>,
     pub(crate) block_height: u64,
-    pub(crate) block_status: BlockStatusGuard,
+    pub(crate) block_status: BlockStatusHandle,
 }
 
 impl<T> RequestsUpdate<T> {
     pub(crate) fn from_chain<U>(
         block: &BlockViewLite,
-        block_status: BlockStatusGuard,
+        block_status: BlockStatusHandle,
         new_requests: Vec<U>,
         completed_requests: Vec<RequestId>,
     ) -> RequestsUpdate<T>

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -1,4 +1,4 @@
-use std::{fmt, sync::Weak};
+use std::fmt;
 
 use mpc_primitives::domain::DomainId;
 use near_indexer_primitives::CryptoHash;
@@ -12,20 +12,20 @@ use crate::{
     indexer::handler::{
         CKDRequestFromChain, SignatureRequestFromChain, VerifyForeignTxRequestFromChain,
     },
-    requests::recent_blocks_tracker::{AtomicBlockStatus, BlockViewLite},
+    requests::recent_blocks_tracker::{BlockStatusGuard, BlockViewLite},
 };
 
 pub(crate) struct RequestsUpdate<T> {
     pub(crate) requests: Vec<T>,
     pub(crate) completed_requests: Vec<RequestId>,
     pub(crate) block_height: u64,
-    pub(crate) block_ref: Weak<AtomicBlockStatus>,
+    pub(crate) block_status: BlockStatusGuard,
 }
 
 impl<T> RequestsUpdate<T> {
     pub(crate) fn from_chain<U>(
         block: &BlockViewLite,
-        block_ref: Weak<AtomicBlockStatus>,
+        block_status: BlockStatusGuard,
         new_requests: Vec<U>,
         completed_requests: Vec<RequestId>,
     ) -> RequestsUpdate<T>
@@ -41,7 +41,7 @@ impl<T> RequestsUpdate<T> {
             requests,
             completed_requests,
             block_height: block.height,
-            block_ref,
+            block_status,
         }
     }
 }


### PR DESCRIPTION
resolves #3451

We have an invariant that assumes pruning a block from the tracker drops its blocks status ref count to zero.
This PR introduces `BlockStatusHandle`, a thin wrapper around `Weak<AtomicBlockStatus>`, ensuring consumers of the block status don't accidentally violate the invariant.