### PR TITLE
refactor: unify gas type to not expose near indexer internals 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -600,9 +600,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1282,7 +1282,7 @@ dependencies = [
  "bitflags 2.11.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
@@ -1783,6 +1783,7 @@ dependencies = [
  "derive_more 2.1.1",
  "ed25519-dalek",
  "insta",
+ "mpc-call-args",
  "near-account-id",
  "near-async",
  "near-client",
@@ -1792,6 +1793,7 @@ dependencies = [
  "near-o11y 2.13.0-rc.1",
  "near-sdk",
  "near-store",
+ "near-token",
  "nearcore",
  "prometheus",
  "rand 0.8.6",
@@ -1812,7 +1814,7 @@ name = "chain-gateway-test-contract"
 version = "3.13.0"
 dependencies = [
  "borsh",
- "derive_more 2.1.1",
+ "mpc-call-args",
  "near-sdk",
  "serde_json",
 ]
@@ -5750,6 +5752,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "mpc-call-args"
+version = "3.13.0"
+dependencies = [
+ "near-gas",
+ "near-token",
+]
+
+[[package]]
 name = "mpc-contract"
 version = "3.13.0"
 dependencies = [
@@ -7401,9 +7411,9 @@ dependencies = [
 
 [[package]]
 name = "near-token"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34de6b54d82d0790b2a56b677e7b4ecb7f021a7e8559f8611065c890d56cfcda"
+checksum = "2a8000d5859172ce4cd29d51ae1af18a80571939f2975ffcae2c00d241ef4507"
 dependencies = [
  "borsh",
  "schemars 0.8.22",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1793,7 +1793,6 @@ dependencies = [
  "near-o11y 2.13.0-rc.1",
  "near-sdk",
  "near-store",
- "near-token",
  "nearcore",
  "prometheus",
  "rand 0.8.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ near-account-id = "2.6.0"
 # Must be bumped in lockstep with `near-primitives`: its types appear in
 # near-primitives' transaction API but are not re-exported there.
 near-crypto-public = { version = "0.36.0", package = "near-crypto" }
+near-gas = "0.3.4"
 near-jsonrpc-client = "0.21.1"
 near-jsonrpc-primitives = "0.36.0"
 near-kit = { version = "0.11.0", default-features = false }
@@ -196,7 +197,6 @@ near-sdk = { version = "5.28.0", features = [
     "legacy",
     "unstable",
 ] }
-near-gas = "0.3.4"
 near-token = "0.3.4"
 near-workspaces = { version = "0.22.2" }
 num_enum = { version = "0.7.6", features = ["complex-expressions"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/include-measurements",
     "crates/launcher-interface",
     "crates/mpc-attestation",
+    "crates/mpc-call-args",
     "crates/near-mpc-bounded-collections",
     "crates/near-mpc-contract-interface",
     "crates/near-mpc-crypto-types",
@@ -56,6 +57,7 @@ foreign-chain-rpc-interfaces = { path = "crates/foreign-chain-rpc-interfaces" }
 include-measurements = { path = "crates/include-measurements" }
 launcher-interface = { path = "crates/launcher-interface" }
 mpc-attestation = { path = "crates/mpc-attestation" }
+mpc-call-args = { path = "crates/mpc-call-args" }
 mpc-contract = { path = "crates/contract", features = ["dev-utils"] }
 mpc-node = { path = "crates/node" }
 mpc-node-config = { path = "crates/node-config" }
@@ -194,6 +196,8 @@ near-sdk = { version = "5.28.0", features = [
     "legacy",
     "unstable",
 ] }
+near-gas = "0.3.4"
+near-token = "0.3.4"
 near-workspaces = { version = "0.22.2" }
 num_enum = { version = "0.7.6", features = ["complex-expressions"] }
 pairing = { version = "0.23.0" }

--- a/crates/chain-gateway-test-contract/Cargo.toml
+++ b/crates/chain-gateway-test-contract/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["cdylib", "lib"]
 
 [dependencies]
 borsh = { workspace = true }
-derive_more = { workspace = true }
+mpc-call-args = { workspace = true }
 near-sdk = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/chain-gateway-test-contract/src/args.rs
+++ b/crates/chain-gateway-test-contract/src/args.rs
@@ -3,43 +3,20 @@ use super::consts::{
     SET_VALUE_IN_PROMISE_GAS, SPAWN_PROMISE_WITH_CALLBACK, SPAWN_PROMISE_WITH_CALLBACK_GAS,
 };
 
-use derive_more::{From, Into};
-use near_sdk::{Gas, NearToken};
+use mpc_call_args::{FunctionCallArgs, NearToken};
 
-#[derive(Clone, Copy, From, Into)]
-pub struct TeraGas(pub u64);
-
-impl TeraGas {
-    pub const fn const_add(self, rhs: Self) -> Self {
-        Self(self.0 + rhs.0)
-    }
-}
-
-impl From<TeraGas> for Gas {
-    fn from(value: TeraGas) -> Self {
-        Gas::from_tgas(value.0)
-    }
-}
-
-pub struct Call {
-    pub method: String,
-    pub args: Vec<u8>,
-    pub deposit: NearToken,
-    pub gas: TeraGas,
-}
-
-pub fn make_set_value_args(value: &str) -> Call {
-    Call {
-        method: SET_VALUE.to_string(),
+pub fn make_set_value_args(value: &str) -> FunctionCallArgs {
+    FunctionCallArgs {
+        method_name: SET_VALUE.to_string(),
         args: serde_json::to_vec(&serde_json::json!({ "value": value })).unwrap(),
         deposit: NearToken::from_near(0),
         gas: SET_VALUE_GAS,
     }
 }
 
-pub fn make_private_set_args(value: &str, succeeds: bool) -> Call {
-    Call {
-        method: PRIVATE_SET.to_string(),
+pub fn make_private_set_args(value: &str, succeeds: bool) -> FunctionCallArgs {
+    FunctionCallArgs {
+        method_name: PRIVATE_SET.to_string(),
         args: serde_json::to_vec(&serde_json::json!({ "value": value, "succeeds": succeeds }))
             .unwrap(),
         deposit: NearToken::from_near(0),
@@ -47,9 +24,9 @@ pub fn make_private_set_args(value: &str, succeeds: bool) -> Call {
     }
 }
 
-pub fn make_set_value_in_promise_args(value: &str, return_error: bool) -> Call {
-    Call {
-        method: SET_VALUE_IN_PROMISE.to_string(),
+pub fn make_set_value_in_promise_args(value: &str, return_error: bool) -> FunctionCallArgs {
+    FunctionCallArgs {
+        method_name: SET_VALUE_IN_PROMISE.to_string(),
         args: serde_json::to_vec(
             &serde_json::json!({ "value": value, "return_error": return_error }),
         )
@@ -62,9 +39,9 @@ pub fn make_set_value_in_promise_args(value: &str, return_error: bool) -> Call {
 pub fn make_spawn_promise_in_callback_args(
     successfully_spawn_promise: bool,
     end_marker: &str,
-) -> Call {
-    Call {
-        method: SPAWN_PROMISE_WITH_CALLBACK.to_string(),
+) -> FunctionCallArgs {
+    FunctionCallArgs {
+        method_name: SPAWN_PROMISE_WITH_CALLBACK.to_string(),
         args: serde_json::to_vec(
             &serde_json::json!({ "successfully_spawn_promise": successfully_spawn_promise, "end_marker": end_marker }),
         )

--- a/crates/chain-gateway-test-contract/src/consts.rs
+++ b/crates/chain-gateway-test-contract/src/consts.rs
@@ -1,4 +1,4 @@
-use crate::args::TeraGas;
+use mpc_call_args::NearGas;
 
 pub const DEFAULT_VALUE: &str = "hello from test";
 
@@ -15,12 +15,7 @@ pub const SET_VALUE_IN_PROMISE: &str = "set_value_in_promise";
 pub const SPAWN_PROMISE_WITH_CALLBACK: &str = "spawn_promise_with_callback";
 
 /* Gas constants */
-// teragas as u64. We don't use near_sdk::Gas on purpose, such that the near indexer can re-use
-// these constants without depending on near_sdk.
-pub const FIVE_TGAS: TeraGas = TeraGas(5);
-pub const SET_VALUE_GAS: TeraGas = FIVE_TGAS;
-pub const PRIVATE_SET_ARGS_GAS: TeraGas = SET_VALUE_GAS;
-pub const SET_VALUE_IN_PROMISE_GAS: TeraGas = SET_VALUE_GAS.const_add(FIVE_TGAS);
-pub const SPAWN_PROMISE_WITH_CALLBACK_GAS: TeraGas = SET_VALUE_IN_PROMISE_GAS
-    .const_add(SET_VALUE_GAS)
-    .const_add(FIVE_TGAS);
+pub const SET_VALUE_GAS: NearGas = NearGas::from_tgas(5);
+pub const PRIVATE_SET_ARGS_GAS: NearGas = NearGas::from_tgas(5);
+pub const SET_VALUE_IN_PROMISE_GAS: NearGas = NearGas::from_tgas(10);
+pub const SPAWN_PROMISE_WITH_CALLBACK_GAS: NearGas = NearGas::from_tgas(20);

--- a/crates/chain-gateway-test-contract/src/lib.rs
+++ b/crates/chain-gateway-test-contract/src/lib.rs
@@ -1,8 +1,9 @@
 pub mod args;
 pub mod consts;
 
-use args::{Call, make_private_set_args, make_set_value_in_promise_args};
+use args::{make_private_set_args, make_set_value_in_promise_args};
 use consts::DEFAULT_VALUE;
+use mpc_call_args::FunctionCallArgs;
 
 use near_sdk::{
     Promise,
@@ -47,17 +48,17 @@ impl Contract {
         if return_error {
             Err("computer says no".to_string())
         } else {
-            let Call {
-                method,
+            let FunctionCallArgs {
+                method_name,
                 args,
                 deposit,
                 gas,
             } = make_private_set_args(&value, true);
             Ok(Promise::new(env::current_account_id()).function_call(
-                method,
+                method_name,
                 args,
                 deposit,
-                gas.into(),
+                gas,
             ))
         }
     }
@@ -72,32 +73,24 @@ impl Contract {
         end_marker: String,
     ) -> Promise {
         // spawn first promise
-        let Call {
-            method,
+        let FunctionCallArgs {
+            method_name,
             args,
             deposit,
             gas,
         } = make_set_value_in_promise_args("doesn't matter", !successfully_spawn_promise);
-        let promise = Promise::new(env::current_account_id()).function_call(
-            method,
-            args,
-            deposit,
-            gas.into(),
-        );
+        let promise =
+            Promise::new(env::current_account_id()).function_call(method_name, args, deposit, gas);
 
         // spawn callback promise to mark conclusion of first promise
-        let Call {
-            method,
+        let FunctionCallArgs {
+            method_name,
             args,
             deposit,
             gas,
         } = make_private_set_args(&end_marker, true);
-        let callback = Promise::new(env::current_account_id()).function_call(
-            method,
-            args,
-            deposit,
-            gas.into(),
-        );
+        let callback =
+            Promise::new(env::current_account_id()).function_call(method_name, args, deposit, gas);
         promise.then(callback)
     }
 

--- a/crates/chain-gateway/Cargo.toml
+++ b/crates/chain-gateway/Cargo.toml
@@ -11,6 +11,7 @@ test-utils = []
 [dependencies]
 derive_more = { workspace = true }
 ed25519-dalek = { workspace = true }
+mpc-call-args = { workspace = true }
 near-account-id = { workspace = true }
 near-async = { workspace = true }
 near-client = { workspace = true }
@@ -18,6 +19,7 @@ near-crypto = { workspace = true }
 near-indexer = { workspace = true }
 near-indexer-primitives = { workspace = true }
 near-o11y = { workspace = true }
+near-token = { workspace = true }
 nearcore = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true }

--- a/crates/chain-gateway/Cargo.toml
+++ b/crates/chain-gateway/Cargo.toml
@@ -19,7 +19,6 @@ near-crypto = { workspace = true }
 near-indexer = { workspace = true }
 near-indexer-primitives = { workspace = true }
 near-o11y = { workspace = true }
-near-token = { workspace = true }
 nearcore = { workspace = true }
 prometheus = { workspace = true }
 serde = { workspace = true }

--- a/crates/chain-gateway/src/lib.rs
+++ b/crates/chain-gateway/src/lib.rs
@@ -8,7 +8,7 @@ pub mod transaction_sender;
 pub mod types;
 
 pub use chain_gateway::{ChainGateway, NodeHandle};
-pub use near_indexer_primitives::types::Gas;
+pub use mpc_call_args::{FunctionCallArgs, NearGas, NearToken};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod mock;

--- a/crates/chain-gateway/src/transaction_sender/signer.rs
+++ b/crates/chain-gateway/src/transaction_sender/signer.rs
@@ -4,7 +4,6 @@ use near_indexer::near_primitives::account::AccessKey;
 use near_indexer_primitives::near_primitives::transaction::{
     FunctionCallAction, SignedTransaction, Transaction, TransactionV0,
 };
-use near_indexer_primitives::types::Gas;
 use std::sync::Mutex;
 
 use crate::types::{FunctionCallArgs, LatestFinalBlockInfo};
@@ -49,7 +48,7 @@ impl TransactionSigner {
         let action = FunctionCallAction {
             method_name: args.method_name,
             args: args.args,
-            gas: Gas::from_gas(args.gas.as_gas()),
+            gas: crate::types::to_action_gas(args.gas),
             deposit: args.deposit,
         };
 
@@ -88,11 +87,9 @@ impl TransactionSigner {
 #[cfg(test)]
 mod tests {
     use ed25519_dalek::SigningKey;
-    use mpc_call_args::{FunctionCallArgs, NearGas};
+    use mpc_call_args::{FunctionCallArgs, NearGas, NearToken};
     use near_account_id::AccountId;
     use near_indexer::near_primitives::{account::AccessKey, transaction::Transaction};
-    use near_indexer_primitives::types::Gas;
-    use near_token::NearToken;
     use rand::{SeedableRng, rngs::StdRng};
 
     use crate::{transaction_sender::TransactionSigner, types::LatestFinalBlockInfo};
@@ -185,7 +182,7 @@ mod tests {
             near_indexer_primitives::near_primitives::transaction::Action::FunctionCall(action) => {
                 assert_eq!(action.method_name, args.method_name);
                 assert_eq!(action.args, args.args);
-                assert_eq!(action.gas, Gas::from_gas(args.gas.as_gas()));
+                assert_eq!(action.gas, crate::types::to_action_gas(args.gas));
             }
             other => panic!("expected FunctionCall action, got {other:?}"),
         }

--- a/crates/chain-gateway/src/transaction_sender/signer.rs
+++ b/crates/chain-gateway/src/transaction_sender/signer.rs
@@ -90,6 +90,7 @@ mod tests {
     use mpc_call_args::{FunctionCallArgs, NearGas, NearToken};
     use near_account_id::AccountId;
     use near_indexer::near_primitives::{account::AccessKey, transaction::Transaction};
+    use near_indexer_primitives::types::Gas;
     use rand::{SeedableRng, rngs::StdRng};
 
     use crate::{transaction_sender::TransactionSigner, types::LatestFinalBlockInfo};
@@ -182,7 +183,7 @@ mod tests {
             near_indexer_primitives::near_primitives::transaction::Action::FunctionCall(action) => {
                 assert_eq!(action.method_name, args.method_name);
                 assert_eq!(action.args, args.args);
-                assert_eq!(action.gas, crate::types::to_action_gas(args.gas));
+                assert_eq!(action.gas, Gas::from_gas(TEST_GAS.as_gas()));
             }
             other => panic!("expected FunctionCall action, got {other:?}"),
         }

--- a/crates/chain-gateway/src/transaction_sender/signer.rs
+++ b/crates/chain-gateway/src/transaction_sender/signer.rs
@@ -4,10 +4,10 @@ use near_indexer::near_primitives::account::AccessKey;
 use near_indexer_primitives::near_primitives::transaction::{
     FunctionCallAction, SignedTransaction, Transaction, TransactionV0,
 };
-use near_indexer_primitives::types::{Balance, Gas};
+use near_indexer_primitives::types::Gas;
 use std::sync::Mutex;
 
-use crate::types::LatestFinalBlockInfo;
+use crate::types::{FunctionCallArgs, LatestFinalBlockInfo};
 
 pub struct TransactionSigner {
     signing_key: SigningKey,
@@ -43,16 +43,14 @@ impl TransactionSigner {
     pub(crate) fn create_and_sign_function_call_tx(
         &self,
         receiver_id: AccountId,
-        method_name: String,
-        args: Vec<u8>,
-        gas: Gas,
+        args: FunctionCallArgs,
         info: LatestFinalBlockInfo,
     ) -> SignedTransaction {
         let action = FunctionCallAction {
-            method_name,
-            args,
-            gas,
-            deposit: Balance::from_near(0),
+            method_name: args.method_name,
+            args: args.args,
+            gas: Gas::from_gas(args.gas.as_gas()),
+            deposit: args.deposit,
         };
 
         let verifying_key = self.signing_key.verifying_key();
@@ -90,14 +88,16 @@ impl TransactionSigner {
 #[cfg(test)]
 mod tests {
     use ed25519_dalek::SigningKey;
+    use mpc_call_args::{FunctionCallArgs, NearGas};
     use near_account_id::AccountId;
     use near_indexer::near_primitives::{account::AccessKey, transaction::Transaction};
     use near_indexer_primitives::types::Gas;
+    use near_token::NearToken;
     use rand::{SeedableRng, rngs::StdRng};
 
     use crate::{transaction_sender::TransactionSigner, types::LatestFinalBlockInfo};
 
-    const TEST_GAS: Gas = Gas::from_gas(300_000_000_000_000);
+    const TEST_GAS: NearGas = NearGas::from_gas(300_000_000_000_000);
 
     #[test]
     fn test_public_key_derives_from_signing_key() {
@@ -141,6 +141,15 @@ mod tests {
         assert_eq!(third, first + 2);
     }
 
+    fn test_function_call() -> FunctionCallArgs {
+        FunctionCallArgs {
+            method_name: "do_something".to_string(),
+            args: b"test args".to_vec(),
+            gas: TEST_GAS,
+            deposit: NearToken::from_yoctonear(0),
+        }
+    }
+
     #[test]
     fn test_create_and_sign_returns_valid_transaction() {
         // Given: a signer
@@ -148,9 +157,7 @@ mod tests {
         let signer = TransactionSigner::from_rng(&mut StdRng::seed_from_u64(SEED));
         let signer_clone = TransactionSigner::from_rng(&mut StdRng::seed_from_u64(SEED));
         let receiver_id: AccountId = "receiver.near".parse().unwrap();
-        let args = b"test args".to_vec();
-        let gas = TEST_GAS;
-        let method_name = "do_something".to_string();
+        let args = test_function_call();
         let info = LatestFinalBlockInfo {
             observed_at: 100.into(),
             value: near_indexer_primitives::CryptoHash::hash_bytes(b"test_bytes"),
@@ -159,9 +166,7 @@ mod tests {
         // When: it signs a transaction
         let signed_tx = signer.create_and_sign_function_call_tx(
             receiver_id.clone(),
-            method_name.clone(),
             args.clone(),
-            gas,
             info.clone(),
         );
 
@@ -178,9 +183,9 @@ mod tests {
         assert_eq!(tx.actions.len(), 1);
         match &tx.actions[0] {
             near_indexer_primitives::near_primitives::transaction::Action::FunctionCall(action) => {
-                assert_eq!(action.method_name, method_name);
-                assert_eq!(action.args, args);
-                assert_eq!(action.gas, gas);
+                assert_eq!(action.method_name, args.method_name);
+                assert_eq!(action.args, args.args);
+                assert_eq!(action.gas, Gas::from_gas(args.gas.as_gas()));
             }
             other => panic!("expected FunctionCall action, got {other:?}"),
         }
@@ -205,9 +210,7 @@ mod tests {
 
         // When: the two signers sign the same transaction
         let receiver_id: AccountId = "receiver.near".parse().unwrap();
-        let args = b"test args".to_vec();
-        let gas = TEST_GAS;
-        let method_name = "do_something".to_string();
+        let args = test_function_call();
         let info = LatestFinalBlockInfo {
             observed_at: 100.into(),
             value: near_indexer_primitives::CryptoHash::hash_bytes(b"test_bytes"),
@@ -216,18 +219,11 @@ mod tests {
         // Then: expect the signed transactions to be an exact match
         let signed_tx = signer.create_and_sign_function_call_tx(
             receiver_id.clone(),
-            method_name.clone(),
             args.clone(),
-            gas,
             info.clone(),
         );
-        let signed_tx_clone = signer_clone.create_and_sign_function_call_tx(
-            receiver_id.clone(),
-            method_name.clone(),
-            args.clone(),
-            gas,
-            info.clone(),
-        );
+        let signed_tx_clone =
+            signer_clone.create_and_sign_function_call_tx(receiver_id.clone(), args, info.clone());
         assert_eq!(signed_tx, signed_tx_clone);
     }
 }

--- a/crates/chain-gateway/src/transaction_sender/traits.rs
+++ b/crates/chain-gateway/src/transaction_sender/traits.rs
@@ -68,13 +68,11 @@ mod tests {
         errors::{ChainGatewayError, ChainGatewayOp},
         mock::{MockChainStateBuilder, MockError},
         transaction_sender::{SubmitFunctionCall, TransactionSigner},
-        types::{FunctionCallArgs, LatestFinalBlockInfo},
+        types::LatestFinalBlockInfo,
     };
 
+    use mpc_call_args::{FunctionCallArgs, NearGas, NearToken};
     use near_account_id::AccountId;
-
-    use crate::NearGas;
-    use near_token::NearToken;
     use rand::{SeedableRng, rngs::StdRng};
 
     fn generate_test_call<R>(rng: &mut R) -> (AccountId, FunctionCallArgs)

--- a/crates/chain-gateway/src/transaction_sender/traits.rs
+++ b/crates/chain-gateway/src/transaction_sender/traits.rs
@@ -1,19 +1,17 @@
 use near_account_id::AccountId;
 use near_indexer_primitives::CryptoHash;
-use near_indexer_primitives::types::Gas;
 
 use crate::errors::{ChainGatewayError, ChainGatewayOp};
 use crate::primitives::{FetchLatestFinalBlockInfo, SubmitSignedTransaction};
 use crate::transaction_sender::TransactionSigner;
+use crate::types::FunctionCallArgs;
 
 pub trait SubmitFunctionCall {
     fn submit_function_call_tx(
         &self,
         signer: &TransactionSigner,
         receiver_id: AccountId,
-        method_name: String,
-        args: Vec<u8>,
-        gas: Gas,
+        call: FunctionCallArgs,
     ) -> impl Future<Output = Result<CryptoHash, ChainGatewayError>> + Send;
 }
 
@@ -25,10 +23,9 @@ where
         &self,
         signer: &TransactionSigner,
         receiver_id: AccountId,
-        method_name: String,
-        args: Vec<u8>,
-        gas: Gas,
+        call: FunctionCallArgs,
     ) -> Result<CryptoHash, ChainGatewayError> {
+        let method_name = call.method_name.clone();
         let info = self.fetch_latest_final_block_info().await.map_err(|err| {
             ChainGatewayError::FetchFinalBlock {
                 op: ChainGatewayOp::SubmitFunctionCallTransaction {
@@ -40,13 +37,7 @@ where
             }
         })?;
 
-        let transaction = signer.create_and_sign_function_call_tx(
-            receiver_id.clone(),
-            method_name.clone(),
-            args,
-            gas,
-            info,
-        );
+        let transaction = signer.create_and_sign_function_call_tx(receiver_id.clone(), call, info);
 
         let tx_hash = transaction.get_hash();
 
@@ -77,23 +68,16 @@ mod tests {
         errors::{ChainGatewayError, ChainGatewayOp},
         mock::{MockChainStateBuilder, MockError},
         transaction_sender::{SubmitFunctionCall, TransactionSigner},
-        types::LatestFinalBlockInfo,
+        types::{FunctionCallArgs, LatestFinalBlockInfo},
     };
 
     use near_account_id::AccountId;
-    use near_indexer::near_primitives::serialize::dec_format::DecType;
 
-    use near_indexer_primitives::types::Gas;
+    use crate::NearGas;
+    use near_token::NearToken;
     use rand::{SeedableRng, rngs::StdRng};
 
-    struct TransactionCall {
-        receiver_id: AccountId,
-        method_name: String,
-        args: Vec<u8>,
-        gas: Gas,
-    }
-
-    fn generate_test_call<R>(rng: &mut R) -> TransactionCall
+    fn generate_test_call<R>(rng: &mut R) -> (AccountId, FunctionCallArgs)
     where
         R: rand::Rng,
     {
@@ -103,13 +87,17 @@ mod tests {
         let method_name = format!("do_something_{suffix}");
         let mut args = vec![0u8; 16];
         rng.fill(&mut args[..]);
-        let gas = Gas::from_u64(300);
-        TransactionCall {
+        let gas = NearGas::from_gas(300);
+        let deposit = NearToken::from_yoctonear(0);
+        (
             receiver_id,
-            method_name,
-            args,
-            gas,
-        }
+            FunctionCallArgs {
+                method_name,
+                args,
+                gas,
+                deposit,
+            },
+        )
     }
 
     #[tokio::test]
@@ -120,17 +108,11 @@ mod tests {
         let mock_chain_state = MockChainStateBuilder::new()
             .with_latest_block(Err(expected_source.clone()))
             .build();
-        let call = generate_test_call(&mut rng);
+        let (receiver_id, call) = generate_test_call(&mut rng);
         let signer = TransactionSigner::from_rng(&mut rng);
         // When
         let res = mock_chain_state
-            .submit_function_call_tx(
-                &signer,
-                call.receiver_id.clone(),
-                call.method_name.clone(),
-                call.args.clone(),
-                call.gas,
-            )
+            .submit_function_call_tx(&signer, receiver_id.clone(), call.clone())
             .await
             .unwrap_err();
         // Then
@@ -139,7 +121,7 @@ mod tests {
             ChainGatewayError::FetchFinalBlock {
                 op: ChainGatewayOp::SubmitFunctionCallTransaction {
                     signer: signer.account_id().to_string(),
-                    receiver_id: call.receiver_id.to_string(),
+                    receiver_id: receiver_id.to_string(),
                     method_name: call.method_name
                 },
                 message: expected_source.to_string()
@@ -154,7 +136,7 @@ mod tests {
         // Given
         const SEED: u64 = 42;
         let mut rng = StdRng::seed_from_u64(SEED);
-        let call = generate_test_call(&mut rng);
+        let (receiver_id, call) = generate_test_call(&mut rng);
         let signer = TransactionSigner::from_rng(&mut rng.clone());
         let signer_clone = TransactionSigner::from_rng(&mut rng);
 
@@ -169,24 +151,12 @@ mod tests {
 
         // When
         let res = mock_chain_state
-            .submit_function_call_tx(
-                &signer,
-                call.receiver_id.clone(),
-                call.method_name.clone(),
-                call.args.clone(),
-                call.gas,
-            )
+            .submit_function_call_tx(&signer, receiver_id.clone(), call.clone())
             .await
             .unwrap();
 
         // Then
-        let expected = signer_clone.create_and_sign_function_call_tx(
-            call.receiver_id,
-            call.method_name,
-            call.args,
-            call.gas,
-            info,
-        );
+        let expected = signer_clone.create_and_sign_function_call_tx(receiver_id, call, info);
 
         assert_eq!(expected.transaction.get_hash_and_size().0, res);
 
@@ -199,7 +169,7 @@ mod tests {
         // Given
         const SEED: u64 = 42;
         let mut rng = StdRng::seed_from_u64(SEED);
-        let call = generate_test_call(&mut rng);
+        let (receiver_id, call) = generate_test_call(&mut rng);
         let signer = TransactionSigner::from_rng(&mut StdRng::seed_from_u64(SEED));
 
         let info = LatestFinalBlockInfo {
@@ -214,13 +184,7 @@ mod tests {
 
         // When
         let res = mock_chain_state
-            .submit_function_call_tx(
-                &signer,
-                call.receiver_id.clone(),
-                call.method_name.clone(),
-                call.args.clone(),
-                call.gas,
-            )
+            .submit_function_call_tx(&signer, receiver_id.clone(), call.clone())
             .await
             .unwrap_err();
 
@@ -230,7 +194,7 @@ mod tests {
             ChainGatewayError::SubmitSignedTransaction {
                 op: ChainGatewayOp::SubmitFunctionCallTransaction {
                     signer: signer.account_id().to_string(),
-                    receiver_id: call.receiver_id.to_string(),
+                    receiver_id: receiver_id.to_string(),
                     method_name: call.method_name
                 },
                 message: expected_source.to_string()

--- a/crates/chain-gateway/src/types.rs
+++ b/crates/chain-gateway/src/types.rs
@@ -2,6 +2,8 @@ use derive_more::{Display, From, Into};
 use near_indexer_primitives::CryptoHash;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
+pub use mpc_call_args::FunctionCallArgs;
+
 use crate::errors::ChainGatewayError;
 
 /// An empty argument struct for contract view calls that take no arguments.

--- a/crates/chain-gateway/src/types.rs
+++ b/crates/chain-gateway/src/types.rs
@@ -1,10 +1,16 @@
 use derive_more::{Display, From, Into};
 use near_indexer_primitives::CryptoHash;
+use near_indexer_primitives::types::Gas;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 pub use mpc_call_args::FunctionCallArgs;
+use mpc_call_args::NearGas;
 
 use crate::errors::ChainGatewayError;
+
+pub(crate) fn to_action_gas(gas: NearGas) -> Gas {
+    Gas::from_gas(gas.as_gas())
+}
 
 /// An empty argument struct for contract view calls that take no arguments.
 #[derive(Serialize)]

--- a/crates/chain-gateway/tests/event_subscriber_integration.rs
+++ b/crates/chain-gateway/tests/event_subscriber_integration.rs
@@ -3,7 +3,6 @@ use std::time::Duration;
 use super::common::localnet::Localnet;
 use crate::common::{accounts::TestAccount, localnet::LocalnetBuilder};
 use chain_gateway::{
-    Gas,
     event_subscriber::{
         block_events::{
             BlockEventId, BlockUpdate, EventData, ExecutorFunctionCallSuccessWithPromiseData,
@@ -16,8 +15,7 @@ use chain_gateway::{
 };
 use chain_gateway_test_contract::{
     args::{
-        Call, make_private_set_args, make_set_value_in_promise_args,
-        make_spawn_promise_in_callback_args,
+        make_private_set_args, make_set_value_in_promise_args, make_spawn_promise_in_callback_args,
     },
     consts::{PRIVATE_SET, SET_VALUE_IN_PROMISE, VIEW_VALUE},
 };
@@ -85,18 +83,10 @@ async fn test_event_subscriber_executor_function_call_success_success_calls_are_
     let observer_gw = &localnet.observer.chain_gateway;
 
     // When: A transaction returning a promise succeeds
-    let Call {
-        method, args, gas, ..
-    } = make_set_value_in_promise_args("succeeds", false);
+    let call = make_set_value_in_promise_args("succeeds", false);
 
     observer_gw
-        .submit_function_call_tx(
-            &test_account.signer,
-            contract_id,
-            method,
-            args.clone(),
-            Gas::from_teragas(gas.into()),
-        )
+        .submit_function_call_tx(&test_account.signer, contract_id, call.clone())
         .await
         .unwrap();
 
@@ -125,7 +115,7 @@ async fn test_event_subscriber_executor_function_call_success_success_calls_are_
         *predecessor_id, test_account.account_id,
         "predecessor_id should match user account"
     );
-    assert_eq!(*args_raw, args, "args must match");
+    assert_eq!(*args_raw, call.args, "args must match");
 
     localnet.shutdown().await;
 }
@@ -148,17 +138,9 @@ async fn test_event_subscriber_executor_function_call_success_failure_calls_are_
     // Add a backmarker to not wait indefinitely or be subject to race conditions.
     let end_marker: &str = "if you read this, you can be sure that the spawned promise has failed";
 
-    let Call {
-        method, args, gas, ..
-    } = make_spawn_promise_in_callback_args(false, end_marker);
+    let call = make_spawn_promise_in_callback_args(false, end_marker);
     observer_gw
-        .submit_function_call_tx(
-            &test_account.signer,
-            contract_id.clone(),
-            method,
-            args,
-            Gas::from_teragas(gas.into()),
-        )
+        .submit_function_call_tx(&test_account.signer, contract_id.clone(), call)
         .await
         .unwrap();
 
@@ -252,21 +234,10 @@ async fn test_event_subscriber_receiver(#[case] expect_success: bool) {
     let observer_gw = &localnet.observer.chain_gateway;
 
     // When: the contract calls itself:
-    let Call {
-        method,
-        args,
-        deposit: _,
-        gas,
-    } = make_private_set_args("maybe it works, maybe it doesn't", expect_success);
+    let call = make_private_set_args("maybe it works, maybe it doesn't", expect_success);
 
     observer_gw
-        .submit_function_call_tx(
-            &contract_signer,
-            contract_id,
-            method,
-            args,
-            Gas::from_teragas(gas.into()),
-        )
+        .submit_function_call_tx(&contract_signer, contract_id, call)
         .await
         .unwrap();
 
@@ -306,21 +277,10 @@ async fn test_event_subscriber_receiver_error_if_non_private_call() {
     let observer_gw = &localnet.observer.chain_gateway;
 
     // When: other than the contract calls it:
-    let Call {
-        method,
-        args,
-        deposit: _,
-        gas,
-    } = make_private_set_args("this will fail", true);
+    let call = make_private_set_args("this will fail", true);
 
     observer_gw
-        .submit_function_call_tx(
-            &test_account.signer,
-            contract_id,
-            method,
-            args,
-            Gas::from_teragas(gas.into()),
-        )
+        .submit_function_call_tx(&test_account.signer, contract_id, call)
         .await
         .unwrap();
 
@@ -371,17 +331,9 @@ async fn test_event_subscriber_channel_buffer_handles_backpressure(
         .await;
 
     for target in ["first", "second"] {
-        let Call {
-            method, args, gas, ..
-        } = make_private_set_args(target, true);
+        let call = make_private_set_args(target, true);
         observer_gw
-            .submit_function_call_tx(
-                &contract_signer,
-                contract_id.clone(),
-                method,
-                args,
-                Gas::from_teragas(gas.into()),
-            )
+            .submit_function_call_tx(&contract_signer, contract_id.clone(), call)
             .await
             .unwrap();
         loop {
@@ -429,17 +381,9 @@ async fn test_block_status_handle_becomes_final() {
 
     // When: one tx that triggers an event and changes contract state.
     let target_value = "becomes-final";
-    let Call {
-        method, args, gas, ..
-    } = make_set_value_in_promise_args(target_value, false);
+    let call = make_set_value_in_promise_args(target_value, false);
     observer_gw
-        .submit_function_call_tx(
-            &test_account.signer,
-            contract_id.clone(),
-            method,
-            args,
-            Gas::from_teragas(gas.into()),
-        )
+        .submit_function_call_tx(&test_account.signer, contract_id.clone(), call)
         .await
         .unwrap();
 

--- a/crates/chain-gateway/tests/sender_integration.rs
+++ b/crates/chain-gateway/tests/sender_integration.rs
@@ -1,9 +1,8 @@
 use std::time::{Duration, Instant};
 
-use chain_gateway::Gas;
 use chain_gateway::types::NoArgs;
 use chain_gateway::{state_viewer::ViewMethod, transaction_sender::SubmitFunctionCall};
-use chain_gateway_test_contract::args::{Call, make_set_value_args};
+use chain_gateway_test_contract::args::make_set_value_args;
 use chain_gateway_test_contract::consts::{DEFAULT_VALUE, VIEW_VALUE};
 
 use crate::common::localnet::LocalnetBuilder;
@@ -37,18 +36,10 @@ async fn test_submit_set_value_and_read_back() {
 
     // Submit set_value transaction via the observer, using a separate user account
     let new_value = "updated by sender test";
-    let Call {
-        method, args, gas, ..
-    } = make_set_value_args(new_value);
+    let call = make_set_value_args(new_value);
 
     observer_gw
-        .submit_function_call_tx(
-            &signer,
-            contract_id.clone(),
-            method,
-            args,
-            Gas::from_teragas(gas.into()),
-        )
+        .submit_function_call_tx(&signer, contract_id.clone(), call)
         .await
         .unwrap();
 

--- a/crates/chain-gateway/tests/view_subscription.rs
+++ b/crates/chain-gateway/tests/view_subscription.rs
@@ -1,12 +1,11 @@
 use std::time::Duration;
 
 use chain_gateway::{
-    Gas,
     state_viewer::{SubscribeToContractMethod, WatchContractState},
     transaction_sender::SubmitFunctionCall,
 };
 use chain_gateway_test_contract::{
-    args::{Call, make_set_value_args},
+    args::make_set_value_args,
     consts::{DEFAULT_VALUE, VIEW_VALUE},
 };
 
@@ -33,18 +32,10 @@ async fn test_subscription() {
     // Submit set_value transaction via the observer, using a separate user account
     let new_value = "updated by sender test";
 
-    let Call {
-        method, args, gas, ..
-    } = make_set_value_args(new_value);
+    let call = make_set_value_args(new_value);
 
     observer_gw
-        .submit_function_call_tx(
-            &signer,
-            contract_id,
-            method,
-            args,
-            Gas::from_teragas(gas.into()),
-        )
+        .submit_function_call_tx(&signer, contract_id, call)
         .await
         .unwrap();
 

--- a/crates/mpc-call-args/Cargo.toml
+++ b/crates/mpc-call-args/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "mpc-call-args"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Receiver-less NEAR function-call descriptor (method, args, gas, deposit) shared across the MPC stack"
+
+[dependencies]
+near-gas = { workspace = true }
+near-token = { workspace = true }
+
+[lints]
+workspace = true

--- a/crates/mpc-call-args/src/lib.rs
+++ b/crates/mpc-call-args/src/lib.rs
@@ -1,0 +1,13 @@
+//! The payload of a NEAR function call, shared across the MPC stack.
+
+pub use near_gas::NearGas;
+pub use near_token::NearToken;
+
+/// A NEAR `FunctionCallAction` payload: method name, encoded args, gas, and deposit.
+#[derive(Debug, Clone)]
+pub struct FunctionCallArgs {
+    pub method_name: String,
+    pub args: Vec<u8>,
+    pub gas: NearGas,
+    pub deposit: NearToken,
+}

--- a/crates/tee-context/src/lib.rs
+++ b/crates/tee-context/src/lib.rs
@@ -6,9 +6,10 @@ pub use near_mpc_contract_interface::types::SubmitParticipantInfoArgs;
 pub use types::{AllowedTeeHashes, TeeNodeIdentity};
 
 use chain_gateway::{
-    Gas,
+    NearGas, NearToken,
     state_viewer::{SubscribeToContractMethod, WatchContractState},
     transaction_sender::{SubmitFunctionCall, TransactionSigner},
+    types::FunctionCallArgs,
 };
 use near_account_id::AccountId;
 use near_mpc_contract_interface::method_names::{
@@ -21,8 +22,8 @@ use tokio_util::sync::CancellationToken;
 
 use mpc_primitives::hash::{DockerImageHash, LauncherDockerComposeHash};
 
-const SUBMIT_ATTESTATION_GAS: Gas = Gas::from_teragas(300);
-const VERIFY_TEE_GAS: Gas = Gas::from_teragas(300);
+const SUBMIT_ATTESTATION_GAS: NearGas = NearGas::from_tgas(300);
+const VERIFY_TEE_GAS: NearGas = NearGas::from_tgas(300);
 
 /// Shared TEE attestation lifecycle context.
 ///
@@ -104,9 +105,12 @@ where
             .submit_function_call_tx(
                 signer,
                 self.governance_contract.clone(),
-                SUBMIT_PARTICIPANT_INFO.to_string(),
-                args_json,
-                SUBMIT_ATTESTATION_GAS,
+                FunctionCallArgs {
+                    method_name: SUBMIT_PARTICIPANT_INFO.to_string(),
+                    args: args_json,
+                    gas: SUBMIT_ATTESTATION_GAS,
+                    deposit: NearToken::from_yoctonear(0),
+                },
             )
             .await
             .map(|_| ())
@@ -119,9 +123,12 @@ where
             .submit_function_call_tx(
                 signer,
                 self.governance_contract.clone(),
-                VERIFY_TEE.to_string(),
-                b"{}".to_vec(),
-                VERIFY_TEE_GAS,
+                FunctionCallArgs {
+                    method_name: VERIFY_TEE.to_string(),
+                    args: b"{}".to_vec(),
+                    gas: VERIFY_TEE_GAS,
+                    deposit: NearToken::from_yoctonear(0),
+                },
             )
             .await
             .map(|_| ())

--- a/docs/chain-gateway-design.md
+++ b/docs/chain-gateway-design.md
@@ -625,21 +625,17 @@ Note that this will be subject to changes in [#2680](https://github.com/near/mpc
 
 ##### Transaction Sender
 
-We propose the following API for the transaction sender:
+The transaction sender exposes the following API:
 
 ```rust
 /// Default impl fetches the latest final block, signs, and submits.
-pub trait SubmitFunctionCall:
-    FetchLatestFinalBlockInfo + SubmitSignedTransaction
-{
-    async fn submit_function_call_tx(
+pub trait SubmitFunctionCall {
+    fn submit_function_call_tx(
         &self,
-        signer: Arc<TransactionSigner>,
+        signer: &TransactionSigner,
         receiver_id: AccountId,
-        method_name: String,
-        args: Vec<u8>,
-        gas: Gas,
-    ) -> Result<CryptoHash, ChainGatewayError>;
+        call: FunctionCallArgs,
+    ) -> impl Future<Output = Result<CryptoHash, ChainGatewayError>> + Send;
 }
 ```
 


### PR DESCRIPTION
resolves #3694 
- unify Gas Type
- introduce FunctionCallArgs type in preparation for extending mpc-contract interface type

Next PRs:
- update contract-interface crate
- hook this up in mpc node (indexer), to prepare migration of chain-gateway crate