### PR TITLE
chore: ignore quick-xml DoS advisories unreachable via our deps

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -26,12 +26,7 @@ ignore = [
   "RUSTSEC-2024-0436", # paste is unmaintained
   "RUSTSEC-2024-0384", # instant is unmaintained
   "RUSTSEC-2023-0089", # atomic-polyfill is unmaintained
-  # quick-xml DoS advisories (both fixed in quick-xml >= 0.41.0). Pulled in
-  # transitively via `pprof -> inferno` (flamegraph SVG *emission*) and via
-  # nearcore's `rust-s3` / `object_store` / `aws-creds` (S3/AWS API responses).
-  # None of these code paths parse attacker-controlled XML, so the vulnerable
-  # code paths are unreachable in our usage. Revisit once upstream releases
-  # depend on quick-xml >= 0.41.0.
+  # TODO(#3732): remove once quick-xml dependency is >= 0.41.0
   "RUSTSEC-2026-0194", # quadratic attribute duplicate-check
   "RUSTSEC-2026-0195", # unbounded namespace-declaration allocation
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -26,6 +26,14 @@ ignore = [
   "RUSTSEC-2024-0436", # paste is unmaintained
   "RUSTSEC-2024-0384", # instant is unmaintained
   "RUSTSEC-2023-0089", # atomic-polyfill is unmaintained
+  # quick-xml DoS advisories (both fixed in quick-xml >= 0.41.0). Pulled in
+  # transitively via `pprof -> inferno` (flamegraph SVG *emission*) and via
+  # nearcore's `rust-s3` / `object_store` / `aws-creds` (S3/AWS API responses).
+  # None of these code paths parse attacker-controlled XML, so the vulnerable
+  # code paths are unreachable in our usage. Revisit once upstream releases
+  # depend on quick-xml >= 0.41.0.
+  "RUSTSEC-2026-0194", # quadratic attribute duplicate-check
+  "RUSTSEC-2026-0195", # unbounded namespace-declaration allocation
 ]
 
 [bans]


### PR DESCRIPTION
resolves https://github.com/near/mpc/issues/3731

  ### Summary

  `cargo make check-extra` (which runs `cargo deny check`) started failing
  on `RUSTSEC-2026-0194` (quick-xml quadratic attribute duplicate-check).
  A second related advisory, `RUSTSEC-2026-0195` (unbounded namespace-
  declaration allocation), landed in the RustSec DB shortly after and hits
  the same set of transitive versions — I've added both.

  Both are fixed in `quick-xml >= 0.41.0`, but the affected versions in our
  lockfile are all pulled in transitively:

  - `pprof 0.15.0 -> inferno 0.11.21 -> quick-xml 0.26.0`
  - `jemalloc_pprof -> inferno 0.12.6 -> quick-xml 0.39.4`
  - `nearcore -> rust-s3 -> quick-xml 0.36.2`
  - `nearcore -> rust-s3 -> aws-creds -> quick-xml 0.32.0`
  - `nearcore -> object_store -> quick-xml 0.39.4`

  ### Why ignore instead of upgrade

  - `pprof 0.15.0` is the latest release and still pins `inferno 0.11.21`.
  - A `[patch.crates-io]` to force `quick-xml >= 0.41.0` won't compile —
    the `Attributes`/reader API changed significantly since 0.26, breaking
    `inferno` and the `rust-s3` family.
  - The nearcore-side chains are gated on a nearcore bump.

  ### Why this is safe for us

  The two advisories describe DoS via *parsing* attacker-controlled XML.
  Our reachable quick-xml call sites don't do that:

  - `crates/node/src/profiler/jemalloc.rs` and `pprof`'s flamegraph
    emission use `inferno` to *write* SVGs from our own profiling data —
    no XML input parsing.
  - `rust-s3` / `object_store` / `aws-creds` parse XML *responses* from
    our configured S3/AWS endpoints; those aren't attacker-controlled in
    our deployment.

  