### PR TITLE
test(e2e): dump node 0 stdout/stderr tails when sigterm_handler test fails

### DIFF
--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -1034,6 +1034,13 @@ impl MpcNodeState {
         }
     }
 
+    pub fn home_dir(&self) -> &Path {
+        match self {
+            MpcNodeState::Running(n) => n.setup().home_dir(),
+            MpcNodeState::Stopped(s) => s.home_dir(),
+        }
+    }
+
     pub fn p2p_public_key(&self) -> Ed25519PublicKey {
         match self {
             MpcNodeState::Running(n) => n.setup().p2p_public_key(),

--- a/crates/e2e-tests/tests/sigterm_handler.rs
+++ b/crates/e2e-tests/tests/sigterm_handler.rs
@@ -1,4 +1,6 @@
+use std::io::{Read, Seek, SeekFrom};
 use std::os::unix::process::ExitStatusExt;
+use std::path::Path;
 use std::time::Duration;
 
 use crate::common;
@@ -25,11 +27,41 @@ async fn sigterm_handler__should_exit_cleanly_instead_of_default_terminating() {
         .terminate_node_with_sigterm(0, Duration::from_secs(30))
         .expect("node did not exit within the SIGTERM grace period");
 
-    // Then: the process exited cleanly with code 0.
+    // Then: the process exited cleanly with code 0. On failure, inline the
+    // tails of node 0's stdout/stderr so the panic message carries
+    // mpc-node's last log lines — tracing → stdout, panics/eprintln →
+    // stderr. The test's tempdir is cleaned on exit, so without this dump
+    // CI only sees the exit signal and we can't tell e.g. a tokio-task
+    // panic that aborted the process during shutdown from a clean failure.
+    let home = cluster.nodes[0].home_dir();
+    let stdout_tail = read_log_tail(&home.join("stdout.log"), 16_384);
+    let stderr_tail = read_log_tail(&home.join("stderr.log"), 16_384);
     assert!(
         status.success(),
-        "mpc-node did not exit cleanly after SIGTERM: code={:?} signal={:?}",
+        "mpc-node did not exit cleanly after SIGTERM: code={:?} signal={:?}\n\
+         --- last 16KB of node 0 stdout.log (mpc-node tracing) ---\n{stdout_tail}\n\
+         --- end stdout.log ---\n\
+         --- last 16KB of node 0 stderr.log (panic backtraces) ---\n{stderr_tail}\n\
+         --- end stderr.log ---",
         status.code(),
         status.signal()
     );
+}
+
+/// Best-effort read of the last `max_bytes` of a log file. Returns a
+/// synthetic placeholder string if the file can't be opened/read.
+fn read_log_tail(path: &Path, max_bytes: usize) -> String {
+    let Ok(mut f) = std::fs::File::open(path) else {
+        return format!("(could not open {})", path.display());
+    };
+    let len = f.metadata().map(|m| m.len()).unwrap_or(0);
+    let skip = len.saturating_sub(max_bytes as u64);
+    if f.seek(SeekFrom::Start(skip)).is_err() {
+        return format!("(seek failed on {})", path.display());
+    }
+    let mut buf = Vec::with_capacity(max_bytes);
+    if f.read_to_end(&mut buf).is_err() {
+        return format!("(read failed on {})", path.display());
+    }
+    String::from_utf8_lossy(&buf).into_owned()
 }


### PR DESCRIPTION
PR #3410 just merged, and Patrick spotted the `sigterm_handler` e2e test failing on his branch with `code=None signal=Some(6)` (SIGABRT) in [this CI run](https://github.com/near/mpc/actions/runs/27267382103/job/80527942157). 5/6 historical runs on the same branch passed, so it's a flake — mpc-node aborts during shutdown instead of exiting cleanly.

This PR adds inline log-tail capture so future failures show what mpc-node was doing right before the abort. Without it the test's tempdir gets cleaned up before we can read the panic backtrace.

Most likely root cause: a tokio task in the indexer's runtime panics when its underlying nearcore actor goes away during `shutdown_all_actors()`. PR #3486 (indexer-drain follow-up) should fix this by draining the runtime cleanly first. I'm running a 5-cycle campaign on #3486's branch now to verify.

## Test plan

- [ ] CI green