### PR TITLE
chore: release v3.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,79 @@ All notable changes to this project will be documented in this file.
 
 This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/).
 
+## [3.12.0] - 2026-06-15
+
+### 🚀 Features
+
+- [#3235](https://github.com/near/mpc/pull/3235)(@pbeza): *(tee-verifier-interface)* Borsh DTOs for the verifier contract boundary (#3235)
+
+- [#3507](https://github.com/near/mpc/pull/3507)(@frolvanya): Aptos support for foreign tx validation requests in mpc contract (#3507)
+
+- [#3237](https://github.com/near/mpc/pull/3237)(@pbeza): *(tee-verifier)* Stateless `dcap_qvl::verify` wrapper contract (#3237)
+
+- [#3525](https://github.com/near/mpc/pull/3525)(@anodar): Add debug info about the number of configured foreign chain RPC providers (#3525)
+
+- [#3504](https://github.com/near/mpc/pull/3504)(@gilcu3): Add a separate runtime for asset generation (#3504)
+
+- [#3508](https://github.com/near/mpc/pull/3508)(@frolvanya): Aptos foreign-chain inspector and node wiring (#3508)
+
+- [#3326](https://github.com/near/mpc/pull/3326)(@SimonRastikian): Adding resharing per-domain (#3326)
+
+- [#3435](https://github.com/near/mpc/pull/3435)(@pbeza): *(indexer)* Add `/debug/recent_transactions` page (#3435)
+
+
+### 🐛 Bug Fixes
+
+- [#3410](https://github.com/near/mpc/pull/3410)(@barakeinav1): *(node)* Handle SIGTERM for graceful shutdown on operator stop (#3410)
+
+- [#3515](https://github.com/near/mpc/pull/3515)(@gilcu3): Add asset id checks for follower paths (#3515)
+
+- [#3519](https://github.com/near/mpc/pull/3519)(@gilcu3): Outgoing connection hanging on unstable network (#3519)
+
+- [#3486](https://github.com/near/mpc/pull/3486)(@barakeinav1): *(node)* Drain embedded near-indexer thread on graceful shutdown (#3486)
+
+- [#3491](https://github.com/near/mpc/pull/3491)(@DSharifi): *(contract)* Add auth check to `remove_non_participant_update_votes`  (#3491)
+
+- [#3532](https://github.com/near/mpc/pull/3532)(@gilcu3): Make sure localnet launcher script kills processes successfully (#3532)
+
+- [#3533](https://github.com/near/mpc/pull/3533)(@barakeinav1): *(tdx)* Default state sync to Peers (DSS); require tier3_public_addr (#3533)
+
+- [#3560](https://github.com/near/mpc/pull/3560)(@gilcu3): *(test)* Remove time bomb from e2e tests (#3560)
+
+
+### 🚜 Refactor
+
+- [#3497](https://github.com/near/mpc/pull/3497)(@kevindeforth): RecentBlocksTracker uses types from chain gateway crate (#3497)
+
+- [#3498](https://github.com/near/mpc/pull/3498)(@kevindeforth): Move recent blocks tracker to chain-gateway crate (#3498)
+
+- [#3344](https://github.com/near/mpc/pull/3344)(@SimonRastikian): Cleaning up the test_utils.rs in threshold signatures crate (#3344)
+
+
+### 📚 Documentation
+
+- [#3458](https://github.com/near/mpc/pull/3458)(@barakeinav1): Require every CVM port (incl. migration `:8079`) bound to a dedicated IP (#3458)
+
+- [#3488](https://github.com/near/mpc/pull/3488)(@barakeinav1): Design doc for auto-removal of unused launcher image hashes (#3488)
+
+- [#3558](https://github.com/near/mpc/pull/3558)(@SimonRastikian): Adding unsaid bits in the contract interface (#3558)
+
+
+### ⚙️ Miscellaneous Tasks
+
+- [#3506](https://github.com/near/mpc/pull/3506)(@barakeinav1): *(tdx)* Default to DSS-first state sync in operator setup (#3506)
+
+- [#3530](https://github.com/near/mpc/pull/3530)(@gilcu3): Align devnet with the workspace deps (#3530)
+
+- [#3544](https://github.com/near/mpc/pull/3544)(@dependabot[bot]): Bump thread-priority from 1.2.0 to 3.0.0 (#3544)
+
+- [#3542](https://github.com/near/mpc/pull/3542)(@dependabot[bot]): Bump the rust-minor-and-patch group across 1 directory with 4 updates (#3542)
+
+- [#3528](https://github.com/near/mpc/pull/3528)(@anodar): Bump protocol version in genesis for localnet deployment (#3528)
+
+- [#3168](https://github.com/near/mpc/pull/3168)(@barakeinav1): *(tee)* Address PR #3155 follow-up nits (#3168)
+
+
 ## [3.11.0] - 2026-05-27
 
 ### 🚀 Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,7 +36,7 @@ This changelog is maintained using [git-cliff](https://git-cliff.org/) and [conv
 
 - [#3486](https://github.com/near/mpc/pull/3486)(@barakeinav1): *(node)* Drain embedded near-indexer thread on graceful shutdown (#3486)
 
-- [#3491](https://github.com/near/mpc/pull/3491)(@DSharifi): *(contract)* Add auth check to `remove_non_participant_update_votes`  (#3491)
+- [#3491](https://github.com/near/mpc/pull/3491)(@DSharifi): *(contract)* Add auth check to `remove_non_participant_update_votes` (#3491)
 
 - [#3532](https://github.com/near/mpc/pull/3532)(@gilcu3): Make sure localnet launcher script kills processes successfully (#3532)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,7 +973,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "attestation"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -992,7 +992,7 @@ dependencies = [
 
 [[package]]
 name = "attestation-cli"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -1200,7 +1200,7 @@ dependencies = [
 
 [[package]]
 name = "backup-cli"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -1770,7 +1770,7 @@ dependencies = [
 
 [[package]]
 name = "chain-gateway"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "base64 0.22.1",
@@ -1805,7 +1805,7 @@ dependencies = [
 
 [[package]]
 name = "chain-gateway-test-contract"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "borsh",
  "derive_more 2.1.1",
@@ -1866,7 +1866,7 @@ dependencies = [
 
 [[package]]
 name = "ckd-example-cli"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "blstrs",
@@ -2112,7 +2112,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "contract-history"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "bs58 0.5.1",
  "reqwest 0.13.4",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "e2e-tests"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "backon",
@@ -3673,7 +3673,7 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "foreign-chain-inspector"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "derive_more 2.1.1",
@@ -3697,7 +3697,7 @@ dependencies = [
 
 [[package]]
 name = "foreign-chain-rpc-interfaces"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "derive_more 2.1.1",
  "ethereum-types",
@@ -4774,7 +4774,7 @@ dependencies = [
 
 [[package]]
 name = "include-measurements"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "attestation",
@@ -5281,7 +5281,7 @@ dependencies = [
 
 [[package]]
 name = "launcher-interface"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "derive_more 2.1.1",
@@ -5725,7 +5725,7 @@ checksum = "7843ec2de400bcbc6a6328c958dc38e5359da6e93e72e37bc5246bf1ae776389"
 
 [[package]]
 name = "mpc-attestation"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "attestation",
@@ -5745,7 +5745,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-contract"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5793,7 +5793,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-devnet"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "blstrs",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5924,7 +5924,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-node-config"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-primitives"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "borsh",
@@ -5963,7 +5963,7 @@ dependencies = [
 
 [[package]]
 name = "mpc-tls"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "ed25519-dalek",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "node-types"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "mpc-attestation",
  "near-mpc-crypto-types",
@@ -11022,7 +11022,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tee-authority"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "anyhow",
  "assert_matches",
@@ -11049,7 +11049,7 @@ dependencies = [
 
 [[package]]
 name = "tee-context"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "chain-gateway",
@@ -11066,7 +11066,7 @@ dependencies = [
 
 [[package]]
 name = "tee-launcher"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "backon",
@@ -11087,7 +11087,7 @@ dependencies = [
 
 [[package]]
 name = "tee-verifier"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "borsh",
  "dcap-qvl",
@@ -11102,7 +11102,7 @@ dependencies = [
 
 [[package]]
 name = "tee-verifier-interface"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "borsh",
  "derive_more 2.1.1",
@@ -11171,7 +11171,7 @@ dependencies = [
 
 [[package]]
 name = "test-migration-contract"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "borsh",
  "near-sdk",
@@ -11179,7 +11179,7 @@ dependencies = [
 
 [[package]]
 name = "test-parallel-contract"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "assert_matches",
  "blstrs",
@@ -11194,7 +11194,7 @@ dependencies = [
 
 [[package]]
 name = "test-port-allocator"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "named-lock",
  "rand 0.8.6",
@@ -11202,7 +11202,7 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "3.11.0"
+version = "3.12.0"
 dependencies = [
  "cargo-near-build",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ members = [
 ]
 
 [workspace.package]
-version = "3.11.0"
+version = "3.12.0"
 edition = "2024"
 license = "MIT"
 repository = "https://github.com/near/mpc"

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -6,7 +6,7 @@ expression: abi
   "schema_version": "0.4.0",
   "metadata": {
     "name": "mpc-contract",
-    "version": "3.11.0",
+    "version": "3.12.0",
     "build": {
       "compiler": "[RUSTC_VERSION]",
       "builder": "[CARGO_NEAR_BUILD_VERSION]"

--- a/third-party-licenses/licenses.html
+++ b/third-party-licenses/licenses.html
@@ -44,10 +44,10 @@
 
         <h2>Overview of licenses:</h2>
         <ul class="licenses-overview">
-            <li><a href="#Apache-2.0">Apache License 2.0</a> (738)</li>
-            <li><a href="#MIT">MIT License</a> (220)</li>
+            <li><a href="#Apache-2.0">Apache License 2.0</a> (707)</li>
+            <li><a href="#MIT">MIT License</a> (217)</li>
             <li><a href="#Unicode-3.0">Unicode License v3</a> (19)</li>
-            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (10)</li>
+            <li><a href="#MPL-2.0">Mozilla Public License 2.0</a> (11)</li>
             <li><a href="#BSD-3-Clause">BSD 3-Clause &quot;New&quot; or &quot;Revised&quot; License</a> (7)</li>
             <li><a href="#CC0-1.0">Creative Commons Zero v1.0 Universal</a> (7)</li>
             <li><a href="#ISC">ISC License</a> (7)</li>
@@ -693,6 +693,8 @@
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/RustCrypto/utils ">cmov 0.5.4</a></li>
+                    <li><a href=" https://github.com/RustCrypto/utils ">ctutils 0.4.2</a></li>
                     <li><a href=" https://github.com/ModProg/derive-where ">derive-where 1.6.1</a></li>
                     <li><a href=" https://github.com/tormol/encode_unicode ">encode_unicode 1.0.0</a></li>
                     <li><a href=" https://github.com/hsivonen/encoding_rs ">encoding_rs 0.8.35</a></li>
@@ -1355,21 +1357,13 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-bforest 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-bforest 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-codegen-shared 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-codegen-shared 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-codegen 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-codegen 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-control 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-control 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-entity 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-entity 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-frontend 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-frontend 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-native 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-native 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/regalloc2 ">regalloc2 0.12.2</a></li>
                     <li><a href=" https://github.com/bytecodealliance/regalloc2 ">regalloc2 0.15.1</a></li>
                     <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.12.16</a></li>
                     <li><a href=" https://github.com/bytecodealliance/target-lexicon ">target-lexicon 0.13.5</a></li>
@@ -1378,13 +1372,9 @@ Software.
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.78.2</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.99.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter ">wasmprinter 0.2.57</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-environ 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-environ 45.0.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-cranelift 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-cranelift 45.0.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-unwinder 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-unwinder 45.0.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime 45.0.0</a></li>
                 </ul>
                 <pre class="license-text">
@@ -1613,47 +1603,45 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-collections 0.2.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.53.0</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.62.2</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-core 0.61.2</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-future 0.2.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-implement 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-interface 0.59.3</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.1.3</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-link 0.2.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-numerics 0.2.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-registry 0.6.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.1.2</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.3.4</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-result 0.4.1</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.4.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-strings 0.5.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.45.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.52.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.59.0</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.60.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-sys 0.61.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-targets 0.53.5</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows-threading 0.1.0</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.53.0</a></li>
+                    <li><a href=" https://github.com/microsoft/windows-rs ">windows 0.61.3</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_aarch64_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_i686_msvc 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnu 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_gnullvm 0.53.1</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.42.2</a></li>
                     <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.52.6</a></li>
-                    <li><a href=" https://github.com/microsoft/windows-rs ">windows_x86_64_msvc 0.53.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -3326,6 +3314,215 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
+                    <li><a href=" https://github.com/danielhenrymantilla/cfg_eval.rs ">cfg_eval 0.1.2</a></li>
+                </ul>
+                <pre class="license-text">                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      &quot;License&quot; shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      &quot;Licensor&quot; shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      &quot;Legal Entity&quot; shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      &quot;control&quot; means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      &quot;You&quot; (or &quot;Your&quot;) shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      &quot;Source&quot; form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      &quot;Object&quot; form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      &quot;Work&quot; shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      &quot;Derivative Works&quot; shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      &quot;Contribution&quot; shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, &quot;submitted&quot;
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as &quot;Not a Contribution.&quot;
+
+      &quot;Contributor&quot; shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a &quot;NOTICE&quot; text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an &quot;AS IS&quot; BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets &quot;[]&quot;
+      replaced with your own identifying information. (Don&#x27;t include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same &quot;printed page&quot; as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2023 Daniel Henry-Mantilla &lt;daniel.henry.mantilla@gmail.com&gt;
+
+   Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="Apache-2.0">Apache License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
                     <li><a href=" https://github.com/polarsignals/rust-jemalloc-pprof ">jemalloc_pprof 0.4.2</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -4163,61 +4360,49 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-async-derive 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-async 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-cache 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chain-primitives 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chunks-primitives 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-client-primitives 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-dyn-configs 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-external-storage 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-fmt 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-indexer-primitives 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-o11y 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-parameters 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-pool 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-stdx 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-store 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-time 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">node-runtime 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/near-account-id ">near-account-id 1.1.4</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-async-derive 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-async 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-cache 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chain-primitives 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chunks-primitives 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-client-primitives 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-crypto 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-dyn-configs 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-external-storage 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-fmt 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-indexer-primitives 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-o11y 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-parameters 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-pool 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-stdx 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-store 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-time 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">node-runtime 2.12.0</a></li>
                     <li><a href=" https://github.com/near/near-account-id ">near-account-id 2.6.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-crypto 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-fmt 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-fmt 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-o11y 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-parameters 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-parameters 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-primitives 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-stdx 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-stdx 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-time 0.28.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-time 0.35.0</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 0.35.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chain-configs 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-config-utils 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-crypto 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-fmt 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-primitives 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-o11y 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-parameters 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives-core 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-primitives 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-core 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-lib 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-schema-checker-macro 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-stdx 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-time 0.36.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-runner 0.36.0</a></li>
                     <li><a href=" https://github.com/juhaku/utoipa ">utoipa-gen 5.4.0</a></li>
                     <li><a href=" https://github.com/juhaku/utoipa ">utoipa-swagger-ui 9.0.2</a></li>
                     <li><a href=" https://github.com/juhaku/utoipa ">utoipa 5.4.0</a></li>
@@ -5069,6 +5254,7 @@ Software.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/krisprice/ipnet ">ipnet 2.12.0</a></li>
+                    <li><a href=" https://github.com/tiborschneider/prefix-trie ">prefix-trie 0.8.4</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -5277,7 +5463,6 @@ Software.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/tikv/rust-prometheus ">prometheus 0.13.4</a></li>
                     <li><a href=" https://github.com/tikv/rust-prometheus ">prometheus 0.14.0</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
@@ -5713,7 +5898,6 @@ Software.
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder 0.20.2</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder_core 0.20.2</a></li>
                     <li><a href=" https://github.com/colin-kiegel/rust-derive-builder ">derive_builder_macro 0.20.2</a></li>
-                    <li><a href=" https://github.com/bluejekyll/enum-as-inner ">enum-as-inner 0.6.1</a></li>
                     <li><a href=" https://github.com/rust-cli/env_logger ">env_filter 1.0.1</a></li>
                     <li><a href=" https://github.com/rust-cli/env_logger ">env_logger 0.11.10</a></li>
                     <li><a href=" https://github.com/near/finite-wasm ">finite-wasm 0.5.0</a></li>
@@ -6161,8 +6345,9 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hickory-dns/hickory-dns ">hickory-proto 0.25.2</a></li>
-                    <li><a href=" https://github.com/hickory-dns/hickory-dns ">hickory-resolver 0.25.2</a></li>
+                    <li><a href=" https://github.com/hickory-dns/hickory-dns ">hickory-net 0.26.1</a></li>
+                    <li><a href=" https://github.com/hickory-dns/hickory-dns ">hickory-proto 0.26.1</a></li>
+                    <li><a href=" https://github.com/hickory-dns/hickory-dns ">hickory-resolver 0.26.1</a></li>
                 </ul>
                 <pre class="license-text">                                 Apache License
                            Version 2.0, January 2004
@@ -7008,7 +7193,7 @@ limitations under the License.</pre>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.12.28</a></li>
-                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.13.3</a></li>
+                    <li><a href=" https://github.com/seanmonstar/reqwest ">reqwest 0.13.4</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -7426,8 +7611,7 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/http ">http 0.2.12</a></li>
-                    <li><a href=" https://github.com/hyperium/http ">http 1.4.0</a></li>
+                    <li><a href=" https://github.com/hyperium/http ">http 1.4.1</a></li>
                 </ul>
                 <pre class="license-text">                              Apache License
                         Version 2.0, January 2004
@@ -9778,7 +9962,7 @@ limitations under the License.
                     <li><a href=" https://github.com/rusticata/der-parser.git ">der-parser 9.0.0</a></li>
                     <li><a href=" https://github.com/rust-fuzz/arbitrary ">derive_arbitrary 1.4.2</a></li>
                     <li><a href=" https://github.com/yaahc/displaydoc ">displaydoc 0.2.5</a></li>
-                    <li><a href=" https://github.com/rayon-rs/either ">either 1.15.0</a></li>
+                    <li><a href=" https://github.com/rayon-rs/either ">either 1.16.0</a></li>
                     <li><a href=" https://github.com/Lymia/enumset ">enumset 1.1.10</a></li>
                     <li><a href=" https://github.com/Lymia/enumset ">enumset_derive 0.14.0</a></li>
                     <li><a href=" https://github.com/indexmap-rs/equivalent ">equivalent 1.0.2</a></li>
@@ -9886,20 +10070,20 @@ limitations under the License.
                     <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework-sys 2.17.0</a></li>
                     <li><a href=" https://github.com/kornelski/rust-security-framework ">security-framework 3.7.0</a></li>
                     <li><a href=" https://github.com/rust-embedded-community/serde-json-core ">serde-json-core 0.6.0</a></li>
-                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.20.0</a></li>
-                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.20.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with 3.21.0</a></li>
+                    <li><a href=" https://github.com/jonasbb/serde_with/ ">serde_with_macros 3.21.0</a></li>
                     <li><a href=" https://github.com/vorner/signal-hook ">signal-hook-registry 1.4.8</a></li>
+                    <li><a href=" https://github.com/seancroach/simd_cesu8 ">simd_cesu8 1.1.1</a></li>
                     <li><a href=" https://github.com/mitsuhiko/similar ">similar 2.7.0</a></li>
                     <li><a href=" https://github.com/servo/rust-smallvec ">smallvec 1.15.1</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.5.10</a></li>
-                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.3</a></li>
+                    <li><a href=" https://github.com/rust-lang/socket2 ">socket2 0.6.4</a></li>
                     <li><a href=" https://github.com/storyyeller/stable_deref_trait ">stable_deref_trait 1.2.1</a></li>
                     <li><a href=" https://github.com/Stebalien/str_stack ">str_stack 0.1.0</a></li>
                     <li><a href=" https://github.com/webrtc-rs/webrtc/tree/master/stun ">stun 0.7.0</a></li>
                     <li><a href=" https://github.com/dtolnay/syn ">syn 1.0.109</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration-sys 0.6.0</a></li>
                     <li><a href=" https://github.com/mullvad/system-configuration-rs ">system-configuration 0.7.0</a></li>
-                    <li><a href=" https://github.com/alexcrichton/tar-rs ">tar 0.4.45</a></li>
+                    <li><a href=" https://github.com/composefs/tar-rs ">tar 0.4.46</a></li>
                     <li><a href=" https://github.com/Stebalien/tempfile ">tempfile 3.27.0</a></li>
                     <li><a href=" https://github.com/Amanieu/thread_local-rs ">thread_local 1.1.9</a></li>
                     <li><a href=" https://github.com/rust-threadpool/rust-threadpool ">threadpool 1.8.1</a></li>
@@ -10773,7 +10957,6 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/RustCrypto/hashes ">blake2 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.10.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.12.0</a></li>
-                    <li><a href=" https://github.com/RustCrypto/utils ">block-buffer 0.9.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/stream-ciphers ">chacha20 0.10.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">cipher 0.4.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats ">const-oid 0.10.2</a></li>
@@ -10783,22 +10966,19 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/RustCrypto/crypto-bigint ">crypto-bigint 0.5.5</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.1.7</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">crypto-common 0.2.1</a></li>
-                    <li><a href=" https://github.com/RustCrypto/traits ">crypto-mac 0.9.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/block-modes ">ctr 0.9.2</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der ">der 0.7.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/der/derive ">der_derive 0.7.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.10.7</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">digest 0.11.2</a></li>
-                    <li><a href=" https://github.com/RustCrypto/traits ">digest 0.9.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits/tree/master/elliptic-curve ">elliptic-curve 0.13.8</a></li>
                     <li><a href=" https://github.com/RustCrypto/universal-hashes ">ghash 0.5.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.12.1</a></li>
-                    <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.9.0</a></li>
+                    <li><a href=" https://github.com/RustCrypto/MACs ">hmac 0.13.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/hybrid-array ">hybrid-array 0.4.10</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">inout 0.1.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/k256 ">k256 0.13.4</a></li>
                     <li><a href=" https://github.com/RustCrypto/sponges/tree/master/keccak ">keccak 0.1.6</a></li>
-                    <li><a href=" https://github.com/RustCrypto/sponges ">keccak 0.2.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">md-5 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/utils ">opaque-debug 0.3.1</a></li>
                     <li><a href=" https://github.com/RustCrypto/elliptic-curves/tree/master/p256 ">p256 0.13.2</a></li>
@@ -10811,9 +10991,7 @@ limitations under the License.</pre>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha1 0.10.6</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.10.9</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.11.0</a></li>
-                    <li><a href=" https://github.com/RustCrypto/hashes ">sha2 0.9.9</a></li>
                     <li><a href=" https://github.com/RustCrypto/hashes ">sha3 0.10.8</a></li>
-                    <li><a href=" https://github.com/RustCrypto/hashes ">sha3 0.11.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits/tree/master/signature ">signature 2.2.0</a></li>
                     <li><a href=" https://github.com/RustCrypto/formats/tree/master/spki ">spki 0.7.3</a></li>
                     <li><a href=" https://github.com/RustCrypto/traits ">universal-hash 0.5.1</a></li>
@@ -12555,22 +12733,22 @@ limitations under the License.
                 <h3 id="Apache-2.0">Apache License 2.0</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">nearcore 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-chunks 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-client 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-epoch-manager 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-indexer 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-client-internal 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-mainnet-res 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-network 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-rosetta-rpc 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-telemetry 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-engine 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-types 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-vm 2.12.0-rc.2</a></li>
-                    <li><a href=" https://github.com/near/nearcore ">near-wallet-contract 2.12.0-rc.2</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">nearcore 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-chunks 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-client 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-epoch-manager 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-indexer 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc-client-internal 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-jsonrpc 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-mainnet-res 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-network 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-rosetta-rpc 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-telemetry 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-engine 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-types 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-vm 2.12.0</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-wallet-contract 2.12.0</a></li>
                     <li><a href=" https://github.com/zakarumych/allocator-api2 ">allocator-api2 0.2.21</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-consensus-any 1.0.42</a></li>
                     <li><a href=" https://github.com/alloy-rs/alloy ">alloy-consensus 1.0.42</a></li>
@@ -12607,15 +12785,13 @@ limitations under the License.
                     <li><a href=" https://github.com/filecoin-project/blstrs ">blstrs 0.7.1</a></li>
                     <li><a href=" https://github.com/elastio/bon ">bon-macros 3.9.1</a></li>
                     <li><a href=" https://github.com/elastio/bon ">bon 3.9.1</a></li>
-                    <li><a href=" https://github.com/near/cargo-near ">cargo-near-build 0.11.1</a></li>
+                    <li><a href=" https://github.com/near/cargo-near ">cargo-near-build 0.11.3</a></li>
                     <li><a href=" https://github.com/emk/cesu8-rs ">cesu8 1.1.0</a></li>
                     <li><a href=" https://github.com/Nullus157/async-compression ">compression-codecs 0.4.37</a></li>
                     <li><a href=" https://github.com/Nullus157/async-compression ">compression-core 0.4.31</a></li>
                     <li><a href=" https://github.com/danipopes/const-hex ">const-hex 1.18.1</a></li>
                     <li><a href=" https://github.com/cesarb/constant_time_eq ">constant_time_eq 0.4.2</a></li>
-                    <li><a href=" https://crates.io/crates/cranelift-assembler-x64 ">cranelift-assembler-x64 0.123.8</a></li>
                     <li><a href=" https://crates.io/crates/cranelift-assembler-x64 ">cranelift-assembler-x64 0.132.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-bitset 0.123.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">cranelift-bitset 0.132.0</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.3.7</a></li>
                     <li><a href=" https://github.com/dirs-dev/dirs-sys-rs ">dirs-sys 0.5.0</a></li>
@@ -12647,7 +12823,9 @@ limitations under the License.
                     <li><a href=" https://github.com/bkchr/impl-trait-for-tuples ">impl-trait-for-tuples 0.2.3</a></li>
                     <li><a href=" https://github.com/yaahc/indenter ">indenter 0.3.4</a></li>
                     <li><a href=" https://github.com/dtolnay/itoa ">itoa 1.0.18</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni-macros 0.22.4</a></li>
                     <li><a href=" https://github.com/jni-rs/jni-sys ">jni-sys-macros 0.4.1</a></li>
+                    <li><a href=" https://github.com/jni-rs/jni-rs ">jni 0.22.4</a></li>
                     <li><a href=" https://github.com/rust-lang/libc ">libc 0.2.186</a></li>
                     <li><a href=" https://github.com/LukasKalbertodt/litrs ">litrs 1.0.0</a></li>
                     <li><a href=" https://github.com/JohnTitor/mach2 ">mach2 0.4.3</a></li>
@@ -12655,12 +12833,19 @@ limitations under the License.
                     <li><a href=" https://github.com/polarsignals/rust-jemalloc-pprof ">mappings 0.5.1</a></li>
                     <li><a href=" https://github.com/stainless-steel/md5 ">md5 0.7.0</a></li>
                     <li><a href=" https://github.com/Frommi/miniz_oxide/tree/master/miniz_oxide ">miniz_oxide 0.8.9</a></li>
-                    <li><a href=" https://github.com/near/near-jsonrpc-client-rs ">near-jsonrpc-client 0.15.1</a></li>
-                    <li><a href=" https://github.com/r-near/near-kit-rs ">near-kit-macros 0.7.2</a></li>
-                    <li><a href=" https://github.com/r-near/near-kit-rs ">near-kit 0.7.2</a></li>
-                    <li><a href=" https://github.com/near/near-sandbox-rs ">near-sandbox 0.3.9</a></li>
-                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk-macros 5.26.1</a></li>
-                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk 5.26.1</a></li>
+                    <li><a href=" https://github.com/rust-windowing/android-ndk-rs ">ndk-context 0.1.1</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-crypto-hash 0.1.0</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-crypto-hash 0.2.0</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-global-contracts 0.1.1</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-global-contracts 0.2.0</a></li>
+                    <li><a href=" https://github.com/near/near-jsonrpc-client-rs ">near-jsonrpc-client 0.21.1</a></li>
+                    <li><a href=" https://github.com/r-near/near-kit-rs ">near-kit-macros 0.11.0</a></li>
+                    <li><a href=" https://github.com/r-near/near-kit-rs ">near-kit 0.11.0</a></li>
+                    <li><a href=" https://github.com/near/near-sandbox-rs ">near-sandbox 0.3.11</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk-core 4.1.1</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk-env 0.1.0</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk-macros 5.28.0</a></li>
+                    <li><a href=" https://github.com/near/near-sdk-rs ">near-sdk 5.28.0</a></li>
                     <li><a href=" https://github.com/near/near-sdk-rs ">near-sys 0.2.9</a></li>
                     <li><a href=" https://github.com/jhpratt/num-conv ">num-conv 0.2.2</a></li>
                     <li><a href=" https://github.com/illicitonion/num_enum ">num_enum 0.7.6</a></li>
@@ -12678,9 +12863,7 @@ limitations under the License.
                     <li><a href=" https://crates.io/crates/primitive-types ">primitive-types 0.10.1</a></li>
                     <li><a href=" https://github.com/paritytech/parity-common ">primitive-types 0.14.0</a></li>
                     <li><a href=" https://github.com/dtolnay/proc-macro2 ">proc-macro2 1.0.106</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime/tree/main/pulley ">pulley-interpreter 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime/tree/main/pulley ">pulley-interpreter 45.0.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime/tree/main/pulley/macros ">pulley-macros 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime/tree/main/pulley/macros ">pulley-macros 45.0.0</a></li>
                     <li><a href=" https://github.com/dtolnay/quote ">quote 1.0.45</a></li>
                     <li><a href=" https://github.com/r-efi/r-efi ">r-efi 5.3.0</a></li>
@@ -12708,7 +12891,7 @@ limitations under the License.
                     <li><a href=" https://github.com/serde-rs/serde ">serde_derive 1.0.228</a></li>
                     <li><a href=" https://github.com/serde-rs/serde ">serde_derive_internals 0.29.1</a></li>
                     <li><a href=" https://github.com/dtolnay/serde-ignored ">serde_ignored 0.1.14</a></li>
-                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.149</a></li>
+                    <li><a href=" https://github.com/serde-rs/json ">serde_json 1.0.150</a></li>
                     <li><a href=" https://github.com/dtolnay/path-to-error ">serde_path_to_error 0.1.20</a></li>
                     <li><a href=" https://github.com/dtolnay/serde-repr ">serde_repr 0.1.20</a></li>
                     <li><a href=" https://github.com/nox/serde_urlencoded ">serde_urlencoded 0.7.1</a></li>
@@ -12740,14 +12923,8 @@ limitations under the License.
                     <li><a href=" https://github.com/MattiasBuelens/wasm-streams/ ">wasm-streams 0.5.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.228.0</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmparser ">wasmparser 0.236.1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasm-tools/tree/main/crates/wasmprinter ">wasmprinter 0.236.1</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-asm-macros 36.0.8</a></li>
                     <li><a href=" https://crates.io/crates/wasmtime-internal-core ">wasmtime-internal-core 45.0.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-jit-icache-coherence 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-jit-icache-coherence 45.0.0</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-math 36.0.8</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-slab 36.0.8</a></li>
-                    <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-versioned-export-macros 36.0.8</a></li>
                     <li><a href=" https://github.com/bytecodealliance/wasmtime ">wasmtime-internal-versioned-export-macros 45.0.0</a></li>
                     <li><a href=" https://github.com/VoidStarKat/widestring-rs ">widestring 1.2.1</a></li>
                     <li><a href=" https://github.com/retep998/winapi-rs ">winapi-i686-pc-windows-gnu 0.4.0</a></li>
@@ -14597,33 +14774,6 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 0.14.32</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2014-2021 Sean McArthur
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the &quot;Software&quot;), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
                     <li><a href=" https://github.com/hyperium/headers ">headers-core 0.3.0</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2023 Sean McArthur
@@ -14680,7 +14830,7 @@ THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.9.0</a></li>
+                    <li><a href=" https://github.com/hyperium/hyper ">hyper 1.10.1</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2014-2026 Sean McArthur
 
@@ -14845,6 +14995,7 @@ SOFTWARE.</pre>
                 <ul class="license-used-by">
                     <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.2.16</a></li>
                     <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.5.18</a></li>
+                    <li><a href=" https://gitlab.redox-os.org/redox-os/syscall ">redox_syscall 0.7.3</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 Redox OS Developers
 
@@ -14874,7 +15025,7 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.13</a></li>
+                    <li><a href=" https://github.com/hyperium/h2 ">h2 0.4.14</a></li>
                 </ul>
                 <pre class="license-text">Copyright (c) 2017 h2 authors
 
@@ -15093,39 +15244,6 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-</pre>
-            </li>
-            <li class="license">
-                <h3 id="MIT">MIT License</h3>
-                <h4>Used by:</h4>
-                <ul class="license-used-by">
-                    <li><a href=" https://github.com/hyperium/http-body ">http-body 0.4.6</a></li>
-                </ul>
-                <pre class="license-text">Copyright (c) 2019 Hyper Contributors
-
-Permission is hereby granted, free of charge, to any
-person obtaining a copy of this software and associated
-documentation files (the &quot;Software&quot;), to deal in the
-Software without restriction, including without
-limitation the rights to use, copy, modify, merge,
-publish, distribute, sublicense, and/or sell copies of
-the Software, and to permit persons to whom the Software
-is furnished to do so, subject to the following
-conditions:
-
-The above copyright notice and this permission notice
-shall be included in all copies or substantial portions
-of the Software.
-
-THE SOFTWARE IS PROVIDED &quot;AS IS&quot;, WITHOUT WARRANTY OF
-ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
-TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
-PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
-SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
-IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
 </pre>
             </li>
             <li class="license">
@@ -15772,7 +15890,6 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/idanarye/rust-smart-default ">smart-default 0.6.0</a></li>
                     <li><a href=" https://github.com/idanarye/rust-smart-default ">smart-default 0.7.1</a></li>
                 </ul>
                 <pre class="license-text">MIT License
@@ -15840,6 +15957,7 @@ SOFTWARE.
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/iddm/thread-priority ">thread-priority 1.2.0</a></li>
+                    <li><a href=" https://github.com/iddm/thread-priority ">thread-priority 3.0.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -16163,7 +16281,7 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler-singlepass 2.12.0-rc.2</a></li>
+                    <li><a href=" https://github.com/near/nearcore ">near-vm-compiler-singlepass 2.12.0</a></li>
                 </ul>
                 <pre class="license-text">MIT License
 
@@ -16662,43 +16780,43 @@ SOFTWARE.
                 <h3 id="MIT">MIT License</h3>
                 <h4>Used by:</h4>
                 <ul class="license-used-by">
-                    <li><a href=" https://crates.io/crates/attestation ">attestation 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/attestation-cli ">attestation-cli 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/backup-cli ">backup-cli 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/chain-gateway ">chain-gateway 3.11.0</a></li>
-                    <li><a href=" https://github.com/near/mpc ">chain-gateway-test-contract 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/ckd-example-cli ">ckd-example-cli 3.11.0</a></li>
-                    <li><a href=" https://github.com/near/mpc ">mpc-contract 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/contract-history ">contract-history 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-devnet ">mpc-devnet 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/e2e-tests ">e2e-tests 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/foreign-chain-inspector ">foreign-chain-inspector 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/foreign-chain-rpc-interfaces ">foreign-chain-rpc-interfaces 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/include-measurements ">include-measurements 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/launcher-interface ">launcher-interface 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-attestation ">mpc-attestation 3.11.0</a></li>
+                    <li><a href=" https://crates.io/crates/attestation ">attestation 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/attestation-cli ">attestation-cli 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/backup-cli ">backup-cli 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/chain-gateway ">chain-gateway 3.12.0</a></li>
+                    <li><a href=" https://github.com/near/mpc ">chain-gateway-test-contract 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/ckd-example-cli ">ckd-example-cli 3.12.0</a></li>
+                    <li><a href=" https://github.com/near/mpc ">mpc-contract 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/contract-history ">contract-history 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-devnet ">mpc-devnet 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/e2e-tests ">e2e-tests 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/foreign-chain-inspector ">foreign-chain-inspector 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/foreign-chain-rpc-interfaces ">foreign-chain-rpc-interfaces 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/include-measurements ">include-measurements 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/launcher-interface ">launcher-interface 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-attestation ">mpc-attestation 3.12.0</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-bounded-collections 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-contract-interface 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-crypto-types 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-sdk 0.0.1</a></li>
                     <li><a href=" https://github.com/near/mpc ">near-mpc-signature-verifier 0.0.1</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-node ">mpc-node 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-node-config ">mpc-node-config 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/node-types ">node-types 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-primitives ">mpc-primitives 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/tee-authority ">tee-authority 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/tee-context ">tee-context 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/tee-launcher ">tee-launcher 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-migration-contract ">test-migration-contract 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-parallel-contract ">test-parallel-contract 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-port-allocator ">test-port-allocator 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/test-utils ">test-utils 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/mpc-tls ">mpc-tls 3.11.0</a></li>
-                    <li><a href=" https://crates.io/crates/utilities ">utilities 3.11.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-node ">mpc-node 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-node-config ">mpc-node-config 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/node-types ">node-types 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-primitives ">mpc-primitives 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-authority ">tee-authority 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-context ">tee-context 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-launcher ">tee-launcher 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-verifier ">tee-verifier 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/tee-verifier-interface ">tee-verifier-interface 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-migration-contract ">test-migration-contract 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-parallel-contract ">test-parallel-contract 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-port-allocator ">test-port-allocator 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/test-utils ">test-utils 3.12.0</a></li>
+                    <li><a href=" https://crates.io/crates/mpc-tls ">mpc-tls 3.12.0</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">aws-creds 0.38.0</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">aws-region 0.27.0</a></li>
                     <li><a href=" https://github.com/oconnor663/blake2_simd ">blake2b_simd 1.0.4</a></li>
-                    <li><a href=" https://github.com/rutrum/convert-case ">convert_case 0.4.0</a></li>
                     <li><a href=" https://crates.io/crates/dstack-sdk-types ">dstack-sdk-types 0.1.3</a></li>
                     <li><a href=" https://crates.io/crates/dstack-sdk ">dstack-sdk 0.1.3</a></li>
                     <li><a href=" https://github.com/paritytech/jsonrpsee ">jsonrpsee-http-client 0.26.0</a></li>
@@ -16707,7 +16825,6 @@ SOFTWARE.
                     <li><a href=" https://github.com/recmo/uint ">ruint-macro 1.2.1</a></li>
                     <li><a href=" https://github.com/recmo/uint ">ruint 1.17.2</a></li>
                     <li><a href=" https://github.com/durch/rust-s3 ">rust-s3 0.36.0</a></li>
-                    <li><a href=" https://github.com/dj8yfo/slipped10 ">slipped10 0.4.6</a></li>
                     <li><a href=" https://github.com/getsentry/symbolic ">symbolic-common 12.17.3</a></li>
                     <li><a href=" https://github.com/getsentry/symbolic ">symbolic-demangle 12.17.3</a></li>
                     <li><a href=" https://github.com/hyperium/tonic ">tonic-prost 0.14.5</a></li>
@@ -17207,7 +17324,6 @@ SOFTWARE.
                 <ul class="license-used-by">
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 1.0.0</a></li>
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more-impl 2.1.1</a></li>
-                    <li><a href=" https://github.com/JelteF/derive_more ">derive_more 0.99.20</a></li>
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more 1.0.0</a></li>
                     <li><a href=" https://github.com/JelteF/derive_more ">derive_more 2.1.1</a></li>
                 </ul>
@@ -18357,6 +18473,387 @@ Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
 
   This Source Code Form is &quot;Incompatible With Secondary Licenses&quot;, as
   defined by the Mozilla Public License, v. 2.0.
+</pre>
+            </li>
+            <li class="license">
+                <h3 id="MPL-2.0">Mozilla Public License 2.0</h3>
+                <h4>Used by:</h4>
+                <ul class="license-used-by">
+                    <li><a href=" https://github.com/sbstp/attohttpc ">attohttpc 0.28.5</a></li>
+                </ul>
+                <pre class="license-text">Mozilla Public License Version 2.0
+&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;&#x3D;
+
+1. Definitions
+--------------
+
+1.1. &quot;Contributor&quot;
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. &quot;Contributor Version&quot;
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor&#x27;s Contribution.
+
+1.3. &quot;Contribution&quot;
+    means Covered Software of a particular Contributor.
+
+1.4. &quot;Covered Software&quot;
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. &quot;Incompatible With Secondary Licenses&quot;
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. &quot;Executable Form&quot;
+    means any form of the work other than Source Code Form.
+
+1.7. &quot;Larger Work&quot;
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. &quot;License&quot;
+    means this document.
+
+1.9. &quot;Licensable&quot;
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. &quot;Modifications&quot;
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. &quot;Patent Claims&quot; of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. &quot;Secondary License&quot;
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. &quot;Source Code Form&quot;
+    means the form of the work preferred for making modifications.
+
+1.14. &quot;You&quot; (or &quot;Your&quot;)
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, &quot;You&quot; includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, &quot;control&quot; means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party&#x27;s
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients&#x27; rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients&#x27; rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an &quot;as is&quot;       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party&#x27;s negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party&#x27;s ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - &quot;Incompatible With Secondary Licenses&quot; Notice
+---------------------------------------------------------
+
+  This Source Code Form is &quot;Incompatible With Secondary Licenses&quot;, as
+defined by the Mozilla Public License, v. 2.0.
 </pre>
             </li>
             <li class="license">


### PR DESCRIPTION
Prepares the 3.12.0 minor release. Generated by `scripts/prepare-release.sh 3.12.0`:

- Bump workspace version 3.11.0 → 3.12.0
- New `## [3.12.0]` CHANGELOG section (git-cliff)
- Update contract ABI snapshot for the version bump
- Regenerate third-party licenses

Merging to `main` triggers the four build workflows; the Release workflow is dispatched afterward to produce the draft release.