### PR TITLE
fix: nits from available foreign chains work (contract changes)

### DIFF
--- a/crates/contract/src/foreign_chains_metadata.rs
+++ b/crates/contract/src/foreign_chains_metadata.rs
@@ -98,6 +98,14 @@ mod tests {
 
     use super::*;
 
+    #[cfg(all(feature = "__abi-generate", not(target_arch = "wasm32")))]
+    #[test]
+    #[expect(non_snake_case)]
+    fn foreign_chains_metadata_borsh_schema__should_not_change() {
+        let schema = borsh::schema::BorshSchemaContainer::for_type::<ForeignChainsMetadata>();
+        insta::assert_debug_snapshot!(schema);
+    }
+
     fn make_key(byte: u8) -> dtos::Ed25519PublicKey {
         dtos::Ed25519PublicKey([byte; 32])
     }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1284,8 +1284,6 @@ impl MpcContract {
 
         if let Some(new_state) = self.protocol_state.vote_cancel_resharing()? {
             self.protocol_state = new_state;
-            // Cancel-resharing reverts to the previous running state, so the
-            // cached available-chains set is still valid — no recompute needed.
         }
 
         Ok(())
@@ -1304,9 +1302,6 @@ impl MpcContract {
 
         if let Some(new_state) = self.protocol_state.vote_cancel_keygen(next_domain_id)? {
             self.protocol_state = new_state;
-            // Cancel-keygen drops incomplete domains, which can change the max ForeignTx
-            // threshold — recompute to keep the cached set consistent.
-            self.recompute_available_foreign_chains();
         }
         Ok(())
     }
@@ -1943,7 +1938,7 @@ impl MpcContract {
             metrics: Default::default(),
             node_foreign_chain_support: Default::default(),
             foreign_chains: Lazy::new(
-                StorageKey::ForeignChainAvailability,
+                StorageKey::ForeignChainMetadata,
                 ForeignChainsMetadata::default(),
             ),
         })
@@ -2014,7 +2009,7 @@ impl MpcContract {
             metrics: Default::default(),
             node_foreign_chain_support: Default::default(),
             foreign_chains: Lazy::new(
-                StorageKey::ForeignChainAvailability,
+                StorageKey::ForeignChainMetadata,
                 ForeignChainsMetadata::default(),
             ),
         })
@@ -4417,7 +4412,7 @@ mod tests {
                 node_migrations: Default::default(),
                 metrics: Default::default(),
                 foreign_chains: Lazy::new(
-                    StorageKey::ForeignChainAvailability,
+                    StorageKey::ForeignChainMetadata,
                     ForeignChainsMetadata::default(),
                 ),
             }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1063,7 +1063,7 @@ impl MpcContract {
         Ok(())
     }
 
-    /// No-op when outside 'Running' and 'Resharing'.
+    /// No-op when outside [`ProtocolContractState::Running`] and [`ProtocolContractState::Resharing`].
     fn recompute_available_foreign_chains(&mut self) {
         let Ok(params) = self.protocol_state.threshold_parameters() else {
             return;

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1063,9 +1063,7 @@ impl MpcContract {
         Ok(())
     }
 
-    /// No-op when `NotInitialized`. For `Resharing`, uses the previous running-state parameters
-    /// (the set still actively signing). For `Initializing`, uses the proposed keygen parameters —
-    /// there is no prior running set, so threshold is derived from the new domain registry.
+    /// No-op when outside 'Running' and 'Resharing'.
     fn recompute_available_foreign_chains(&mut self) {
         let Ok(params) = self.protocol_state.threshold_parameters() else {
             return;
@@ -1211,8 +1209,6 @@ impl MpcContract {
         if let Some(new_state) = self.protocol_state.vote_reshared(key_event_id)? {
             // Resharing has concluded, transition to running state
             self.protocol_state = new_state;
-            // update_cache iterates active_tls_keys only, so departed nodes' configs are
-            // already excluded — correct result even before cleanup promises run.
             self.recompute_available_foreign_chains();
 
             // Spawn a promise to clean up votes from non-participants.

--- a/crates/contract/src/snapshots/mpc_contract__foreign_chains_metadata__tests__foreign_chains_metadata_borsh_schema__should_not_change.snap
+++ b/crates/contract/src/snapshots/mpc_contract__foreign_chains_metadata__tests__foreign_chains_metadata_borsh_schema__should_not_change.snap
@@ -1,0 +1,247 @@
+---
+source: crates/contract/src/foreign_chains_metadata.rs
+expression: schema
+---
+BorshSchemaContainer {
+    declaration: "ForeignChainsMetadata",
+    definitions: {
+        "AllowedProviders": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "entries",
+                        "IterableMap",
+                    ),
+                ],
+            ),
+        },
+        "AvailableForeignChains": Struct {
+            fields: UnnamedFields(
+                [
+                    "BTreeSet<ForeignChain>",
+                ],
+            ),
+        },
+        "BTreeSet<ForeignChain>": Sequence {
+            length_width: 4,
+            length_range: 0..=4294967295,
+            elements: "ForeignChain",
+        },
+        "ForeignChain": Enum {
+            tag_width: 1,
+            variants: [
+                (
+                    0,
+                    "Solana",
+                    "ForeignChain__Solana",
+                ),
+                (
+                    1,
+                    "Bitcoin",
+                    "ForeignChain__Bitcoin",
+                ),
+                (
+                    2,
+                    "Ethereum",
+                    "ForeignChain__Ethereum",
+                ),
+                (
+                    3,
+                    "Base",
+                    "ForeignChain__Base",
+                ),
+                (
+                    4,
+                    "Bnb",
+                    "ForeignChain__Bnb",
+                ),
+                (
+                    5,
+                    "Arbitrum",
+                    "ForeignChain__Arbitrum",
+                ),
+                (
+                    6,
+                    "Abstract",
+                    "ForeignChain__Abstract",
+                ),
+                (
+                    7,
+                    "Starknet",
+                    "ForeignChain__Starknet",
+                ),
+                (
+                    8,
+                    "Polygon",
+                    "ForeignChain__Polygon",
+                ),
+                (
+                    9,
+                    "HyperEvm",
+                    "ForeignChain__HyperEvm",
+                ),
+                (
+                    10,
+                    "Ton",
+                    "ForeignChain__Ton",
+                ),
+                (
+                    11,
+                    "Aptos",
+                    "ForeignChain__Aptos",
+                ),
+            ],
+        },
+        "ForeignChainRpcWhitelist": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "entries",
+                        "AllowedProviders",
+                    ),
+                    (
+                        "votes",
+                        "ProviderVotes",
+                    ),
+                ],
+            ),
+        },
+        "ForeignChain__Abstract": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Aptos": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Arbitrum": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Base": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Bitcoin": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Bnb": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Ethereum": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__HyperEvm": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Polygon": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Solana": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Starknet": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Ton": Struct {
+            fields: Empty,
+        },
+        "ForeignChainsMetadata": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "rpc_whitelist",
+                        "ForeignChainRpcWhitelist",
+                    ),
+                    (
+                        "available_foreign_chains",
+                        "AvailableForeignChains",
+                    ),
+                    (
+                        "foreign_chains_configs",
+                        "IterableMap",
+                    ),
+                ],
+            ),
+        },
+        "IndexMap": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "prefix",
+                        "Vec<u8>",
+                    ),
+                ],
+            ),
+        },
+        "IterableMap": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "keys",
+                        "Vector",
+                    ),
+                    (
+                        "values",
+                        "LookupMap",
+                    ),
+                ],
+            ),
+        },
+        "LookupMap": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "prefix",
+                        "Vec<u8>",
+                    ),
+                ],
+            ),
+        },
+        "ProviderVotes": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "pending",
+                        "Votes<(AuthenticatedParticipantId, ForeignChain)>",
+                    ),
+                ],
+            ),
+        },
+        "Vec<u8>": Sequence {
+            length_width: 4,
+            length_range: 0..=4294967295,
+            elements: "u8",
+        },
+        "Vector": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "len",
+                        "u32",
+                    ),
+                    (
+                        "values",
+                        "IndexMap",
+                    ),
+                ],
+            ),
+        },
+        "Votes<(AuthenticatedParticipantId, ForeignChain)>": Struct {
+            fields: NamedFields(
+                [
+                    (
+                        "proposal_by_voter",
+                        "IterableMap",
+                    ),
+                    (
+                        "votes_by_proposal",
+                        "IterableMap",
+                    ),
+                ],
+            ),
+        },
+        "u32": Primitive(
+            4,
+        ),
+        "u8": Primitive(
+            1,
+        ),
+    },
+}

--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -31,5 +31,5 @@ pub enum StorageKey {
     ForeignChainProviderVotesByVoterV1,
     ForeignChainProviderVotesByProposalV1,
     ForeignChainsConfigs,
-    ForeignChainAvailability,
+    ForeignChainMetadata,
 }

--- a/crates/contract/src/v3_12_0_state.rs
+++ b/crates/contract/src/v3_12_0_state.rs
@@ -60,7 +60,7 @@ impl From<MpcContract> for crate::MpcContract {
             node_migrations: old.node_migrations,
             metrics: old.metrics,
             foreign_chains: Lazy::new(
-                StorageKey::ForeignChainAvailability,
+                StorageKey::ForeignChainMetadata,
                 ForeignChainsMetadata {
                     rpc_whitelist: old.foreign_chain_rpc_whitelist,
                     ..Default::default()


### PR DESCRIPTION
Followup on: https://github.com/near/mpc/pull/3511

- Rename Storage key `ForeignChainAvailability` to `ForeignChainMetadata` which is more suitable name for storing foreign chain metadata (shouldn't be a breaking change as we haven't deployed changes containing previous `ForeignChainAvailability` storage key)
- Add test that will detect changes in ForeignChainMetadata layout since that's stored with Lazy (raw bytes) so otherwise won't be detected until contract upgrade
- Drop recomputation of available foreign chains in vote_cancel_keygen avoid risk of running out of gas in this critical method, it now only happens 
when : 
 	- node registers foreign chains config (in register_foreign_chains_config)
 	- after key resharing concludes (in vote_reshared)
 	- when nodes vote to update/whitelist foreign chains providers (in vote_update_foreign_chain_providers)
 	- node concludes migration (conclude_node_migration)

 	