### PR TITLE
feat(foreign-tx): sui support in contract interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]

--- a/crates/contract/src/snapshots/mpc_contract__foreign_chains_metadata__tests__foreign_chains_metadata_borsh_schema__should_not_change.snap
+++ b/crates/contract/src/snapshots/mpc_contract__foreign_chains_metadata__tests__foreign_chains_metadata_borsh_schema__should_not_change.snap
@@ -90,6 +90,11 @@ BorshSchemaContainer {
                     "Aptos",
                     "ForeignChain__Aptos",
                 ),
+                (
+                    12,
+                    "Sui",
+                    "ForeignChain__Sui",
+                ),
             ],
         },
         "ForeignChainRpcWhitelist": Struct {
@@ -137,6 +142,9 @@ BorshSchemaContainer {
             fields: Empty,
         },
         "ForeignChain__Starknet": Struct {
+            fields: Empty,
+        },
+        "ForeignChain__Sui": Struct {
             fields: Empty,
         },
         "ForeignChain__Ton": Struct {

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -24,6 +24,7 @@ use near_account_id::AccountId;
 use near_mpc_contract_interface::types::{
     AptosAddress, AptosEvent, AptosExtractedValue, AptosExtractor, AptosFinality, AptosRpcRequest,
     AptosTxId, Curve, DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+    SuiAddress, SuiEvent, SuiExtractedValue, SuiExtractor, SuiFinality, SuiRpcRequest, SuiTxId,
     SupportedForeignChains, TonAddress, TonCellBody, TonExtractedValue, TonExtractor, TonFinality,
     TonLog, TonRpcRequest, TonTxId,
 };
@@ -826,6 +827,18 @@ pub fn aptos_extracted_values() -> Vec<ExtractedValue> {
     )]
 }
 
+pub fn sui_extracted_values() -> Vec<ExtractedValue> {
+    vec![ExtractedValue::SuiExtractedValue(SuiExtractedValue::Event(
+        SuiEvent {
+            package_id: SuiAddress([1; 32]),
+            transaction_module: "omni_bridge".to_string(),
+            sender: SuiAddress([2; 32]),
+            type_tag: format!("0x{}::omni_bridge::InitTransfer", "01".repeat(32)),
+            bcs: vec![0xde, 0xad, 0xbe, 0xef],
+        },
+    ))]
+}
+
 pub fn bnb_evm_request() -> ForeignChainRpcRequest {
     ForeignChainRpcRequest::Bnb(EvmRpcRequest {
         tx_id: EvmTxId([0xbb; 32]),
@@ -883,5 +896,13 @@ pub fn aptos_request() -> ForeignChainRpcRequest {
         tx_id: AptosTxId([0xbb; 32]),
         finality: AptosFinality::Committed,
         extractors: vec![AptosExtractor::Event { event_index: 0 }],
+    })
+}
+
+pub fn sui_request() -> ForeignChainRpcRequest {
+    ForeignChainRpcRequest::Sui(SuiRpcRequest {
+        tx_id: SuiTxId([0xbb; 32]),
+        finality: SuiFinality::Checkpointed,
+        extractors: vec![SuiExtractor::Event { event_index: 0 }],
     })
 }

--- a/crates/contract/tests/sandbox/foreign_chain_request.rs
+++ b/crates/contract/tests/sandbox/foreign_chain_request.rs
@@ -6,7 +6,7 @@ use crate::sandbox::common::{
     bitcoin_extracted_values, bitcoin_request, bnb_evm_request, bogus_ton_log_extracted_value,
     ethereum_evm_request, evm_block_hash_extracted_values, hyper_evm_request, polygon_evm_request,
     register_foreign_chain_configuration, sign_foreign_tx_response, starknet_extracted_values,
-    starknet_request, ton_request,
+    starknet_request, sui_extracted_values, sui_request, ton_request,
 };
 use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types::{
@@ -31,6 +31,7 @@ const SIGNATURE_TIMEOUT_BLOCKS: u64 = 200;
 #[case::hyper_evm(hyper_evm_request(), evm_block_hash_extracted_values())]
 #[case::ton(ton_request(), bogus_ton_log_extracted_value())]
 #[case::aptos(aptos_request(), aptos_extracted_values())]
+#[case::sui(sui_request(), sui_extracted_values())]
 #[tokio::test]
 async fn verify_foreign_transaction__should_succeed(
     #[case] rpc_request: ForeignChainRpcRequest,
@@ -205,6 +206,7 @@ async fn verify_foreign_transaction__should_fan_out_response_to_duplicates_from_
 #[case::hyper_evm(hyper_evm_request())]
 #[case::ton(ton_request())]
 #[case::aptos(aptos_request())]
+#[case::sui(sui_request())]
 #[tokio::test]
 async fn verify_foreign_transaction__should_reject_without_policy(
     #[case] rpc_request: ForeignChainRpcRequest,
@@ -253,6 +255,7 @@ async fn verify_foreign_transaction__should_reject_without_policy(
 #[case::hyper_evm(hyper_evm_request())]
 #[case::ton(ton_request())]
 #[case::aptos(aptos_request())]
+#[case::sui(sui_request())]
 #[tokio::test]
 async fn verify_foreign_transaction__should_timeout_without_response(
     #[case] rpc_request: ForeignChainRpcRequest,

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -251,6 +251,11 @@ expression: abi
                       11,
                       "Aptos",
                       "ForeignChain__Aptos"
+                    ],
+                    [
+                      12,
+                      "Sui",
+                      "ForeignChain__Sui"
                     ]
                   ]
                 }
@@ -286,6 +291,9 @@ expression: abi
                 "Struct": null
               },
               "ForeignChain__Starknet": {
+                "Struct": null
+              },
+              "ForeignChain__Sui": {
                 "Struct": null
               },
               "ForeignChain__Ton": {
@@ -2186,6 +2194,11 @@ expression: abi
                           11,
                           "Aptos",
                           "ForeignChain__Aptos"
+                        ],
+                        [
+                          12,
+                          "Sui",
+                          "ForeignChain__Sui"
                         ]
                       ]
                     }
@@ -2221,6 +2234,9 @@ expression: abi
                     "Struct": null
                   },
                   "ForeignChain__Starknet": {
+                    "Struct": null
+                  },
+                  "ForeignChain__Sui": {
                     "Struct": null
                   },
                   "ForeignChain__Ton": {
@@ -3113,7 +3129,8 @@ expression: abi
             "Polygon",
             "HyperEvm",
             "Ton",
-            "Aptos"
+            "Aptos",
+            "Sui"
           ]
         },
         "ForeignChainConfiguration": {
@@ -3265,6 +3282,18 @@ expression: abi
               "properties": {
                 "Aptos": {
                   "$ref": "#/definitions/AptosRpcRequest"
+                }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "required": [
+                "Sui"
+              ],
+              "properties": {
+                "Sui": {
+                  "$ref": "#/definitions/SuiRpcRequest"
                 }
               },
               "additionalProperties": false
@@ -4788,6 +4817,66 @@ expression: abi
         },
         "StarknetTxId": {
           "$ref": "#/definitions/StarknetFelt"
+        },
+        "SuiExtractor": {
+          "oneOf": [
+            {
+              "type": "object",
+              "required": [
+                "Event"
+              ],
+              "properties": {
+                "Event": {
+                  "type": "object",
+                  "required": [
+                    "event_index"
+                  ],
+                  "properties": {
+                    "event_index": {
+                      "type": "integer",
+                      "format": "uint64",
+                      "minimum": 0.0
+                    }
+                  }
+                }
+              },
+              "additionalProperties": false
+            }
+          ]
+        },
+        "SuiFinality": {
+          "description": "Sui has no reorgs; a transaction is final once it is included in a committee-certified checkpoint.",
+          "type": "string",
+          "enum": [
+            "Checkpointed"
+          ]
+        },
+        "SuiRpcRequest": {
+          "type": "object",
+          "required": [
+            "extractors",
+            "finality",
+            "tx_id"
+          ],
+          "properties": {
+            "extractors": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/SuiExtractor"
+              }
+            },
+            "finality": {
+              "$ref": "#/definitions/SuiFinality"
+            },
+            "tx_id": {
+              "$ref": "#/definitions/SuiTxId"
+            }
+          }
+        },
+        "SuiTxId": {
+          "description": "32-byte Sui transaction digest (Blake2b-256 of the signed transaction data). Sui APIs display it base58-encoded; here it is carried as raw bytes (hex in JSON).",
+          "type": "string",
+          "pattern": "^(?:[0-9A-Fa-f]{2})*$"
         },
         "SupportedForeignChains": {
           "type": "array",

--- a/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+++ b/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
@@ -180,6 +180,7 @@ pub enum ForeignChainRpcRequest {
     HyperEvm(EvmRpcRequest),
     Ton(TonRpcRequest),
     Aptos(AptosRpcRequest),
+    Sui(SuiRpcRequest),
 }
 
 impl ForeignChainRpcRequest {
@@ -197,6 +198,7 @@ impl ForeignChainRpcRequest {
             Self::HyperEvm(_) => ForeignChain::HyperEvm,
             Self::Ton(_) => ForeignChain::Ton,
             Self::Aptos(_) => ForeignChain::Aptos,
+            Self::Sui(_) => ForeignChain::Sui,
         }
     }
 }
@@ -724,6 +726,179 @@ pub enum AptosExtractedValue {
     Event(AptosEvent),
 }
 
+/// 32-byte Sui transaction digest (Blake2b-256 of the signed transaction data).
+/// Sui APIs display it base58-encoded; here it is carried as raw bytes (hex in JSON).
+#[serde_as]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    derive_more::Into,
+    derive_more::From,
+    derive_more::AsRef,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct SuiTxId(#[serde_as(as = "Hex")] pub [u8; 32]);
+
+#[serde_as]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+    derive_more::Into,
+    derive_more::From,
+    derive_more::AsRef,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct SuiAddress(#[serde_as(as = "Hex")] pub [u8; 32]);
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct SuiRpcRequest {
+    pub tx_id: SuiTxId,
+    pub finality: SuiFinality,
+    pub extractors: Vec<SuiExtractor>,
+}
+
+/// Sui has no reorgs; a transaction is final once it is included in a
+/// committee-certified checkpoint.
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+#[non_exhaustive]
+pub enum SuiFinality {
+    Checkpointed,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+#[non_exhaustive]
+#[repr(u8)]
+#[borsh(use_discriminant = true)]
+pub enum SuiExtractor {
+    Event { event_index: u64 } = 1,
+}
+
+/// A Sui Move event as observed on-chain.
+///
+/// `type_tag` carries every address in canonical long form (`0x` + 64 lowercase hex),
+/// and `bcs` carries the BCS-serialized event contents. Both are provider-independent,
+/// unlike the API's `parsedJson` rendering, which may vary across node versions.
+#[serde_as]
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct SuiEvent {
+    pub package_id: SuiAddress,
+    pub transaction_module: String,
+    pub sender: SuiAddress,
+    pub type_tag: String,
+    #[serde_as(as = "Hex")]
+    pub bcs: Vec<u8>,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+#[non_exhaustive]
+pub enum SuiExtractedValue {
+    Event(SuiEvent),
+}
+
 #[derive(
     Debug,
     Clone,
@@ -993,6 +1168,7 @@ pub enum ExtractedValue {
     StarknetExtractedValue(StarknetExtractedValue),
     TonExtractedValue(TonExtractedValue),
     AptosExtractedValue(AptosExtractedValue),
+    SuiExtractedValue(SuiExtractedValue),
 }
 
 #[derive(
@@ -1094,6 +1270,7 @@ pub enum ForeignChain {
     HyperEvm,
     Ton,
     Aptos,
+    Sui,
 }
 
 #[derive(
@@ -1804,6 +1981,14 @@ mod tests {
         }),
         ForeignChain::Aptos,
     )]
+    #[case::sui(
+        ForeignChainRpcRequest::Sui(SuiRpcRequest {
+            tx_id: SuiTxId([0; 32]),
+            finality: SuiFinality::Checkpointed,
+            extractors: vec![],
+        }),
+        ForeignChain::Sui,
+    )]
     fn foreign_chain_rpc_request_chain__should_return_correct_chain(
         #[case] request: ForeignChainRpcRequest,
         #[case] expected_chain: ForeignChain,
@@ -1930,6 +2115,33 @@ mod tests {
                     data: "{\"amount\":\"100\"}".to_string(),
                 }),
             )],
+        });
+
+        // When
+        let hash = payload.compute_msg_hash().unwrap();
+
+        // Then
+        insta::assert_json_snapshot!(hex::encode(hash.0));
+    }
+
+    #[test]
+    fn foreign_tx_sign_payload_v1_sui__should_have_consistent_hash() {
+        // Given
+        let payload = ForeignTxSignPayload::V1(ForeignTxSignPayloadV1 {
+            request: ForeignChainRpcRequest::Sui(SuiRpcRequest {
+                tx_id: SuiTxId([0xdd; 32]),
+                finality: SuiFinality::Checkpointed,
+                extractors: vec![SuiExtractor::Event { event_index: 0 }],
+            }),
+            values: vec![ExtractedValue::SuiExtractedValue(SuiExtractedValue::Event(
+                SuiEvent {
+                    package_id: SuiAddress([0x11; 32]),
+                    transaction_module: "omni_bridge".to_string(),
+                    sender: SuiAddress([0x22; 32]),
+                    type_tag: format!("0x{}::omni_bridge::InitTransfer", "11".repeat(32)),
+                    bcs: vec![0xde, 0xad, 0xbe, 0xef],
+                },
+            ))],
         });
 
         // When

--- a/crates/near-mpc-contract-interface/src/types/snapshots/near_mpc_contract_interface__types__foreign_chain__tests__foreign_tx_sign_payload_v1_sui__should_have_consistent_hash.snap
+++ b/crates/near-mpc-contract-interface/src/types/snapshots/near_mpc_contract_interface__types__foreign_chain__tests__foreign_tx_sign_payload_v1_sui__should_have_consistent_hash.snap
@@ -1,0 +1,5 @@
+---
+source: crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+expression: "hex::encode(hash.0)"
+---
+"feb837d1f4a762a8a4faaa5d828be88c5b3427a5cc1e553ff27271a10caf15a6"


### PR DESCRIPTION
## Summary

Adds Sui as a supported foreign chain for the contract's `verify_foreign_transaction`
flow — the **contract-interface (DTO) half** of Sui support.

This is one of a two-PR split (see the follow-up inspector PR for the node side), keeping
the contract-interface changes reviewable independently from the inspector logic — same
split as Aptos.

## What's included

- **New wire types** in `near-mpc-contract-interface`
  (`crates/near-mpc-contract-interface/src/types/foreign_chain.rs`):
  - `SuiTxId` — 32-byte transaction digest (Blake2b-256 of the signed tx data). Sui APIs
    display it base58-encoded; the DTO carries raw bytes (hex in JSON) like every other
    chain's tx id, and the inspector converts at the RPC boundary
  - `SuiAddress` — 32-byte address / object id (hex)
  - `SuiRpcRequest { tx_id, finality, extractors }`
  - `SuiFinality::Checkpointed` — Sui has no reorgs; a transaction is final once included
    in a committee-certified checkpoint, so a single finality level
  - `SuiExtractor::Event { event_index } = 1` — discriminant `1`, mirroring the log/event
    extractor on EVM/Starknet/TON/Aptos; discriminant `0` is left as the conventional
    block-hash slot
  - `SuiEvent { package_id, transaction_module, sender, type_tag, bcs }` — carries the
    event's **BCS bytes** rather than the API's `parsedJson` rendering: BCS is the
    protocol-certified encoding (covered by the effects' `eventsDigest`), while
    `parsedJson` is produced by version-dependent node code and could differ across
    providers running different node versions, breaking the fan-out quorum. `type_tag`
    is normalized by the inspector to canonical long-form addresses (`0x` + 64 hex)
  - `SuiExtractedValue::Event(SuiEvent)`
  - variant wiring: `ForeignChainRpcRequest::Sui`, `ExtractedValue::SuiExtractedValue`,
    `ForeignChain::Sui`, and the `ForeignChainRpcRequest::chain()` arm — all appended
    last, preserving existing borsh discriminants
- **No `crates/contract/src` logic changes** — the contract is generic over
  `ForeignChain`, so it picks up Sui transitively through the DTO enums (same as the TON
  and Aptos contract PRs).
- **Snapshots**:
  - regenerated `crates/contract/tests/snapshots/abi__abi_has_not_changed.snap` — now
    includes the Sui types and the `ForeignChain__Sui` variant (additive only)
  - regenerated `foreign_chains_metadata` borsh-schema snapshot — additive only:
    variant `(12, "Sui", "ForeignChain__Sui")` (this snapshot test postdates the Aptos
    PRs, hence a change here where #3507 had none)
  - new `foreign_tx_sign_payload_v1_sui__should_have_consistent_hash.snap` — pins the V1
    Sui sign-payload hash
- **Sandbox tests**: `sui_request()` / `sui_extracted_values()` fixtures in
  `tests/sandbox/common.rs`, and `#[case::sui(...)]` added to the three parameterized
  `verify_foreign_transaction__*` tests in `tests/sandbox/foreign_chain_request.rs`

## Testing

- `near-mpc-contract-interface` unit tests (consistent-hash + chain mapping) pass.
- `test_abi_has_not_changed` and `foreign_chains_metadata_borsh_schema__should_not_change`
  pass against the regenerated snapshots.
- Contract WASM size: 1,516,004 bytes vs the 1,520,000-byte limit — **only ~4 KB of
  headroom left** (main is at 1,508,697; the Sui DTOs add ~7.3 KB). Within the limit, but
  the next DTO addition will likely need the #3475 cleanup or a limit bump.

## Out of scope

- The node-side inspector, Sui RPC client, node wiring, config-tester golden vectors, and
  localnet docs — see the follow-up inspector PR.
