### PR TITLE
fix: repro issues related to docker caching and skopeo versions

### DIFF
--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -100,28 +100,44 @@ buildkit_image_name="buildkit_${buildkit_version}"
 
 if ! docker buildx inspect ${buildkit_image_name} &>/dev/null; then
     docker buildx create --use --driver-opt image=moby/buildkit:v${buildkit_version} --name ${buildkit_image_name}
+else
+    # A reused builder may hold a stale local-context cache: buildkit keys
+    # context changes on (size, mtime), but the touch above resets mtime, so a
+    # changed file with unchanged size looks identical and the stale copy is
+    # reused. Prune only type=source.local to force a fresh read (base-image and
+    # apt caches are kept). A freshly created builder has no cache, so we only
+    # prune when reusing one. `|| true`: the builder's container is bootstrapped
+    # lazily on first build and may not exist yet, leaving nothing to prune.
+    docker buildx prune --builder "${buildkit_image_name}" --filter type=source.local -f >/dev/null 2>&1 || true
 fi
 
 
+# Build a reproducible image to a docker-archive tar, then load it into the
+# docker daemon. skopeo computes the manifest digest from the tar (not via the
+# docker-daemon transport), so a host daemon whose API is incompatible with the
+# skopeo version can't affect reproducibility. The daemon load is only for
+# downstream consumers (`docker run`, runtime checks) that need the image there.
 build_reproducible_image() {
   local image_name=$1
   local dockerfile_path=$2
+  local tar_path=$3
   docker buildx build --builder "${buildkit_image_name}" --no-cache \
     --build-arg SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" \
-    --output "type=docker,name=$image_name,rewrite-timestamp=true" \
+    --output "type=docker,name=$image_name,dest=$tar_path,rewrite-timestamp=true" \
     --progress plain -f "$dockerfile_path" .
+  docker load -i "$tar_path"
 }
 
-# Compress a locally built image via skopeo to a temp directory.
+# Compress a built image tar via skopeo to a temp directory.
 # Prints the temp dir path to stdout. The manifest digest can be
 # computed from $dir/manifest.json.
 skopeo_compress() {
-    local image_name="$1"
+    local tar_path="$1"
     local td
     td=$(mktemp -d)
-    # Compress the built image to a local directory, which implicitly computes
+    # Compress the image to a local directory, which implicitly computes
     # the manifest digest in $td/manifest.json
-    skopeo copy --all --dest-compress "docker-daemon:${image_name}:latest" "dir:$td" >&2
+    skopeo copy --all --dest-compress "docker-archive:${tar_path}" "dir:$td" >&2
     echo "$td"
 }
 
@@ -133,8 +149,9 @@ if $USE_RUST_LAUNCHER; then
     SOURCE_DATE_EPOCH=$SOURCE_DATE_EPOCH repro-env build --env SOURCE_DATE_EPOCH -- cargo build -p tee-launcher --profile reproducible --locked
     rust_launcher_binary_hash=$(sha256sum target/reproducible/tee-launcher | cut -d' ' -f1)
 
-    build_reproducible_image "$RUST_LAUNCHER_IMAGE_NAME" "$DOCKERFILE_RUST_LAUNCHER"
-    rust_launcher_skopeo_dir="$(skopeo_compress "$RUST_LAUNCHER_IMAGE_NAME")"
+    rust_launcher_tar="$(mktemp --suffix=.tar)"
+    build_reproducible_image "$RUST_LAUNCHER_IMAGE_NAME" "$DOCKERFILE_RUST_LAUNCHER" "$rust_launcher_tar"
+    rust_launcher_skopeo_dir="$(skopeo_compress "$rust_launcher_tar")"
     rust_launcher_manifest_digest="$(manifest_digest_from_dir "$rust_launcher_skopeo_dir")"
 fi
 
@@ -182,14 +199,16 @@ if $USE_NODE || $USE_NODE_GCP; then
 fi
 
 if $USE_NODE; then
-    build_reproducible_image "$NODE_IMAGE_NAME" "$DOCKERFILE_NODE"
-    node_skopeo_dir="$(skopeo_compress "$NODE_IMAGE_NAME")"
+    node_tar="$(mktemp --suffix=.tar)"
+    build_reproducible_image "$NODE_IMAGE_NAME" "$DOCKERFILE_NODE" "$node_tar"
+    node_skopeo_dir="$(skopeo_compress "$node_tar")"
     node_manifest_digest="$(manifest_digest_from_dir "$node_skopeo_dir")"
 fi
 
 if $USE_NODE_GCP; then
-    build_reproducible_image "$NODE_GCP_IMAGE_NAME" "$DOCKERFILE_NODE_GCP"
-    node_gcp_skopeo_dir="$(skopeo_compress "$NODE_GCP_IMAGE_NAME")"
+    node_gcp_tar="$(mktemp --suffix=.tar)"
+    build_reproducible_image "$NODE_GCP_IMAGE_NAME" "$DOCKERFILE_NODE_GCP" "$node_gcp_tar"
+    node_gcp_skopeo_dir="$(skopeo_compress "$node_gcp_tar")"
     node_gcp_manifest_digest="$(manifest_digest_from_dir "$node_gcp_skopeo_dir")"
 fi
 


### PR DESCRIPTION
Closes #3579 

Note: I left the relatively long comments here because I think they are essential to understand and justify the added steps

We are not yet pinning the version of skopeo, as it is linked to the Ubuntu version anyway. Might be needed in the future though.