### PR TITLE
chore(deps): bump crossbeam-epoch to 0.9.20 (RUSTSEC-2026-0204)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2474,9 +2474,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
`cargo deny` advisories are failing repo-wide (on `main` and open PRs) on RUSTSEC-2026-0204 — an invalid pointer dereference in `crossbeam-epoch` 0.9.18's `fmt::Pointer` impl, reached transitively via `near-store`.

Bumps the lockfile to the fixed 0.9.20 (semver-compatible patch; lockfile-only, no manifest change).

Advisory: https://rustsec.org/advisories/RUSTSEC-2026-0204