### PR TITLE
fix: pattern in changes.yml for detecting code changes

### DIFF
--- a/.github/workflows/changes.yml
+++ b/.github/workflows/changes.yml
@@ -33,10 +33,9 @@ jobs:
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
-          # Match everything, excluding .md and docs/ folder (assumes there's no
-          # executable in docs/ folder).
+          # Match everything, excluding .md files and the docs/ folder.
           filters: |
             code:
               - '**'
-              - '!**.md'
-              - '!docs/**'
+              - '!**/*.md'
+              - '!docs/**/*'


### PR DESCRIPTION
Bug was that this was only covering *.md files in root folder and anything directly in docs/ folder, not `something_else/doc.md` or `docs/foreign_tx/docs.md`.

Closes: https://github.com/near/mpc/issues/3561