### PR TITLE
feat: aptos support for foreign tx validation requests in mpc contract

### DIFF
--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -22,7 +22,8 @@ use mpc_contract::{
 };
 use near_account_id::AccountId;
 use near_mpc_contract_interface::types::{
-    Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+    AptosAddress, AptosEvent, AptosExtractedValue, AptosExtractor, AptosFinality, AptosRpcRequest,
+    AptosTxId, Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
     SupportedForeignChains, TonAddress, TonCellBody, TonExtractedValue, TonExtractor, TonFinality,
     TonLog, TonRpcRequest, TonTxId,
 };
@@ -811,6 +812,17 @@ pub fn bogus_ton_log_extracted_value() -> Vec<ExtractedValue> {
     ))]
 }
 
+pub fn aptos_extracted_values() -> Vec<ExtractedValue> {
+    vec![ExtractedValue::AptosExtractedValue(
+        AptosExtractedValue::Event(AptosEvent {
+            account_address: AptosAddress([1; 32]),
+            sequence_number: 0,
+            type_tag: "0x1::omni_bridge::InitTransfer".to_string(),
+            data: r#"{"amount":"100"}"#.to_string(),
+        }),
+    )]
+}
+
 pub fn bnb_evm_request() -> ForeignChainRpcRequest {
     ForeignChainRpcRequest::Bnb(EvmRpcRequest {
         tx_id: EvmTxId([0xbb; 32]),
@@ -860,5 +872,13 @@ pub fn ton_request() -> ForeignChainRpcRequest {
             workchain: 0,
             hash: Hash256([1; 32]),
         },
+    })
+}
+
+pub fn aptos_request() -> ForeignChainRpcRequest {
+    ForeignChainRpcRequest::Aptos(AptosRpcRequest {
+        tx_id: AptosTxId([0xbb; 32]),
+        finality: AptosFinality::Committed,
+        extractors: vec![AptosExtractor::Event { event_index: 0 }],
     })
 }

--- a/crates/contract/tests/sandbox/foreign_chain_request.rs
+++ b/crates/contract/tests/sandbox/foreign_chain_request.rs
@@ -1,8 +1,8 @@
 #![allow(non_snake_case)]
 
 use crate::sandbox::common::{
-    SandboxTestSetup, abstract_evm_request, arbitrum_evm_request,
-    await_pending_foreign_tx_request_observed_on_contract, base_evm_request,
+    SandboxTestSetup, abstract_evm_request, aptos_extracted_values, aptos_request,
+    arbitrum_evm_request, await_pending_foreign_tx_request_observed_on_contract, base_evm_request,
     bitcoin_extracted_values, bitcoin_request, bnb_evm_request, bogus_ton_log_extracted_value,
     ethereum_evm_request, evm_block_hash_extracted_values, hyper_evm_request, polygon_evm_request,
     register_foreign_chain_configuration, sign_foreign_tx_response, starknet_extracted_values,
@@ -30,6 +30,7 @@ const SIGNATURE_TIMEOUT_BLOCKS: u64 = 200;
 #[case::polygon(polygon_evm_request(), evm_block_hash_extracted_values())]
 #[case::hyper_evm(hyper_evm_request(), evm_block_hash_extracted_values())]
 #[case::ton(ton_request(), bogus_ton_log_extracted_value())]
+#[case::aptos(aptos_request(), aptos_extracted_values())]
 #[tokio::test]
 async fn verify_foreign_transaction__should_succeed(
     #[case] rpc_request: ForeignChainRpcRequest,
@@ -203,6 +204,7 @@ async fn verify_foreign_transaction__should_fan_out_response_to_duplicates_from_
 #[case::polygon(polygon_evm_request())]
 #[case::hyper_evm(hyper_evm_request())]
 #[case::ton(ton_request())]
+#[case::aptos(aptos_request())]
 #[tokio::test]
 async fn verify_foreign_transaction__should_reject_without_policy(
     #[case] rpc_request: ForeignChainRpcRequest,
@@ -250,6 +252,7 @@ async fn verify_foreign_transaction__should_reject_without_policy(
 #[case::polygon(polygon_evm_request())]
 #[case::hyper_evm(hyper_evm_request())]
 #[case::ton(ton_request())]
+#[case::aptos(aptos_request())]
 #[tokio::test]
 async fn verify_foreign_transaction__should_timeout_without_response(
     #[case] rpc_request: ForeignChainRpcRequest,

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -246,11 +246,19 @@ expression: abi
                       10,
                       "Ton",
                       "ForeignChain__Ton"
+                    ],
+                    [
+                      11,
+                      "Aptos",
+                      "ForeignChain__Aptos"
                     ]
                   ]
                 }
               },
               "ForeignChain__Abstract": {
+                "Struct": null
+              },
+              "ForeignChain__Aptos": {
                 "Struct": null
               },
               "ForeignChain__Arbitrum": {
@@ -2064,11 +2072,19 @@ expression: abi
                           10,
                           "Ton",
                           "ForeignChain__Ton"
+                        ],
+                        [
+                          11,
+                          "Aptos",
+                          "ForeignChain__Aptos"
                         ]
                       ]
                     }
                   },
                   "ForeignChain__Abstract": {
+                    "Struct": null
+                  },
+                  "ForeignChain__Aptos": {
                     "Struct": null
                   },
                   "ForeignChain__Arbitrum": {
@@ -2213,6 +2229,64 @@ expression: abi
               }
             }
           }
+        },
+        "AptosExtractor": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "Event"
+              ],
+              "properties": {
+                "Event": {
+                  "type": "object",
+                  "required": [
+                    "event_index"
+                  ],
+                  "properties": {
+                    "event_index": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "AptosFinality": {
+          "type": "string",
+          "enum": [
+            "Committed"
+          ]
+        },
+        "AptosRpcRequest": {
+          "type": "object",
+          "required": [
+            "extractors",
+            "finality",
+            "tx_id"
+          ],
+          "properties": {
+            "extractors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/AptosExtractor"
+              }
+            },
+            "finality": {
+              "$ref": "#/definitions/AptosFinality"
+            },
+            "tx_id": {
+              "$ref": "#/definitions/AptosTxId"
+            }
+          }
+        },
+        "AptosTxId": {
+          "type": "string",
+          "pattern": "^(?:[0-9A-Fa-f]{2})*$"
         },
         "AttemptId": {
           "description": "Attempt identifier within a key event. Incremented for each attempt within the same epoch and domain.",
@@ -2895,7 +2969,8 @@ expression: abi
             "Starknet",
             "Polygon",
             "HyperEvm",
-            "Ton"
+            "Ton",
+            "Aptos"
           ]
         },
         "ForeignChainConfiguration": {
@@ -3035,6 +3110,18 @@ expression: abi
               "properties": {
                 "Ton": {
                   "$ref": "#/definitions/TonRpcRequest"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "Aptos"
+              ],
+              "properties": {
+                "Aptos": {
+                  "$ref": "#/definitions/AptosRpcRequest"
                 }
               },
               "additionalProperties": false

--- a/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+++ b/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
@@ -179,6 +179,7 @@ pub enum ForeignChainRpcRequest {
     Polygon(EvmRpcRequest),
     HyperEvm(EvmRpcRequest),
     Ton(TonRpcRequest),
+    Aptos(AptosRpcRequest),
 }
 
 impl ForeignChainRpcRequest {
@@ -195,6 +196,7 @@ impl ForeignChainRpcRequest {
             Self::Polygon(_) => ForeignChain::Polygon,
             Self::HyperEvm(_) => ForeignChain::HyperEvm,
             Self::Ton(_) => ForeignChain::Ton,
+            Self::Aptos(_) => ForeignChain::Aptos,
         }
     }
 }
@@ -561,6 +563,167 @@ pub enum TonExtractedValue {
     Log(TonLog),
 }
 
+#[serde_as]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    derive_more::Into,
+    derive_more::From,
+    derive_more::AsRef,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct AptosTxId(#[serde_as(as = "Hex")] pub [u8; 32]);
+
+#[serde_as]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    derive_more::Into,
+    derive_more::From,
+    derive_more::AsRef,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct AptosAddress(#[serde_as(as = "Hex")] pub [u8; 32]);
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct AptosRpcRequest {
+    pub tx_id: AptosTxId,
+    pub finality: AptosFinality,
+    pub extractors: Vec<AptosExtractor>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+#[non_exhaustive]
+pub enum AptosFinality {
+    Committed,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+#[non_exhaustive]
+#[repr(u8)]
+#[borsh(use_discriminant = true)]
+pub enum AptosExtractor {
+    Event { event_index: u64 } = 1,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct AptosEvent {
+    pub account_address: AptosAddress,
+    pub sequence_number: u64,
+    pub type_tag: String,
+    pub data: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+#[non_exhaustive]
+pub enum AptosExtractedValue {
+    Event(AptosEvent),
+}
+
 #[derive(
     Debug,
     Clone,
@@ -829,6 +992,7 @@ pub enum ExtractedValue {
     EvmExtractedValue(EvmExtractedValue),
     StarknetExtractedValue(StarknetExtractedValue),
     TonExtractedValue(TonExtractedValue),
+    AptosExtractedValue(AptosExtractedValue),
 }
 
 #[derive(
@@ -929,6 +1093,7 @@ pub enum ForeignChain {
     Polygon,
     HyperEvm,
     Ton,
+    Aptos,
 }
 
 #[derive(
@@ -1561,6 +1726,14 @@ mod tests {
         }),
         ForeignChain::Ton,
     )]
+    #[case::aptos(
+        ForeignChainRpcRequest::Aptos(AptosRpcRequest {
+            tx_id: AptosTxId([0; 32]),
+            finality: AptosFinality::Committed,
+            extractors: vec![],
+        }),
+        ForeignChain::Aptos,
+    )]
     fn foreign_chain_rpc_request_chain__should_return_correct_chain(
         #[case] request: ForeignChainRpcRequest,
         #[case] expected_chain: ForeignChain,
@@ -1661,6 +1834,32 @@ mod tests {
                         .unwrap(),
                 },
             ))],
+        });
+
+        // When
+        let hash = payload.compute_msg_hash().unwrap();
+
+        // Then
+        insta::assert_json_snapshot!(hex::encode(hash.0));
+    }
+
+    #[test]
+    fn foreign_tx_sign_payload_v1_aptos__should_have_consistent_hash() {
+        // Given
+        let payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+            request: ForeignChainRpcRequest::Aptos(AptosRpcRequest {
+                tx_id: AptosTxId([0xcc; 32]),
+                finality: AptosFinality::Committed,
+                extractors: vec![AptosExtractor::Event { event_index: 0 }],
+            }),
+            values: vec![ExtractedValue::AptosExtractedValue(
+                AptosExtractedValue::Event(AptosEvent {
+                    account_address: AptosAddress([0x00; 32]),
+                    sequence_number: 0,
+                    type_tag: "0xdeadbeef::omni_bridge::InitTransfer".to_string(),
+                    data: "{\"amount\":\"100\"}".to_string(),
+                }),
+            )],
         });
 
         // When

--- a/crates/near-mpc-contract-interface/src/types/snapshots/near_mpc_contract_interface__types__foreign_chain__tests__foreign_tx_sign_payload_v1_aptos__should_have_consistent_hash.snap
+++ b/crates/near-mpc-contract-interface/src/types/snapshots/near_mpc_contract_interface__types__foreign_chain__tests__foreign_tx_sign_payload_v1_aptos__should_have_consistent_hash.snap
@@ -1,0 +1,5 @@
+---
+source: crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+expression: "hex::encode(hash.0)"
+---
+"35c0b8faf873f86a506f63c48e480857262d5a3cd91ba61330b28cc426cad74c"


### PR DESCRIPTION
## Summary

Adds Aptos as a supported foreign chain for the contract's `verify_foreign_transaction`
flow — the **contract-interface (DTO) half** of Aptos support.

This is one of a two-PR split (see #3508 for the node/inspector side), keeping the
contract-interface changes reviewable independently from the inspector logic.

## What's included

- **New wire types** in `near-mpc-contract-interface`
  (`crates/near-mpc-contract-interface/src/types/foreign_chain.rs`):
  - `AptosTxId` — 32-byte SHA3-256 tx hash (hex), `AptosAddress` — 32-byte account address (hex)
  - `AptosRpcRequest { tx_id, finality, extractors }`
  - `AptosFinality::Committed` — Aptos has BFT instant finality (no confirmations / no reorgs),
    so a single "committed" level
  - `AptosExtractor::Event { event_index } = 1` — discriminant `1`, mirroring the log/event
    extractor on EVM/Starknet/TON; discriminant `0` is left as the conventional block-hash slot
  - `AptosEvent { account_address, sequence_number, type_tag, data }`
  - `AptosExtractedValue::Event(AptosEvent)`
  - variant wiring: `ForeignChainRpcRequest::Aptos`, `ExtractedValue::AptosExtractedValue`,
    `ForeignChain::Aptos`, and the `ForeignChainRpcRequest::chain()` arm
- **No `crates/contract/src` logic changes** — the contract is generic over `ForeignChain`
  (the provider whitelist is keyed by it; there is no per-chain matching), so it picks up Aptos
  transitively through the DTO enums. This matches the TON contract PR, which also touched no
  contract source.
- **Snapshots**:
  - regenerated `crates/contract/tests/snapshots/abi__abi_has_not_changed.snap` — now includes
    the Aptos types and the `ForeignChain__Aptos` variant
  - new `foreign_tx_sign_payload_v1_aptos__should_have_consistent_hash.snap` — pins the V1
    Aptos sign-payload hash
  - the borsh-schema snapshot is intentionally unchanged: adding a `ForeignChain` variant does
    not alter `MpcContract`'s borsh schema (verified, same as TON)
- **Sandbox tests**: `aptos_request()` / `aptos_extracted_values()` fixtures in
  `tests/sandbox/common.rs`, and `#[case::aptos(...)]` added to the existing parameterized
  `verify_foreign_transaction__*` tests in `tests/sandbox/foreign_chain_request.rs`

## Testing

- `near-mpc-contract-interface` unit tests (consistent-hash + chain mapping) pass.
- `test_abi_has_not_changed` passes against the regenerated snapshot.
- Contract WASM size: 1,445,894 bytes, within the 1,500,000-byte limit (no bump needed).

## Out of scope

- The node-side inspector, Aptos RPC client, and node wiring — see #3508.
