### PR TITLE
chore: bump cargo near and use its new check feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1485,7 +1485,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -1656,12 +1656,13 @@ dependencies = [
 
 [[package]]
 name = "cargo-near-build"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ac5d02ecf67ee2978f7514b6893d94c74c1b79c26a6b9f83e044d70bd7a6b4"
+checksum = "663db26ba261f4ca79499cb6847b91b9c40976e0b9da7c01a40fb3f063964967"
 dependencies = [
  "bon",
  "bs58 0.5.1",
+ "bytesize",
  "camino",
  "cargo_metadata",
  "colored",
@@ -2001,7 +2002,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3047,7 +3048,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.2",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3458,7 +3459,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5019,7 +5020,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7889,7 +7890,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10060,7 +10061,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10140,7 +10141,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11290,7 +11291,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12941,7 +12942,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ bs58 = { version = "0.5.1" }
 built = { version = "0.8", features = ["git2", "chrono"] }
 byteorder = "1.5.0"
 bytes = { version = "1.11.1" }
-cargo-near-build = "0.11.3"
+cargo-near-build = "0.11.5"
 clap = { version = "4.6.1", features = ["derive", "env"] }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 curve25519-dalek = { version = "4.1.3", features = [

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,6 +18,7 @@ dependencies = [
   "check-docs",
   "clippy",
   "clippy-all-features",
+  "contract-check",
 ]
 
 [tasks.check-all]
@@ -47,6 +48,23 @@ args = [
 [tasks.clippy]
 command = "cargo"
 args = ["clippy", "--all-targets", "--locked", "--", "-D", "warnings"]
+
+# The wasm32 + `--cfg near` counterpart of the `clippy` task: it lints the contract
+# crates in the build config they actually deploy under, which plain `cargo clippy`
+# (host target, no `--cfg near`) can't reach. `RUSTFLAGS=-Dwarnings` makes it a gate;
+# Cargo caps lints on non-workspace deps, so only our crates can fail.
+[tasks.contract-check]
+description = "Lint contract crates under the real build config via `cargo near check`"
+script = '''
+#!/usr/bin/env bash
+set -euo pipefail
+# Contract crates are exactly the workspace cdylibs; ask Cargo so the list self-maintains.
+cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(any(.targets[].crate_types[]; . == "cdylib")) | .manifest_path' \
+  | while read -r manifest; do
+      cargo near check --clippy --locked --env 'RUSTFLAGS=-Dwarnings' --manifest-path "$manifest"
+    done
+'''
 
 [tasks.fmt]
 command = "cargo"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -49,22 +49,10 @@ args = [
 command = "cargo"
 args = ["clippy", "--all-targets", "--locked", "--", "-D", "warnings"]
 
-# The wasm32 + `--cfg near` counterpart of the `clippy` task: it lints the contract
-# crates in the build config they actually deploy under, which plain `cargo clippy`
-# (host target, no `--cfg near`) can't reach. `RUSTFLAGS=-Dwarnings` makes it a gate;
-# Cargo caps lints on non-workspace deps, so only our crates can fail.
 [tasks.contract-check]
 description = "Lint contract crates under the real build config via `cargo near check`"
-script = '''
-#!/usr/bin/env bash
-set -euo pipefail
-# Contract crates are exactly the workspace cdylibs; ask Cargo so the list self-maintains.
-cargo metadata --no-deps --format-version 1 \
-  | jq -r '.packages[] | select(any(.targets[].crate_types[]; . == "cdylib")) | .manifest_path' \
-  | while read -r manifest; do
-      cargo near check --clippy --locked --env 'RUSTFLAGS=-Dwarnings' --manifest-path "$manifest"
-    done
-'''
+command = "bash"
+args = ["scripts/check-contract-clippy.sh"]
 
 [tasks.fmt]
 command = "cargo"

--- a/crates/chain-gateway-test-contract/Cargo.toml
+++ b/crates/chain-gateway-test-contract/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/near/mpc"
 ignored = ["borsh"]
 
 [package.metadata.near.reproducible_build]
-image = "sourcescan/cargo-near:0.21.1-rust-1.97.0"
-image_digest = "sha256:7ba2b3251f29e5d29fca1611cb5298fc44bafddcff8cab2e143b1e491da16633"
+image = "sourcescan/cargo-near:0.22.0-rust-1.97.0"
+image_digest = "sha256:b193c8640a27172f83136a0f0aab2a9bf9d09f6ba0e6afd187addfaa9b92bae0"
 passed_env = []
 container_build_command = ["cargo", "near", "build", "non-reproducible-wasm", "--locked"]
 

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -18,9 +18,9 @@ repository = "https://github.com/near/mpc"
 [package.metadata.near.reproducible_build]
 # docker image, descriptor of build environment; pinned to match
 # `rust-toolchain.toml` (1.97.0)
-image = "sourcescan/cargo-near:0.21.1-rust-1.97.0"
+image = "sourcescan/cargo-near:0.22.0-rust-1.97.0"
 # tag after colon above serves only descriptive purpose; image is identified by digest
-image_digest = "sha256:7ba2b3251f29e5d29fca1611cb5298fc44bafddcff8cab2e143b1e491da16633"
+image_digest = "sha256:b193c8640a27172f83136a0f0aab2a9bf9d09f6ba0e6afd187addfaa9b92bae0"
 # list of environment variables names, whose values, if set, will be used as external build parameters
 # in a reproducible manner
 # supported by `sourcescan/cargo-near:0.10.1-rust-1.82.0` image or later images

--- a/crates/contract/src/crypto_shared/kdf.rs
+++ b/crates/contract/src/crypto_shared/kdf.rs
@@ -1,14 +1,10 @@
 use crate::crypto_shared::types::k256_types;
 use curve25519_dalek::constants::ED25519_BASEPOINT_POINT;
-#[cfg(target_arch = "wasm32")]
-use k256::EncodedPoint;
 use k256::{
     Secp256k1,
     elliptic_curve::{CurveArithmetic, PrimeField, point::AffineCoordinates},
 };
 use near_mpc_contract_interface::types::Tweak;
-#[cfg(target_arch = "wasm32")]
-use near_sdk::env;
 
 use near_mpc_contract_interface::types as dtos;
 

--- a/crates/mpc-attestation/src/attestation.rs
+++ b/crates/mpc-attestation/src/attestation.rs
@@ -27,7 +27,10 @@ use crate::alloc::string::{String, ToString};
 // TODO(#1639): extract timestamp from certificate itself
 pub const DEFAULT_EXPIRATION_DURATION_SECONDS: u64 = 60 * 60 * 24; // 1 day
 
-#[expect(clippy::large_enum_variant)]
+// `large_enum_variant` fires only where `usize` is 64-bit; under the contract's
+// wasm32 build the variants are close enough in size that it doesn't, so gate the
+// expectation to non-wasm targets to keep it fulfilled in both configs.
+#[cfg_attr(not(target_arch = "wasm32"), expect(clippy::large_enum_variant))]
 #[derive(Clone, Debug, Serialize, Deserialize, BorshSerialize, BorshDeserialize)]
 pub enum Attestation {
     Dstack(DstackAttestation),

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -8,8 +8,8 @@ edition = { workspace = true }
 ignored = ["borsh"]
 
 [package.metadata.near.reproducible_build]
-image = "sourcescan/cargo-near:0.21.1-rust-1.97.0"
-image_digest = "sha256:7ba2b3251f29e5d29fca1611cb5298fc44bafddcff8cab2e143b1e491da16633"
+image = "sourcescan/cargo-near:0.22.0-rust-1.97.0"
+image_digest = "sha256:b193c8640a27172f83136a0f0aab2a9bf9d09f6ba0e6afd187addfaa9b92bae0"
 passed_env = []
 container_build_command = [
     "cargo",

--- a/nix/cargo-near.nix
+++ b/nix/cargo-near.nix
@@ -11,16 +11,16 @@
 
 rustPlatform.buildRustPackage rec {
   pname = "cargo-near";
-  version = "0.21.1";
+  version = "0.22.0";
 
   src = fetchFromGitHub {
     owner = "near";
     repo = "cargo-near";
     rev = "cargo-near-v${version}";
-    hash = "sha256-O/RljsKHw1ayptqA1x/yYFOfBYhPENxqgGpdNeoBsOc=";
+    hash = "sha256-NCmfh+Va5eOqcysxqzJEuMJ/X+++4cv9gYgV6v8FQHk=";
   };
 
-  cargoHash = "sha256-MjARNIPBd429eBebtP84OpWpH8nYhlIDAqt7thTqGk8=";
+  cargoHash = "sha256-kDjFyovfa3jQeY9i5tWcqshpw0zYppeFmJVWvZDW7cg=";
 
   nativeBuildInputs = [
     pkg-config

--- a/scripts/check-contract-clippy.sh
+++ b/scripts/check-contract-clippy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Lint contract crates under the real build config via `cargo near check`.
+#
+# The wasm32 + `--cfg near` counterpart of plain `cargo clippy`: it lints the
+# contract crates in the build config they actually deploy under, which the host
+# target (no `--cfg near`) can't reach. `RUSTFLAGS=-Dwarnings` makes it a gate;
+# Cargo caps lints on non-workspace deps, so only our crates can fail.
+#
+# Contract crates are exactly the workspace cdylibs; ask Cargo so the list self-maintains.
+cargo metadata --no-deps --format-version 1 \
+  | jq -r '.packages[] | select(any(.targets[].crate_types[]; . == "cdylib")) | .manifest_path' \
+  | while read -r manifest; do
+      cargo near check --clippy --locked --env 'RUSTFLAGS=-Dwarnings' --manifest-path "$manifest"
+    done


### PR DESCRIPTION
Closes #3814 


~~Notice we are not bumping the images from sourcescan we use for reproducible builds, because they do not support rust 1.93 anymore for their cargo near 0.22 versions. This has not been a problem in the past, but if possible we should ask them to publish that image as well to keep everything in sync.~~