### PR TITLE
chore: bump rust version to 1.97

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7451,9 +7451,9 @@ dependencies = [
 
 [[package]]
 name = "near-sys"
-version = "0.2.9"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c212278351251aa342eab33a9d64f99294bc5784cda10107867a72dda699bb"
+checksum = "48b26c10a43e1dccab24e80dd38c3bf73eab9c95da54fcce1144f2b58ef5b507"
 
 [[package]]
 name = "near-telemetry"

--- a/crates/chain-gateway-test-contract/Cargo.toml
+++ b/crates/chain-gateway-test-contract/Cargo.toml
@@ -9,8 +9,8 @@ repository = "https://github.com/near/mpc"
 ignored = ["borsh"]
 
 [package.metadata.near.reproducible_build]
-image = "sourcescan/cargo-near:0.21.1-rust-1.93.0"
-image_digest = "sha256:79b789c81ba19ec30794a6b1046b02dcaf5c055994b22cc7c9af67ab5096b095"
+image = "sourcescan/cargo-near:0.21.1-rust-1.97.0"
+image_digest = "sha256:7ba2b3251f29e5d29fca1611cb5298fc44bafddcff8cab2e143b1e491da16633"
 passed_env = []
 container_build_command = ["cargo", "near", "build", "non-reproducible-wasm", "--locked"]
 

--- a/crates/contract/Cargo.toml
+++ b/crates/contract/Cargo.toml
@@ -17,10 +17,10 @@ repository = "https://github.com/near/mpc"
 # in https://github.com/near/NEPs/blob/master/neps/nep-0330.md
 [package.metadata.near.reproducible_build]
 # docker image, descriptor of build environment; pinned to match
-# `rust-toolchain.toml` (1.93.0)
-image = "sourcescan/cargo-near:0.21.1-rust-1.93.0"
+# `rust-toolchain.toml` (1.97.0)
+image = "sourcescan/cargo-near:0.21.1-rust-1.97.0"
 # tag after colon above serves only descriptive purpose; image is identified by digest
-image_digest = "sha256:79b789c81ba19ec30794a6b1046b02dcaf5c055994b22cc7c9af67ab5096b095"
+image_digest = "sha256:7ba2b3251f29e5d29fca1611cb5298fc44bafddcff8cab2e143b1e491da16633"
 # list of environment variables names, whose values, if set, will be used as external build parameters
 # in a reproducible manner
 # supported by `sourcescan/cargo-near:0.10.1-rust-1.82.0` image or later images

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -6034,7 +6034,7 @@ mod tests {
         // then
         let error_string = result.unwrap_err().to_string();
         assert!(error_string
-        .contains("Invalid TEE Remote Attestation: TeeQuoteStatus is invalid: the submitted attestation failed verification, reason: Custom(\"the allowed mpc image hashes list is empty\")"), "Got error: {}", &error_string);
+        .contains("Invalid TEE Remote Attestation: TeeQuoteStatus is invalid: the submitted attestation failed verification, reason: Custom(\"the allowed mpc image hashes list is empty\")"), "Got error: {}", error_string);
     }
 
     /// **TLS key validation** - Tests that TEE attestation fails when TLS key doesn't match the one in report data.
@@ -6084,7 +6084,7 @@ mod tests {
         // then
         let error_string = result.unwrap_err().to_string();
         assert!(error_string
-        .contains("Invalid TEE Remote Attestation: TeeQuoteStatus is invalid: the submitted attestation failed verification, reason: WrongHash { name: \"report_data\""), "Got error: {}", &error_string);
+        .contains("Invalid TEE Remote Attestation: TeeQuoteStatus is invalid: the submitted attestation failed verification, reason: WrongHash { name: \"report_data\""), "Got error: {}", error_string);
     }
 
     fn make_launcher_hash(byte: u8) -> LauncherImageHash {

--- a/crates/contract/tests/sandbox/vote.rs
+++ b/crates/contract/tests/sandbox/vote.rs
@@ -150,8 +150,7 @@ async fn test_cancel_keygen() -> anyhow::Result<()> {
         panic!("expected running state");
     };
     let epoch_id: u64 = init_running.keyset.epoch_id.0;
-    let mut next_domain_id: u64 = init_running.domains.next_domain_id;
-    for protocol in ALL_PROTOCOLS {
+    for (next_domain_id, protocol) in (init_running.domains.next_domain_id..).zip(ALL_PROTOCOLS) {
         let curve = Curve::from(*protocol);
         let threshold = init_running.parameters.threshold.0 as usize;
 
@@ -238,7 +237,6 @@ async fn test_cancel_keygen() -> anyhow::Result<()> {
         // assert that the epoch id did not change
         assert_eq!(running.keyset.epoch_id.0, epoch_id);
         assert_eq!(running.domains.next_domain_id, next_domain_id + 1);
-        next_domain_id += 1;
     }
     Ok(())
 }

--- a/crates/devnet/src/mpc.rs
+++ b/crates/devnet/src/mpc.rs
@@ -641,8 +641,7 @@ impl MpcVoteAddDomainsCmd {
             }
         };
         let mut proposal = Vec::new();
-        let mut next_domain = domains.next_domain_id;
-        for protocol in &protocols {
+        for (next_domain, protocol) in (domains.next_domain_id..).zip(&protocols) {
             let purpose = match protocol {
                 Protocol::ConfidentialKeyDerivation => DomainPurpose::CKD,
                 Protocol::CaitSith | Protocol::DamgardEtAl | Protocol::Frost => DomainPurpose::Sign,
@@ -653,7 +652,6 @@ impl MpcVoteAddDomainsCmd {
                 reconstruction_threshold: ReconstructionThreshold::new(2),
                 purpose,
             });
-            next_domain += 1;
         }
 
         let from_accounts = get_voter_account_ids(mpc_setup, &self.voters);

--- a/crates/foreign-chain-config-tester/src/main.rs
+++ b/crates/foreign-chain-config-tester/src/main.rs
@@ -362,7 +362,7 @@ fn mark_skipped(
     reason: &str,
     out: &mut Vec<ProviderResult>,
 ) {
-    for (name, _) in cfg.providers.iter() {
+    for name in cfg.providers.keys() {
         out.push(ProviderResult::skipped(chain, provider_name(name), reason));
     }
 }

--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -437,7 +437,7 @@ pub fn load_listening_blocks_file(home_dir: &Path) -> anyhow::Result<bool> {
         }
         Err(err) => Err(anyhow::anyhow!(
             "Could not find file {:?}: {}",
-            &listen_blocks_file,
+            listen_blocks_file,
             err
         )),
     }

--- a/crates/node/src/providers/ecdsa/triple.rs
+++ b/crates/node/src/providers/ecdsa/triple.rs
@@ -481,7 +481,7 @@ mod tests {
 
         Ok(triples
             .into_iter()
-            .chain(passive_triples.await.unwrap().into_iter())
+            .chain(passive_triples.await.unwrap())
             .collect())
     }
 

--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -8,8 +8,8 @@ edition = { workspace = true }
 ignored = ["borsh"]
 
 [package.metadata.near.reproducible_build]
-image = "sourcescan/cargo-near:0.21.1-rust-1.93.0"
-image_digest = "sha256:79b789c81ba19ec30794a6b1046b02dcaf5c055994b22cc7c9af67ab5096b095"
+image = "sourcescan/cargo-near:0.21.1-rust-1.97.0"
+image_digest = "sha256:7ba2b3251f29e5d29fca1611cb5298fc44bafddcff8cab2e143b1e491da16633"
 passed_env = []
 container_build_command = [
     "cargo",

--- a/crates/threshold-signatures/src/crypto/hash.rs
+++ b/crates/threshold-signatures/src/crypto/hash.rs
@@ -128,7 +128,7 @@ pub mod test {
         let a = HashOutput([1u8; 32]);
         let b = HashOutput([1u8; 32]);
         let result = a.ct_eq(&b);
-        assert!(result.unwrap_u8() == 1);
+        assert_eq!(result.unwrap_u8(), 1);
     }
 
     #[test]
@@ -136,7 +136,7 @@ pub mod test {
         let a = HashOutput([1u8; 32]);
         let b = HashOutput([2u8; 32]);
         let result = a.ct_eq(&b);
-        assert!(result.unwrap_u8() == 0);
+        assert_eq!(result.unwrap_u8(), 0);
     }
 
     /// Hashes a message string into an arbitrary scalar

--- a/crates/threshold-signatures/src/crypto/polynomials.rs
+++ b/crates/threshold-signatures/src/crypto/polynomials.rs
@@ -493,8 +493,8 @@ mod test {
 
         let mut poly = Polynomial::<C>::new(&coefficients).unwrap();
         let point = <<C as frost_core::Ciphersuite>::Group as Group>::Field::zero();
-        assert!(zero_coeff != poly.eval_at_zero().unwrap().0);
-        assert!(zero_coeff != poly.eval_at_point(point).unwrap().0);
+        assert_ne!(zero_coeff, poly.eval_at_zero().unwrap().0);
+        assert_ne!(zero_coeff, poly.eval_at_point(point).unwrap().0);
 
         poly.set_nonzero_constant(zero_coeff).unwrap();
         assert_eq!(zero_coeff, poly.eval_at_zero().unwrap().0);

--- a/crates/threshold-signatures/src/dkg.rs
+++ b/crates/threshold-signatures/src/dkg.rs
@@ -703,10 +703,10 @@ pub mod test {
         let participants_2 = generate_participants(3);
         let hash_1 = domain_separate_hash(&mut cnt.clone(), &participants_1);
         let hash_2 = domain_separate_hash(&mut cnt, &participants_2);
-        assert!(hash_1 == hash_2);
+        assert_eq!(hash_1, hash_2);
         // incremented
         let hash_2 = domain_separate_hash(&mut cnt, &participants_2);
-        assert!(hash_1 != hash_2);
+        assert_ne!(hash_1, hash_2);
     }
 
     fn compute_private_key<C: Ciphersuite>(
@@ -735,7 +735,7 @@ pub mod test {
         <C::Group as Group>::Element: std::fmt::Debug,
     {
         let result = run_keygen::<C, R>(participants, threshold, rng);
-        assert!(result.len() == participants.len());
+        assert_eq!(result.len(), participants.len());
         assert_public_key_invariant(&result);
 
         let pub_key = result[0].1.public_key.to_element();

--- a/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/presign.rs
+++ b/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/presign.rs
@@ -338,8 +338,8 @@ mod test {
         for ((p, triple0), triple1) in participants
             .iter()
             .take(3)
-            .zip(triple0_shares.into_iter())
-            .zip(triple1_shares.into_iter())
+            .zip(triple0_shares)
+            .zip(triple1_shares)
         {
             let keygen_out = make_keygen_output(&f, &pk, *p);
 
@@ -359,7 +359,7 @@ mod test {
 
         let result = run_protocol(protocols).unwrap();
 
-        assert!(result.len() == 3);
+        assert_eq!(result.len(), 3);
         assert_eq!(result[0].1.big_r, result[1].1.big_r);
         assert_eq!(result[1].1.big_r, result[2].1.big_r);
 

--- a/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/test.rs
+++ b/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/test.rs
@@ -155,18 +155,14 @@ pub fn run_presign(
     pub1: &TriplePub,
     threshold: ReconstructionThreshold,
 ) -> Vec<(Participant, PresignOutput)> {
-    assert!(participants.len() == shares0.len());
-    assert!(participants.len() == shares1.len());
+    assert_eq!(participants.len(), shares0.len());
+    assert_eq!(participants.len(), shares1.len());
 
     let mut protocols: GenProtocol<PresignOutput> = Vec::with_capacity(participants.len());
 
     let participant_list: Vec<Participant> = participants.iter().map(|(p, _)| *p).collect();
 
-    for (((p, keygen_out), share0), share1) in participants
-        .into_iter()
-        .zip(shares0.into_iter())
-        .zip(shares1.into_iter())
-    {
+    for (((p, keygen_out), share0), share1) in participants.into_iter().zip(shares0).zip(shares1) {
         let protocol = presign(
             &participant_list,
             p,

--- a/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/triples/generation.rs
+++ b/crates/threshold-signatures/src/ecdsa/ot_based_ecdsa/triples/generation.rs
@@ -887,7 +887,7 @@ mod test {
 
         let result = run_protocol(protocols).unwrap();
 
-        assert!(result.len() == participants.len());
+        assert_eq!(result.len(), participants.len());
         assert_eq!(result[0].1.1, result[1].1.1);
         assert_eq!(result[1].1.1, result[2].1.1);
 
@@ -973,7 +973,7 @@ mod test {
 
         let result = run_protocol(protocols).unwrap();
 
-        assert!(result.len() == participants.len());
+        assert_eq!(result.len(), participants.len());
         assert_eq!(result[0].1[0].1, result[1].1[0].1);
         assert_eq!(result[1].1[0].1, result[2].1[0].1);
 

--- a/crates/threshold-signatures/src/ecdsa/robust_ecdsa/presign.rs
+++ b/crates/threshold-signatures/src/ecdsa/robust_ecdsa/presign.rs
@@ -562,7 +562,7 @@ mod test {
 
         let result = run_protocol(protocols).unwrap();
 
-        assert!(result.len() == 5);
+        assert_eq!(result.len(), 5);
         // testing that big_r is the same accross participants
         assert!(result.windows(2).all(|w| w[0].1.big_r == w[1].1.big_r));
 

--- a/crates/threshold-signatures/tests/ckd.rs
+++ b/crates/threshold-signatures/tests/ckd.rs
@@ -33,7 +33,7 @@ fn test_ckd() {
 
     let keys = run_keygen(&participants, threshold.into());
 
-    assert!(keys.len() == participants.len());
+    assert_eq!(keys.len(), participants.len());
 
     let public_key = keys.get(&participants[0]).unwrap().public_key;
     let coordinator = choose_coordinator_at_random(&participants);
@@ -112,7 +112,7 @@ fn test_ckd_pv() {
 
     let keys = run_keygen(&participants, threshold.into());
 
-    assert!(keys.len() == participants.len());
+    assert_eq!(keys.len(), participants.len());
 
     let public_key = keys.get(&participants[0]).unwrap().public_key;
     let coordinator = choose_coordinator_at_random(&participants);

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -62,7 +62,7 @@ The contract carries [NEP-330](https://github.com/near/NEPs/blob/master/neps/nep
 build metadata in `crates/contract/Cargo.toml`
 (`[package.metadata.near.reproducible_build]`), which pins a
 `sourcescan/cargo-near` Docker image whose tag and digest match
-`rust-toolchain.toml` (`1.93.0`). This metadata is embedded in the WASM, which
+`rust-toolchain.toml` (`1.97.0`). This metadata is embedded in the WASM, which
 lets automated third-party verifiers such as sourcescan.io and nearblocks replay
 the build and confirm the on-chain contract matches the published source. This
 is the build CI publishes as the release artifact. It requires `docker`:

--- a/flake.lock
+++ b/flake.lock
@@ -45,11 +45,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780024773,
-        "narHash": "sha256-aU9nlrS9S+IJ2EiCzsaxzOXUhggogqTrJojBicE6Oeg=",
+        "lastModified": 1784091390,
+        "narHash": "sha256-aILAwrBQPhKldL98N8lmsbfst3OPtbMM4vT2VXn40/Y=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "40b0a3a193e0840c76174b4a322874c8f6dd0a63",
+        "rev": "a7887636a3959168bd1ba7ef24a8a70b168dcb56",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # This needs to be at least as high as the nearcore's toolchain version.
-channel = "1.93.0"
+channel = "1.97.0"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]
 targets = ["wasm32-unknown-unknown"]
 profile = "default"


### PR DESCRIPTION
Closes #3818 

triggered basically from this [thread](https://nearone.slack.com/archives/C0A64SAMDNG/p1784100801277899?thread_ts=1784100007.927279&cid=C0A64SAMDNG)

most changes are the usual new clippy requirements

And the bonus, contract size went from `1515313 bytes` in main to `1465301 bytes`