### PR TITLE
chore: Skipping specific PRs in the changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -84,6 +84,7 @@ commit_parsers = [
     { message = "^style", group = "<!-- 5 -->🎨 Styling" },
     { message = "^test", group = "<!-- 6 -->🧪 Testing" },
     { message = "^chore\\(release\\): prepare for", skip = true },
+    { message = "^release: v[0-9]+\\.[0-9]+\\.[0-9]+", skip = true },
     { message = "^chore\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },


### PR DESCRIPTION
Tiny fix for not adding release PRs in the CHANGELOG.md. cargo-cliff now skips all PRs that has the release format in the title i.e.
release: X.X.X 