### PR TITLE
refactor: shortening the line to StdRng::seed_from_u64

### DIFF
--- a/crates/e2e-tests/tests/cancellation_of_resharing.rs
+++ b/crates/e2e-tests/tests/cancellation_of_resharing.rs
@@ -2,7 +2,7 @@ use crate::common;
 
 use e2e_tests::CLUSTER_WAIT_TIMEOUT;
 use near_mpc_contract_interface::types::ProtocolContractState;
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 /// Tests resharing cancellation and retry.
 ///
@@ -20,7 +20,7 @@ async fn test_cancellation_of_resharing() {
             c.presignatures_to_buffer = 2;
         })
         .await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
 
     // Begin resharing to 5 nodes [0..5], threshold 3.
     tracing::info!("beginning resharing to nodes 0-4, threshold 3");

--- a/crates/e2e-tests/tests/cleanup_lagging_node.rs
+++ b/crates/e2e-tests/tests/cleanup_lagging_node.rs
@@ -3,7 +3,7 @@ use crate::common;
 use e2e_tests::{CLUSTER_WAIT_TIMEOUT, DEFAULT_PRESIGNATURES_TO_BUFFER, metrics};
 use mpc_node_config::MAX_INDEXER_HEIGHT_DIFF;
 use near_mpc_contract_interface::types::DomainPurpose;
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 /// Verify that when a node falls behind in block ingestion past the
 /// `MAX_INDEXER_HEIGHT_DIFF` threshold, the other nodes clean up all
@@ -13,7 +13,7 @@ use rand::SeedableRng;
 #[expect(non_snake_case)]
 async fn cleanup_lagging_node__should_purge_offline_presignatures_and_keep_signing() {
     // given
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     let (cluster, running) =
         common::must_setup_cluster(common::CLEANUP_LAGGING_NODE_PORT_SEED, |_| {}).await;
 

--- a/crates/e2e-tests/tests/distinct_reconstruction_thresholds.rs
+++ b/crates/e2e-tests/tests/distinct_reconstruction_thresholds.rs
@@ -8,7 +8,7 @@ use e2e_tests::{CLUSTER_WAIT_TIMEOUT, metrics};
 use near_mpc_contract_interface::types::{
     DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
 };
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 /// Each domain signs under its own reconstruction threshold, not the governance
 /// threshold. With 6 nodes and 1 killed, Cait-Sith (needs all 6) can no longer sign
@@ -17,7 +17,7 @@ use rand::SeedableRng;
 #[expect(non_snake_case)]
 async fn distinct_reconstruction_thresholds__should_use_per_domain_threshold_when_nodes_are_down() {
     // Given
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     let (mut cluster, contract_state) =
         must_setup_cluster(DISTINCT_RECONSTRUCTION_THRESHOLDS_PORT_SEED, |c| {
             c.num_nodes = 6;

--- a/crates/e2e-tests/tests/key_resharing.rs
+++ b/crates/e2e-tests/tests/key_resharing.rs
@@ -6,7 +6,7 @@ use mpc_primitives::domain::DomainId;
 use near_mpc_contract_interface::types::{
     DomainConfig, DomainPurpose, Protocol, ProtocolContractState, ReconstructionThreshold,
 };
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 /// Tests single-domain key generation and multiple rounds of resharing
 /// with participant set changes, verifying liveness after each round.
@@ -21,7 +21,7 @@ async fn test_key_resharing() {
         c.presignatures_to_buffer = 2;
     })
     .await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
 
     // Verify initial state: 2 participants, threshold 2.
     assert_eq!(running.parameters.participants.participants.len(), 2);
@@ -122,7 +122,7 @@ async fn test_multi_domain() {
         c.presignatures_to_buffer = 2;
     })
     .await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     assert_eq!(running.domains.next_domain_id, 3);
     common::send_sign_request(&cluster, &running, &mut rng, cluster.default_user_account())
         .await

--- a/crates/e2e-tests/tests/lost_assets.rs
+++ b/crates/e2e-tests/tests/lost_assets.rs
@@ -2,7 +2,7 @@ use crate::common;
 
 use e2e_tests::{CLUSTER_WAIT_TIMEOUT, metrics};
 use near_mpc_contract_interface::types::DomainPurpose;
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 const PRESIGNATURES_TO_BUFFER: usize = 8;
 
@@ -13,7 +13,7 @@ const PRESIGNATURES_TO_BUFFER: usize = 8;
 #[tokio::test]
 async fn dead_node_presignatures_purged_and_signing_recovers() {
     // given
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     let (mut cluster, running) = common::must_setup_cluster(common::LOST_ASSETS_PORT_SEED, |c| {
         c.presignatures_to_buffer = PRESIGNATURES_TO_BUFFER;
     })

--- a/crates/e2e-tests/tests/request_during_resharing.rs
+++ b/crates/e2e-tests/tests/request_during_resharing.rs
@@ -4,7 +4,7 @@ use crate::common::{
 };
 use near_mpc_contract_interface::types::{Protocol, ProtocolContractState};
 
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 /// Tests that signature and CKD requests are processed using the previous
 /// running state's threshold while resharing is in progress.
@@ -44,7 +44,7 @@ async fn test_request_during_resharing() {
     // then
     let ckd_domain = must_get_domain(&contract_state, Protocol::ConfidentialKeyDerivation);
 
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     for i in 0..3 {
         tracing::info!(i, "sending sign requests during resharing");
         sign_all_domains(&cluster, &contract_state, &mut rng).await;

--- a/crates/e2e-tests/tests/request_lifecycle.rs
+++ b/crates/e2e-tests/tests/request_lifecycle.rs
@@ -5,7 +5,7 @@ use crate::common::{
 };
 
 use near_mpc_contract_interface::types::{Curve, DomainPurpose, Protocol, SignatureResponse};
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 #[tokio::test]
 #[expect(non_snake_case)]
@@ -17,7 +17,7 @@ async fn mpc_cluster__should_sign_with_scheme_matching_domain() {
         !running.domains.domains.is_empty(),
         "expected at least one domain, got none"
     );
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     for domain in &running.domains.domains {
         tracing::info!(domain_id = ?domain.id, purpose = ?domain.purpose, curve = ?Curve::from(domain.protocol), "sending request");
         match domain.purpose {
@@ -94,7 +94,7 @@ async fn mpc_cluster__should_successfully_process_robust_ecdsa_requests() {
 
     let domain = must_get_domain(&running, Protocol::DamgardEtAl);
 
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
 
     // when
     let outcome = cluster

--- a/crates/e2e-tests/tests/timeout_metric.rs
+++ b/crates/e2e-tests/tests/timeout_metric.rs
@@ -2,7 +2,7 @@ use crate::common;
 
 use e2e_tests::{CLUSTER_WAIT_TIMEOUT, metrics};
 use near_mpc_contract_interface::types::DomainPurpose;
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 /// When a sign request can't be answered (because too many participants are
 /// down), the contract calls `fail_on_timeout` and each alive node's indexer
@@ -13,7 +13,7 @@ use rand::SeedableRng;
 #[expect(non_snake_case)]
 async fn timeout_metric__should_increment_when_signature_times_out() {
     // given — 2-of-2 cluster (one node down ⇒ signing impossible)
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     let (mut cluster, running) =
         common::must_setup_cluster(common::TIMEOUT_METRIC_PORT_SEED, |c| {
             c.num_nodes = 2;

--- a/crates/e2e-tests/tests/update_participant_url.rs
+++ b/crates/e2e-tests/tests/update_participant_url.rs
@@ -4,7 +4,7 @@ use backon::{ConstantBuilder, Retryable};
 use e2e_tests::MpcCluster;
 use near_account_id::AccountId;
 use near_mpc_contract_interface::types::ProtocolContractState;
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 /// End-to-end acceptance for #3677: a `update_participant_url` call on a real cluster is accepted,
 /// the new URL is reflected in state, and the network keeps signing without a resharing.
@@ -14,7 +14,7 @@ async fn update_participant_url__should_keep_signing_after_url_update() {
     // Given
     let (cluster, running) =
         common::must_setup_cluster(common::UPDATE_PARTICIPANT_URL_PORT_SEED, |_| {}).await;
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     let user = cluster.default_user_account().clone();
     common::send_sign_request(&cluster, &running, &mut rng, &user)
         .await

--- a/crates/e2e-tests/tests/web_endpoints.rs
+++ b/crates/e2e-tests/tests/web_endpoints.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use anyhow::Context;
 use e2e_tests::MpcNodeState;
 use near_mpc_contract_interface::types::DomainPurpose;
-use rand::SeedableRng;
+use rand::{SeedableRng, rngs::StdRng};
 
 async fn fetch_body(client: &reqwest::Client, node: usize, url: &str) -> anyhow::Result<String> {
     client
@@ -101,7 +101,7 @@ async fn test_web_endpoints() {
 
     // Send one request per domain.
     assert!(!running.domains.domains.is_empty(), "no domains found");
-    let mut rng = rand::rngs::StdRng::seed_from_u64(0);
+    let mut rng = StdRng::seed_from_u64(0);
     for domain in &running.domains.domains {
         let outcome = match domain.purpose {
             DomainPurpose::Sign => {


### PR DESCRIPTION
Tiny PR, follows a comment from Reynaldo:
https://github.com/near/mpc/pull/3640#discussion_r3558931990