### PR TITLE
fix(node): drain embedded near-indexer thread on graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5898,6 +5898,7 @@ dependencies = [
  "near-mpc-crypto-types",
  "near-o11y 2.12.0",
  "near-sdk",
+ "near-store",
  "near-time 2.12.0",
  "node-types",
  "num_enum",

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -57,6 +57,7 @@ near-mpc-contract-interface = { workspace = true, features = [
 near-mpc-crypto-types = { workspace = true }
 near-o11y = { workspace = true }
 near-sdk = { workspace = true, features = ["non-contract-usage"] }
+near-store = { workspace = true }
 near-time = { workspace = true }
 node-types = { workspace = true }
 num_enum = { workspace = true }

--- a/crates/node/src/indexer/real.rs
+++ b/crates/node/src/indexer/real.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 #[cfg(feature = "network-hardship-simulation")]
 use std::time::Duration;
 use tokio::sync::{Mutex, mpsc, oneshot, watch};
+use tokio_util::sync::CancellationToken;
 
 #[cfg(feature = "network-hardship-simulation")]
 pub async fn check_block_processing(process_blocks_sender: watch::Sender<bool>, home_dir: PathBuf) {
@@ -60,6 +61,7 @@ pub fn spawn_real_indexer(
     migration_state_sender: watch::Sender<(u64, ContractMigrationInfo)>,
     tls_public_key: VerifyingKey,
     foreign_chains: mpc_node_config::ForeignChainsConfig,
+    shutdown_token: CancellationToken,
 ) -> IndexerAPI<impl TransactionSender, RealForeignChainPolicyReader> {
     let (contract_state_sender_oneshot, contract_state_receiver_oneshot) = oneshot::channel();
     let (migration_info_sender_oneshot, migration_info_receiver_oneshot) = oneshot::channel();
@@ -205,27 +207,46 @@ pub fn spawn_real_indexer(
                 )
             };
 
-            // below function runs indefinitely and only returns in case of an error.
+            // `listen_blocks` runs indefinitely and only returns in case of an
+            // error. To shut the indexer thread down cleanly on SIGTERM we
+            // race it against `shutdown_token.cancelled()`: when the parent
+            // cancels the token, the select! arm completes, `block_on`
+            // returns, the indexer's tokio runtime drops, and every
+            // `tokio::spawn`'d monitor task (each holding
+            // `Arc<IndexerState>` → `Arc<RocksDB>`) is aborted as the
+            // runtime is dropped. That's what lets
+            // `RocksDB::block_until_all_instances_are_dropped()` in `run.rs`
+            // actually return on the SIGTERM path.
             #[cfg(feature = "network-hardship-simulation")]
-            let indexer_result = listen_blocks(
-                stream,
-                mpc_indexer_config.concurrency,
-                Arc::clone(&indexer_state.stats),
-                mpc_indexer_config.mpc_contract_id,
-                block_update_sender,
-                process_blocks_receiver,
-            )
-            .await;
+            let indexer_result = tokio::select! {
+                res = listen_blocks(
+                    stream,
+                    mpc_indexer_config.concurrency,
+                    Arc::clone(&indexer_state.stats),
+                    mpc_indexer_config.mpc_contract_id,
+                    block_update_sender,
+                    process_blocks_receiver,
+                ) => res,
+                _ = shutdown_token.cancelled() => {
+                    tracing::info!("Indexer thread received shutdown signal; exiting listen_blocks.");
+                    Ok(())
+                }
+            };
 
             #[cfg(not(feature = "network-hardship-simulation"))]
-            let indexer_result = listen_blocks(
-                stream,
-                mpc_indexer_config.concurrency,
-                Arc::clone(&indexer_state.stats),
-                mpc_indexer_config.mpc_contract_id,
-                block_update_sender,
-            )
-            .await;
+            let indexer_result = tokio::select! {
+                res = listen_blocks(
+                    stream,
+                    mpc_indexer_config.concurrency,
+                    Arc::clone(&indexer_state.stats),
+                    mpc_indexer_config.mpc_contract_id,
+                    block_update_sender,
+                ) => res,
+                _ = shutdown_token.cancelled() => {
+                    tracing::info!("Indexer thread received shutdown signal; exiting listen_blocks.");
+                    Ok(())
+                }
+            };
 
             if indexer_exit_sender.send(indexer_result).is_err() {
                 tracing::error!("Indexer thread could not send result back to main driver.")

--- a/crates/node/src/run.rs
+++ b/crates/node/src/run.rs
@@ -184,6 +184,12 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
 
     // Create Indexer and wait for indexer to be synced.
     let (indexer_exit_sender, indexer_exit_receiver) = oneshot::channel();
+    // Dedicated cancellation token for the indexer thread. Cancelled after
+    // `shutdown_all_actors()` below so the indexer's terminal `listen_blocks`
+    // race exits, its tokio runtime drops, and the Arc<RocksDB> references
+    // held by its spawned monitor tasks are released — enabling
+    // `RocksDB::block_until_all_instances_are_dropped()` to return.
+    let indexer_shutdown_token = CancellationToken::new();
     let indexer_api = spawn_real_indexer(
         config.home_dir.clone(),
         node_config.indexer.clone(),
@@ -195,6 +201,7 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
         migration_state_sender,
         *tls_public_key,
         node_config.foreign_chains.clone(),
+        indexer_shutdown_token.clone(),
     );
 
     let cancellation_token = CancellationToken::new();
@@ -266,13 +273,24 @@ pub async fn run_mpc_node(config: StartConfig) -> anyhow::Result<()> {
     info!(?exit_result, "Image hash watcher exited.");
 
     // Stop nearcore's actor system so its tasks have a chance to commit any
-    // in-flight RocksDB batches before the process exits. We deliberately
-    // skip `RocksDB::block_until_all_instances_are_dropped()` here (which
-    // neard's standalone binary calls next): in this embedding it would
-    // hang past any reasonable grace period, and the orchestrator would
-    // SIGKILL us before the graceful path completes.
+    // in-flight RocksDB batches before the process exits.
     info!("Stopping nearcore actor system.");
     near_async::shutdown_all_actors();
+
+    // Cancel the indexer's terminal `listen_blocks` race; that lets the
+    // indexer thread's `block_on` return, its tokio runtime drop, and every
+    // spawned monitor task (each holding `Arc<IndexerState>` →
+    // `Arc<RocksDB>`) be aborted with the runtime.
+    info!("Cancelling indexer shutdown token.");
+    indexer_shutdown_token.cancel();
+
+    // Now block until every RocksDB instance has actually been dropped —
+    // mirroring what neard's standalone binary does on its SIGTERM path.
+    // Without the cancellation above this call would hang forever because
+    // the indexer thread's monitor tasks keep their Arc<RocksDB> alive.
+    info!("Waiting for RocksDB instances to gracefully shut down.");
+    near_store::db::RocksDB::block_until_all_instances_are_dropped();
+    info!("RocksDB shutdown complete.");
 
     exit_reason
 }


### PR DESCRIPTION
Closes #3485. Follow-up on #3410.

## Changes

- `spawn_real_indexer` takes a `CancellationToken`; `listen_blocks` is raced against `token.cancelled()` in a `tokio::select!`, so the indexer thread's outer `block_on` returns when shutdown is requested.
- `run.rs`'s SIGTERM path: after `shutdown_all_actors()`, cancel the token, then call `near_store::db::RocksDB::block_until_all_instances_are_dropped()` (which was deliberately omitted in #3410 because without this drain it would hang).

Repro campaign results: see [#3485 (comment)](https://github.com/near/mpc/issues/3485#issuecomment-4677378052).

## Test plan

- [ ] CI green
- [ ] Manual: `kill -TERM <pid>` on a local mpc-node; expect the shutdown sequence in stdout.log to end with `RocksDB shutdown complete.` (vs. process killed mid-flight at ~100 ms with #3410 alone).
