### PR TITLE
docs: adding unsaid bits in the contract interface

### DIFF
--- a/crates/near-mpc-contract-interface/README.md
+++ b/crates/near-mpc-contract-interface/README.md
@@ -11,6 +11,11 @@ From a development perspective, this crate also helps us in a few ways:
 1. It makes it easier to be lean on dependencies to not accidentally include complex types in the interface.
 2. It allows us to control how these objects are serialized.
 
+The serialized (JSON/borsh) wire format of these types *is* the public contract.
+The MPC contract is free to refactor its internal types — storage layout,
+invariant enforcement, `near-sdk` integration — without breaking callers, as
+long as the wire format defined here is preserved.
+
 ## Vision
 While this crate only contains plain data types (or DTOs) at the time of writing,
 long term we may want to extend this to also include helper functions to construct
@@ -21,7 +26,10 @@ The contract interface is designed to only be used by the MPC contract
 and its callers, decoupling any direct dependencies on the MPC contract.
 
 Moreover, the interface crate should be lean and only depend on primitive
-types and serialization utilities.
+types and serialization utilities. The types here are plain data carriers:
+unlike the contract's internal types, they enforce no invariants and expose
+their fields directly. Validation belongs to the contract, which maps between
+its internal types and these DTOs at its own boundary.
 
 ```text
  ┌───────────┐ ┌────────┐ ┌──────────────┐
@@ -42,6 +50,18 @@ types and serialization utilities.
  │ Primitive types ││ Serialization utilities │
  └─────────────────┘└─────────────────────────┘
 ```
+
+### Design rules
+A couple of conventions keep the crate lean and the wire format robust:
+
+1. **`near-sdk` is not a dependency.** The whole point of the crate is that
+   consumers (the node, SDKs, external tools) don't need the full contract
+   stack. Types that genuinely need `near-sdk` are gated behind the `near`
+   feature rather than pulled in unconditionally.
+2. **Prefer typed wrappers over bare `String`s.** Use typed wrappers
+   instead of raw `String`s (e.g. `Ed25519PublicKey` from `near-mpc-crypto-types`)
+   so that malformed values are rejected at deserialization, rather than
+   deep in caller logic.
 
 ### A note on conversion logic
 Currently this crate is intentionally free from any conversion

--- a/crates/near-mpc-contract-interface/README.md
+++ b/crates/near-mpc-contract-interface/README.md
@@ -54,7 +54,7 @@ its internal types and these DTOs at its own boundary.
 ### Design rules
 A couple of conventions keep the crate lean and the wire format robust:
 
-1. **`near-sdk` is not a dependency.** The whole point of the crate is that
+1. **`near-sdk` is not a dependency.** This means that
    consumers (the node, SDKs, external tools) don't need the full contract
    stack. Types that genuinely need `near-sdk` are gated behind the `near`
    feature rather than pulled in unconditionally.


### PR DESCRIPTION
Closes #2876 

This adds unsaid bits that existed in a closed PR https://github.com/near/mpc/pull/2887. The previous PR was closed because many things were redundant to the README file.
After a [discussion](https://github.com/near/mpc/pull/2887#pullrequestreview-4436105837) and in private slack with Marten, we decided to shrink the closed PR into this one
  
