### PR TITLE
docs(tdx): warn that changing app-compose breaks the sealed disk

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -890,7 +890,7 @@ Use the following custom settings for MPC:
 1. Launcher docker compose file - provided above.
 2. VM HW setting (use exactly those settings, since vCPU/Memory are measured):
     vCPU number=8, Memory = 64GB, disk = 1000 GB
-3. Pre-launch Script and Init Script - both must be empty (a non-empty script fails attestation). Caution: the Pre-launch Script may not be empty by default - clear it before deploying.
+3. Pre-launch Script and Init Script - both must be empty. They are part of the app-compose and are **measured** (see the warning below), so a non-empty script both fails attestation *and* changes the disk-sealing key. Caution: the Pre-launch Script may not be empty by default - clear it before deploying.
 4. user-config - provided above
 5. Toggles:
    - KMS = disable
@@ -914,6 +914,19 @@ Use the following custom settings for MPC:
 ![VMM Web Page (1/2)](./attachments/VMM_web_page_deploy_1.png)
 
 ![VMM Web Page (2/2)](./attachments/VMM_web_page_deploy_2.png)
+
+> **⚠️ Never change the app-compose of a running node — it can permanently destroy your keyshares.**
+>
+> With the `local-sgx` key provider, the LUKS key that encrypts the CVM data disk (keyshares + P2P identity) is derived from the boot measurements `MRTD + RTMR0..RTMR3`. The app-compose — the launcher compose, the pre-launch/init scripts, and the toggles above — is hashed into `RTMR3` as the `compose_hash`. **Any change to it changes the derived key, so the existing encrypted disk can no longer be unsealed**, and the node fails to boot with `Failed to open encrypted data disk` / `No key available with this passphrase`.
+>
+> Editing config through the **web UI is especially dangerous**: it re-serializes `app-compose.json` on save. dstack hashes a normalized form (sorted keys, compact separators), but the re-serialization can still alter *measured content* — e.g. dropping the trailing newline inside the embedded `docker_compose_file` string — which changes `compose_hash` even when the visible settings look unchanged. Do not use the UI to "just look at" or tweak a live node's config. Note that memory/vCPU changes are equally destructive (they feed `RTMR0`).
+>
+> **Recovery** if the disk won't unseal after a config change:
+> 1. Regenerate a *byte-hash-identical* app-compose from the original inputs via [`deploy-launcher.sh`](#using-the-script) (it never adds scripts and pins vCPU/Memory).
+> 2. Confirm `sha256sum .app-compose.json` matches the pre-incident `compose_hash` — the 32 bytes after the leading `01` in the boot log's `mr_config_id`.
+> 3. Push it to the existing CVM: `vmm-cli.py --url $VMM_RPC update-app-compose <vm_id> .app-compose.json`, then `stop`/`start` the CVM.
+>
+> If the hash cannot be reproduced, the keyshares on that disk are unrecoverable — deploy a fresh CVM and re-establish the node via resharing. See also [Launcher / CVM Upgrade](#launcher--cvm-upgrade), which covers the other case where the sealing key legitimately changes.
 
 #### Using the script
 

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1909,11 +1909,6 @@ re-serializes the app-compose on save.)
    vmm-cli.py --url $VMM_RPC stop <vm_id> && vmm-cli.py --url $VMM_RPC start <vm_id>
    ```
 
-If the original measurements can't be reproduced, the keyshares on that disk are
-unrecoverable — deploy a fresh CVM and re-establish the node via resharing. See
-also [Launcher / CVM Upgrade](#launcher--cvm-upgrade), which covers the case where
-the sealing key legitimately changes.
-
 ### Wiping the NEAR indexer data (force a re-sync)
 
 **Symptom:** the embedded NEAR node won't sync — it stays at genesis, reports stale/corrupt

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -915,7 +915,7 @@ Use the following custom settings for MPC:
 
 ![VMM Web Page (2/2)](./attachments/VMM_web_page_deploy_2.png)
 
-> **⚠️ Never change the app-compose of a running node** — the node will not be able to start, since the disk is encrypted with a key derived from the app-compose measurement. If this happens, see [Troubleshooting: node won't start after an app-compose change](#node-wont-start-after-an-app-compose-change) to recover.
+> **⚠️ Never change the app-compose (or the vCPU/memory) of a running node** — it will fail to start, since the disk is encrypted with a key derived from those measured inputs. If this happens, see [Troubleshooting: node won't start after an app-compose change](#node-wont-start-after-an-app-compose-change) to recover.
 
 #### Using the script
 
@@ -1905,8 +1905,8 @@ re-serializes the app-compose on save.)
 3. Push it to the existing CVM and restart:
 
    ```bash
-   vmm-cli.py --url $VMM_RPC update-app-compose <vm_id> .app-compose.json
-   vmm-cli.py --url $VMM_RPC stop <vm_id> && vmm-cli.py --url $VMM_RPC start <vm_id>
+   python $VMM_CLI_PATH --url $VMM_URL update-app-compose <vm-id> .app-compose.json
+   python $VMM_CLI_PATH --url $VMM_URL stop <vm-id> && python $VMM_CLI_PATH --url $VMM_URL start <vm-id>
    ```
 
 ### Wiping the NEAR indexer data (force a re-sync)

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1888,12 +1888,11 @@ No key available with this passphrase
 Error: Failed to open encrypted data disk
 ```
 
-**Why:** with the `local-sgx` key provider the data-disk encryption key is derived
-from the boot measurements `MRTD + RTMR0..RTMR3`. The app-compose is hashed into
-`RTMR3` (as `compose_hash`) and memory/vCPU feed `RTMR0`, so any change re-derives
-a different key and the existing disk can no longer be unsealed. The web UI is
-especially easy to trip on: it re-serializes `app-compose.json` on save, which can
-change `compose_hash` even when the visible settings look unchanged.
+**Why:** the disk-encryption key is derived from the node's boot measurements,
+which include the app-compose and the memory/vCPU settings. Change any of them and
+the node derives a different key that can't unseal the existing disk. (The web UI
+can trigger this even when the visible settings look unchanged, since it
+re-serializes the app-compose on save.)
 
 **Fix — restore the exact original measurements.** The disk data is intact; do
 **not** reformat it.

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -915,18 +915,7 @@ Use the following custom settings for MPC:
 
 ![VMM Web Page (2/2)](./attachments/VMM_web_page_deploy_2.png)
 
-> **⚠️ Never change the app-compose of a running node — it can permanently destroy your keyshares.**
->
-> With the `local-sgx` key provider, the LUKS key that encrypts the CVM data disk (keyshares + P2P identity) is derived from the boot measurements `MRTD + RTMR0..RTMR3`. The app-compose — the launcher compose, the pre-launch/init scripts, and the toggles above — is hashed into `RTMR3` as the `compose_hash`. **Any change to it changes the derived key, so the existing encrypted disk can no longer be unsealed**, and the node fails to boot with `Failed to open encrypted data disk` / `No key available with this passphrase`.
->
-> Editing config through the **web UI is especially dangerous**: it re-serializes `app-compose.json` on save. dstack hashes a normalized form (sorted keys, compact separators), but the re-serialization can still alter *measured content* — e.g. dropping the trailing newline inside the embedded `docker_compose_file` string — which changes `compose_hash` even when the visible settings look unchanged. Do not use the UI to "just look at" or tweak a live node's config. Note that memory/vCPU changes are equally destructive (they feed `RTMR0`).
->
-> **Recovery** if the disk won't unseal after a config change:
-> 1. Regenerate a *byte-hash-identical* app-compose from the original inputs via [`deploy-launcher.sh`](#using-the-script) (it never adds scripts and pins vCPU/Memory).
-> 2. Confirm `sha256sum .app-compose.json` matches the pre-incident `compose_hash` — the 32 bytes after the leading `01` in the boot log's `mr_config_id`.
-> 3. Push it to the existing CVM: `vmm-cli.py --url $VMM_RPC update-app-compose <vm_id> .app-compose.json`, then `stop`/`start` the CVM.
->
-> If the hash cannot be reproduced, the keyshares on that disk are unrecoverable — deploy a fresh CVM and re-establish the node via resharing. See also [Launcher / CVM Upgrade](#launcher--cvm-upgrade), which covers the other case where the sealing key legitimately changes.
+> **⚠️ Never change the app-compose of a running node** — the node will not be able to start, since the disk is encrypted with a key derived from the app-compose measurement. If this happens, see [Troubleshooting: node won't start after an app-compose change](#node-wont-start-after-an-app-compose-change) to recover.
 
 #### Using the script
 
@@ -1887,6 +1876,44 @@ python $VMM_CLI_PATH --url $VMM_URL start <vm-id>
 
 Common failure scenarios and how to diagnose them. This section grows as new
 cases are identified.
+
+### Node won't start after an app-compose change
+
+**Symptom:** after changing the app-compose (a pre-launch/init script, a toggle,
+the launcher compose) — or editing config through the **web UI**, or changing
+**memory/vCPU** — the CVM no longer boots and `dstack-prepare` fails with:
+
+```text
+No key available with this passphrase
+Error: Failed to open encrypted data disk
+```
+
+**Why:** with the `local-sgx` key provider the data-disk encryption key is derived
+from the boot measurements `MRTD + RTMR0..RTMR3`. The app-compose is hashed into
+`RTMR3` (as `compose_hash`) and memory/vCPU feed `RTMR0`, so any change re-derives
+a different key and the existing disk can no longer be unsealed. The web UI is
+especially easy to trip on: it re-serializes `app-compose.json` on save, which can
+change `compose_hash` even when the visible settings look unchanged.
+
+**Fix — restore the exact original measurements.** The disk data is intact; do
+**not** reformat it.
+
+1. Regenerate a *byte-hash-identical* app-compose from the original inputs via
+   [`deploy-launcher.sh`](#using-the-script) (it never adds scripts and pins
+   vCPU/Memory). Revert any memory/vCPU change back to 8 vCPU / 64 GB.
+2. Confirm `sha256sum .app-compose.json` matches the original `compose_hash` — the
+   32 bytes after the leading `01` in a pre-incident boot log's `mr_config_id`.
+3. Push it to the existing CVM and restart:
+
+   ```bash
+   vmm-cli.py --url $VMM_RPC update-app-compose <vm_id> .app-compose.json
+   vmm-cli.py --url $VMM_RPC stop <vm_id> && vmm-cli.py --url $VMM_RPC start <vm_id>
+   ```
+
+If the original measurements can't be reproduced, the keyshares on that disk are
+unrecoverable — deploy a fresh CVM and re-establish the node via resharing. See
+also [Launcher / CVM Upgrade](#launcher--cvm-upgrade), which covers the case where
+the sealing key legitimately changes.
 
 ### Wiping the NEAR indexer data (force a re-sync)
 


### PR DESCRIPTION
## Summary

Closes #3742.

Adds a warning + recovery recipe to the TDX external guide after a testnet
incident where an operator (`stakin-mpc2.testnet`, node 13) added a pre-launch
script via the dstack UI to inspect data, restarted, and bricked the CVM:
`Failed to open encrypted data disk` / `No key available with this passphrase`.

**Why it happened:** with the `local-sgx` key provider the LUKS disk key is
derived from `MRTD + RTMR0..RTMR3`. The app-compose (launcher compose,
pre-launch/init scripts, toggles) is hashed into `RTMR3` as `compose_hash`, so
any change re-derives a different key and the existing encrypted disk can no
longer be unsealed. Clearing the script again via the UI didn't help: the UI
re-serializes `app-compose.json` and dropped the trailing newline inside the
embedded `docker_compose_file` string, which survives dstack's normalized
hashing and changes `compose_hash`. Recovery was to regenerate a
byte-hash-identical app-compose via `deploy-launcher.sh` and push it with
`update-app-compose`.

## Changes

- `docs/running-an-mpc-node-in-tdx-external-guide.md`:
  - Item 3 (Pre-launch/Init Script) now notes the scripts are *measured* and that a non-empty script also changes the disk-sealing key.
  - New ⚠️ callout in the web-interface section: why app-compose changes destroy keyshares, the UI re-serialization footgun, that memory/vCPU changes are equally destructive, and a step-by-step recovery (regenerate → verify `sha256sum` → `update-app-compose` → restart; else fresh CVM + reshare). Cross-references *Launcher / CVM Upgrade*.

## Notes

Docs-only. Opened as draft for review of the mechanism wording (esp. the
normalized-hash detail) before merge.
