### PR TITLE
chore: Bump protocol version in genesis for localnet deployment

### DIFF
--- a/deployment/localnet/genesis.json
+++ b/deployment/localnet/genesis.json
@@ -1,5 +1,5 @@
 {
-  "protocol_version": 81,
+  "protocol_version": 84,
   "genesis_time": "2025-10-28T17:50:46.895503491Z",
   "chain_id": "mpc-localnet",
   "genesis_height": 0,


### PR DESCRIPTION
closes #3527 