### PR TITLE
ci: run doctests in CI (and fix contract README doctest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,14 @@ jobs:
         if: needs.changes.outputs.code_changed != 'false'
         run: nix develop --command cargo nextest run --cargo-profile=test-release --all-features --locked ${{ matrix.nextest-args }}
 
+      # nextest does not run doctests, so they are never exercised by the step
+      # above. Run them once (workspace-wide) on the node leg, whose test build
+      # already compiled mpc-node and most of its dependency tree with the same
+      # `test-release` profile, so this reuses those artifacts.
+      - name: Run doctests
+        if: needs.changes.outputs.code_changed != 'false' && matrix.group == 'node'
+        run: nix develop --command cargo test --doc --workspace --all-features --locked --profile test-release
+
   mpc-contract-reproducible-build:
     name: "MPC contract reproducible build"
     needs: changes

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -22,7 +22,7 @@ dependencies = [
 
 [tasks.check-all]
 description = "Run all checks"
-dependencies = ["check-all-fast", "nextest"]
+dependencies = ["check-all-fast", "nextest", "doctests"]
 
 [tasks.check-extra]
 description = "Run extra checks"
@@ -70,6 +70,21 @@ args = [
   "--all-features",
   "--all-targets",
   "--locked",
+]
+
+# `cargo nextest` does not run doctests, so they need a separate `cargo test --doc`
+# invocation to be exercised at all. `--profile test-release` matches the nextest
+# task so the two share build artifacts.
+[tasks.doctests]
+command = "cargo"
+args = [
+  "test",
+  "--doc",
+  "--workspace",
+  "--all-features",
+  "--locked",
+  "--profile",
+  "test-release",
 ]
 
 [tasks.zizmor]

--- a/crates/contract/README.md
+++ b/crates/contract/README.md
@@ -359,7 +359,7 @@ The MPC nodes will eventually run inside a Trusted Execution Environments (TEE).
 
 Participants that run their node inside a TEE will have to submit the following TEE related data to the contract:
 
-```rust
+```rust,ignore
 pub struct DstackAttestation {
     /// TEE Remote Attestation Quote that proves the participant's identity.
     pub quote: Quote,


### PR DESCRIPTION
Closes #3783

## Problem

`cargo nextest` — what CI runs for the test suite — does not execute doctests at all (https://nexte.st/docs/running/), and `cargo make check-docs` only runs `cargo doc` (intra-doc link checking). So **doctests were never exercised in CI**, which is why the broken contract README doctest (a regression from #3729) slipped through. Running `cargo test --doc --workspace --all-features` locally is the only thing that caught it.

## Changes

- **Fix the broken doctest**: mark the `DstackAttestation` example in `crates/contract/README.md` (pulled in as a doctest via `#![doc = include_str!("../README.md")]`) as `rust,ignore` — it references `Quote`, `Collateral`, `TcbInfo`, `ExpectedMeasurements` without imports and only illustrates the struct shape.
- **Run doctests in CI**: add a `Run doctests` step to the `mpc-unittests` **node** leg. That leg already compiles `mpc-node` and most of the workspace under the `test-release` profile, so the doctest run reuses those artifacts rather than paying for a fresh build or a new job/cache.
- **Local parity**: add a `doctests` cargo-make task and wire it into `check-all`, so `cargo make check-all` catches doctest breakage locally too.

A full `cargo test --doc --workspace --all-features` run confirms the contract block was the only broken doctest in the repo; everything else is green.

## Note / possible follow-up

A PR that changes *only* `.md` files is classified docs-only by `changes.yml` and skips all test jobs, including this doctest step. Since the two crate READMEs are doctest *sources*, a doctest broken by a README-only edit would still pass PR CI (it would fail on the subsequent `push` to `main`, where `code_changed` defaults to `true`). Left as-is to keep this PR focused; happy to tighten `changes.yml` in a follow-up if wanted.