### PR TITLE
fix(launcher): reuse MPC container across restarts to preserve logs

### DIFF
--- a/crates/tee-launcher/assets/mpc-node-docker-compose.tee.template.yml
+++ b/crates/tee-launcher/assets/mpc-node-docker-compose.tee.template.yml
@@ -1,3 +1,5 @@
+name: mpc-node
+
 services:
   mpc-node:
     image: "{{IMAGE_NAME}}@{{MANIFEST_DIGEST}}"

--- a/crates/tee-launcher/assets/mpc-node-docker-compose.template.yml
+++ b/crates/tee-launcher/assets/mpc-node-docker-compose.template.yml
@@ -1,3 +1,5 @@
+name: mpc-node
+
 services:
   mpc-node:
     image: "{{IMAGE_NAME}}@{{MANIFEST_DIGEST}}"

--- a/crates/tee-launcher/src/compose.rs
+++ b/crates/tee-launcher/src/compose.rs
@@ -59,13 +59,11 @@ pub fn launch_mpc_container(
     let compose_file = render_compose_file(platform, port_mappings, image_name, manifest_digest)?;
     let compose_path = compose_file.path().display().to_string();
 
-    // Remove any existing container from a previous run (by name, independent of compose file)
-    let _ = Command::new("docker")
-        .args(["rm", "-f", MPC_CONTAINER_NAME])
-        .output();
-
+    // Use a stable compose project (`-p`) so the container is reused across
+    // restarts rather than recreated, preserving its logs. Compose
+    // recreates it only when the rendered config (e.g. image digest) changes.
     let run_output = Command::new("docker")
-        .args(["compose", "-f", &compose_path, "up", "-d"])
+        .args(["compose", "-p", "mpc", "-f", &compose_path, "up", "-d"])
         .output()
         .map_err(|inner| LauncherError::DockerRunFailed {
             image_hash: manifest_digest.clone(),

--- a/crates/tee-launcher/src/compose.rs
+++ b/crates/tee-launcher/src/compose.rs
@@ -59,11 +59,12 @@ pub fn launch_mpc_container(
     let compose_file = render_compose_file(platform, port_mappings, image_name, manifest_digest)?;
     let compose_path = compose_file.path().display().to_string();
 
-    // Use a stable compose project (`-p`) so the container is reused across
-    // restarts rather than recreated, preserving its logs. Compose
-    // recreates it only when the rendered config (e.g. image digest) changes.
+    // The compose file pins a stable top-level project `name`, so the
+    // container is reused across restarts rather than recreated, preserving its
+    // logs. Compose recreates it only when the rendered config (e.g. image
+    // digest) changes.
     let run_output = Command::new("docker")
-        .args(["compose", "-p", "mpc", "-f", &compose_path, "up", "-d"])
+        .args(["compose", "-f", &compose_path, "up", "-d"])
         .output()
         .map_err(|inner| LauncherError::DockerRunFailed {
             image_hash: manifest_digest.clone(),
@@ -262,5 +263,20 @@ mod tests {
 
         // then
         assert!(!rendered.contains("environment:"));
+    }
+
+    #[test]
+    fn includes_stable_project_name() {
+        // given
+        let port_mappings = empty_port_mappings();
+        let digest = sample_digest();
+
+        // when
+        let rendered = render(Platform::Tee, &port_mappings, &digest);
+
+        // then — a stable top-level project name keeps Compose reusing the
+        // container across restarts instead of recreating it (which would wipe
+        // its logs)
+        assert!(rendered.contains("name: mpc-node"));
     }
 }

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -966,6 +966,10 @@ Full flag reference and `.env` field-by-field documentation:
 Dstack provides a dedicated web page to view CVM information, including links to the Docker logs.
 More details can be found in [Phala's guide](https://github.com/Dstack-TEE/dstack?tab=readme-ov-file#deploy-an-app).
 
+> **Log retention:** the MPC container is reused across **restarts**, so its
+> logs are preserved and remain viewable here after a restart. An **upgrade**
+> (new image) recreates the container, which clears its logs.
+
 ---
 
 #### Local Access


### PR DESCRIPTION
Closes #3695.

The launcher recreated the MPC container on every boot (`docker rm -f` + `docker compose up -d`), wiping its logs. Run Compose under a stable project (`-p mpc`) and drop the `rm -f`, so the container is reused across restarts and its logs persist — viewable via the existing dstack log interface. No name-conflict cleanup is needed: a launcher change re-keys the CVM disk, so a new launcher always boots on a fresh disk.

Scope: restart only. Logs are still reset on **upgrade** (new image digest → container recreated) — tracked in #3702.

Verified on a dstack TDX localnet: restart → logs preserved; upgrade → logs reset.