### PR TITLE
refactor(foreign-tx): migrate sui foreign chain json-rpc interfaces to grpc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1253,6 +1253,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
+name = "bcs"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b6598a2f5d564fb7855dc6b06fd1c38cff5a72bd8b863a4d021938497b440a"
+dependencies = [
+ "serde",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.65.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1454,6 +1464,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bnum"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "119771309b95163ec7aaf79810da82f7cd0599c19722d48b9c03894dca833966"
+
+[[package]]
 name = "bon"
 version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1593,6 +1609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "bytestring"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
+dependencies = [
+ "bytes",
 ]
 
 [[package]]
@@ -3704,7 +3729,6 @@ name = "foreign-chain-inspector"
 version = "3.13.0"
 dependencies = [
  "assert_matches",
- "base64 0.22.1",
  "bs58 0.5.1",
  "derive_more 2.1.1",
  "ethereum-types",
@@ -3743,12 +3767,16 @@ version = "3.13.0"
 dependencies = [
  "derive_more 2.1.1",
  "ethereum-types",
+ "http",
  "jsonrpsee",
  "mpc-primitives",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
+ "sui-rpc",
  "thiserror 2.0.18",
+ "tokio",
+ "tonic 0.14.5",
 ]
 
 [[package]]
@@ -9766,6 +9794,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "roaring"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
 name = "rocksdb"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10930,6 +10968,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
+name = "sui-rpc"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00a313a63f07ada0be04c03e9d6e8c1d176e5a469ee6e3b6f973dee525667311"
+dependencies = [
+ "base64 0.22.1",
+ "bcs",
+ "bytes",
+ "futures",
+ "http",
+ "http-body",
+ "prost 0.14.3",
+ "prost-types",
+ "serde",
+ "serde_json",
+ "sui-sdk-types",
+ "tap",
+ "tokio",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "tower",
+]
+
+[[package]]
+name = "sui-sdk-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f800c4c3539246ba94a825f6afe7faab0bc8fc4dda56c6cfa493ea2a32ecbd"
+dependencies = [
+ "base64ct",
+ "bcs",
+ "blake2",
+ "bnum",
+ "bs58 0.5.1",
+ "bytes",
+ "bytestring",
+ "itertools 0.14.0",
+ "roaring",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "serde_with",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "symbolic-common"
 version = "12.17.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11772,6 +11856,7 @@ dependencies = [
  "tower-service",
  "tracing",
  "webpki-roots",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -238,6 +238,7 @@ sha3 = "0.10.8"
 signature = "2.2.0"
 socket2 = "0.6.3"
 subtle = "2.6.1"
+sui-rpc = "0.3.1"
 syn = "2.0"
 tempfile = "3.27.0"
 test-log = "0.2.20"
@@ -253,6 +254,7 @@ tokio-rustls = { version = "0.26.4", default-features = false }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.12", features = ["time"] }
 toml = "1.1.2"
+tonic = { version = "0.14.2", default-features = false }
 tower = "0.5.3"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = [

--- a/crates/foreign-chain-config-tester/README.md
+++ b/crates/foreign-chain-config-tester/README.md
@@ -7,8 +7,11 @@ production.
 
 For each configured provider it runs a fixed request against a known reference
 transaction — the same inspector and auth handling the node uses — and compares
-the result against a known-good value. Every provider is checked independently:
-one bad provider does not stop the others from being reported.
+the result against a known-good value. Sui is the exception: its providers prune
+transactions after a few weeks, so the check instead verifies the provider's
+chain identity and inspects a transaction from its latest checkpoint. Every
+provider is checked independently: one bad provider does not stop the others
+from being reported.
 
 ## Usage
 

--- a/crates/foreign-chain-config-tester/src/checks.rs
+++ b/crates/foreign-chain-config-tester/src/checks.rs
@@ -3,6 +3,7 @@
 use std::time::Duration;
 
 use anyhow::{Context, bail, ensure};
+use foreign_chain_inspector::ForeignChainInspectionError;
 use foreign_chain_inspector::{
     BlockConfirmations, EthereumFinality, ForeignChainInspector,
     aptos::{
@@ -20,12 +21,15 @@ use foreign_chain_inspector::{
         inspector::{StarknetExtractor, StarknetFinality, StarknetInspector},
     },
     sui::{
-        SuiExtractedValue, SuiTransactionDigest,
-        inspector::{SuiExtractor, SuiFinality, SuiInspector},
+        SuiTransactionDigest,
+        inspector::{SuiFinality, SuiInspector},
     },
 };
 use foreign_chain_rpc_interfaces::aptos::ReqwestAptosClient;
+use foreign_chain_rpc_interfaces::sui::SuiRpcClient;
 use http::{HeaderName, HeaderValue};
+
+use crate::golden;
 
 fn verify_block_hash(expected: [u8; 32], got: [u8; 32]) -> anyhow::Result<()> {
     if got != expected {
@@ -106,35 +110,52 @@ pub async fn check_starknet(
     }
 }
 
-pub async fn check_sui(
-    client: HttpClient,
-    tx: [u8; 32],
-    expected_type_tag: &str,
-    expected_package_id: [u8; 32],
-) -> anyhow::Result<()> {
+/// Sui providers prune the gRPC read path after a few weeks, so unlike the other chains
+/// there is no long-lived reference transaction to pin extracted values against. Instead
+/// this verifies the provider's chain identity (the genesis digest never changes) and runs
+/// the real inspector over a transaction from the provider's latest checkpoint.
+pub async fn check_sui(client: impl SuiRpcClient, expected_chain_id: &str) -> anyhow::Result<()> {
+    let info = client
+        .get_service_info()
+        .await
+        .context("failed to fetch service info")?;
+    let chain_id = info
+        .chain_id
+        .as_deref()
+        .context("provider returned no chain id")?;
+    ensure!(
+        chain_id == expected_chain_id,
+        "chain id mismatch: expected {expected_chain_id}, got {chain_id} — is this provider on the expected network?",
+    );
+    let height = info
+        .checkpoint_height
+        .context("provider returned no checkpoint height")?;
+
+    let checkpoint = client
+        .get_checkpoint(height)
+        .await
+        .context("failed to fetch the latest checkpoint")?
+        .checkpoint
+        .context("provider returned no checkpoint")?;
+    let digest = checkpoint
+        .transactions
+        .first()
+        .and_then(|tx| tx.digest.as_deref())
+        .context("latest checkpoint carries no transaction digest")?;
+    let tx = golden::base58_32(digest)?;
+
     let inspector = SuiInspector::new(client);
-    let values = inspector
+    match inspector
         .extract(
             SuiTransactionDigest::from(tx),
             SuiFinality::Checkpointed,
-            vec![SuiExtractor::Event { event_index: 0 }],
+            vec![],
         )
-        .await?;
-    match values.into_iter().next().context("RPC returned no value")? {
-        SuiExtractedValue::Event(event) => {
-            ensure!(
-                event.type_tag == expected_type_tag,
-                "event type tag mismatch: expected {expected_type_tag}, got {} — is this provider on the expected network?",
-                event.type_tag,
-            );
-            ensure!(
-                event.package_id.0 == expected_package_id,
-                "event package id mismatch: expected 0x{}, got 0x{}",
-                hex::encode(expected_package_id),
-                hex::encode(event.package_id.0),
-            );
-            Ok(())
-        }
+        .await
+    {
+        // A failed transaction still proves the provider serves canonical checkpointed data.
+        Ok(_) | Err(ForeignChainInspectionError::TransactionFailed) => Ok(()),
+        Err(e) => Err(e).context("failed to inspect a transaction from the latest checkpoint"),
     }
 }
 
@@ -226,86 +247,90 @@ mod tests {
         mock.assert_async().await;
     }
 
-    fn golden_sui_body(vector: &golden::SuiVector, type_tag: &str) -> serde_json::Value {
-        serde_json::json!({
-            "digest": vector.tx,
-            "effects": { "status": { "status": "success" } },
-            "events": [{
-                "id": { "txDigest": vector.tx, "eventSeq": "0" },
-                "packageId": vector.event_package_id,
-                "transactionModule": "sui_system",
-                "sender": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "type": type_tag,
-                "bcsEncoding": "base64",
-                "bcs": "AQAAAAAAAAA="
-            }],
-            "checkpoint": "9769"
-        })
+    use foreign_chain_rpc_interfaces::sui::proto::{
+        Checkpoint, ExecutedTransaction, ExecutionStatus, GetCheckpointResponse,
+        GetServiceInfoResponse, GetTransactionResponse, TransactionEffects,
+    };
+    use foreign_chain_rpc_interfaces::sui::{Status, SuiRpcClient};
+
+    const CHECKPOINT_HEIGHT: u64 = 296_112_296;
+
+    struct MockSuiClient {
+        chain_id: String,
     }
 
-    fn sui_rpc_mock(server: &MockServer, result: serde_json::Value) {
-        server.mock(|when, then| {
-            when.method(POST).path("/");
-            then.status(200)
-                .header("content-type", "application/json")
-                .json_body(serde_json::json!({
-                    "jsonrpc": "2.0",
-                    "result": result,
-                    "id": 0
-                }));
-        });
+    impl MockSuiClient {
+        fn probe_digest() -> String {
+            bs58::encode([0xab; 32]).into_string()
+        }
+    }
+
+    impl SuiRpcClient for MockSuiClient {
+        async fn get_transaction(&self, digest: &str) -> Result<GetTransactionResponse, Status> {
+            Ok(GetTransactionResponse::default().with_transaction(
+                ExecutedTransaction::default()
+                    .with_digest(digest)
+                    .with_effects(
+                        TransactionEffects::default()
+                            .with_status(ExecutionStatus::default().with_success(true)),
+                    )
+                    .with_checkpoint(CHECKPOINT_HEIGHT),
+            ))
+        }
+
+        async fn get_service_info(&self) -> Result<GetServiceInfoResponse, Status> {
+            Ok(GetServiceInfoResponse::default()
+                .with_chain_id(self.chain_id.clone())
+                .with_checkpoint_height(CHECKPOINT_HEIGHT))
+        }
+
+        async fn get_checkpoint(
+            &self,
+            sequence_number: u64,
+        ) -> Result<GetCheckpointResponse, Status> {
+            Ok(GetCheckpointResponse::default().with_checkpoint(
+                Checkpoint::default()
+                    .with_sequence_number(sequence_number)
+                    .with_transactions(vec![
+                        ExecutedTransaction::default().with_digest(Self::probe_digest()),
+                    ]),
+            ))
+        }
     }
 
     #[tokio::test]
-    async fn check_sui__should_pass_when_provider_returns_golden_event() {
+    async fn check_sui__should_pass_when_provider_is_on_the_expected_network() {
         // Given
-        let server = MockServer::start_async().await;
         let sui = golden::golden_set(golden::Network::Mainnet).sui.unwrap();
-        sui_rpc_mock(&server, golden_sui_body(&sui, sui.event_type_tag));
-        let client = foreign_chain_inspector::build_http_client(
-            server.base_url(),
-            foreign_chain_inspector::RpcAuthentication::KeyInUrl,
-        )
-        .unwrap();
+        let client = MockSuiClient {
+            chain_id: sui.chain_id.to_string(),
+        };
 
         // When
-        let result = check_sui(
-            client,
-            golden::base58_32(sui.tx).unwrap(),
-            sui.event_type_tag,
-            golden::hex32(sui.event_package_id).unwrap(),
-        )
-        .await;
+        let result = check_sui(client, sui.chain_id).await;
 
         // Then
         result.unwrap();
     }
 
     #[tokio::test]
-    async fn check_sui__should_fail_when_event_type_tag_differs() {
-        // Given — the provider serves an event of a different type (short-form here; the
-        // inspector normalizes it to the long form before the comparison).
-        let server = MockServer::start_async().await;
-        let sui = golden::golden_set(golden::Network::Mainnet).sui.unwrap();
-        sui_rpc_mock(&server, golden_sui_body(&sui, "0xdead::wrong::Event"));
-        let client = foreign_chain_inspector::build_http_client(
-            server.base_url(),
-            foreign_chain_inspector::RpcAuthentication::KeyInUrl,
-        )
-        .unwrap();
+    async fn check_sui__should_fail_when_chain_id_differs() {
+        // Given — a provider on a different network.
+        let client = MockSuiClient {
+            chain_id: golden::golden_set(golden::Network::Testnet)
+                .sui
+                .unwrap()
+                .chain_id
+                .to_string(),
+        };
+        let expected = golden::golden_set(golden::Network::Mainnet).sui.unwrap();
 
         // When
-        let result = check_sui(
-            client,
-            golden::base58_32(sui.tx).unwrap(),
-            sui.event_type_tag,
-            golden::hex32(sui.event_package_id).unwrap(),
-        )
-        .await;
+        let result = check_sui(client, expected.chain_id).await;
 
         // Then
         let error = result.unwrap_err().to_string();
-        assert!(error.contains("event type tag mismatch"), "{error}");
+        assert!(error.contains("chain id mismatch"), "{error}");
     }
 
     #[tokio::test]

--- a/crates/foreign-chain-config-tester/src/checks.rs
+++ b/crates/foreign-chain-config-tester/src/checks.rs
@@ -110,6 +110,9 @@ pub async fn check_starknet(
     }
 }
 
+/// How far behind the reported tip the Sui probe transaction is taken from.
+const CHECKPOINT_PROBE_OFFSET: u64 = 10;
+
 /// Sui providers prune the gRPC read path after a few weeks, so unlike the other chains
 /// there is no long-lived reference transaction to pin extracted values against. Instead
 /// this verifies the provider's chain identity (the genesis digest never changes) and runs
@@ -130,9 +133,12 @@ pub async fn check_sui(client: impl SuiRpcClient, expected_chain_id: &str) -> an
     let height = info
         .checkpoint_height
         .context("provider returned no checkpoint height")?;
+    // Load-balanced providers may answer consecutive calls from different backends; probing
+    // slightly behind the reported tip keeps the check off the backend-sync race.
+    let probe_height = height.saturating_sub(CHECKPOINT_PROBE_OFFSET);
 
     let checkpoint = client
-        .get_checkpoint(height)
+        .get_checkpoint(probe_height)
         .await
         .context("failed to fetch the latest checkpoint")?
         .checkpoint

--- a/crates/foreign-chain-config-tester/src/golden.rs
+++ b/crates/foreign-chain-config-tester/src/golden.rs
@@ -33,13 +33,13 @@ pub struct AptosVector {
     pub event_sequence_number: u64,
 }
 
-/// `tx` is the base58 transaction digest; `event_type_tag` is in the normalized
-/// canonical long form the inspector emits; `event_package_id` is full-length hex.
+/// Sui fullnodes prune the gRPC read path after a few weeks, so a fixed reference
+/// transaction would age out. The check instead verifies the provider's chain identity
+/// (the base58 genesis checkpoint digest, which never changes) and probes a transaction
+/// from the provider's latest checkpoint.
 #[derive(Clone, Copy)]
 pub struct SuiVector {
-    pub tx: &'static str,
-    pub event_type_tag: &'static str,
-    pub event_package_id: &'static str,
+    pub chain_id: &'static str,
 }
 
 pub struct GoldenSet {
@@ -101,9 +101,7 @@ const MAINNET: GoldenSet = GoldenSet {
         event_sequence_number: 822_198_006,
     }),
     sui: Some(SuiVector {
-        tx: "8eBMXpC8Np7RNDwwiGwSmeev1cSoc7w3fPXdikhH7RZo",
-        event_type_tag: "0x0000000000000000000000000000000000000000000000000000000000000003::validator_set::ValidatorEpochInfoEventV2",
-        event_package_id: "0x0000000000000000000000000000000000000000000000000000000000000003",
+        chain_id: "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S",
     }),
 };
 
@@ -131,9 +129,7 @@ const TESTNET: GoldenSet = GoldenSet {
         event_sequence_number: 302_761_912,
     }),
     sui: Some(SuiVector {
-        tx: "tWa95dbKCRHEGwTijpMdDJrQTRw3YsafoWtxgwnu7pH",
-        event_type_tag: "0x0000000000000000000000000000000000000000000000000000000000000003::validator::StakingRequestEvent",
-        event_package_id: "0x0000000000000000000000000000000000000000000000000000000000000003",
+        chain_id: "69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD",
     }),
 };
 
@@ -228,8 +224,7 @@ mod tests {
                 hex32(v.tx).unwrap();
             }
             if let Some(v) = set.sui {
-                base58_32(v.tx).unwrap();
-                hex32(v.event_package_id).unwrap();
+                base58_32(v.chain_id).unwrap();
             }
         }
     }

--- a/crates/foreign-chain-config-tester/src/main.rs
+++ b/crates/foreign-chain-config-tester/src/main.rs
@@ -24,6 +24,7 @@ use foreign_chain_inspector::hyperevm::inspector::HyperEvm;
 use foreign_chain_inspector::polygon::inspector::Polygon;
 use foreign_chain_inspector::{RpcAuthentication, build_http_client};
 use foreign_chain_rpc_auth::auth_config_to_rpc_auth;
+use foreign_chain_rpc_interfaces::sui::GrpcSuiClient;
 use http::{HeaderName, HeaderValue};
 use mpc_node_config::foreign_chains::RpcProviderName;
 use mpc_node_config::{ForeignChainConfig, ForeignChainProviderConfig, ForeignChainsConfig};
@@ -301,19 +302,10 @@ async fn run_sui(
         return;
     };
     let timeout = timeout_of(cfg);
-    let parsed = golden::base58_32(vector.tx)
-        .and_then(|tx| golden::hex32(vector.event_package_id).map(|package_id| (tx, package_id)));
     for (name, provider) in cfg.providers.iter() {
-        let status = match (&parsed, prepare_jsonrpc(provider)) {
-            (Err(e), _) => Status::Failed(format!("invalid golden vector: {e:#}")),
-            (Ok(_), Err(e)) => Status::Failed(format!("{e:#}")),
-            (Ok((tx, package_id)), Ok(client)) => {
-                run_check(
-                    timeout,
-                    checks::check_sui(client, *tx, vector.event_type_tag, *package_id),
-                )
-                .await
-            }
+        let status = match prepare_sui(provider, timeout) {
+            Err(e) => Status::Failed(format!("{e:#}")),
+            Ok(client) => run_check(timeout, checks::check_sui(client, vector.chain_id)).await,
         };
         out.push(ProviderResult {
             chain: "sui",
@@ -321,6 +313,23 @@ async fn run_sui(
             status,
         });
     }
+}
+
+fn prepare_sui(
+    provider: &ForeignChainProviderConfig,
+    timeout: Duration,
+) -> anyhow::Result<GrpcSuiClient> {
+    let mut url = provider.rpc_url.clone();
+    let auth = auth_config_to_rpc_auth(provider.auth.clone(), &mut url)?;
+    let header = match auth {
+        RpcAuthentication::KeyInUrl => None,
+        RpcAuthentication::CustomHeader {
+            header_name,
+            header_value,
+        } => Some((header_name, header_value)),
+    };
+    GrpcSuiClient::new(url, header, timeout)
+        .map_err(|e| anyhow::anyhow!("failed to build the Sui gRPC client: {e}"))
 }
 
 fn mark_skipped(

--- a/crates/foreign-chain-inspector/Cargo.toml
+++ b/crates/foreign-chain-inspector/Cargo.toml
@@ -5,7 +5,6 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-base64 = { workspace = true }
 bs58 = { workspace = true }
 derive_more = { workspace = true }
 ethereum-types = { workspace = true }

--- a/crates/foreign-chain-inspector/src/sui/inspector.rs
+++ b/crates/foreign-chain-inspector/src/sui/inspector.rs
@@ -197,10 +197,25 @@ impl SuiExtractor {
                     .as_deref()
                     .map(normalize_type_tag)
                     .ok_or_else(|| malformed_event_field("event_type"))?;
-                let bcs = event
+                let contents = event
                     .contents
                     .as_ref()
-                    .and_then(|contents| contents.value.as_ref())
+                    .ok_or_else(|| malformed_event_field("bcs contents"))?;
+                // When present, the type name shipped alongside the BCS bytes must agree with
+                // the event type we sign; a mismatch means the payload and its claimed type
+                // come apart. Both sides are normalized so a provider that renders the two
+                // fields with different address forms is not rejected spuriously.
+                if let Some(name) = contents.name.as_deref() {
+                    let normalized_name = normalize_type_tag(name);
+                    if normalized_name != type_tag {
+                        return Err(ForeignChainInspectionError::MalformedRpcResponse(format!(
+                            "event contents type {normalized_name:?} does not match the event type {type_tag:?}"
+                        )));
+                    }
+                }
+                let bcs = contents
+                    .value
+                    .as_ref()
                     .map(|value| value.to_vec())
                     .ok_or_else(|| malformed_event_field("bcs contents"))?;
 

--- a/crates/foreign-chain-inspector/src/sui/inspector.rs
+++ b/crates/foreign-chain-inspector/src/sui/inspector.rs
@@ -31,6 +31,11 @@ pub enum SuiExtractor {
     Event { event_index: usize },
 }
 
+/// Unlike the JSON-RPC API, the gRPC [`Event`](foreign_chain_rpc_interfaces::sui::proto::Event)
+/// carries no per-event sequence number or transaction digest, so a provider serving a
+/// reordered event list cannot be detected from a single response; the array order is the
+/// certified order as served. Cross-provider protection comes from the fan-out quorum, and
+/// the type name embedded in the event's BCS message is cross-checked against the event type.
 impl<Client> ForeignChainInspector for SuiInspector<Client>
 where
     Client: SuiRpcClient,
@@ -68,7 +73,7 @@ where
 
         match finality {
             SuiFinality::Checkpointed => {
-                // The node sets `checkpoint` only once the transaction is included in a
+                // The server sets `checkpoint` only once the transaction is included in a
                 // certified checkpoint; until then the verdict is "not final yet", not an error.
                 if tx.checkpoint.is_none() {
                     return Err(ForeignChainInspectionError::NotFinalized);

--- a/crates/foreign-chain-inspector/src/sui/inspector.rs
+++ b/crates/foreign-chain-inspector/src/sui/inspector.rs
@@ -1,36 +1,12 @@
 use crate::sui::{SuiExtractedValue, SuiTransactionDigest};
 use crate::{ForeignChainInspectionError, ForeignChainInspector, HexBytes};
-use base64::Engine as _;
-use foreign_chain_rpc_interfaces::sui::{
-    GetTransactionBlockArgs, SuiEventResponse, TransactionBlockResponse,
-};
-use jsonrpsee::core::client::ClientT;
-use jsonrpsee::core::client::error::Error as RpcClientError;
+use foreign_chain_rpc_interfaces::sui::proto::ExecutedTransaction;
+use foreign_chain_rpc_interfaces::sui::{Code, Status, SuiRpcClient};
 use near_mpc_contract_interface::types::{SuiAddress, SuiEvent};
 use std::borrow::Cow;
 
-const GET_TRANSACTION_BLOCK_METHOD: &str = "sui_getTransactionBlock";
-
 /// A 32-byte Sui digest is at most 44 base58 characters.
 const DIGEST_MAX_BASE58_LEN: usize = 44;
-
-/// Upper bound on a base58 event payload we will decode. Like [`DIGEST_MAX_BASE58_LEN`], this
-/// caps `bs58`'s superlinear decode against an oversized provider response. It exceeds any real
-/// event payload by orders of magnitude (Sui bridge and system events are well under a kilobyte),
-/// and only the long-deprecated pre-v1.26 base58 event encoding reaches this path at all —
-/// current nodes send base64, which decodes in linear time.
-const EVENT_BCS_MAX_BASE58_LEN: usize = 16_384;
-
-/// Upper bound on a base64 event payload we will decode. Base64 decoding is linear, so unlike
-/// [`EVENT_BCS_MAX_BASE58_LEN`] this is not a CPU guard — it rejects absurd responses before
-/// allocating for them. Sized above the base64 form (~342k characters) of Sui's protocol limit
-/// on emitted event size (`max_event_emit_size`, 256 KB), so every protocol-legal event passes.
-const EVENT_BCS_MAX_BASE64_LEN: usize = 400_000;
-
-/// Message prefix a Sui node returns for an unknown (or pruned) transaction digest.
-/// Its JSON-RPC error code (-32602) is shared with invalid-params errors, so the
-/// message is the only discriminator.
-const TRANSACTION_NOT_FOUND_MESSAGE_PREFIX: &str = "Could not find the referenced transaction";
 
 #[derive(Clone)]
 pub struct SuiInspector<Client> {
@@ -57,7 +33,7 @@ pub enum SuiExtractor {
 
 impl<Client> ForeignChainInspector for SuiInspector<Client>
 where
-    Client: ClientT + Send + Sync,
+    Client: SuiRpcClient,
 {
     type TransactionId = SuiTransactionDigest;
     type Finality = SuiFinality;
@@ -70,21 +46,29 @@ where
         finality: SuiFinality,
         extractors: Vec<SuiExtractor>,
     ) -> Result<Vec<SuiExtractedValue>, ForeignChainInspectionError> {
-        let args = GetTransactionBlockArgs {
-            digest: bs58::encode(*tx_id).into_string(),
+        let digest = bs58::encode(*tx_id).into_string();
+
+        let response = self
+            .client
+            .get_transaction(&digest)
+            .await
+            .map_err(classify_status)?;
+        let Some(tx) = response.transaction else {
+            return Err(ForeignChainInspectionError::MalformedRpcResponse(
+                "response is missing the transaction".to_string(),
+            ));
         };
 
-        let tx: TransactionBlockResponse = self
-            .client
-            .request(GET_TRANSACTION_BLOCK_METHOD, &args)
-            .await
-            .map_err(classify_rpc_error)?;
-
-        ensure_digest_matches(&tx_id, &tx.digest)?;
+        let Some(returned_digest) = &tx.digest else {
+            return Err(ForeignChainInspectionError::MalformedRpcResponse(
+                "transaction is missing the requested digest".to_string(),
+            ));
+        };
+        ensure_digest_matches(&tx_id, returned_digest)?;
 
         match finality {
             SuiFinality::Checkpointed => {
-                // The read API sets `checkpoint` only once the transaction is included in a
+                // The node sets `checkpoint` only once the transaction is included in a
                 // certified checkpoint; until then the verdict is "not final yet", not an error.
                 if tx.checkpoint.is_none() {
                     return Err(ForeignChainInspectionError::NotFinalized);
@@ -92,12 +76,17 @@ where
             }
         }
 
-        let Some(effects) = &tx.effects else {
-            return Err(ForeignChainInspectionError::MalformedRpcResponse(
-                "transaction response is missing the requested effects".to_string(),
-            ));
-        };
-        if effects.status.status != "success" {
+        let success = tx
+            .effects
+            .as_ref()
+            .and_then(|effects| effects.status.as_ref())
+            .and_then(|status| status.success)
+            .ok_or_else(|| {
+                ForeignChainInspectionError::MalformedRpcResponse(
+                    "transaction is missing the requested execution status".to_string(),
+                )
+            })?;
+        if !success {
             return Err(ForeignChainInspectionError::TransactionFailed);
         }
 
@@ -110,27 +99,21 @@ where
     }
 }
 
-/// A `Call` error is a substantive answer from a working node: an unknown digest maps to
-/// [`ForeignChainInspectionError::TransactionNotFound`], any other rejection is
-/// deterministic and must not be dropped from the fan-out quorum as a mere hiccup.
-/// Transport-level failures stay transient via
-/// [`ForeignChainInspectionError::ClientError`].
-fn classify_rpc_error(error: RpcClientError) -> ForeignChainInspectionError {
-    match error {
-        RpcClientError::Call(object) => {
-            if object
-                .message()
-                .starts_with(TRANSACTION_NOT_FOUND_MESSAGE_PREFIX)
-            {
-                ForeignChainInspectionError::TransactionNotFound
-            } else {
-                ForeignChainInspectionError::RpcRequestRejected(object.to_string())
-            }
-        }
-        RpcClientError::ParseError(e) => {
-            ForeignChainInspectionError::MalformedRpcResponse(e.to_string())
-        }
-        other => ForeignChainInspectionError::ClientError(other),
+/// gRPC status codes carry the verdict semantics directly: `NotFound` is the node's
+/// deterministic answer for an unknown (or pruned) digest, other deterministic rejections
+/// (bad request, auth, unimplemented method) must count as substantive verdicts in the
+/// fan-out, and only genuine provider hiccups stay transient.
+fn classify_status(status: Status) -> ForeignChainInspectionError {
+    match status.code() {
+        Code::NotFound => ForeignChainInspectionError::TransactionNotFound,
+        Code::DeadlineExceeded
+        | Code::Unavailable
+        | Code::ResourceExhausted
+        | Code::Internal
+        | Code::Unknown
+        | Code::Cancelled
+        | Code::Aborted => ForeignChainInspectionError::RpcRequestFailed(status.to_string()),
+        _ => ForeignChainInspectionError::RpcRequestRejected(status.to_string()),
     }
 }
 
@@ -170,35 +153,60 @@ fn ensure_digest_matches(
 impl SuiExtractor {
     fn extract_value(
         &self,
-        tx: &TransactionBlockResponse,
+        tx: &ExecutedTransaction,
     ) -> Result<SuiExtractedValue, ForeignChainInspectionError> {
         match self {
             SuiExtractor::Event { event_index } => {
-                let event = tx
+                let events = tx
                     .events
+                    .as_ref()
+                    .map(|events| events.events.as_slice())
+                    .unwrap_or_default();
+                let event = events
                     .get(*event_index)
                     .ok_or(ForeignChainInspectionError::LogIndexOutOfBounds)?;
 
-                ensure_event_id_consistent(event, *event_index, &tx.digest)?;
-
-                let package_id = parse_sui_address(&event.package_id).map_err(|reason| {
-                    ForeignChainInspectionError::MalformedRpcResponse(format!(
-                        "failed to parse event package_id: {reason}"
-                    ))
-                })?;
-                let sender = parse_sui_address(&event.sender).map_err(|reason| {
-                    ForeignChainInspectionError::MalformedRpcResponse(format!(
-                        "failed to parse event sender: {reason}"
-                    ))
-                })?;
-
-                let bcs = decode_event_bcs(event)?;
-
-                let type_tag = normalize_type_tag(&event.event_type);
+                let package_id = event
+                    .package_id
+                    .as_deref()
+                    .ok_or_else(|| malformed_event_field("package_id"))
+                    .and_then(|s| {
+                        parse_sui_address(s).map_err(|reason| {
+                            ForeignChainInspectionError::MalformedRpcResponse(format!(
+                                "failed to parse event package_id: {reason}"
+                            ))
+                        })
+                    })?;
+                let sender = event
+                    .sender
+                    .as_deref()
+                    .ok_or_else(|| malformed_event_field("sender"))
+                    .and_then(|s| {
+                        parse_sui_address(s).map_err(|reason| {
+                            ForeignChainInspectionError::MalformedRpcResponse(format!(
+                                "failed to parse event sender: {reason}"
+                            ))
+                        })
+                    })?;
+                let transaction_module = event
+                    .module
+                    .clone()
+                    .ok_or_else(|| malformed_event_field("module"))?;
+                let type_tag = event
+                    .event_type
+                    .as_deref()
+                    .map(normalize_type_tag)
+                    .ok_or_else(|| malformed_event_field("event_type"))?;
+                let bcs = event
+                    .contents
+                    .as_ref()
+                    .and_then(|contents| contents.value.as_ref())
+                    .map(|value| value.to_vec())
+                    .ok_or_else(|| malformed_event_field("bcs contents"))?;
 
                 Ok(SuiExtractedValue::Event(SuiEvent {
                     package_id,
-                    transaction_module: event.transaction_module.clone(),
+                    transaction_module,
                     sender,
                     type_tag,
                     bcs,
@@ -208,65 +216,8 @@ impl SuiExtractor {
     }
 }
 
-/// The certified event order is the array order: `id.eventSeq` equals the position and
-/// `id.txDigest` echoes the transaction. A response violating either served a reordered
-/// or foreign event list, which must not be signed even when only one provider is
-/// configured.
-fn ensure_event_id_consistent(
-    event: &SuiEventResponse,
-    event_index: usize,
-    tx_digest: &str,
-) -> Result<(), ForeignChainInspectionError> {
-    if event.id.tx_digest != tx_digest {
-        return Err(ForeignChainInspectionError::MalformedRpcResponse(format!(
-            "event txDigest {:?} does not match the transaction digest {tx_digest:?}",
-            event.id.tx_digest
-        )));
-    }
-    if event.id.event_seq != event_index.to_string() {
-        return Err(ForeignChainInspectionError::MalformedRpcResponse(format!(
-            "event at position {event_index} carries eventSeq {:?}",
-            event.id.event_seq
-        )));
-    }
-    Ok(())
-}
-
-fn decode_event_bcs(event: &SuiEventResponse) -> Result<Vec<u8>, ForeignChainInspectionError> {
-    match event.bcs_encoding.as_deref() {
-        Some("base64") => {
-            if event.bcs.len() > EVENT_BCS_MAX_BASE64_LEN {
-                return Err(ForeignChainInspectionError::MalformedRpcResponse(format!(
-                    "base64 event bcs is too long: {} characters",
-                    event.bcs.len()
-                )));
-            }
-            base64::engine::general_purpose::STANDARD
-                .decode(&event.bcs)
-                .map_err(|e| {
-                    ForeignChainInspectionError::MalformedRpcResponse(format!(
-                        "non-base64 event bcs: {e}"
-                    ))
-                })
-        }
-        // Nodes before v1.26 emitted base58 without a `bcsEncoding` tag.
-        Some("base58") | None => {
-            if event.bcs.len() > EVENT_BCS_MAX_BASE58_LEN {
-                return Err(ForeignChainInspectionError::MalformedRpcResponse(format!(
-                    "base58 event bcs is too long: {} characters",
-                    event.bcs.len()
-                )));
-            }
-            bs58::decode(&event.bcs).into_vec().map_err(|e| {
-                ForeignChainInspectionError::MalformedRpcResponse(format!(
-                    "non-base58 event bcs: {e}"
-                ))
-            })
-        }
-        Some(other) => Err(ForeignChainInspectionError::MalformedRpcResponse(format!(
-            "unknown event bcs encoding: {other:?}"
-        ))),
-    }
+fn malformed_event_field(field: &str) -> ForeignChainInspectionError {
+    ForeignChainInspectionError::MalformedRpcResponse(format!("event is missing its {field}"))
 }
 
 /// Rewrites every address inside a Move struct tag to Sui's canonical long form —
@@ -328,77 +279,53 @@ fn parse_sui_address(s: &str) -> Result<SuiAddress, String> {
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use jsonrpsee::types::ErrorObject;
     use rstest::rstest;
 
     #[test]
-    fn classify_rpc_error__should_map_unknown_digest_to_transaction_not_found() {
-        // Given — the exact envelope a mainnet node returns for an unknown digest.
-        let error = RpcClientError::Call(ErrorObject::owned(
-            -32602,
-            "Could not find the referenced transaction [TransactionDigest(88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd29)].",
-            None::<()>,
-        ));
+    fn classify_status__should_map_not_found_to_transaction_not_found() {
+        // Given — the status a node returns for an unknown or pruned digest.
+        let status =
+            Status::not_found("Transaction 88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd29 not found");
 
         // When
-        let classified = classify_rpc_error(error);
+        let classified = classify_status(status);
 
         // Then — a substantive (non-transient) verdict.
         assert_matches!(classified, ForeignChainInspectionError::TransactionNotFound);
         assert!(!classified.is_transient());
     }
 
-    #[test]
-    fn classify_rpc_error__should_map_other_call_errors_to_rejected() {
-        // Given
-        let error = RpcClientError::Call(ErrorObject::owned(
-            -32602,
-            "Invalid params",
-            Some("Deserialization failed"),
-        ));
+    #[rstest]
+    #[case::deadline_exceeded(Code::DeadlineExceeded)]
+    #[case::unavailable(Code::Unavailable)]
+    #[case::resource_exhausted(Code::ResourceExhausted)]
+    #[case::internal(Code::Internal)]
+    #[case::unknown(Code::Unknown)]
+    fn classify_status__should_keep_provider_hiccups_transient(#[case] code: Code) {
+        // Given / When
+        let classified = classify_status(Status::new(code, "provider hiccup"));
 
-        // When
-        let classified = classify_rpc_error(error);
+        // Then — the provider is dropped from the quorum instead of blocking it.
+        assert_matches!(classified, ForeignChainInspectionError::RpcRequestFailed(_));
+        assert!(classified.is_transient());
+    }
 
-        // Then — deterministic rejection: retrying cannot change it, and the fan-out
-        // must not validate on the remaining providers alone.
+    #[rstest]
+    #[case::invalid_argument(Code::InvalidArgument)]
+    #[case::unauthenticated(Code::Unauthenticated)]
+    #[case::permission_denied(Code::PermissionDenied)]
+    #[case::unimplemented(Code::Unimplemented)]
+    fn classify_status__should_reject_deterministic_errors(#[case] code: Code) {
+        // Given / When
+        let classified = classify_status(Status::new(code, "deterministic rejection"));
+
+        // Then — non-transient: retrying cannot change it, and the fan-out must not
+        // validate on the remaining providers alone.
         assert_matches!(
             classified,
             ForeignChainInspectionError::RpcRequestRejected(_)
         );
         assert!(!classified.is_transient());
-    }
-
-    #[test]
-    fn classify_rpc_error__should_map_parse_errors_to_malformed_response() {
-        // Given
-        let serde_error = serde_json::from_str::<u64>("not-json").unwrap_err();
-
-        // When
-        let classified = classify_rpc_error(RpcClientError::ParseError(serde_error));
-
-        // Then
-        assert_matches!(
-            classified,
-            ForeignChainInspectionError::MalformedRpcResponse(_)
-        );
-        assert!(!classified.is_transient());
-    }
-
-    #[test]
-    fn classify_rpc_error__should_keep_transport_errors_transient() {
-        // Given
-        let error = RpcClientError::Transport(Box::new(std::io::Error::new(
-            std::io::ErrorKind::ConnectionRefused,
-            "connection refused",
-        )));
-
-        // When
-        let classified = classify_rpc_error(error);
-
-        // Then — a provider hiccup: dropped from the quorum instead of blocking it.
-        assert_matches!(classified, ForeignChainInspectionError::ClientError(_));
-        assert!(classified.is_transient());
     }
 
     #[test]
@@ -533,129 +460,5 @@ mod tests {
     fn parse_sui_address__should_reject_overlong_address() {
         let too_long = format!("0x{}", "a".repeat(65));
         parse_sui_address(&too_long).unwrap_err();
-    }
-
-    fn event_response(event_seq: &str, tx_digest: &str) -> SuiEventResponse {
-        SuiEventResponse {
-            id: foreign_chain_rpc_interfaces::sui::SuiEventId {
-                tx_digest: tx_digest.to_string(),
-                event_seq: event_seq.to_string(),
-            },
-            package_id: "0x2".to_string(),
-            transaction_module: "m".to_string(),
-            sender: "0x1".to_string(),
-            event_type: "0x2::m::E".to_string(),
-            bcs: base64::engine::general_purpose::STANDARD.encode([0xde, 0xad]),
-            bcs_encoding: Some("base64".to_string()),
-        }
-    }
-
-    #[test]
-    fn ensure_event_id_consistent__should_accept_matching_id() {
-        // Given / When / Then
-        ensure_event_id_consistent(&event_response("3", "digest"), 3, "digest").unwrap();
-    }
-
-    #[rstest]
-    #[case::wrong_seq("4", "digest")]
-    #[case::wrong_digest("3", "other-digest")]
-    fn ensure_event_id_consistent__should_reject_inconsistent_id(
-        #[case] event_seq: &str,
-        #[case] event_tx_digest: &str,
-    ) {
-        // Given
-        let event = event_response(event_seq, event_tx_digest);
-
-        // When / Then
-        assert_matches!(
-            ensure_event_id_consistent(&event, 3, "digest"),
-            Err(ForeignChainInspectionError::MalformedRpcResponse(_))
-        );
-    }
-
-    #[test]
-    fn decode_event_bcs__should_decode_base64_encoding() {
-        // Given
-        let event = event_response("0", "digest");
-
-        // When / Then
-        assert_eq!(decode_event_bcs(&event).unwrap(), vec![0xde, 0xad]);
-    }
-
-    #[test]
-    fn decode_event_bcs__should_decode_legacy_base58_without_encoding_tag() {
-        // Given
-        let mut event = event_response("0", "digest");
-        event.bcs = bs58::encode([0xde, 0xad]).into_string();
-        event.bcs_encoding = None;
-
-        // When / Then
-        assert_eq!(decode_event_bcs(&event).unwrap(), vec![0xde, 0xad]);
-    }
-
-    #[test]
-    fn decode_event_bcs__should_decode_explicitly_tagged_base58() {
-        // Given — a node that tags its base58 output must decode to the same bytes as base64.
-        let mut event = event_response("0", "digest");
-        event.bcs = bs58::encode([0xde, 0xad]).into_string();
-        event.bcs_encoding = Some("base58".to_string());
-
-        // When / Then
-        assert_eq!(decode_event_bcs(&event).unwrap(), vec![0xde, 0xad]);
-    }
-
-    #[test]
-    fn decode_event_bcs__should_reject_oversized_base58_without_decoding() {
-        // Given — a base58 payload far larger than any real event; superlinear decode is
-        // bounded by rejecting it on length.
-        let mut event = event_response("0", "digest");
-        event.bcs = "1".repeat(1_000_000);
-        event.bcs_encoding = Some("base58".to_string());
-
-        // When / Then
-        assert_matches!(
-            decode_event_bcs(&event),
-            Err(ForeignChainInspectionError::MalformedRpcResponse(_))
-        );
-    }
-
-    #[test]
-    fn decode_event_bcs__should_reject_oversized_base64() {
-        // Given — a base64 payload beyond the protocol's maximum emitted event size.
-        let mut event = event_response("0", "digest");
-        event.bcs = "A".repeat(EVENT_BCS_MAX_BASE64_LEN + 4);
-        event.bcs_encoding = Some("base64".to_string());
-
-        // When / Then
-        assert_matches!(
-            decode_event_bcs(&event),
-            Err(ForeignChainInspectionError::MalformedRpcResponse(_))
-        );
-    }
-
-    #[test]
-    fn decode_event_bcs__should_reject_unknown_encoding() {
-        // Given
-        let mut event = event_response("0", "digest");
-        event.bcs_encoding = Some("hex".to_string());
-
-        // When / Then
-        assert_matches!(
-            decode_event_bcs(&event),
-            Err(ForeignChainInspectionError::MalformedRpcResponse(_))
-        );
-    }
-
-    #[test]
-    fn decode_event_bcs__should_reject_invalid_base64_as_malformed_response() {
-        // Given
-        let mut event = event_response("0", "digest");
-        event.bcs = "!!!not-base64!!!".to_string();
-
-        // When / Then
-        assert_matches!(
-            decode_event_bcs(&event),
-            Err(ForeignChainInspectionError::MalformedRpcResponse(_))
-        );
     }
 }

--- a/crates/foreign-chain-inspector/tests/sui_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/sui_inspector.rs
@@ -213,6 +213,28 @@ async fn extract__should_reject_response_missing_execution_status_as_malformed()
 }
 
 #[tokio::test]
+async fn extract__should_reject_status_without_success_flag_as_malformed() {
+    // Given — a status message whose `success` flag is unset. Real servers always populate
+    // it (verified live for both outcomes); a response without it violates the API contract
+    // and no verdict is derived from it.
+    let mut tx = checkpointed_tx(vec![]);
+    tx.effects = Some(TransactionEffects::default().with_status(ExecutionStatus::default()));
+    let inspector = SuiInspector::new(MockSuiClient::transaction(tx));
+
+    // When
+    let response = inspector
+        .extract(tx_id(), SuiFinality::Checkpointed, vec![])
+        .await;
+
+    // Then
+    assert_matches!(
+        response,
+        Err(ForeignChainInspectionError::MalformedRpcResponse(_))
+    );
+    assert!(!response.unwrap_err().is_transient());
+}
+
+#[tokio::test]
 async fn extract__should_reject_response_missing_transaction_as_malformed() {
     // Given — a `GetTransactionResponse` whose transaction section is absent entirely.
     let inspector = SuiInspector::new(MockSuiClient {

--- a/crates/foreign-chain-inspector/tests/sui_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/sui_inspector.rs
@@ -125,7 +125,13 @@ async fn extract__should_return_normalized_event_for_checkpointed_transaction() 
 #[tokio::test]
 async fn extract__should_return_correct_event_for_specific_index() {
     // Given a transaction with two events.
-    let second = framework_event().with_event_type("0x3::validator::StakingRequestEvent");
+    let second = framework_event()
+        .with_event_type("0x3::validator::StakingRequestEvent")
+        .with_contents(
+            Bcs::default()
+                .with_name("0x3::validator::StakingRequestEvent")
+                .with_value(EVENT_BCS_BYTES.to_vec()),
+        );
     let tx = checkpointed_tx(vec![framework_event(), second]);
     let inspector = SuiInspector::new(MockSuiClient::transaction(tx));
 
@@ -327,6 +333,87 @@ async fn extract__should_reject_event_missing_bcs_contents_as_malformed() {
     assert_matches!(
         response,
         Err(ForeignChainInspectionError::MalformedRpcResponse(_))
+    );
+}
+
+#[tokio::test]
+async fn extract__should_reject_event_whose_contents_type_differs() {
+    // Given — the type name shipped with the BCS bytes disagrees with the event type.
+    let event = framework_event().with_contents(
+        Bcs::default()
+            .with_name("0x3::validator::StakingRequestEvent")
+            .with_value(EVENT_BCS_BYTES.to_vec()),
+    );
+    let inspector = SuiInspector::new(MockSuiClient::transaction(checkpointed_tx(vec![event])));
+
+    // When
+    let response = inspector
+        .extract(
+            tx_id(),
+            SuiFinality::Checkpointed,
+            vec![SuiExtractor::Event { event_index: 0 }],
+        )
+        .await;
+
+    // Then
+    assert_matches!(
+        response,
+        Err(ForeignChainInspectionError::MalformedRpcResponse(_))
+    );
+}
+
+#[tokio::test]
+async fn extract__should_accept_event_without_contents_type_name() {
+    // Given — the type name inside the BCS message is optional metadata.
+    let event =
+        framework_event().with_contents(Bcs::default().with_value(EVENT_BCS_BYTES.to_vec()));
+    let inspector = SuiInspector::new(MockSuiClient::transaction(checkpointed_tx(vec![event])));
+
+    // When
+    let extracted_values = inspector
+        .extract(
+            tx_id(),
+            SuiFinality::Checkpointed,
+            vec![SuiExtractor::Event { event_index: 0 }],
+        )
+        .await
+        .expect("extract should succeed");
+
+    // Then
+    assert_eq!(
+        extracted_values,
+        vec![SuiExtractedValue::Event(expected_event())],
+    );
+}
+
+#[tokio::test]
+async fn extract__should_accept_contents_type_in_different_address_form() {
+    // Given — the same type, rendered long-form in the contents name and short-form in the
+    // event type; normalization must reconcile the two.
+    let event = framework_event().with_contents(
+        Bcs::default()
+            .with_name(format!(
+                "0x{}3::validator_set::ValidatorEpochInfoEventV2",
+                "0".repeat(63)
+            ))
+            .with_value(EVENT_BCS_BYTES.to_vec()),
+    );
+    let inspector = SuiInspector::new(MockSuiClient::transaction(checkpointed_tx(vec![event])));
+
+    // When
+    let extracted_values = inspector
+        .extract(
+            tx_id(),
+            SuiFinality::Checkpointed,
+            vec![SuiExtractor::Event { event_index: 0 }],
+        )
+        .await
+        .expect("extract should succeed");
+
+    // Then
+    assert_eq!(
+        extracted_values,
+        vec![SuiExtractedValue::Event(expected_event())],
     );
 }
 

--- a/crates/foreign-chain-inspector/tests/sui_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/sui_inspector.rs
@@ -1,29 +1,54 @@
 #![allow(non_snake_case)]
 
-pub mod common;
-
-use crate::common::{FixedResponseRpcClient, mock_client_from_fixed_response};
-
 use assert_matches::assert_matches;
-use base64::Engine as _;
 use foreign_chain_inspector::{
-    ForeignChainInspectionError, ForeignChainInspector, RpcAuthentication, build_http_client,
+    ForeignChainInspectionError, ForeignChainInspector,
     sui::{
         SuiExtractedValue, SuiTransactionDigest,
         inspector::{SuiExtractor, SuiFinality, SuiInspector},
     },
 };
-use foreign_chain_rpc_interfaces::sui::{
-    ExecutionStatus, SuiEventId, SuiEventResponse, TransactionBlockEffects,
-    TransactionBlockResponse,
+use foreign_chain_rpc_interfaces::sui::proto::{
+    Bcs, Event, ExecutedTransaction, ExecutionStatus, GetCheckpointResponse,
+    GetServiceInfoResponse, GetTransactionResponse, TransactionEffects, TransactionEvents,
 };
-use httpmock::prelude::*;
-use httpmock::{HttpMockRequest, HttpMockResponse};
-use jsonrpsee::core::client::error::Error as RpcClientError;
-use jsonrpsee::types::ErrorObject;
+use foreign_chain_rpc_interfaces::sui::{Status, SuiRpcClient};
 use near_mpc_contract_interface::types::{SuiAddress, SuiEvent};
 
 const EVENT_BCS_BYTES: [u8; 4] = [0xde, 0xad, 0xbe, 0xef];
+
+/// A client that always returns a hard-coded `GetTransaction` response.
+struct MockSuiClient {
+    response: Result<GetTransactionResponse, Status>,
+}
+
+impl MockSuiClient {
+    fn transaction(tx: ExecutedTransaction) -> Self {
+        Self {
+            response: Ok(GetTransactionResponse::default().with_transaction(tx)),
+        }
+    }
+
+    fn status(status: Status) -> Self {
+        Self {
+            response: Err(status),
+        }
+    }
+}
+
+impl SuiRpcClient for MockSuiClient {
+    async fn get_transaction(&self, _digest: &str) -> Result<GetTransactionResponse, Status> {
+        self.response.clone()
+    }
+
+    async fn get_service_info(&self) -> Result<GetServiceInfoResponse, Status> {
+        unimplemented!("get_service_info() not used by the inspector")
+    }
+
+    async fn get_checkpoint(&self, _sequence_number: u64) -> Result<GetCheckpointResponse, Status> {
+        unimplemented!("get_checkpoint() not used by the inspector")
+    }
+}
 
 fn tx_id() -> SuiTransactionDigest {
     SuiTransactionDigest::from([0xab; 32])
@@ -33,34 +58,29 @@ fn tx_digest_base58() -> String {
     bs58::encode([0xab; 32]).into_string()
 }
 
-fn framework_event(event_seq: &str) -> SuiEventResponse {
-    SuiEventResponse {
-        id: SuiEventId {
-            tx_digest: tx_digest_base58(),
-            event_seq: event_seq.to_string(),
-        },
-        package_id: "0x0000000000000000000000000000000000000000000000000000000000000003"
-            .to_string(),
-        transaction_module: "sui_system".to_string(),
-        sender: "0x0000000000000000000000000000000000000000000000000000000000000000".to_string(),
+fn framework_event() -> Event {
+    Event::default()
+        .with_package_id("0x0000000000000000000000000000000000000000000000000000000000000003")
+        .with_module("sui_system")
+        .with_sender("0x0000000000000000000000000000000000000000000000000000000000000000")
         // Short-form framework address: the inspector must normalize it to the long form.
-        event_type: "0x3::validator_set::ValidatorEpochInfoEventV2".to_string(),
-        bcs: base64::engine::general_purpose::STANDARD.encode(EVENT_BCS_BYTES),
-        bcs_encoding: Some("base64".to_string()),
-    }
+        .with_event_type("0x3::validator_set::ValidatorEpochInfoEventV2")
+        .with_contents(
+            Bcs::default()
+                .with_name("0x3::validator_set::ValidatorEpochInfoEventV2")
+                .with_value(EVENT_BCS_BYTES.to_vec()),
+        )
 }
 
-fn checkpointed_tx(events: Vec<SuiEventResponse>) -> TransactionBlockResponse {
-    TransactionBlockResponse {
-        digest: tx_digest_base58(),
-        effects: Some(TransactionBlockEffects {
-            status: ExecutionStatus {
-                status: "success".to_string(),
-            },
-        }),
-        events,
-        checkpoint: Some("296112296".to_string()),
-    }
+fn checkpointed_tx(events: Vec<Event>) -> ExecutedTransaction {
+    ExecutedTransaction::default()
+        .with_digest(tx_digest_base58())
+        .with_effects(
+            TransactionEffects::default()
+                .with_status(ExecutionStatus::default().with_success(true)),
+        )
+        .with_events(TransactionEvents::default().with_events(events))
+        .with_checkpoint(296_112_296u64)
 }
 
 fn expected_event() -> SuiEvent {
@@ -81,8 +101,9 @@ fn expected_event() -> SuiEvent {
 #[tokio::test]
 async fn extract__should_return_normalized_event_for_checkpointed_transaction() {
     // Given
-    let mock_client = mock_client_from_fixed_response(checkpointed_tx(vec![framework_event("0")]));
-    let inspector = SuiInspector::new(mock_client);
+    let inspector = SuiInspector::new(MockSuiClient::transaction(checkpointed_tx(vec![
+        framework_event(),
+    ])));
 
     // When
     let extracted_values = inspector
@@ -94,7 +115,7 @@ async fn extract__should_return_normalized_event_for_checkpointed_transaction() 
         .await
         .expect("extract should succeed");
 
-    // Then — type_tag address padded to long form, bcs decoded to raw bytes.
+    // Then — type_tag address padded to long form, bcs carried as raw bytes.
     assert_eq!(
         extracted_values,
         vec![SuiExtractedValue::Event(expected_event())],
@@ -104,10 +125,9 @@ async fn extract__should_return_normalized_event_for_checkpointed_transaction() 
 #[tokio::test]
 async fn extract__should_return_correct_event_for_specific_index() {
     // Given a transaction with two events.
-    let mut second = framework_event("1");
-    second.event_type = "0x3::validator::StakingRequestEvent".to_string();
-    let tx = checkpointed_tx(vec![framework_event("0"), second]);
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(tx));
+    let second = framework_event().with_event_type("0x3::validator::StakingRequestEvent");
+    let tx = checkpointed_tx(vec![framework_event(), second]);
+    let inspector = SuiInspector::new(MockSuiClient::transaction(tx));
 
     // When
     let extracted_values = inspector
@@ -133,7 +153,7 @@ async fn extract__should_return_not_finalized_when_checkpoint_is_missing() {
     // Given — executed but not yet included in a certified checkpoint.
     let mut tx = checkpointed_tx(vec![]);
     tx.checkpoint = None;
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(tx));
+    let inspector = SuiInspector::new(MockSuiClient::transaction(tx));
 
     // When
     let response = inspector
@@ -149,12 +169,10 @@ async fn extract__should_return_not_finalized_when_checkpoint_is_missing() {
 async fn extract__should_return_transaction_failed_when_execution_failed() {
     // Given
     let mut tx = checkpointed_tx(vec![]);
-    tx.effects = Some(TransactionBlockEffects {
-        status: ExecutionStatus {
-            status: "failure".to_string(),
-        },
-    });
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(tx));
+    tx.effects = Some(
+        TransactionEffects::default().with_status(ExecutionStatus::default().with_success(false)),
+    );
+    let inspector = SuiInspector::new(MockSuiClient::transaction(tx));
 
     // When
     let response = inspector
@@ -169,11 +187,31 @@ async fn extract__should_return_transaction_failed_when_execution_failed() {
 }
 
 #[tokio::test]
-async fn extract__should_reject_response_missing_effects_as_malformed() {
-    // Given — effects were requested via `showEffects`, so their absence violates the API.
+async fn extract__should_reject_response_missing_execution_status_as_malformed() {
+    // Given — the execution status was requested via the read mask, so its absence
+    // violates the API contract.
     let mut tx = checkpointed_tx(vec![]);
     tx.effects = None;
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(tx));
+    let inspector = SuiInspector::new(MockSuiClient::transaction(tx));
+
+    // When
+    let response = inspector
+        .extract(tx_id(), SuiFinality::Checkpointed, vec![])
+        .await;
+
+    // Then
+    assert_matches!(
+        response,
+        Err(ForeignChainInspectionError::MalformedRpcResponse(_))
+    );
+}
+
+#[tokio::test]
+async fn extract__should_reject_response_missing_transaction_as_malformed() {
+    // Given — a `GetTransactionResponse` whose transaction section is absent entirely.
+    let inspector = SuiInspector::new(MockSuiClient {
+        response: Ok(GetTransactionResponse::default()),
+    });
 
     // When
     let response = inspector
@@ -189,15 +227,10 @@ async fn extract__should_reject_response_missing_effects_as_malformed() {
 
 #[tokio::test]
 async fn extract__should_return_transaction_not_found_for_unknown_digest() {
-    // Given — the JSON-RPC error a node returns for an unknown or pruned digest.
-    let mock_client = FixedResponseRpcClient::new(|| {
-        Err(RpcClientError::Call(ErrorObject::owned(
-            -32602,
-            "Could not find the referenced transaction [TransactionDigest(88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd29)].",
-            None::<()>,
-        )))
-    });
-    let inspector = SuiInspector::new(mock_client);
+    // Given — the status a node returns for an unknown or pruned digest.
+    let inspector = SuiInspector::new(MockSuiClient::status(Status::not_found(
+        "Transaction 88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd29 not found",
+    )));
 
     // When
     let response = inspector
@@ -213,15 +246,11 @@ async fn extract__should_return_transaction_not_found_for_unknown_digest() {
 }
 
 #[tokio::test]
-async fn extract__should_propagate_transport_errors_as_transient() {
-    // Given
-    let mock_client = FixedResponseRpcClient::new(|| {
-        Err(RpcClientError::Transport(Box::new(std::io::Error::new(
-            std::io::ErrorKind::ConnectionRefused,
-            "connection refused",
-        ))))
-    });
-    let inspector = SuiInspector::new(mock_client);
+async fn extract__should_propagate_unavailable_provider_as_transient() {
+    // Given — the status a lazy tonic channel yields when the endpoint is unreachable.
+    let inspector = SuiInspector::new(MockSuiClient::status(Status::unavailable(
+        "error trying to connect: connection refused",
+    )));
 
     // When
     let response = inspector
@@ -229,15 +258,18 @@ async fn extract__should_propagate_transport_errors_as_transient() {
         .await;
 
     // Then
-    assert_matches!(response, Err(ForeignChainInspectionError::ClientError(_)));
+    assert_matches!(
+        response,
+        Err(ForeignChainInspectionError::RpcRequestFailed(_))
+    );
     assert!(response.unwrap_err().is_transient());
 }
 
 #[tokio::test]
 async fn extract__should_return_error_when_event_index_out_of_bounds() {
     // Given
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(checkpointed_tx(vec![
-        framework_event("0"),
+    let inspector = SuiInspector::new(MockSuiClient::transaction(checkpointed_tx(vec![
+        framework_event(),
     ])));
 
     // When
@@ -260,8 +292,8 @@ async fn extract__should_return_error_when_event_index_out_of_bounds() {
 async fn extract__should_reject_response_with_mismatched_digest() {
     // Given — the backend echoes a different transaction than queried.
     let mut tx = checkpointed_tx(vec![]);
-    tx.digest = bs58::encode([0xcd; 32]).into_string();
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(tx));
+    tx.digest = Some(bs58::encode([0xcd; 32]).into_string());
+    let inspector = SuiInspector::new(MockSuiClient::transaction(tx));
 
     // When
     let response = inspector
@@ -276,11 +308,11 @@ async fn extract__should_reject_response_with_mismatched_digest() {
 }
 
 #[tokio::test]
-async fn extract__should_reject_event_with_reordered_sequence() {
-    // Given — the event at position 0 claims eventSeq 1: a reordered or filtered list.
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(checkpointed_tx(vec![
-        framework_event("1"),
-    ])));
+async fn extract__should_reject_event_missing_bcs_contents_as_malformed() {
+    // Given — an event whose BCS payload is absent.
+    let mut event = framework_event();
+    event.contents = None;
+    let inspector = SuiInspector::new(MockSuiClient::transaction(checkpointed_tx(vec![event])));
 
     // When
     let response = inspector
@@ -301,7 +333,7 @@ async fn extract__should_reject_event_with_reordered_sequence() {
 #[tokio::test]
 async fn extract__should_return_empty_when_no_extractors_are_requested() {
     // Given
-    let inspector = SuiInspector::new(mock_client_from_fixed_response(checkpointed_tx(vec![])));
+    let inspector = SuiInspector::new(MockSuiClient::transaction(checkpointed_tx(vec![])));
 
     // When
     let extracted_values = inspector
@@ -312,105 +344,4 @@ async fn extract__should_return_empty_when_no_extractors_are_requested() {
     // Then
     let expected: Vec<SuiExtractedValue> = vec![];
     assert_eq!(expected, extracted_values);
-}
-
-fn setup_sui_rpc_mock(server: &MockServer, result: serde_json::Value) {
-    server.mock(|when, then| {
-        when.method(POST).path("/");
-        then.respond_with(move |req: &HttpMockRequest| {
-            let body: serde_json::Value =
-                serde_json::from_slice(req.body().as_ref()).expect("valid json-rpc request");
-            assert_eq!(
-                body["method"].as_str().expect("method field"),
-                "sui_getTransactionBlock"
-            );
-            assert_eq!(
-                body["params"],
-                serde_json::json!([
-                    tx_digest_base58(),
-                    { "showEffects": true, "showEvents": true }
-                ])
-            );
-
-            let response_body = serde_json::json!({
-                "jsonrpc": "2.0",
-                "result": result,
-                "id": body["id"],
-            });
-
-            HttpMockResponse::builder()
-                .status(200)
-                .header("content-type", "application/json")
-                .body(serde_json::to_string(&response_body).unwrap())
-                .build()
-        });
-    });
-}
-
-#[tokio::test]
-async fn extract__should_return_event_via_http_rpc_client() {
-    // Given
-    let server = MockServer::start();
-    setup_sui_rpc_mock(
-        &server,
-        serde_json::to_value(checkpointed_tx(vec![framework_event("0")])).unwrap(),
-    );
-    let client = build_http_client(server.url("/"), RpcAuthentication::KeyInUrl).unwrap();
-    let inspector = SuiInspector::new(client);
-
-    // When
-    let extracted_values = inspector
-        .extract(
-            tx_id(),
-            SuiFinality::Checkpointed,
-            vec![SuiExtractor::Event { event_index: 0 }],
-        )
-        .await
-        .expect("extract should succeed");
-
-    // Then
-    assert_eq!(
-        extracted_values,
-        vec![SuiExtractedValue::Event(expected_event())],
-    );
-}
-
-#[tokio::test]
-async fn extract__should_return_transaction_not_found_via_http_rpc_client() {
-    // Given — the exact not-found error envelope a mainnet node returns; jsonrpsee must
-    // surface it as a call error that classifies as `TransactionNotFound`.
-    let server = MockServer::start();
-    server.mock(|when, then| {
-        when.method(POST).path("/");
-        then.respond_with(move |req: &HttpMockRequest| {
-            let body: serde_json::Value =
-                serde_json::from_slice(req.body().as_ref()).expect("valid json-rpc request");
-            let response_body = serde_json::json!({
-                "jsonrpc": "2.0",
-                "error": {
-                    "code": -32602,
-                    "message": "Could not find the referenced transaction [TransactionDigest(88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd29)]."
-                },
-                "id": body["id"],
-            });
-            HttpMockResponse::builder()
-                .status(200)
-                .header("content-type", "application/json")
-                .body(serde_json::to_string(&response_body).unwrap())
-                .build()
-        });
-    });
-    let client = build_http_client(server.url("/"), RpcAuthentication::KeyInUrl).unwrap();
-    let inspector = SuiInspector::new(client);
-
-    // When
-    let response = inspector
-        .extract(tx_id(), SuiFinality::Checkpointed, vec![])
-        .await;
-
-    // Then
-    assert_matches!(
-        response,
-        Err(ForeignChainInspectionError::TransactionNotFound)
-    );
 }

--- a/crates/foreign-chain-inspector/tests/sui_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/sui_rpc_manual.rs
@@ -1,13 +1,18 @@
+use std::time::Duration;
+
 use foreign_chain_inspector::{
-    ForeignChainInspector, RpcAuthentication, build_http_client,
+    ForeignChainInspector,
     sui::{
         SuiExtractedValue, SuiTransactionDigest,
         inspector::{SuiExtractor, SuiFinality, SuiInspector},
     },
 };
+use foreign_chain_rpc_interfaces::sui::GrpcSuiClient;
 use near_mpc_contract_interface::types::SuiAddress;
 
-const PUBLIC_NODE_URL: &str = "https://fullnode.mainnet.sui.io:443";
+/// The Sui Foundation archive retains full history; regular fullnodes prune the gRPC read
+/// path after a few weeks, which would age a fixed reference digest out.
+const PUBLIC_ARCHIVE_URL: &str = "https://archive.mainnet.sui.io";
 
 /// The first epoch-change transaction on Sui mainnet (checkpoint 9769), whose first event
 /// is `0x3::validator_set::ValidatorEpochInfoEventV2` emitted by the system package `0x3`.
@@ -19,8 +24,12 @@ const EXPECTED_EVENT_MODULE: &str = "sui_system";
 #[tokio::test]
 async fn inspector_extracts_event_against_live_rpc_provider() {
     // given
-    let client =
-        build_http_client(PUBLIC_NODE_URL.to_string(), RpcAuthentication::KeyInUrl).unwrap();
+    let client = GrpcSuiClient::new(
+        PUBLIC_ARCHIVE_URL.to_string(),
+        None,
+        Duration::from_secs(10),
+    )
+    .unwrap();
     let inspector = SuiInspector::new(client);
     let tx_id = parse_tx_digest(CHECKPOINTED_TX_DIGEST);
 

--- a/crates/foreign-chain-rpc-interfaces/Cargo.toml
+++ b/crates/foreign-chain-rpc-interfaces/Cargo.toml
@@ -7,12 +7,18 @@ license.workspace = true
 [dependencies]
 derive_more = { workspace = true }
 ethereum-types = { workspace = true }
+http = { workspace = true }
 jsonrpsee = { workspace = true }
 mpc-primitives = { workspace = true }
 reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+sui-rpc = { workspace = true }
 thiserror = { workspace = true }
+tonic = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/foreign-chain-rpc-interfaces/src/sui.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/sui.rs
@@ -1,96 +1,125 @@
-use crate::to_rpc_params_impl;
+use std::future::Future;
+use std::time::Duration;
 
-use jsonrpsee::core::traits::ToRpcParams;
-use serde::{Deserialize, Serialize};
+use http::{HeaderName, HeaderValue};
+use sui_rpc::field::{FieldMask, FieldMaskUtil as _};
+use sui_rpc::proto::sui::rpc::v2::{
+    GetCheckpointRequest, GetCheckpointResponse, GetServiceInfoRequest, GetServiceInfoResponse,
+    GetTransactionRequest, GetTransactionResponse, get_checkpoint_request::CheckpointId,
+};
 
-/// Request args for `sui_getTransactionBlock`.
-pub struct GetTransactionBlockArgs {
-    /// Base58-encoded 32-byte transaction digest.
-    pub digest: String,
+pub use sui_rpc::proto::sui::rpc::v2 as proto;
+pub use tonic::{Code, Status};
+
+/// The exact fields the inspector verifies.
+const TRANSACTION_READ_MASK: &[&str] = &[
+    "digest",
+    "checkpoint",
+    "effects.status",
+    "events.events.package_id",
+    "events.events.module",
+    "events.events.sender",
+    "events.events.event_type",
+    "events.events.contents",
+];
+
+/// Sections needed to pick a probe transaction from a checkpoint.
+const CHECKPOINT_READ_MASK: &[&str] = &["sequence_number", "transactions.digest"];
+
+/// Client interface for the Sui gRPC API (`sui.rpc.v2.LedgerService`).
+pub trait SuiRpcClient: Send + Sync {
+    /// `digest` is the base58-encoded transaction digest.
+    fn get_transaction(
+        &self,
+        digest: &str,
+    ) -> impl Future<Output = Result<GetTransactionResponse, Status>> + Send;
+
+    fn get_service_info(
+        &self,
+    ) -> impl Future<Output = Result<GetServiceInfoResponse, Status>> + Send;
+
+    fn get_checkpoint(
+        &self,
+        sequence_number: u64,
+    ) -> impl Future<Output = Result<GetCheckpointResponse, Status>> + Send;
 }
 
-#[derive(Serialize)]
-#[serde(rename_all = "camelCase")]
-struct TransactionBlockResponseOptions {
-    show_effects: bool,
-    show_events: bool,
+#[derive(Clone)]
+pub struct GrpcSuiClient {
+    client: sui_rpc::Client,
+    timeout: Duration,
 }
 
-impl Serialize for GetTransactionBlockArgs {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        // `sui_getTransactionBlock` expects [digest, options]. Effects and events are the
-        // only response sections the inspector verifies; requesting nothing else keeps the
-        // cross-provider divergence surface minimal.
-        let options = TransactionBlockResponseOptions {
-            show_effects: true,
-            show_events: true,
-        };
-        (&self.digest, options).serialize(serializer)
+impl GrpcSuiClient {
+    /// `auth_header` is sent with every request (for `Header` auth). gRPC has no notion of
+    /// auth in the URL path or query, so header auth is the only supported scheme.
+    ///
+    /// Must be called within a tokio runtime: the (lazy) channel captures the runtime handle.
+    pub fn new(
+        url: String,
+        auth_header: Option<(HeaderName, HeaderValue)>,
+        timeout: Duration,
+    ) -> Result<Self, Status> {
+        let mut client = sui_rpc::Client::new(url)?;
+        if let Some((name, value)) = auth_header {
+            let mut header_map = http::HeaderMap::new();
+            header_map.insert(name, value);
+            let mut headers = sui_rpc::client::HeadersInterceptor::new();
+            *headers.headers_mut() = tonic::metadata::MetadataMap::from_headers(header_map);
+            client = client.with_headers(headers);
+        }
+        Ok(Self { client, timeout })
+    }
+
+    fn request_with_timeout<T>(&self, message: T) -> tonic::Request<T> {
+        let mut request = tonic::Request::new(message);
+        request.set_timeout(self.timeout);
+        request
     }
 }
 
-impl ToRpcParams for &GetTransactionBlockArgs {
-    to_rpc_params_impl!();
-}
+impl SuiRpcClient for GrpcSuiClient {
+    fn get_transaction(
+        &self,
+        digest: &str,
+    ) -> impl Future<Output = Result<GetTransactionResponse, Status>> + Send {
+        let mut client = self.client.clone();
+        let request = self.request_with_timeout(
+            GetTransactionRequest::default()
+                .with_digest(digest)
+                .with_read_mask(FieldMask::from_paths(TRANSACTION_READ_MASK.iter().copied())),
+        );
+        async move {
+            let response = client.ledger_client().get_transaction(request).await?;
+            Ok(response.into_inner())
+        }
+    }
 
-/// Partial RPC response for `sui_getTransactionBlock`, limited to the fields the
-/// inspector verifies so that envelope additions by providers keep deserializing.
-/// <https://docs.sui.io/sui-api-ref#sui_gettransactionblock>
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct TransactionBlockResponse {
-    /// Base58-encoded digest of the transaction, echoing the query key.
-    pub digest: String,
-    /// Present when requested via `showEffects`; carries the execution status.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effects: Option<TransactionBlockEffects>,
-    /// Events in `eventSeq` order; empty when the transaction emitted none or failed.
-    #[serde(default)]
-    pub events: Vec<SuiEventResponse>,
-    /// Sequence number (decimal string) of the checkpoint that includes the transaction.
-    /// Omitted until the transaction is included in a certified checkpoint, so its
-    /// presence is the finality signal.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub checkpoint: Option<String>,
-}
+    fn get_service_info(
+        &self,
+    ) -> impl Future<Output = Result<GetServiceInfoResponse, Status>> + Send {
+        let mut client = self.client.clone();
+        let request = self.request_with_timeout(GetServiceInfoRequest::default());
+        async move {
+            let response = client.ledger_client().get_service_info(request).await?;
+            Ok(response.into_inner())
+        }
+    }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TransactionBlockEffects {
-    pub status: ExecutionStatus,
-}
-
-/// `{"status":"success"}` or `{"status":"failure","error":"…"}`. The `error` prose is
-/// node-generated (not certified data), so only `status` is modelled.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub struct ExecutionStatus {
-    pub status: String,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SuiEventResponse {
-    pub id: SuiEventId,
-    pub package_id: String,
-    pub transaction_module: String,
-    pub sender: String,
-    #[serde(rename = "type")]
-    pub event_type: String,
-    /// BCS-serialized event contents, encoded per `bcs_encoding`.
-    pub bcs: String,
-    /// `"base64"` on current nodes; pre-1.26 nodes emitted base58 without this field.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub bcs_encoding: Option<String>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct SuiEventId {
-    pub tx_digest: String,
-    /// Zero-based index (decimal string) of the event within the transaction.
-    pub event_seq: String,
+    fn get_checkpoint(
+        &self,
+        sequence_number: u64,
+    ) -> impl Future<Output = Result<GetCheckpointResponse, Status>> + Send {
+        let mut client = self.client.clone();
+        let mut message = GetCheckpointRequest::default()
+            .with_read_mask(FieldMask::from_paths(CHECKPOINT_READ_MASK.iter().copied()));
+        message.checkpoint_id = Some(CheckpointId::SequenceNumber(sequence_number));
+        let request = self.request_with_timeout(message);
+        async move {
+            let response = client.ledger_client().get_checkpoint(request).await?;
+            Ok(response.into_inner())
+        }
+    }
 }
 
 #[cfg(test)]
@@ -98,132 +127,52 @@ pub struct SuiEventId {
 mod tests {
     use super::*;
 
-    #[test]
-    fn serialize_get_transaction_block_args__should_emit_digest_and_options() {
+    #[tokio::test]
+    async fn grpc_sui_client_new__should_accept_https_url() {
+        // Given / When / Then — the channel is lazy, so no connection is made here.
+        GrpcSuiClient::new(
+            "https://fullnode.mainnet.sui.io".to_string(),
+            None,
+            Duration::from_secs(5),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn grpc_sui_client_new__should_accept_auth_header() {
         // Given
-        let args = GetTransactionBlockArgs {
-            digest: "88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd3z".to_string(),
-        };
+        let auth_header = Some((
+            HeaderName::from_static("x-api-key"),
+            HeaderValue::from_static("secret-token"),
+        ));
 
-        // When
-        let serialized = serde_json::to_value(&args).unwrap();
+        // When / Then
+        GrpcSuiClient::new(
+            "https://sui.example.com".to_string(),
+            auth_header,
+            Duration::from_secs(5),
+        )
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn grpc_sui_client_new__should_reject_invalid_url() {
+        // Given / When
+        let result = GrpcSuiClient::new("not a url".to_string(), None, Duration::from_secs(5));
 
         // Then
-        assert_eq!(
-            serialized,
-            serde_json::json!([
-                "88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd3z",
-                { "showEffects": true, "showEvents": true }
-            ])
-        );
+        assert!(result.is_err());
     }
 
     #[test]
-    fn deserialize_transaction_block__should_parse_checkpointed_transaction_with_event() {
-        // Given — a mainnet fullnode response (non-verified fields trimmed for brevity;
-        // `timestampMs` kept to show extra fields are tolerated).
-        let json = serde_json::json!({
-            "digest": "88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd3z",
-            "effects": {
-                "messageVersion": "v1",
-                "status": { "status": "success" },
-                "executedEpoch": "1182",
-                "eventsDigest": "9R3ac9bP8QUDTjj5s6u1n9DsH6vMEFdwW1oSR9seSR1w"
-            },
-            "events": [
-                {
-                    "id": {
-                        "txDigest": "88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd3z",
-                        "eventSeq": "0"
-                    },
-                    "packageId": "0x55300367a2d40813727ccac4ecee977a39fb9cdb46f2e6b2c354b9798f5de2c0",
-                    "transactionModule": "pyth",
-                    "sender": "0x782439361331665cf8a79162fa3769d90338ece1ea9f7a78481c0afa7873aa3d",
-                    "type": "0x55300367a2d40813727ccac4ecee977a39fb9cdb46f2e6b2c354b9798f5de2c0::event::PriceFeedUpdateEvent",
-                    "parsedJson": { "timestamp": "1783511682" },
-                    "bcsEncoding": "base64",
-                    "bcs": "IOugcyOV+une"
-                }
-            ],
-            "timestampMs": "1783511682250",
-            "checkpoint": "296112296"
-        });
-
-        // When
-        let tx: TransactionBlockResponse = serde_json::from_value(json).unwrap();
+    fn transaction_read_mask__should_request_only_verified_sections() {
+        // Given / When
+        let request = GetTransactionRequest::default()
+            .with_digest("digest")
+            .with_read_mask(FieldMask::from_paths(TRANSACTION_READ_MASK.iter().copied()));
 
         // Then
-        assert_eq!(tx.digest, "88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd3z");
-        assert_eq!(tx.checkpoint.as_deref(), Some("296112296"));
-        assert_eq!(tx.effects.unwrap().status.status, "success");
-        assert_eq!(tx.events.len(), 1);
-        let event = &tx.events[0];
-        assert_eq!(event.id.event_seq, "0");
-        assert_eq!(event.transaction_module, "pyth");
-        assert_eq!(event.bcs_encoding.as_deref(), Some("base64"));
-        assert_eq!(
-            event.event_type,
-            "0x55300367a2d40813727ccac4ecee977a39fb9cdb46f2e6b2c354b9798f5de2c0::event::PriceFeedUpdateEvent"
-        );
-    }
-
-    #[test]
-    fn deserialize_transaction_block__should_parse_failed_transaction() {
-        // Given — a failed execution: `error` prose alongside the status is ignored.
-        let json = serde_json::json!({
-            "digest": "3MZKT3GiqcZJFtn18S1Qufd3jLZTmf5rBL2gCMofkVbn",
-            "effects": {
-                "status": {
-                    "status": "failure",
-                    "error": "MoveAbort(MoveLocation { … }, 3) in command 1"
-                }
-            },
-            "events": [],
-            "checkpoint": "296112100"
-        });
-
-        // When
-        let tx: TransactionBlockResponse = serde_json::from_value(json).unwrap();
-
-        // Then
-        assert_eq!(tx.effects.unwrap().status.status, "failure");
-        assert!(tx.events.is_empty());
-    }
-
-    #[test]
-    fn deserialize_transaction_block__should_parse_uncheckpointed_transaction() {
-        // Given — a locally-executed transaction not yet included in a checkpoint: the
-        // `checkpoint` key is omitted entirely (never null).
-        let json = serde_json::json!({
-            "digest": "88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd3z",
-            "effects": { "status": { "status": "success" } },
-            "events": []
-        });
-
-        // When
-        let tx: TransactionBlockResponse = serde_json::from_value(json).unwrap();
-
-        // Then
-        assert_eq!(tx.checkpoint, None);
-    }
-
-    #[test]
-    fn deserialize_event__should_tolerate_missing_bcs_encoding() {
-        // Given — the pre-1.26 event shape: base58 `bcs`, no `bcsEncoding` field.
-        let json = serde_json::json!({
-            "id": { "txDigest": "88XKXHJRmGzkfwJa8PhoeDkqt4kxz8AEsB1UTzAbtd3z", "eventSeq": "0" },
-            "packageId": "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "transactionModule": "sui_system",
-            "sender": "0x0000000000000000000000000000000000000000000000000000000000000000",
-            "type": "0x3::validator_set::ValidatorEpochInfoEventV2",
-            "bcs": "3mJr7AoUXx2Wqd"
-        });
-
-        // When
-        let event: SuiEventResponse = serde_json::from_value(json).unwrap();
-
-        // Then
-        assert_eq!(event.bcs_encoding, None);
-        assert_eq!(event.bcs, "3mJr7AoUXx2Wqd");
+        assert_eq!(request.digest.as_deref(), Some("digest"));
+        assert_eq!(request.read_mask.unwrap().paths, TRANSACTION_READ_MASK);
     }
 }

--- a/crates/node-config/src/foreign_chains.rs
+++ b/crates/node-config/src/foreign_chains.rs
@@ -119,8 +119,8 @@ impl ForeignChainsConfig {
 
         let mut seen_rpc_urls = BTreeSet::new();
 
-        for (foreign_chain_config, _identifier) in configured_chains {
-            for provider in foreign_chain_config.providers.values() {
+        for (foreign_chain_config, identifier) in configured_chains {
+            for (provider_name, provider) in foreign_chain_config.providers.iter() {
                 let rpc_url = &provider.rpc_url;
 
                 // is a valid URL
@@ -136,6 +136,16 @@ impl ForeignChainsConfig {
 
                 // valid auth configuration
                 provider.validate_auth_config()?;
+
+                // Sui providers are reached over gRPC, which carries credentials in request
+                // metadata; a token substituted into the URL path or query would never be sent.
+                if identifier == dtos::ForeignChain::Sui {
+                    anyhow::ensure!(
+                        matches!(provider.auth, AuthConfig::None | AuthConfig::Header { .. }),
+                        "sui provider `{}` uses path or query auth, but gRPC providers support only header auth",
+                        provider_name.as_str(),
+                    );
+                }
             }
         }
 
@@ -807,7 +817,7 @@ foreign_chains:
 
     #[test]
     fn config_parsing__should_succeed_with_sui_auth_providers() {
-        // Given — one provider with the API key in the URL path and one with a header token.
+        // Given — gRPC providers authenticate via headers; one bearer token and one API key.
         let yaml = r#"
 my_near_account_id: test.near
 near_responder_account_id: test.near
@@ -844,10 +854,11 @@ foreign_chains:
     max_retries: 3
     providers:
       blockdaemon:
-        rpc_url: "https://svc.blockdaemon.com/sui/mainnet/native/{api_key}"
+        rpc_url: "https://svc.blockdaemon.com"
         auth:
-          kind: path
-          placeholder: "{api_key}"
+          kind: header
+          name: Authorization
+          scheme: Bearer
           token:
             val: "blockdaemon-secret"
       nownodes:
@@ -873,5 +884,62 @@ foreign_chains:
             .as_ref()
             .expect("sui config should be present");
         assert_eq!(sui.providers.len(), 2);
+    }
+
+    #[test]
+    fn config_validation__should_reject_sui_provider_with_path_auth() {
+        // Given — path auth substitutes the token into the URL, which gRPC never sends.
+        let yaml = r#"
+my_near_account_id: test.near
+near_responder_account_id: test.near
+number_of_responder_keys: 1
+web_ui:
+  host: localhost
+  port: 8080
+migration_web_ui:
+  host: localhost
+  port: 8081
+pprof_bind_address: 127.0.0.1:34001
+indexer:
+  validate_genesis: false
+  sync_mode: Latest
+  finality: optimistic
+  concurrency: 1
+  mpc_contract_id: mpc-contract.test.near
+triple:
+  concurrency: 1
+  desired_triples_to_buffer: 1
+  timeout_sec: 60
+  parallel_triple_generation_stagger_time_sec: 1
+presignature:
+  concurrency: 1
+  desired_presignatures_to_buffer: 1
+  timeout_sec: 60
+signature:
+  timeout_sec: 60
+ckd:
+  timeout_sec: 60
+foreign_chains:
+  sui:
+    timeout_sec: 30
+    max_retries: 3
+    providers:
+      keyinpath:
+        rpc_url: "https://sui.example.com/{api_key}"
+        auth:
+          kind: path
+          placeholder: "{api_key}"
+          token:
+            val: "secret"
+"#;
+
+        // When
+        let config: ConfigFile =
+            serde_yaml::from_str(yaml).expect("yaml fixture should be correct");
+        let result = config.validate();
+
+        // Then
+        let error = result.unwrap_err().to_string();
+        assert!(error.contains("support only header auth"), "{error}");
     }
 }

--- a/crates/node/src/providers/verify_foreign_tx.rs
+++ b/crates/node/src/providers/verify_foreign_tx.rs
@@ -21,6 +21,7 @@ use foreign_chain_inspector::sui::inspector::SuiInspector;
 use foreign_chain_inspector::{FanOut, RpcAuthentication};
 use foreign_chain_rpc_auth::auth_config_to_rpc_auth;
 use foreign_chain_rpc_interfaces::aptos::ReqwestAptosClient;
+use foreign_chain_rpc_interfaces::sui::GrpcSuiClient;
 use mpc_node_config::{ConfigFile, ForeignChainConfig, ForeignChainsConfig};
 use near_mpc_contract_interface::types as dtos;
 use std::sync::Arc;
@@ -44,7 +45,7 @@ pub(crate) struct ForeignChainInspectors<Client> {
     pub hyper_evm: Option<FanOut<HyperEvmInspector<Client>>>,
     pub polygon: Option<FanOut<PolygonInspector<Client>>>,
     pub aptos: Option<FanOut<AptosInspector<ReqwestAptosClient>>>,
-    pub sui: Option<FanOut<SuiInspector<Client>>>,
+    pub sui: Option<FanOut<SuiInspector<GrpcSuiClient>>>,
 }
 
 impl ForeignChainInspectors<HttpClient> {
@@ -77,6 +78,23 @@ impl ForeignChainInspectors<HttpClient> {
                 let client = foreign_chain_inspector::build_http_client(url, rpc_auth)?;
                 Ok(new_inspector(client))
             }
+        }
+
+        fn new_sui_inspector(
+            url: String,
+            rpc_auth: RpcAuthentication,
+            timeout: Duration,
+        ) -> anyhow::Result<SuiInspector<GrpcSuiClient>> {
+            let auth_header = match rpc_auth {
+                RpcAuthentication::KeyInUrl => None,
+                RpcAuthentication::CustomHeader {
+                    header_name,
+                    header_value,
+                } => Some((header_name, header_value)),
+            };
+            let client = GrpcSuiClient::new(url, auth_header, timeout)
+                .map_err(|e| anyhow::anyhow!("failed to build the Sui gRPC client: {e}"))?;
+            Ok(SuiInspector::new(client))
         }
 
         fn new_aptos_inspector(
@@ -126,7 +144,7 @@ impl ForeignChainInspectors<HttpClient> {
                 with_http_client(PolygonInspector::new),
             )?,
             aptos: build_fanout(config.aptos.as_ref(), new_aptos_inspector)?,
-            sui: build_fanout(config.sui.as_ref(), with_http_client(SuiInspector::new))?,
+            sui: build_fanout(config.sui.as_ref(), new_sui_inspector)?,
         })
     }
 }

--- a/docs/localnet/mpc-config.template.toml
+++ b/docs/localnet/mpc-config.template.toml
@@ -100,7 +100,7 @@ timeout_sec = 30
 max_retries = 3
 
 [node.foreign_chains.sui.providers.public]
-rpc_url = "https://fullnode.mainnet.sui.io"
+rpc_url = "https://archive.mainnet.sui.io"
 
 [node.foreign_chains.sui.providers.public.auth]
 kind = "none"

--- a/docs/localnet/mpc-configs/config.yaml.template
+++ b/docs/localnet/mpc-configs/config.yaml.template
@@ -66,6 +66,6 @@ foreign_chains:
     max_retries: 3
     providers:
       public:
-        rpc_url: "https://fullnode.mainnet.sui.io"
+        rpc_url: "https://archive.mainnet.sui.io"
         auth:
           kind: none


### PR DESCRIPTION
Official SUI docs mentions that JSON-RPC was [deprecated](https://docs.sui.io/references/sui-api) and they're suggesting to [migrate to gRPC](https://docs.sui.io/develop/accessing-data/json-rpc-migration). This is an experimental branch that explores migration to gRPC, so the future of this branch is still TBD. It can be closed if we agree that relying on JSON-RPC is acceptable or merged if we decide that it's using gRPC is a better approach
