### PR TITLE
test(e2e): derive expected foreign chains from the ForeignChain enum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3164,6 +3164,7 @@ dependencies = [
  "rstest",
  "serde",
  "serde_json",
+ "strum 0.26.3",
  "tempfile",
  "test-utils",
  "threshold-signatures",
@@ -6786,6 +6787,7 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sha2 0.10.9",
+ "strum 0.26.3",
 ]
 
 [[package]]
@@ -10821,6 +10823,9 @@ name = "strum"
 version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros 0.26.4",
+]
 
 [[package]]
 name = "strum_macros"

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -42,6 +42,7 @@ mpc-primitives = { workspace = true }
 near-mpc-bounded-collections = { workspace = true }
 regex = { workspace = true }
 rstest = { workspace = true }
+strum = { version = "0.26.3", features = ["derive"] }
 threshold-signatures = { workspace = true }
 tracing-subscriber = { workspace = true }
 

--- a/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
+++ b/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
@@ -12,6 +12,7 @@ use httpmock::prelude::*;
 use mpc_node_config::foreign_chains::RpcProviderName;
 use mpc_node_config::{ForeignChainConfig, ForeignChainProviderConfig, ForeignChainsConfig};
 use near_mpc_bounded_collections::NonEmptyBTreeMap;
+use strum::IntoEnumIterator;
 use near_mpc_contract_interface::types::{
     AptosExtractor, AptosRpcRequest, AptosTxId, BitcoinExtractor, BitcoinRpcRequest, BitcoinTxId,
     BlockConfirmations, DomainConfig, DomainId, DomainPurpose, EvmExtractor, EvmFinality,
@@ -228,19 +229,29 @@ async fn setup_foreign_tx_cluster() -> anyhow::Result<ForeignTxTestEnv> {
 
     let fc_config = build_foreign_chains_config(&urls);
 
-    let expected_chains: std::collections::BTreeSet<ForeignChain> = [
-        ForeignChain::Bitcoin,
-        ForeignChain::Abstract,
-        ForeignChain::Bnb,
-        ForeignChain::Starknet,
-        ForeignChain::Base,
-        ForeignChain::Arbitrum,
-        ForeignChain::HyperEvm,
-        ForeignChain::Polygon,
-        ForeignChain::Aptos,
-    ]
-    .into_iter()
-    .collect();
+    // Chains deliberately NOT exercised here; every other `ForeignChain` variant is
+    // expected, so a newly added chain is covered automatically unless excluded below.
+    //   - Solana:   no inspector wired for foreign-tx verification.
+    //   - Ethereum: left unconfigured; reused below as the unsupported-chain rejection case.
+    //   - Ton:      not wired for foreign-tx (no `mpc_node_config` field / mock).
+    let excluded: std::collections::BTreeSet<ForeignChain> =
+        [ForeignChain::Solana, ForeignChain::Ethereum, ForeignChain::Ton]
+            .into_iter()
+            .collect();
+    let expected_chains: std::collections::BTreeSet<ForeignChain> =
+        ForeignChain::iter().filter(|c| !excluded.contains(c)).collect();
+
+    // Sync guard: every expected chain must actually be configured on the nodes by
+    // `build_foreign_chains_config`, otherwise it can't be node-available and the
+    // `available_set == expected_chains` assertion below would time out. On a new
+    // `ForeignChain` variant, wire it into the config/mocks or add it to `excluded`.
+    let configured_chains: std::collections::BTreeSet<ForeignChain> =
+        fc_config.iter_chains().map(|(chain, _)| chain).collect();
+    assert_eq!(
+        expected_chains, configured_chains,
+        "expected_chains must match chains configured by build_foreign_chains_config; \
+         add the new variant to the config/mocks or to `excluded`",
+    );
 
     let (cluster, _running) =
         common::must_setup_cluster(common::FOREIGN_TX_VALIDATION_PORT_SEED, |c| {

--- a/crates/near-mpc-contract-interface/Cargo.toml
+++ b/crates/near-mpc-contract-interface/Cargo.toml
@@ -33,6 +33,7 @@ sha2 = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { workspace = true, optional = true }
+strum = { version = "0.26.3", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = { workspace = true }

--- a/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+++ b/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
@@ -1080,6 +1080,7 @@ pub enum StarknetExtractedValue {
     all(feature = "abi", not(target_arch = "wasm32")),
     derive(schemars::JsonSchema, borsh::BorshSchema)
 )]
+#[cfg_attr(not(target_arch = "wasm32"), derive(strum::EnumIter))]
 #[non_exhaustive]
 pub enum ForeignChain {
     Solana,


### PR DESCRIPTION
Stacked on top of #3641 — a suggested hardening for the foreign-chain availability test, for @anodar to pull in (or take as a review comment) if it looks good.

## What

`foreign_chain_tx_validation.rs` hard-coded the 9 expected available chains as a literal. If a new `ForeignChain` variant is added, the test silently won't cover it. This derives the expected set instead:

- `expected_chains = ForeignChain::iter().filter(|c| !excluded.contains(c))`, with an explicit `excluded` set (`Solana`, `Ethereum`, `Ton`) — each commented with why it's not exercised.
- A newly added chain is therefore covered **automatically** unless consciously excluded.
- A sync-guard `assert_eq!(expected_chains, configured_chains)` ties the expected set to what `build_foreign_chains_config` actually configures (via the existing `ForeignChainsConfig::iter_chains()`), so a variant that's expected-but-unconfigured fails fast with a clear message instead of a confusing availability timeout.

## How

- Adds a wasm-gated `#[cfg_attr(not(target_arch = "wasm32"), derive(strum::EnumIter))]` to `ForeignChain` — excluded from the on-chain contract build, so the contract WASM is unaffected.
- `strum` added as a non-wasm target dep of `near-mpc-contract-interface` and a dev-dep of `e2e-tests`.

Behavior is unchanged today (the exclusion set reproduces the prior 9 chains); the value is future-proofing.

## Verification

- `cargo check -p near-mpc-contract-interface` (host) and `cargo test -p e2e-tests --no-run` compile.
- Wasm gate: the derive is compiled only for non-wasm targets, so the contract build does not pull in `strum`.
