### PR TITLE
refactor: RecentBlocksTracker uses types from chain gateway crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6004,6 +6004,7 @@ dependencies = [
  "bs58 0.5.1",
  "built",
  "bytes",
+ "chain-gateway",
  "clap",
  "derive_more 2.1.1",
  "ed25519-dalek",

--- a/crates/chain-gateway/src/event_subscriber/block_events.rs
+++ b/crates/chain-gateway/src/event_subscriber/block_events.rs
@@ -2,7 +2,7 @@ use derive_more::{Deref, From};
 use near_account_id::AccountId;
 use near_indexer_primitives::CryptoHash;
 
-use crate::types::BlockHeight;
+use crate::types::{BlockEntropy, BlockHeight};
 
 /// The BlockUpdate returned by the Chain indexer.
 /// Similar to [`ChainBlockUpdate`](../../node/src/indexer/handler.rs) in the `mpc-node` crate.
@@ -13,14 +13,14 @@ pub struct BlockUpdate {
 }
 
 /// Context for a single block
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct BlockContext {
     pub hash: CryptoHash,
     pub height: BlockHeight,
     pub prev_hash: CryptoHash,
     pub last_final_block: CryptoHash,
-    pub block_entropy: CryptoHash,
-    pub block_timestamp_nanosec: u64,
+    pub entropy: BlockEntropy,
+    pub timestamp_nanosec: u64,
 }
 
 #[derive(Debug)]

--- a/crates/chain-gateway/src/event_subscriber/streamer/block_processor.rs
+++ b/crates/chain-gateway/src/event_subscriber/streamer/block_processor.rs
@@ -75,8 +75,8 @@ fn process_block(
         hash: streamer_message.block.header.hash,
         height: streamer_message.block.header.height.into(),
         prev_hash: streamer_message.block.header.prev_hash,
-        block_entropy: streamer_message.block.header.random_value,
-        block_timestamp_nanosec: streamer_message.block.header.timestamp_nanosec,
+        entropy: streamer_message.block.header.random_value.into(),
+        timestamp_nanosec: streamer_message.block.header.timestamp_nanosec,
         last_final_block: streamer_message.block.header.last_final_block,
     };
     BlockUpdate {

--- a/crates/chain-gateway/src/types.rs
+++ b/crates/chain-gateway/src/types.rs
@@ -13,6 +13,34 @@ pub struct NoArgs {}
 )]
 pub struct BlockHeight(u64);
 
+impl BlockHeight {
+    pub fn saturating_add(self, delta: u64) -> Self {
+        BlockHeight(self.0.saturating_add(delta))
+    }
+    pub fn saturating_sub(self, delta: u64) -> Self {
+        BlockHeight(self.0.saturating_sub(delta))
+    }
+    /// Block distance from `earlier` to `self`. Saturates to `0` if `earlier > self`.
+    pub fn blocks_since(self, earlier: BlockHeight) -> u64 {
+        self.0.saturating_sub(earlier.0)
+    }
+}
+
+#[derive(Clone, Into, Debug)]
+pub struct BlockEntropy([u8; 32]);
+
+impl BlockEntropy {
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.0
+    }
+}
+
+impl From<CryptoHash> for BlockEntropy {
+    fn from(value: CryptoHash) -> Self {
+        BlockEntropy(value.into())
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct ObservedState<T = Vec<u8>> {
     pub observed_at: BlockHeight,

--- a/crates/node/Cargo.toml
+++ b/crates/node/Cargo.toml
@@ -18,6 +18,7 @@ base64 = { workspace = true }
 borsh = { workspace = true }
 bs58 = { workspace = true }
 bytes = { workspace = true }
+chain-gateway = { workspace = true }
 clap = { workspace = true }
 derive_more = { workspace = true }
 ed25519-dalek = { workspace = true }

--- a/crates/node/src/indexer/handler.rs
+++ b/crates/node/src/indexer/handler.rs
@@ -1,10 +1,10 @@
 use crate::indexer::stats::IndexerStats;
 use crate::metrics;
-use crate::requests::recent_blocks_tracker::BlockViewLite;
 use crate::types::CKDId;
 use crate::types::SignatureId;
 use crate::types::VerifyForeignTxId;
 use anyhow::Context;
+use chain_gateway::event_subscriber::block_events::BlockContext;
 use futures::StreamExt;
 use mpc_primitives::domain::DomainId;
 use near_account_id::AccountId;
@@ -82,7 +82,7 @@ pub struct VerifyForeignTxRequestFromChain {
 
 #[derive(Clone)]
 pub struct ChainBlockUpdate {
-    pub block: BlockViewLite,
+    pub block: BlockContext,
     pub signature_requests: Vec<SignatureRequestFromChain>,
     pub completed_signatures: Vec<SignatureId>,
     pub ckd_requests: Vec<CKDRequestFromChain>,
@@ -250,9 +250,9 @@ async fn handle_message(
 
     block_update_sender
         .send(ChainBlockUpdate {
-            block: BlockViewLite {
+            block: BlockContext {
                 hash: streamer_message.block.header.hash,
-                height: streamer_message.block.header.height,
+                height: streamer_message.block.header.height.into(),
                 prev_hash: streamer_message.block.header.prev_hash,
                 last_final_block: streamer_message.block.header.last_final_block,
                 entropy: streamer_message.block.header.random_value.into(),

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -233,7 +233,7 @@ where
                         break;
                     };
 
-                    self.client.update_indexer_height(block_update.block.height);
+                    self.client.update_indexer_height(block_update.block.height.into());
 
                     let AddBlockResult{ block_status } = recent_blocks.add_block(&block_update.block);
 

--- a/crates/node/src/requests/debug.rs
+++ b/crates/node/src/requests/debug.rs
@@ -185,7 +185,11 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs> Debug
         for request in self.requests.values() {
             let debug_line =
                 request.debug_print(&self.clock, self.my_participant_id, &eligible_leaders);
-            request_lines.push((request.block_height, request.request.get_id(), debug_line));
+            request_lines.push((
+                request.block_height.into(),
+                request.request.get_id(),
+                debug_line,
+            ));
         }
 
         for completed in &self.recently_completed_requests.requests {

--- a/crates/node/src/requests/queue.rs
+++ b/crates/node/src/requests/queue.rs
@@ -4,6 +4,7 @@ use crate::indexer::types::ChainRespondArgs;
 use crate::primitives::ParticipantId;
 use crate::requests::metrics;
 use crate::types::{self, Request, RequestId, RequestsUpdate};
+use chain_gateway::types::BlockHeight;
 use k256::sha2::Sha256;
 use near_indexer_primitives::CryptoHash;
 use near_indexer_primitives::types::NumBlocks;
@@ -86,8 +87,8 @@ struct IndexedRespondTx {
     // TODO(#3318): We could share the `block_height` through the same guard as
     // `block_status`, however, that's a larger refactor and this change will only truly make sense
     // once we start improving the metrics with #3318, so we defer it to later and accept to hold a
-    // u64 for each response.
-    block_height: u64,
+    // `BlockHeight` for each response.
+    block_height: BlockHeight,
 }
 
 impl Default for IndexedRespondTxs {
@@ -144,7 +145,7 @@ enum AggregateResponseStatus {
     /// Indicates that one of the responses is included in a block that was finalized on chain.
     Resolved {
         received_at: near_time::Instant,
-        block_height: u64,
+        block_height: BlockHeight,
     },
 }
 
@@ -157,7 +158,7 @@ pub(super) struct QueuedRequest<RequestType: Request, ChainRespondArgsType: Chai
     /// Respond transactions for this request observed in indexed blocks.
     indexed_respond_txs: IndexedRespondTxs,
 
-    pub block_height: u64,
+    pub block_height: BlockHeight,
 
     /// A pre-computed order of participants that we consider for leader selection.
     /// The leader for the request would be the first in this list that is eligible
@@ -252,7 +253,7 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs>
     pub fn new(
         clock: &near_time::Clock,
         request: RequestType,
-        block_height: u64,
+        block_height: BlockHeight,
         status: BlockStatusHandle,
         all_participants: &[ParticipantId],
         time_indexed: near_time::Instant,
@@ -328,7 +329,7 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs>
         self.active_attempt.strong_count() > 0
     }
 
-    fn is_older_than(&self, cutoff_block: u64) -> bool {
+    fn is_older_than(&self, cutoff_block: BlockHeight) -> bool {
         cutoff_block > self.block_height
     }
 
@@ -344,7 +345,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
         &mut self,
         my_participant_id: ParticipantId,
         eligible_leaders: &HashSet<ParticipantId>,
-        cutoff_block: u64,
+        cutoff_block: BlockHeight,
         now: near_time::Instant,
     ) -> RequestStatus<RequestType, ChainRespondArgsType> {
         if !self.update_next_check_due(now) {
@@ -416,7 +417,7 @@ enum RequestStatus<RequestType: Request, ChainRespondArgsType: ChainRespondArgs>
     Attempt(Arc<GenerationAttempt<RequestType, ChainRespondArgsType>>),
     Resolve {
         received_at: near_time::Instant,
-        block_height: u64,
+        block_height: BlockHeight,
     },
 }
 
@@ -601,7 +602,8 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
         let mut requests_to_remove: Vec<(RequestId, Removal)> = Vec::new();
 
         // any request strictly older than `cutoff_block` will be considered expired
-        let cutoff_block = maximum_height.saturating_sub(REQUEST_EXPIRATION_BLOCKS) + 1;
+        let cutoff_block: BlockHeight =
+            (maximum_height.saturating_sub(REQUEST_EXPIRATION_BLOCKS) + 1).into();
 
         for (id, request) in &mut self.requests {
             let _span = tracing::debug_span!(
@@ -609,7 +611,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                 "process_request",
                 request_type = %RequestType::get_type(),
                 request_id = %request.request.get_id(),
-                block_height = request.block_height,
+                block_height = %request.block_height,
             )
             .entered();
             match request.process(self.my_participant_id, &eligible_leaders, cutoff_block, now) {
@@ -634,7 +636,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                 } => {
                     mpc_pending_queue_finalized_responses.inc();
                     // Response block ≥ request block by construction; saturate just in case.
-                    let latency_blocks = block_height.saturating_sub(request.block_height);
+                    let latency_blocks = block_height.blocks_since(request.block_height);
                     let latency_duration = received_at.signed_duration_since(request.time_indexed);
 
                     request_response_latency_blocks.observe(latency_blocks as f64);
@@ -661,7 +663,7 @@ impl<RequestType: Request + Clone, ChainRespondArgsType: ChainRespondArgs>
                 };
                 self.recently_completed_requests
                     .add_completed_request(CompletedRequest {
-                        indexed_block_height: request.block_height,
+                        indexed_block_height: request.block_height.into(),
                         request: request.request,
                         progress: request.computation_progress,
                         completion_delay,
@@ -897,7 +899,7 @@ mod tests {
             let update = RequestsUpdate {
                 requests: self.requests_to_submit.clone(),
                 completed_requests: self.responses_to_submit.clone(),
-                block_height: new_height,
+                block_height: new_height.into(),
                 block_status,
             };
             self.requests_to_submit = Vec::new();
@@ -924,7 +926,7 @@ mod tests {
             let update = RequestsUpdate {
                 requests: self.requests_to_submit.clone(),
                 completed_requests: self.responses_to_submit.clone(),
-                block_height: new_height,
+                block_height: new_height.into(),
                 block_status,
             };
             self.requests_to_submit = Vec::new();

--- a/crates/node/src/requests/recent_blocks_tracker.rs
+++ b/crates/node/src/requests/recent_blocks_tracker.rs
@@ -1,9 +1,8 @@
-use derive_more::Into;
+use chain_gateway::event_subscriber::block_events::BlockContext;
+use chain_gateway::types::BlockHeight;
 use near_indexer_primitives::CryptoHash;
-use near_indexer_primitives::types::BlockHeight;
 use std::collections::{HashMap, VecDeque};
 use std::fmt::Debug;
-use std::ops::Add;
 use std::sync::atomic::{AtomicU8, Ordering};
 use std::sync::{Arc, Mutex, Weak};
 
@@ -208,7 +207,7 @@ pub struct AddBlockResult {
 /// Represents a block in the recent blockchain.
 struct BlockNode {
     hash: CryptoHash,
-    height: u64,
+    height: BlockHeight,
     /// Indicates the finality status of this block. Held as `Arc`.
     /// A [`BlockStatusHandle`] is handed out via [`AddBlockResult::block_status`] to consumers,
     /// allowing them to observe status changes and detect pruning.
@@ -295,32 +294,6 @@ impl BlockNode {
     }
 }
 
-#[derive(Clone, Into)]
-pub struct BlockEntropy([u8; 32]);
-
-impl BlockEntropy {
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.0
-    }
-}
-
-impl From<CryptoHash> for BlockEntropy {
-    fn from(value: CryptoHash) -> Self {
-        BlockEntropy(value.into())
-    }
-}
-
-/// A view of a block that is sufficient for the RecentBlocksTracker.
-#[derive(Clone)]
-pub struct BlockViewLite {
-    pub hash: CryptoHash,
-    pub height: u64,
-    pub prev_hash: CryptoHash,
-    pub last_final_block: CryptoHash,
-    pub entropy: BlockEntropy,
-    pub timestamp_nanosec: u64,
-}
-
 impl RecentBlocksTracker {
     pub fn new(window_size: u64) -> Self {
         Self {
@@ -328,14 +301,14 @@ impl RecentBlocksTracker {
             root_children: Vec::new(),
             canonical_head: Weak::new(),
             final_head: None,
-            maximum_height_available: 0,
+            maximum_height_available: 0.into(),
             hash_to_node: HashMap::new(),
         }
     }
 
     /// Adds a block to the tracker. This is expected to be called for EVERY block given by the
     /// indexer (whether or not it is interesting).
-    pub fn add_block(&mut self, block: &BlockViewLite) -> AddBlockResult {
+    pub fn add_block(&mut self, block: &BlockContext) -> AddBlockResult {
         if let Some(node) = self.hash_to_node.get(&block.hash) {
             tracing::error!(
                 target: "recent_blocks_tracker",
@@ -448,7 +421,7 @@ impl RecentBlocksTracker {
     /// to `subtrees_to_remove`
     fn update_roots(
         &mut self,
-        new_final_height: u64,
+        new_final_height: BlockHeight,
         subtrees_to_remove: &mut VecDeque<Arc<BlockNode>>,
     ) {
         let mut new_root_children = Vec::new();
@@ -524,14 +497,14 @@ impl RecentBlocksTracker {
     /// This is typically canonical_head.height - window_size + 1, but in case of delayed finality,
     /// we ensure that the final head is not pruned. Otherwise, not only would the logic be very
     /// messy, but also we would not be able to provide a contiguous stream of finalized blocks.
-    fn minimum_height_to_keep(&self) -> Option<u64> {
+    fn minimum_height_to_keep(&self) -> Option<BlockHeight> {
         let Some(final_head) = &self.final_head else {
             return None;
         };
         Some(
             self.maximum_height_available
                 .saturating_sub(self.window_size)
-                .add(1)
+                .saturating_add(1)
                 .min(final_head.height),
         )
     }
@@ -569,9 +542,9 @@ impl Debug for RecentBlocksTracker {
             "   Recent blocks: (Window = {} to {}, GC limit {})",
             self.maximum_height_available
                 .saturating_sub(self.window_size)
-                .add(1),
+                .saturating_add(1),
             self.maximum_height_available,
-            self.minimum_height_to_keep().unwrap_or(0)
+            self.minimum_height_to_keep().unwrap_or(0.into())
         )?;
         let final_head = self.final_head.as_ref().map(|n| n.hash);
         let canonical_head = self.canonical_head.upgrade().map(|n| n.hash);
@@ -596,7 +569,9 @@ impl Debug for RecentBlocksTracker {
 pub mod tests {
     use crate::requests::recent_blocks_tracker::{AtomicBlockStatus, BlockStatusHandle};
 
-    use super::{BlockEntropy, BlockStatus, BlockViewLite, RecentBlocksTracker};
+    use super::{BlockStatus, RecentBlocksTracker};
+    use chain_gateway::event_subscriber::block_events::BlockContext;
+    use chain_gateway::types::BlockEntropy;
     use near_indexer::near_primitives::hash::hash;
     use near_indexer_primitives::CryptoHash;
     use std::collections::HashSet;
@@ -633,7 +608,7 @@ pub mod tests {
             parent.last_final_block()
         }
 
-        pub fn to_block_view(&self) -> BlockViewLite {
+        pub fn to_block_view(&self) -> BlockContext {
             let parent_hash = match self.parent.clone() {
                 Some(parent) => parent.hash,
                 None => {
@@ -664,9 +639,9 @@ pub mod tests {
                 }
             };
 
-            BlockViewLite {
+            BlockContext {
                 hash: self.hash,
-                height: self.height,
+                height: self.height.into(),
                 entropy: self.entropy.clone(),
                 timestamp_nanosec: self.timestamp_nanosec,
                 prev_hash: parent_hash,
@@ -1097,7 +1072,7 @@ pub mod tests {
         tester.add(&b1);
         tester.add(&b2);
         tester.add(&b3);
-        assert_eq!(tester.tracker.minimum_height_to_keep(), Some(1))
+        assert_eq!(tester.tracker.minimum_height_to_keep(), Some(1.into()))
     }
 
     #[test]

--- a/crates/node/src/types.rs
+++ b/crates/node/src/types.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+use chain_gateway::{event_subscriber::block_events::BlockContext, types::BlockHeight};
 use mpc_primitives::domain::DomainId;
 use near_indexer_primitives::CryptoHash;
 use near_mpc_contract_interface::types::{Payload, Tweak};
@@ -12,19 +13,19 @@ use crate::{
     indexer::handler::{
         CKDRequestFromChain, SignatureRequestFromChain, VerifyForeignTxRequestFromChain,
     },
-    requests::recent_blocks_tracker::{BlockStatusHandle, BlockViewLite},
+    requests::recent_blocks_tracker::BlockStatusHandle,
 };
 
 pub(crate) struct RequestsUpdate<T> {
     pub(crate) requests: Vec<T>,
     pub(crate) completed_requests: Vec<RequestId>,
-    pub(crate) block_height: u64,
+    pub(crate) block_height: BlockHeight,
     pub(crate) block_status: BlockStatusHandle,
 }
 
 impl<T> RequestsUpdate<T> {
     pub(crate) fn from_chain<U>(
-        block: &BlockViewLite,
+        block: &BlockContext,
         block_status: BlockStatusHandle,
         new_requests: Vec<U>,
         completed_requests: Vec<RequestId>,
@@ -81,11 +82,11 @@ pub struct CKDRequest {
 }
 
 pub(crate) trait FromChain<T> {
-    fn from_chain(chain_value: T, block: &BlockViewLite) -> Self;
+    fn from_chain(chain_value: T, block: &BlockContext) -> Self;
 }
 
 impl FromChain<CKDRequestFromChain> for CKDRequest {
-    fn from_chain(chain_value: CKDRequestFromChain, block: &BlockViewLite) -> Self {
+    fn from_chain(chain_value: CKDRequestFromChain, block: &BlockContext) -> Self {
         let CKDRequestFromChain {
             ckd_id,
             receipt_id,
@@ -119,7 +120,7 @@ pub struct SignatureRequest {
 }
 
 impl FromChain<SignatureRequestFromChain> for SignatureRequest {
-    fn from_chain(chain_value: SignatureRequestFromChain, block: &BlockViewLite) -> Self {
+    fn from_chain(chain_value: SignatureRequestFromChain, block: &BlockContext) -> Self {
         let SignatureRequestFromChain {
             signature_id,
             receipt_id,
@@ -164,7 +165,7 @@ pub struct VerifyForeignTxRequest {
 }
 
 impl FromChain<VerifyForeignTxRequestFromChain> for VerifyForeignTxRequest {
-    fn from_chain(chain_value: VerifyForeignTxRequestFromChain, block: &BlockViewLite) -> Self {
+    fn from_chain(chain_value: VerifyForeignTxRequestFromChain, block: &BlockContext) -> Self {
         let VerifyForeignTxRequestFromChain {
             verify_foreign_tx_id,
             receipt_id,


### PR DESCRIPTION
resolves #3496 
will simplify diff when moving recent blocks tracker to chain gateway