### PR TITLE
chore: drop post 3.12 migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6778,7 +6778,6 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sha2 0.10.9",
- "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -15,7 +15,7 @@ use mpc_contract::{
         key_state::{AttemptId, EpochId, KeyForDomain, Keyset},
         participants::{ParticipantInfo, Participants},
         test_utils::{bogus_ed25519_public_key, infer_purpose_from_protocol},
-        thresholds::{Threshold, ThresholdParameters},
+        thresholds::{ProposedThresholdParameters, Threshold, ThresholdParameters},
     },
     tee::tee_state::NodeId,
     update::{ProposeUpdateArgs, UpdateId},
@@ -43,7 +43,7 @@ use near_workspaces::{Contract, network::Sandbox, result::ExecutionSuccess};
 use rand_core::CryptoRngCore;
 use serde_json::json;
 use signature::hazmat::PrehashSigner;
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::time::Duration;
 use tokio_util::time::FutureExt as _;
 
@@ -591,7 +591,10 @@ pub async fn execute_key_generation_and_add_random_state(
         ThresholdParameters::new(participants, Threshold::new(threshold.0 + 1)).unwrap();
     let dummy_proposal = json!({
         "prospective_epoch_id": 1,
-        "proposal": &dummy_threshold_parameters,
+        "proposal": ProposedThresholdParameters::new(
+            dummy_threshold_parameters,
+            BTreeMap::new(),
+        ),
     });
     accounts[0]
         .call(contract.id(), method_names::VOTE_NEW_PARAMETERS)

--- a/crates/contract/tests/sandbox/utils/resharing_utils.rs
+++ b/crates/contract/tests/sandbox/utils/resharing_utils.rs
@@ -4,11 +4,12 @@ use crate::sandbox::utils::{
     transactions::execute_async_transactions,
 };
 use dtos::{AttemptId, EpochId, KeyEventId};
-use mpc_contract::primitives::thresholds::ThresholdParameters;
+use mpc_contract::primitives::thresholds::{ProposedThresholdParameters, ThresholdParameters};
 use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types::{self as dtos, ProtocolContractState};
 use near_workspaces::{Account, Contract};
 use serde_json::json;
+use std::collections::BTreeMap;
 
 pub async fn conclude_resharing(
     contract: &Contract,
@@ -61,6 +62,7 @@ pub async fn vote_new_parameters(
     persistent_participants: &[Account],
     new_participants: &[Account],
 ) -> anyhow::Result<()> {
+    let proposal = ProposedThresholdParameters::new(proposal.clone(), BTreeMap::new());
     let json_args = json!({
         "prospective_epoch_id": prospective_epoch_id,
         "proposal": proposal,

--- a/crates/contract/tests/sandbox/vote.rs
+++ b/crates/contract/tests/sandbox/vote.rs
@@ -20,13 +20,14 @@ use dtos::{
 };
 use mpc_contract::primitives::{
     test_utils::infer_purpose_from_protocol,
-    thresholds::{Threshold, ThresholdParameters},
+    thresholds::{ProposedThresholdParameters, Threshold, ThresholdParameters},
 };
 use near_mpc_contract_interface::types::ReconstructionThreshold;
 use near_mpc_contract_interface::{method_names, types as dtos};
 use near_workspaces::{Account, Contract, Worker, network::Sandbox};
 use rstest::rstest;
 use serde_json::json;
+use std::collections::BTreeMap;
 
 #[tokio::test]
 async fn test_keygen() -> anyhow::Result<()> {
@@ -639,7 +640,10 @@ async fn test_cancelled_epoch_cannot_be_reused(
                 .call(contract.id(), method_names::VOTE_NEW_PARAMETERS)
                 .args_json(json!({
                     "prospective_epoch_id": cancelled_epoch_id.0,
-                    "proposal": threshold_parameters,
+                    "proposal": ProposedThresholdParameters::new(
+                        threshold_parameters.clone(),
+                        BTreeMap::new(),
+                    ),
                 }))
                 .transact()
                 .await?
@@ -808,7 +812,10 @@ async fn vote_new_parameters_errors_if_new_participant_is_missing_valid_attestat
             .max_gas()
             .args_json(json!({
                 "prospective_epoch_id": dtos::EpochId(epoch_id.0 + 1),
-                "proposal": threshold_parameters,
+                "proposal": ProposedThresholdParameters::new(
+                    threshold_parameters.clone(),
+                    BTreeMap::new(),
+                ),
             }))
             .transact()
             .await

--- a/crates/near-mpc-contract-interface/Cargo.toml
+++ b/crates/near-mpc-contract-interface/Cargo.toml
@@ -30,7 +30,6 @@ serde = { workspace = true }
 serde_repr = { workspace = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
-thiserror = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { workspace = true, optional = true }

--- a/crates/near-mpc-contract-interface/src/types/state.rs
+++ b/crates/near-mpc-contract-interface/src/types/state.rs
@@ -150,13 +150,7 @@ pub struct ThresholdParameters {
 /// keeps the current ones; a populated map must reference only existing domains
 /// (contract-validated), is applied to the `DomainRegistry` on resharing, and
 /// never persists onto the stored [`ThresholdParameters`].
-//
-// Native nested shape; serde is routed through
-// [`ProposedThresholdParametersCompat`] for wire back-compat (flat JSON), borsh
-// stays positional. The ABI reflects this nested shape, not the flat compat JSON
-// (schemars can't see serde `from`/`into`) — intentional, gone after 3.11.2.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
-#[serde(try_from = "ProposedThresholdParametersCompat")]
 #[cfg_attr(
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema)
@@ -165,48 +159,6 @@ pub struct ProposedThresholdParameters {
     pub parameters: ThresholdParameters,
     #[serde(default)]
     pub per_domain_thresholds: BTreeMap<DomainId, ReconstructionThreshold>,
-}
-
-// TODO(#3495): delete this struct after version 3.12 is deployed.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-struct ProposedThresholdParametersCompat {
-    participants: Option<Participants>,
-    threshold: Option<Threshold>,
-    parameters: Option<ThresholdParameters>,
-    per_domain_thresholds: Option<BTreeMap<DomainId, ReconstructionThreshold>>,
-}
-
-impl TryFrom<ProposedThresholdParametersCompat> for ProposedThresholdParameters {
-    type Error = ProposedThresholdParametersDecodeError;
-    fn try_from(compat: ProposedThresholdParametersCompat) -> Result<Self, Self::Error> {
-        match (
-            compat.participants,
-            compat.threshold,
-            compat.parameters,
-            compat.per_domain_thresholds,
-        ) {
-            (Some(participants), Some(threshold), None, None) => Ok(Self {
-                parameters: ThresholdParameters {
-                    participants,
-                    threshold,
-                },
-                per_domain_thresholds: BTreeMap::new(),
-            }),
-            (None, None, Some(parameters), per_domain_thresholds) => Ok(Self {
-                parameters,
-                per_domain_thresholds: per_domain_thresholds.unwrap_or(BTreeMap::new()),
-            }),
-            _ => Err(Self::Error::IncorrectShape),
-        }
-    }
-}
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum ProposedThresholdParametersDecodeError {
-    #[error(
-        "ProposedThresholdParameters must be compatible with 3.11 ThresholdParameters or 3.12 ProposedThresholdParameters"
-    )]
-    IncorrectShape,
 }
 
 // =============================================================================
@@ -501,24 +453,6 @@ mod tests {
                 },
             )],
         }
-    }
-
-    #[test]
-    #[expect(non_snake_case)]
-    fn proposed_threshold_parameters__handles_legacy_proposal_payload() {
-        // Given
-        let participants = sample_participants();
-        let legacy = serde_json::to_value(ThresholdParameters {
-            participants,
-            threshold: Threshold::new(1),
-        })
-        .unwrap();
-
-        // When
-        let parsed: ProposedThresholdParameters = serde_json::from_value(legacy).unwrap();
-
-        // Then
-        assert!(parsed.per_domain_thresholds.is_empty());
     }
 
     #[test]

--- a/crates/node/src/db.rs
+++ b/crates/node/src/db.rs
@@ -103,20 +103,7 @@ impl SecretDB {
             .into_iter()
             .collect();
         let all_cfs: Vec<&String> = known_cfs.union(&on_disk_cfs).collect();
-        let mut db = rocksdb::DB::open_cf(&options, path, &all_cfs)?;
-
-        // One-time cleanup: drop the legacy unprefixed triple column family
-        // (former `DBCol::Triple`) if a pre-3.12 binary left it on disk. Its
-        // contents are dead — every triple now lives in the per-`t`
-        // `DBCol::TripleV2`. Dropping reclaims the SST files rather than leaving
-        // tombstones behind.
-        // TODO(#3456): remove this cleanup once 3.12 has rolled out to all
-        // nodes, so no node still carries the column on disk.
-        let legacy_triple = "triple";
-        if on_disk_cfs.contains(legacy_triple) {
-            db.drop_cf(legacy_triple)?;
-            tracing::info!("Dropped legacy '{legacy_triple}' column family on startup");
-        }
+        let db = rocksdb::DB::open_cf(&options, path, &all_cfs)?;
 
         Ok(Self { db, cipher }.into())
     }
@@ -301,35 +288,6 @@ mod tests {
         );
 
         Ok(())
-    }
-
-    #[test]
-    #[expect(non_snake_case)]
-    fn secret_db_new__should_drop_legacy_triple_column_family_on_startup() {
-        // Given a DB that still carries the populated legacy "triple" column
-        // family on disk (as a pre-3.12 binary would have left it).
-        let dir = tempfile::tempdir().expect("tempdir should be created");
-        let key = [1; 16];
-        let legacy_triple = "triple";
-        {
-            let mut options = rocksdb::Options::default();
-            options.create_if_missing(true);
-            options.create_missing_column_families(true);
-            let cfs = [legacy_triple, "triple_v2", "presignature"];
-            let db = rocksdb::DB::open_cf(&options, dir.path(), cfs).expect("db should open");
-            let cf = db.cf_handle(legacy_triple).unwrap();
-            db.put_cf(&cf, b"key", b"value").unwrap();
-        }
-
-        // When the DB is opened through SecretDB and then closed.
-        {
-            let _db = SecretDB::new(dir.path(), key).expect("SecretDB should open");
-        }
-
-        // Then the legacy column family is gone from disk.
-        let options = rocksdb::Options::default();
-        let on_disk = rocksdb::DB::list_cf(&options, dir.path()).expect("list_cf should succeed");
-        assert!(!on_disk.contains(&legacy_triple.to_string()));
     }
 
     #[test]


### PR DESCRIPTION
Closes #3495 and #3456

This PR should be delete only, but it seemed we had missed a couple of places in the sandbox tests where the vote format needed to be updated. These only surface now because the backward compatibility is now gone.