### PR TITLE
fix: default non-TDX nodes to Peers (decentralized) state sync

### DIFF
--- a/deployment/start.sh
+++ b/deployment/start.sh
@@ -43,7 +43,10 @@ config['store']['load_mem_tries_for_tracked_shards'] = True
 if "$MPC_ENV" == "mpc-localnet":
     config['state_sync_enabled'] = False
 else:
-    config['state_sync']['sync']['ExternalStorage']['external_storage_fallback_threshold'] = 0
+    # Decentralized (peer-to-peer) state sync; centralized bucket sync is
+    # deprecated. Re-applied on every start, so existing nodes drop any stale
+    # ExternalStorage config on their next restart.
+    config['state_sync']['sync'] = "Peers"
 
 # Track whichever shard the contract account is on.
 config['tracked_shards_config'] = {'Accounts': ["$MPC_CONTRACT_ID"]}


### PR DESCRIPTION
Closes #3535

Switches the non-TDX node entrypoint (`deployment/start.sh`) from the deprecated centralized `ExternalStorage` state-sync mode to decentralized (peer-to-peer) state sync — the non-TDX sibling of #3526/#3533.

```python
# before: config['state_sync']['sync']['ExternalStorage']['external_storage_fallback_threshold'] = 0
config['state_sync']['sync'] = "Peers"
```

- `update_near_node_config()` runs on **every** start (not just first init), so this also **auto-remediates existing non-TDX nodes** on their next restart/upgrade — relevant to the near/mpc-private#360 3.11.0 segfault, which was traced to the presence of the `ExternalStorage` config.
- No tier3 fail-closed guard here (that's TDX-only — non-TDX nodes have a real public IP, no SLIRP NAT; `start.sh` never set `tier3_public_addr`).

**Testing:** run the new image's `start.sh` against an existing `config.json` that has the `ExternalStorage` block → confirm it's rewritten to `sync: "Peers"` and the node state-syncs on the new version without segfaulting (NEAR sync is testable on a non-participant node).
