### PR TITLE
chore: bump to nearcore 2.13.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1812,10 +1812,10 @@ dependencies = [
  "near-account-id",
  "near-async",
  "near-client",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-indexer",
  "near-indexer-primitives",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "near-sdk",
  "near-store",
  "nearcore",
@@ -5973,17 +5973,17 @@ dependencies = [
  "near-account-id",
  "near-async",
  "near-client",
- "near-config-utils 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
  "near-indexer",
  "near-indexer-primitives",
  "near-mpc-bounded-collections",
  "near-mpc-contract-interface",
  "near-mpc-crypto-types",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "near-sdk",
  "near-store",
- "near-time 2.13.0-rc.2",
+ "near-time 2.13.1",
  "node-types",
  "num_enum",
  "pprof",
@@ -6192,14 +6192,14 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "crossbeam-channel",
  "futures",
  "near-async-derive",
- "near-o11y 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-time 2.13.1",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
@@ -6212,8 +6212,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6222,8 +6222,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -6231,8 +6231,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6245,19 +6245,19 @@ dependencies = [
  "lru 0.16.4",
  "near-async",
  "near-cache",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -6301,19 +6301,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.1.1",
- "near-config-utils 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "serde",
@@ -6326,33 +6326,33 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-crypto 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
  "near-async",
  "near-chain",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chunks-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "near-store",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -6364,17 +6364,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6385,22 +6385,22 @@ dependencies = [
  "near-async",
  "near-cache",
  "near-chain",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -6425,14 +6425,14 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.18",
@@ -6453,8 +6453,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -6490,8 +6490,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -6502,9 +6502,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
  "primitive-types 0.10.1",
  "rand 0.8.6",
  "secp256k1 0.27.0",
@@ -6536,14 +6536,14 @@ checksum = "b8fd0822ff3a82bdccda49b787cb11530512a929bfd13fd0d9fbd510b6360200"
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
- "near-chain-configs 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -6551,18 +6551,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
  "near-cache",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -6576,12 +6576,12 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "object_store",
  "percent-encoding",
  "reqwest 0.13.4",
@@ -6602,10 +6602,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-primitives-core 2.13.0-rc.2",
+ "near-primitives-core 2.13.1",
 ]
 
 [[package]]
@@ -6657,22 +6657,22 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-indexer-primitives",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -6684,33 +6684,33 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "bs58 0.4.0",
  "easy-ext",
  "futures",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-client",
  "near-client-primitives",
  "near-epoch-manager",
  "near-jsonrpc-client-internal",
- "near-jsonrpc-primitives 2.13.0-rc.2",
+ "near-jsonrpc-primitives 2.13.1",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
  "near-store",
  "parking_lot 0.12.5",
  "serde",
@@ -6742,12 +6742,12 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
- "near-jsonrpc-primitives 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-jsonrpc-primitives 2.13.1",
+ "near-primitives 2.13.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -6774,16 +6774,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-time 2.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6835,12 +6835,12 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-account-id",
- "near-chain-configs 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
+ "near-primitives 2.13.1",
  "serde_json",
 ]
 
@@ -6936,8 +6936,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6953,12 +6953,12 @@ dependencies = [
  "lru 0.16.4",
  "named-lock",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
- "near-fmt 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
+ "near-crypto 2.13.1",
+ "near-fmt 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.5",
@@ -7003,13 +7003,13 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives-core 2.13.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -7045,14 +7045,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -7063,13 +7063,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
  "rand 0.8.6",
 ]
 
@@ -7118,8 +7118,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -7134,13 +7134,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto 2.13.0-rc.2",
- "near-fmt 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-fmt 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
+ "near-time 2.13.1",
  "num-rational 0.3.2",
  "ordered-float 4.6.0",
  "primitive-types 0.10.1",
@@ -7185,8 +7185,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -7196,7 +7196,7 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-gas",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-schema-checker-lib 2.13.1",
  "near-token",
  "num-rational 0.3.2",
  "serde",
@@ -7208,8 +7208,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "derive_more 2.1.1",
@@ -7218,14 +7218,14 @@ dependencies = [
  "insta",
  "near-account-id",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
  "node-runtime",
  "serde",
  "serde_json",
@@ -7267,8 +7267,8 @@ checksum = "37ad456b1bd9876772d6c0b557d100d518d60dd13e359daca8e0293828e29a05"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -7282,11 +7282,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-schema-checker-core 2.13.0-rc.2",
- "near-schema-checker-macro 2.13.0-rc.2",
+ "near-schema-checker-core 2.13.1",
+ "near-schema-checker-macro 2.13.1",
 ]
 
 [[package]]
@@ -7297,8 +7297,8 @@ checksum = "731a7b9cc155e291f149f2f6f8f88f5cab512b772aaf301f9defb4e4bceb1629"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-sdk"
@@ -7395,13 +7395,13 @@ checksum = "f35191f9d7a78d5cdca9788e648dce89ebbb74faef4abfa6992ed7f1fb300369"
 
 [[package]]
 name = "near-stdx"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-store"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -7418,18 +7418,18 @@ dependencies = [
  "itoa",
  "lru 0.16.4",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-external-storage",
- "near-fmt 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
- "near-vm-runner 2.13.0-rc.2",
+ "near-fmt 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
+ "near-time 2.13.1",
+ "near-vm-runner 2.13.1",
  "num_cpus",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -7457,12 +7457,12 @@ checksum = "48b26c10a43e1dccab24e80dd38c3bf73eab9c95da54fcce1144f2b58ef5b507"
 
 [[package]]
 name = "near-telemetry"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
  "near-async",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -7482,8 +7482,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -7504,8 +7504,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.1",
@@ -7520,8 +7520,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -7539,8 +7539,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.1",
@@ -7603,8 +7603,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "blst",
@@ -7617,12 +7617,12 @@ dependencies = [
  "finite-wasm 0.6.1",
  "lru 0.16.4",
  "memoffset 0.8.0",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -7653,8 +7653,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
@@ -7664,8 +7664,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "cc",
@@ -7685,12 +7685,12 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.13.0-rc.2",
- "near-vm-runner 2.13.0-rc.2",
+ "near-primitives-core 2.13.1",
+ "near-vm-runner 2.13.1",
 ]
 
 [[package]]
@@ -7757,8 +7757,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7771,28 +7771,28 @@ dependencies = [
  "itertools 0.14.0",
  "near-async",
  "near-chain",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-jsonrpc",
- "near-jsonrpc-primitives 2.13.0-rc.2",
+ "near-jsonrpc-primitives 2.13.1",
  "near-mainnet-res",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -7826,8 +7826,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
@@ -7835,13 +7835,13 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "near-async",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-primitives-core 2.13.1",
  "near-store",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "near-wallet-contract",
  "parking_lot 0.12.5",
  "rand 0.8.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -275,16 +275,16 @@ zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zstd = "0.13.3"
 
 # NEAR CORE DEPENDENCIES:
-near-async = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-store = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-nearcore = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
+near-async = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-store = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+nearcore = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
 
 ## Outdated dependencies we cannot upgrade ##
 # Version 0.8.3 requires rustc 1.88

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,4 +6,4 @@ pub mod contract_types;
 /// Single source of truth shared by the e2e-tests crate and the contract test crates.
 /// `scripts/check-sandbox-image-version.sh` enforces that this stays in lockstep with
 /// the workspace's nearcore tag.
-pub const DEFAULT_SANDBOX_VERSION: &str = "2.13.0-rc.2";
+pub const DEFAULT_SANDBOX_VERSION: &str = "2.13.1";


### PR DESCRIPTION
Bumps nearcore `2.13.0-rc.2` → `2.13.1` on `main` (tag + `DEFAULT_SANDBOX_VERSION` + regenerated `Cargo.lock`). 2.13.1 (CODE_YELLOW) includes the rc.3 state-sync change and is compatible with **both testnet and mainnet**.

Closes #3817. Part of the 3.13.2 release (#3789).