### PR TITLE
docs: document back-migration known limitations

### DIFF
--- a/docs/migration-service.md
+++ b/docs/migration-service.md
@@ -488,7 +488,7 @@ https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf - pa
 
 The current back-migration flow (a node returning to the participant set after being migrated out, i.e. A → B → A) has two known limitations:
 
-1. **The returning node must be restarted between the forward and back migrations.** The migration service is designed for a single onboarding cycle and does not re-initialize for a subsequent migration without a restart. The restart also forces a fresh on-chain attestation submission, which feeds into limitation 2.
+1. **The returning node must be restarted between the forward and back migrations.** The migration service is designed for a single onboarding cycle and does not re-initialize for a subsequent migration without a restart. The restart also forces a fresh on-chain attestation submission, which resolves the second limitation outlined below.
 
 2. **The returning node's on-chain attestation must be current.** Before the contract finalizes a back-migration, it validates the destination node's TEE attestation. If the attestation has expired or been revoked while the node was out of the participant set, the contract will reject the migration. The restart in limitation 1 satisfies this in most cases; otherwise the node's periodic resubmission keeps the attestation current.
 

--- a/docs/migration-service.md
+++ b/docs/migration-service.md
@@ -478,17 +478,17 @@ See [(#949)](https://github.com/near/mpc/issues/949)
 
 > **Implementation Strategy**: Similar to MPC nodes, the backup service will first be developed as a standalone application that uses mocked attestations. This allows development and testing of the blockchain interface, contract monitoring, and automatic backup/recovery flows in a controlled environment. Once the core functionality is stable, the service can be migrated into a TEE with real attestations.
 
-## Known Limitations
-
-The current back-migration flow (a node returning to the participant set after being migrated out, i.e. A → B → A) has two known limitations:
-
-1. **The returning node must be restarted between the forward and back migrations.** The onboarding state machine in the migration service exits on first `OnboardingJob::Done` and drops the keyshare-import receiver. A node returning to the participant set therefore needs to be restarted between the forward and back directions so the migration service rebinds the receiver before the second round of keyshares can be PUT.
-
-2. **The returning node must have a valid on-chain attestation.** Before the contract finalizes a back-migration, it validates the destination node's TEE attestation. If the attestation has expired or been revoked while the node was out of the participant set, the contract will not accept the migration. Attestation freshness must be ensured before initiating the back direction.
-
 ## Materials
 
 https://nearone.slack.com/archives/C07UW93JVQ8/p1753830474083739
 NIST SP 800-56A https://csrc.nist.gov/pubs/sp/800/56/a/r3/final
 https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-56Ar3.pdf - page 105 - 106
+
+## Known Limitations
+
+The current back-migration flow (a node returning to the participant set after being migrated out, i.e. A → B → A) has two known limitations:
+
+1. **The returning node must be restarted between the forward and back migrations.** The migration service is designed for a single onboarding cycle and does not re-initialize for a subsequent migration without a restart. The restart also forces a fresh on-chain attestation submission, which feeds into limitation 2.
+
+2. **The returning node's on-chain attestation must be current.** Before the contract finalizes a back-migration, it validates the destination node's TEE attestation. If the attestation has expired or been revoked while the node was out of the participant set, the contract will reject the migration. The restart in limitation 1 satisfies this in most cases; otherwise the node's periodic resubmission keeps the attestation current.
 

--- a/docs/migration-service.md
+++ b/docs/migration-service.md
@@ -478,6 +478,14 @@ See [(#949)](https://github.com/near/mpc/issues/949)
 
 > **Implementation Strategy**: Similar to MPC nodes, the backup service will first be developed as a standalone application that uses mocked attestations. This allows development and testing of the blockchain interface, contract monitoring, and automatic backup/recovery flows in a controlled environment. Once the core functionality is stable, the service can be migrated into a TEE with real attestations.
 
+## Known Limitations
+
+The current back-migration flow (a node returning to the participant set after being migrated out, i.e. A → B → A) has two known limitations:
+
+1. **The returning node must be restarted between the forward and back migrations.** The onboarding state machine in the migration service exits on first `OnboardingJob::Done` and drops the keyshare-import receiver. A node returning to the participant set therefore needs to be restarted between the forward and back directions so the migration service rebinds the receiver before the second round of keyshares can be PUT.
+
+2. **The returning node must have a valid on-chain attestation.** Before the contract finalizes a back-migration, it validates the destination node's TEE attestation. If the attestation has expired or been revoked while the node was out of the participant set, the contract will not accept the migration. Attestation freshness must be ensured before initiating the back direction.
+
 ## Materials
 
 https://nearone.slack.com/archives/C07UW93JVQ8/p1753830474083739

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -387,4 +387,11 @@ If backup-cli cannot connect to your node:
 
 - **Verify firewall rules**: Ensure the backup service can reach the node's address and that port 8079 is open and accessible.
 
+## Known Limitations
+
+The back-migration flow (returning to a previously-active node, i.e. A → B → A) has two operator-facing limitations:
+
+1. **Node A must be restarted before back-migration.** After the forward migration A → B completes, A's migration service is no longer accepting keyshares. Before initiating the back-migration B → A, stop and start A again so the migration service is reinitialized and ready to receive keyshares from B.
+
+2. **Node A's on-chain attestation must be current.** Before the contract finalizes the back-migration, it validates A's TEE attestation. If A's attestation has expired or been revoked while A was outside the participant set, the back-migration will not complete. Verify A has a fresh attestation registered on the contract before initiating B → A.
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -391,7 +391,7 @@ If backup-cli cannot connect to your node:
 
 The back-migration flow (returning to a previously-active node, i.e. A → B → A) has two operator-facing limitations:
 
-1. **Node A must be restarted before back-migration.** After the forward migration A → B completes, A's migration service is no longer accepting keyshares. Before initiating the back-migration B → A, stop and start A again so the migration service is reinitialized and ready to receive keyshares from B.
+1. **Restart Node A before initiating the back-migration.** Stop and start A so its migration service is reinitialized and ready to receive keyshares from B. The restart also forces A to submit a fresh on-chain attestation (see next bullet).
 
-2. **Node A's on-chain attestation must be current.** Before the contract finalizes the back-migration, it validates A's TEE attestation. If A's attestation has expired or been revoked while A was outside the participant set, the back-migration will not complete. Verify A has a fresh attestation registered on the contract before initiating B → A.
+2. **A's on-chain attestation must be current.** The contract rejects the back-migration if A's attestation has expired or been revoked while A was outside the participant set. Restarting A (limitation 1) forces a fresh attestation submission immediately; otherwise, A's normal periodic resubmission updates the attestation roughly every hour.
 


### PR DESCRIPTION
Closes #3612.

Adds a "Known Limitations" appendix at the end of both:

- `docs/node-migration-guide.md` (operator-facing wording)
- `docs/migration-service.md` (design wording)

Covers the two current back-migration limitations:

1. The returning node must be restarted between forward and back migrations.
2. The returning node's on-chain TEE attestation must be current.
