### PR TITLE
demo(tee-verifier): reuse mpc-attestation collateral parsing in the verify_quote test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11368,6 +11368,7 @@ dependencies = [
  "dcap-qvl",
  "getrandom 0.2.17",
  "hex",
+ "mpc-attestation",
  "near-sdk",
  "rstest",
  "tee-verifier",

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -41,6 +41,7 @@ getrandom = { workspace = true, features = ["custom"] }
 
 [dev-dependencies]
 hex = { workspace = true }
+mpc-attestation = { workspace = true, features = ["test-utils"] }
 rstest = { workspace = true }
 tee-verifier = { path = ".", features = ["test-utils"] }
 test-utils = { workspace = true }

--- a/crates/tee-verifier/src/conversions.rs
+++ b/crates/tee-verifier/src/conversions.rs
@@ -12,12 +12,12 @@ use tee_verifier_interface::{
 };
 
 /// Converts an interface type into its `dcap_qvl` counterpart `T`.
-pub(crate) trait IntoDcapType<T> {
+pub trait IntoDcapType<T> {
     fn into_dcap_type(self) -> T;
 }
 
 /// Converts a `dcap_qvl` type into its `tee-verifier-interface` counterpart `T`.
-pub(crate) trait IntoInterfaceType<T> {
+pub trait IntoInterfaceType<T> {
     fn into_interface_type(self) -> T;
 }
 
@@ -41,6 +41,23 @@ impl IntoDcapType<dcap_qvl::QuoteCollateralV3> for Collateral {
 impl IntoDcapType<Vec<u8>> for QuoteBytes {
     fn into_dcap_type(self) -> Vec<u8> {
         self.0
+    }
+}
+
+impl IntoInterfaceType<Collateral> for dcap_qvl::QuoteCollateralV3 {
+    fn into_interface_type(self) -> Collateral {
+        Collateral {
+            pck_crl_issuer_chain: self.pck_crl_issuer_chain,
+            root_ca_crl: self.root_ca_crl,
+            pck_crl: self.pck_crl,
+            tcb_info_issuer_chain: self.tcb_info_issuer_chain,
+            tcb_info: self.tcb_info,
+            tcb_info_signature: self.tcb_info_signature,
+            qe_identity_issuer_chain: self.qe_identity_issuer_chain,
+            qe_identity: self.qe_identity,
+            qe_identity_signature: self.qe_identity_signature,
+            pck_certificate_chain: self.pck_certificate_chain,
+        }
     }
 }
 

--- a/crates/tee-verifier/src/lib.rs
+++ b/crates/tee-verifier/src/lib.rs
@@ -11,7 +11,7 @@
 use near_sdk::{env, near};
 use tee_verifier_interface::{Collateral, QuoteBytes, VerificationResult, VerifierError};
 
-mod conversions;
+pub mod conversions;
 use conversions::{IntoDcapType as _, IntoInterfaceType as _};
 
 // `dcap-qvl`'s `contract` feature pulls in `getrandom` but doesn't enable

--- a/crates/tee-verifier/tests/verify_quote.rs
+++ b/crates/tee-verifier/tests/verify_quote.rs
@@ -14,6 +14,7 @@
 use near_sdk::{test_utils::VMContextBuilder, testing_env};
 use std::time::Duration;
 use tee_verifier::TeeVerifier;
+use tee_verifier::conversions::IntoInterfaceType as _;
 use tee_verifier_interface::{
     Collateral, QuoteBytes, Report, TDReport10, TcbStatus, TcbStatusWithAdvisory,
     VerificationResult, VerifiedReport, VerifierError,
@@ -21,26 +22,14 @@ use tee_verifier_interface::{
 use test_utils::attestation::{VALID_ATTESTATION_TIMESTAMP, collateral as collateral_json, quote};
 
 fn make_collateral() -> Collateral {
-    // `test_utils::attestation::collateral()` returns a `serde_json::Value`
-    // matching `attestation::Collateral`'s JSON shape. We re-parse it
-    // into the interface crate's mirror type by extracting the same
-    // field names that `dcap_qvl::QuoteCollateralV3` uses.
-    let v = collateral_json();
-    Collateral {
-        pck_crl_issuer_chain: v["pck_crl_issuer_chain"].as_str().unwrap().to_string(),
-        root_ca_crl: hex::decode(v["root_ca_crl"].as_str().unwrap()).unwrap(),
-        pck_crl: hex::decode(v["pck_crl"].as_str().unwrap()).unwrap(),
-        tcb_info_issuer_chain: v["tcb_info_issuer_chain"].as_str().unwrap().to_string(),
-        tcb_info: v["tcb_info"].as_str().unwrap().to_string(),
-        tcb_info_signature: hex::decode(v["tcb_info_signature"].as_str().unwrap()).unwrap(),
-        qe_identity_issuer_chain: v["qe_identity_issuer_chain"].as_str().unwrap().to_string(),
-        qe_identity: v["qe_identity"].as_str().unwrap().to_string(),
-        qe_identity_signature: hex::decode(v["qe_identity_signature"].as_str().unwrap()).unwrap(),
-        pck_certificate_chain: v
-            .get("pck_certificate_chain")
-            .and_then(|s| s.as_str())
-            .map(str::to_string),
-    }
+    // Reuse `mpc_attestation`'s collateral parser (which hex-decodes the
+    // fixture's byte fields into a `dcap_qvl::QuoteCollateralV3`) rather than
+    // re-mapping the JSON by hand, then convert that into the interface mirror.
+    let dcap: dcap_qvl::QuoteCollateralV3 =
+        mpc_attestation::collateral::Collateral::try_from(collateral_json())
+            .expect("fixture collateral parses")
+            .into();
+    dcap.into_interface_type()
 }
 
 fn make_quote_bytes() -> QuoteBytes {


### PR DESCRIPTION
Demonstrates one way to address @gilcu3's comment on #3237 ([r3387007113](https://github.com/near/mpc/pull/3237#discussion_r3387007113)): the `verify_quote` test's `make_collateral()` hand-maps the fixture JSON into the interface `Collateral` and hex-decodes the byte fields itself, duplicating logic that already exists.

This branch reuses `mpc_attestation::collateral::Collateral`'s `TryFrom<Value>` parser (which owns the hex-decoding) to produce a `dcap_qvl::QuoteCollateralV3`, then converts it to the interface mirror via a new public `IntoInterfaceType<Collateral>` impl (the inverse of the existing interface→dcap one). The test drops its hand-rolled JSON/hex mapping; all 21 `tee-verifier` tests still pass.

**Why this is a draft / for discussion, not folded into #3237:** it adds a dev-dependency on `mpc-attestation` to `tee-verifier`. Per `docs/design/attestation-verifier-contract.md`, `tee-verifier` is meant to be a standalone, MPC-agnostic, reusable verifier that other teams (Proximity, Defuse) can adopt without linking MPC-specific crates — and `mpc-attestation` is explicitly the MPC-specific framing. Even a dev-only dep works against that goal, so the hand-rolled mapping in #3237 may be the right trade-off for a shared crate. Opening this so the reviewer can weigh the reuse against the coupling.

Targets `feat/tee-verifier-contract` so the diff is just this change.
