### PR TITLE
docs(migration): fix backup-key (Step 3) and P2P-key (Step 4) retrieval for TEE nodes

### DIFF
--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -139,41 +139,17 @@ For additional security, the backup and restore process encrypts keyshares durin
 **Important:** The `MPC_BACKUP_ENCRYPTION_KEY_HEX` must be the same between the backup-cli and the node it is currently communicating with (e.g., the old node when running `get-keyshares`, and the new node when running `put-keyshares`).
 
 
-### Obtain the encryption key (differs for TEE vs non-TEE nodes)
+### Retrieve a key from an existing node.
 
-How you obtain `MPC_BACKUP_ENCRYPTION_KEY_HEX` depends on whether the node runs
-inside a TEE (TDX/dstack) or not.
-
-If the key is not provided (neither the `MPC_BACKUP_ENCRYPTION_KEY_HEX` env var nor
-the `[mpc_node_config.secrets] backup_encryption_key_hex` config field is set), the
-node auto-generates one and writes it to `$MPC_HOME_DIR/backup_encryption_key.hex`.
-Whether you can *read that file back* is the difference:
-
-**Non-TEE nodes.** `$MPC_HOME_DIR` is on the host filesystem, so you can retrieve
-the auto-generated key directly:
+**Note:** If your node has been running without the `MPC_BACKUP_ENCRYPTION_KEY_HEX` environment variable set, the node automatically generates an encryption key and stores it in a file called `backup_encryption_key.hex` in your `$MPC_HOME_DIR` directory. You can retrieve it with:
 
 ```bash
 export BACKUP_ENCRYPTION_KEY=$(cat $MPC_HOME_DIR/backup_encryption_key.hex)
 ```
 
-**TEE (TDX/dstack) nodes.** `$MPC_HOME_DIR` (`/data`) lives **inside the CVM's
-encrypted disk**, which the operator cannot read, and `/public_data` does not
-expose the key. So an auto-generated key is **unrecoverable** — you could never
-give `backup-cli` a matching key. You must instead **set the key yourself before
-first start**, in the node's user-config, and keep a copy outside the CVM:
+Copy this key and set it as the `BACKUP_ENCRYPTION_KEY` environment variable for the backup-cli when running `get-keyshares`.
 
-```toml
-[mpc_node_config.secrets]
-backup_encryption_key_hex = "<your 32-byte hex key>"
-```
-
-Store that value in your secret store — it is the `BACKUP_ENCRYPTION_KEY` you pass
-to `backup-cli`. The user-config is **not measured**, so you can set or rotate it
-via `update-user-config` without affecting the sealed disk (see the
-[TDX external guide](https://github.com/near/mpc/blob/main/docs/running-an-mpc-node-in-tdx-external-guide.md)).
-
-In both cases, set the resulting key as the `BACKUP_ENCRYPTION_KEY` environment
-variable for the backup-cli when running `get-keyshares`.
+> **TEE (TDX/dstack) nodes:** `$MPC_HOME_DIR` (`/data`) is inside the CVM's encrypted disk, so you cannot read the auto-generated `backup_encryption_key.hex`. Set `backup_encryption_key_hex` in the `[mpc_node_config.secrets]` block of the node's user-config **before first start** and keep a copy outside the CVM — that is the key you pass to the backup-cli.
 
 
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -156,7 +156,7 @@ Copy this key and set it as the `BACKUP_ENCRYPTION_KEY` environment variable for
 backup_encryption_key_hex = "<your 32-byte hex key>"
 ```
 
-This is the key you pass to the backup-cli. The node reads it from the config on every start, so you can add or change it on a running node via `update-user-config` + restart.
+This is the key you pass to the backup-cli — if the node is already deployed, it is the value you set in `backup_encryption_key_hex` at deploy time. The node reads it from the config on every start, so you can add or change it on a running node via `update-user-config` + restart.
 
 
 
@@ -177,9 +177,16 @@ Now backup the keyshares from your currently running node.
 
 You'll need:
 - **MPC node address**: The host where your node is running (e.g., `node.example.com`)
-- **MPC node P2P public key**: The Ed25519 public key used for P2P communication (found in your node's startup logs or configuration)
+- **MPC node P2P public key**: The Ed25519 public key used for P2P communication
 
-Both those values can be found on the contract.
+On a TDX node these are **not** available in the node's startup logs or config (you can't access them). Get both from either source:
+
+- **The contract** — your node is registered there. In the `state` view (or `get_tee_accounts`), your participant entry gives the address as `url` and the P2P public key as `tls_public_key`.
+- **The node's public-data endpoint:**
+
+  ```bash
+  export P2P_KEY=$(curl -s http://<IP>:8080/public_data | jq -r ".near_p2p_public_key")
+  ```
 
 ### Get Contract State
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -179,7 +179,7 @@ You'll need:
 - **MPC node address**: The host where your node is running (e.g., `node.example.com`)
 - **MPC node P2P public key**: The Ed25519 public key used for P2P communication
 
-On a TDX node these are **not** available in the node's startup logs or config (you can't access them). Get both from either source:
+Both are available from either source:
 
 - **The contract** — your node is registered there. In the `state` view (or `get_tee_accounts`), your participant entry gives the address as `url` and the P2P public key as `tls_public_key`.
 - **The node's public-data endpoint:**

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -176,13 +176,8 @@ Now backup the keyshares from your currently running node.
 ### Obtain Node Information
 
 You'll need:
-- **MPC node address**: The host where your node is running (e.g., `node.example.com`)
-- **MPC node P2P public key**: The Ed25519 public key used for P2P communication
-
-Both are available from either source:
-
-- **The contract** — your node is registered there. In the `state` view (or `get_tee_accounts`), your participant entry gives the address as `url` and the P2P public key as `tls_public_key`.
-- **The node's public-data endpoint:**
+- **MPC node address**: The host where your node is running (e.g., `node.example.com`). Available from the contract — your participant entry's `url` in the `state` view.
+- **MPC node P2P public key**: The Ed25519 public key used for P2P communication. Available from the contract (your participant's `tls_public_key` in `state` / `get_tee_accounts`), or from the node's public-data endpoint:
 
   ```bash
   export P2P_KEY=$(curl -s http://<IP>:8080/public_data | jq -r ".near_p2p_public_key")

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -139,15 +139,41 @@ For additional security, the backup and restore process encrypts keyshares durin
 **Important:** The `MPC_BACKUP_ENCRYPTION_KEY_HEX` must be the same between the backup-cli and the node it is currently communicating with (e.g., the old node when running `get-keyshares`, and the new node when running `put-keyshares`).
 
 
-### Retrieve a key from an existing node.
+### Obtain the encryption key (differs for TEE vs non-TEE nodes)
 
-**Note:** If your node has been running without the `MPC_BACKUP_ENCRYPTION_KEY_HEX` environment variable set, the node automatically generates an encryption key and stores it in a file called `backup_encryption_key.hex` in your `$MPC_HOME_DIR` directory. You can retrieve it with:
+How you obtain `MPC_BACKUP_ENCRYPTION_KEY_HEX` depends on whether the node runs
+inside a TEE (TDX/dstack) or not.
+
+If the key is not provided (neither the `MPC_BACKUP_ENCRYPTION_KEY_HEX` env var nor
+the `[mpc_node_config.secrets] backup_encryption_key_hex` config field is set), the
+node auto-generates one and writes it to `$MPC_HOME_DIR/backup_encryption_key.hex`.
+Whether you can *read that file back* is the difference:
+
+**Non-TEE nodes.** `$MPC_HOME_DIR` is on the host filesystem, so you can retrieve
+the auto-generated key directly:
 
 ```bash
 export BACKUP_ENCRYPTION_KEY=$(cat $MPC_HOME_DIR/backup_encryption_key.hex)
 ```
 
-Copy this key and set it as the `BACKUP_ENCRYPTION_KEY` environment variable for the backup-cli when running `get-keyshares`.
+**TEE (TDX/dstack) nodes.** `$MPC_HOME_DIR` (`/data`) lives **inside the CVM's
+encrypted disk**, which the operator cannot read, and `/public_data` does not
+expose the key. So an auto-generated key is **unrecoverable** — you could never
+give `backup-cli` a matching key. You must instead **set the key yourself before
+first start**, in the node's user-config, and keep a copy outside the CVM:
+
+```toml
+[mpc_node_config.secrets]
+backup_encryption_key_hex = "<your 32-byte hex key>"
+```
+
+Store that value in your secret store — it is the `BACKUP_ENCRYPTION_KEY` you pass
+to `backup-cli`. The user-config is **not measured**, so you can set or rotate it
+via `update-user-config` without affecting the sealed disk (see the
+[TDX external guide](https://github.com/near/mpc/blob/main/docs/running-an-mpc-node-in-tdx-external-guide.md)).
+
+In both cases, set the resulting key as the `BACKUP_ENCRYPTION_KEY` environment
+variable for the backup-cli when running `get-keyshares`.
 
 
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -149,7 +149,14 @@ export BACKUP_ENCRYPTION_KEY=$(cat $MPC_HOME_DIR/backup_encryption_key.hex)
 
 Copy this key and set it as the `BACKUP_ENCRYPTION_KEY` environment variable for the backup-cli when running `get-keyshares`.
 
-> **TEE (TDX/dstack) nodes:** `$MPC_HOME_DIR` (`/data`) is inside the CVM's encrypted disk, so you cannot read the auto-generated `backup_encryption_key.hex`. Provide the key yourself instead: set `backup_encryption_key_hex` in the `[mpc_node_config.secrets]` block of the node's user-config and keep a copy outside the CVM — that is the key you pass to the backup-cli. The node reads it from the config on every start, so you can add or change it on a running node via `update-user-config` + restart.
+**TEE (TDX/dstack) nodes:** `$MPC_HOME_DIR` (`/data`) is inside the CVM's encrypted disk, so you cannot read the auto-generated `backup_encryption_key.hex`. Provide the key yourself instead: set it in the `[mpc_node_config.secrets]` block of the node's `user-config.toml` (see [Prepare MPC Node Configuration](https://github.com/near/mpc/blob/main/docs/running-an-mpc-node-in-tdx-external-guide.md#prepare-mpc-node-configuration) in the operator guide) and keep a copy outside the CVM:
+
+```toml
+[mpc_node_config.secrets]
+backup_encryption_key_hex = "<your 32-byte hex key>"
+```
+
+This is the key you pass to the backup-cli. The node reads it from the config on every start, so you can add or change it on a running node via `update-user-config` + restart.
 
 
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -149,7 +149,7 @@ export BACKUP_ENCRYPTION_KEY=$(cat $MPC_HOME_DIR/backup_encryption_key.hex)
 
 Copy this key and set it as the `BACKUP_ENCRYPTION_KEY` environment variable for the backup-cli when running `get-keyshares`.
 
-> **TEE (TDX/dstack) nodes:** `$MPC_HOME_DIR` (`/data`) is inside the CVM's encrypted disk, so you cannot read the auto-generated `backup_encryption_key.hex`. Set `backup_encryption_key_hex` in the `[mpc_node_config.secrets]` block of the node's user-config **before first start** and keep a copy outside the CVM — that is the key you pass to the backup-cli.
+> **TEE (TDX/dstack) nodes:** `$MPC_HOME_DIR` (`/data`) is inside the CVM's encrypted disk, so you cannot read the auto-generated `backup_encryption_key.hex`. Provide the key yourself instead: set `backup_encryption_key_hex` in the `[mpc_node_config.secrets]` block of the node's user-config and keep a copy outside the CVM — that is the key you pass to the backup-cli. The node reads it from the config on every start, so you can add or change it on a running node via `update-user-config` + restart.
 
 
 


### PR DESCRIPTION
Closes #3750.

Fixes two spots in `docs/node-migration-guide.md` that don't work for **TEE
(TDX/dstack)** nodes — both surfaced during a real operator backup:

- **Step 3 (backup encryption key):** split retrieval into **non-TEE** (`cat` the
  auto-generated file, as before) vs **TEE** (use `backup_encryption_key_hex` from
  the user-config — the value set at deploy time; shown in TOML, linked to the
  operator guide's config section). Notes that a TEE node's auto-generated key is
  unrecoverable, and that the field can be set/rotated via `update-user-config`
  (user-config is not measured).
- **Step 4 (MPC node P2P public key):** dropped the incorrect "found in your
  node's startup logs or configuration." The **address** comes from the contract
  (participant `url`); the **P2P public key** from the contract (`tls_public_key`)
  or the node's `/public_data` endpoint.

See #3750 for background and acceptance criteria. Docs-only.