### PR TITLE
ci: reuse nix dev cache in mpc-node nix build

### DIFF
--- a/.github/workflows/nix-build-mpc-node.yml
+++ b/.github/workflows/nix-build-mpc-node.yml
@@ -29,11 +29,7 @@ jobs:
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # v22
 
       - name: Restore /nix from cache
-        uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569 # v7.0.2
-        with:
-          primary-key: nix-${{ runner.os }}-mpc-node-${{ hashFiles('flake.nix', 'flake.lock', 'nix/**', 'rust-toolchain.toml', 'Cargo.lock') }}
-          restore-prefixes-first-match: nix-${{ runner.os }}-mpc-node-
-          save: ${{ github.ref == 'refs/heads/main' }}
+        uses: ./.github/actions/restore-nix-cache
 
       - name: Build mpc-node
         run: nix build --print-build-logs .#mpc-node


### PR DESCRIPTION
Closes #3130 

By reusing cache we avoid bloating the github cache, and anyway this is not a bottleneck in CI, so win win. Reproducibility is preserved (not surprising, but tested locally anyway)