### PR TITLE
chore: bump to nearcore 2.13.1 (#3808)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1786,10 +1786,10 @@ dependencies = [
  "near-account-id",
  "near-async",
  "near-client",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-indexer",
  "near-indexer-primitives",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "near-sdk",
  "near-store",
  "nearcore",
@@ -5881,17 +5881,17 @@ dependencies = [
  "near-account-id",
  "near-async",
  "near-client",
- "near-config-utils 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
  "near-indexer",
  "near-indexer-primitives",
  "near-mpc-bounded-collections",
  "near-mpc-contract-interface",
  "near-mpc-crypto-types",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "near-sdk",
  "near-store",
- "near-time 2.13.0-rc.2",
+ "near-time 2.13.1",
  "node-types",
  "num_enum",
  "pprof",
@@ -6100,14 +6100,14 @@ dependencies = [
 
 [[package]]
 name = "near-async"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "crossbeam-channel",
  "futures",
  "near-async-derive",
- "near-o11y 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-time 2.13.1",
  "parking_lot 0.12.5",
  "serde",
  "serde_json",
@@ -6120,8 +6120,8 @@ dependencies = [
 
 [[package]]
 name = "near-async-derive"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6130,8 +6130,8 @@ dependencies = [
 
 [[package]]
 name = "near-cache"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "lru 0.16.4",
  "parking_lot 0.12.5",
@@ -6139,8 +6139,8 @@ dependencies = [
 
 [[package]]
 name = "near-chain"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6153,19 +6153,19 @@ dependencies = [
  "lru 0.16.4",
  "near-async",
  "near-cache",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -6209,19 +6209,19 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "bytesize",
  "chrono",
  "derive_more 2.1.1",
- "near-config-utils 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
  "serde",
@@ -6234,33 +6234,33 @@ dependencies = [
 
 [[package]]
 name = "near-chain-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-crypto 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "thiserror 2.0.18",
  "tracing",
 ]
 
 [[package]]
 name = "near-chunks"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "itertools 0.14.0",
  "lru 0.16.4",
  "near-async",
  "near-chain",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chunks-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-epoch-manager",
  "near-network",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "near-store",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -6272,17 +6272,17 @@ dependencies = [
 
 [[package]]
 name = "near-chunks-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
 ]
 
 [[package]]
 name = "near-client"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -6293,22 +6293,22 @@ dependencies = [
  "near-async",
  "near-cache",
  "near-chain",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-chunks",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -6333,14 +6333,14 @@ dependencies = [
 
 [[package]]
 name = "near-client-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-chain-primitives",
  "near-chunks-primitives",
- "near-crypto 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "serde",
  "strum 0.24.1",
  "thiserror 2.0.18",
@@ -6361,8 +6361,8 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "json_comments",
@@ -6398,8 +6398,8 @@ dependencies = [
 
 [[package]]
 name = "near-crypto"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "aws-lc-rs",
  "blake2",
@@ -6410,9 +6410,9 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "near-account-id",
- "near-config-utils 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
  "primitive-types 0.10.1",
  "rand 0.8.6",
  "secp256k1 0.27.0",
@@ -6444,14 +6444,14 @@ checksum = "b8fd0822ff3a82bdccda49b787cb11530512a929bfd13fd0d9fbd510b6360200"
 
 [[package]]
 name = "near-dyn-configs"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
- "near-chain-configs 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
+ "near-time 2.13.1",
  "serde_json",
  "thiserror 2.0.18",
  "tokio",
@@ -6459,18 +6459,18 @@ dependencies = [
 
 [[package]]
 name = "near-epoch-manager"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "itertools 0.14.0",
  "near-cache",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
  "num-bigint 0.3.3",
  "num-rational 0.3.2",
@@ -6484,12 +6484,12 @@ dependencies = [
 
 [[package]]
 name = "near-external-storage"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "object_store",
  "percent-encoding",
  "reqwest 0.13.4",
@@ -6510,10 +6510,10 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-primitives-core 2.13.0-rc.2",
+ "near-primitives-core 2.13.1",
 ]
 
 [[package]]
@@ -6565,22 +6565,22 @@ dependencies = [
 
 [[package]]
 name = "near-indexer"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "futures",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-indexer-primitives",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
  "near-store",
  "nearcore",
  "node-runtime",
@@ -6592,33 +6592,33 @@ dependencies = [
 
 [[package]]
 name = "near-indexer-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "serde",
 ]
 
 [[package]]
 name = "near-jsonrpc"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "bs58 0.4.0",
  "easy-ext",
  "futures",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-client",
  "near-client-primitives",
  "near-epoch-manager",
  "near-jsonrpc-client-internal",
- "near-jsonrpc-primitives 2.13.0-rc.2",
+ "near-jsonrpc-primitives 2.13.1",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
  "near-store",
  "parking_lot 0.12.5",
  "serde",
@@ -6650,12 +6650,12 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client-internal"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
- "near-jsonrpc-primitives 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-jsonrpc-primitives 2.13.1",
+ "near-primitives 2.13.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -6682,16 +6682,16 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-time 2.13.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -6743,12 +6743,12 @@ dependencies = [
 
 [[package]]
 name = "near-mainnet-res"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "near-account-id",
- "near-chain-configs 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
+ "near-primitives 2.13.1",
  "serde_json",
 ]
 
@@ -6842,8 +6842,8 @@ dependencies = [
 
 [[package]]
 name = "near-network"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -6859,12 +6859,12 @@ dependencies = [
  "lru 0.16.4",
  "named-lock",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
- "near-fmt 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
+ "near-crypto 2.13.1",
+ "near-fmt 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "near-store",
  "opentelemetry",
  "parking_lot 0.12.5",
@@ -6909,13 +6909,13 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-primitives-core 2.13.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -6951,14 +6951,14 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
  "enum-map",
  "near-account-id",
- "near-primitives-core 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
  "num-rational 0.3.2",
  "serde",
  "serde_repr",
@@ -6969,13 +6969,13 @@ dependencies = [
 
 [[package]]
 name = "near-pool"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "borsh",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-primitives 2.13.1",
  "rand 0.8.6",
 ]
 
@@ -7024,8 +7024,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -7040,13 +7040,13 @@ dependencies = [
  "enum-map",
  "hex",
  "itertools 0.14.0",
- "near-crypto 2.13.0-rc.2",
- "near-fmt 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-fmt 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
+ "near-time 2.13.1",
  "num-rational 0.3.2",
  "ordered-float 4.6.0",
  "primitive-types 0.10.1",
@@ -7091,8 +7091,8 @@ dependencies = [
 
 [[package]]
 name = "near-primitives-core"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "arbitrary",
  "base64 0.21.7",
@@ -7102,7 +7102,7 @@ dependencies = [
  "enum-map",
  "near-account-id",
  "near-gas",
- "near-schema-checker-lib 2.13.0-rc.2",
+ "near-schema-checker-lib 2.13.1",
  "near-token",
  "num-rational 0.3.2",
  "serde",
@@ -7114,8 +7114,8 @@ dependencies = [
 
 [[package]]
 name = "near-rosetta-rpc"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "axum",
  "derive_more 2.1.1",
@@ -7124,14 +7124,14 @@ dependencies = [
  "insta",
  "near-account-id",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-client",
  "near-client-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
  "node-runtime",
  "serde",
  "serde_json",
@@ -7173,8 +7173,8 @@ checksum = "37ad456b1bd9876772d6c0b557d100d518d60dd13e359daca8e0293828e29a05"
 
 [[package]]
 name = "near-schema-checker-core"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -7188,11 +7188,11 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-lib"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
- "near-schema-checker-core 2.13.0-rc.2",
- "near-schema-checker-macro 2.13.0-rc.2",
+ "near-schema-checker-core 2.13.1",
+ "near-schema-checker-macro 2.13.1",
 ]
 
 [[package]]
@@ -7203,8 +7203,8 @@ checksum = "731a7b9cc155e291f149f2f6f8f88f5cab512b772aaf301f9defb4e4bceb1629"
 
 [[package]]
 name = "near-schema-checker-macro"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-sdk"
@@ -7301,13 +7301,13 @@ checksum = "f35191f9d7a78d5cdca9788e648dce89ebbb74faef4abfa6992ed7f1fb300369"
 
 [[package]]
 name = "near-stdx"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 
 [[package]]
 name = "near-store"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -7324,18 +7324,18 @@ dependencies = [
  "itoa",
  "lru 0.16.4",
  "near-async",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
- "near-crypto 2.13.0-rc.2",
+ "near-crypto 2.13.1",
  "near-external-storage",
- "near-fmt 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
- "near-time 2.13.0-rc.2",
- "near-vm-runner 2.13.0-rc.2",
+ "near-fmt 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
+ "near-time 2.13.1",
+ "near-vm-runner 2.13.1",
  "num_cpus",
  "parking_lot 0.12.5",
  "rand 0.8.6",
@@ -7363,12 +7363,12 @@ checksum = "c7c212278351251aa342eab33a9d64f99294bc5784cda10107867a72dda699bb"
 
 [[package]]
 name = "near-telemetry"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "futures",
  "near-async",
- "near-o11y 2.13.0-rc.2",
+ "near-o11y 2.13.1",
  "reqwest 0.13.4",
  "serde",
  "serde_json",
@@ -7388,8 +7388,8 @@ dependencies = [
 
 [[package]]
 name = "near-time"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "parking_lot 0.12.5",
  "serde",
@@ -7410,8 +7410,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "enumset",
  "finite-wasm 0.5.1",
@@ -7426,8 +7426,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-compiler-singlepass"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "dynasm",
  "dynasmrt",
@@ -7445,8 +7445,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-engine"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "finite-wasm 0.5.1",
@@ -7509,8 +7509,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "blst",
@@ -7523,12 +7523,12 @@ dependencies = [
  "finite-wasm 0.6.1",
  "lru 0.16.4",
  "memoffset 0.8.0",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
- "near-schema-checker-lib 2.13.0-rc.2",
- "near-stdx 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives-core 2.13.1",
+ "near-schema-checker-lib 2.13.1",
+ "near-stdx 2.13.1",
  "near-vm-compiler",
  "near-vm-compiler-singlepass",
  "near-vm-engine",
@@ -7559,8 +7559,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-types"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "indexmap 2.14.0",
  "num-traits",
@@ -7570,8 +7570,8 @@ dependencies = [
 
 [[package]]
 name = "near-vm-vm"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "backtrace",
  "cc",
@@ -7591,12 +7591,12 @@ dependencies = [
 
 [[package]]
 name = "near-wallet-contract"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
- "near-primitives-core 2.13.0-rc.2",
- "near-vm-runner 2.13.0-rc.2",
+ "near-primitives-core 2.13.1",
+ "near-vm-runner 2.13.1",
 ]
 
 [[package]]
@@ -7663,8 +7663,8 @@ dependencies = [
 
 [[package]]
 name = "nearcore"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "anyhow",
  "borsh",
@@ -7677,28 +7677,28 @@ dependencies = [
  "itertools 0.14.0",
  "near-async",
  "near-chain",
- "near-chain-configs 2.13.0-rc.2",
+ "near-chain-configs 2.13.1",
  "near-chain-primitives",
  "near-chunks",
  "near-client",
  "near-client-primitives",
- "near-config-utils 2.13.0-rc.2",
- "near-crypto 2.13.0-rc.2",
+ "near-config-utils 2.13.1",
+ "near-crypto 2.13.1",
  "near-dyn-configs",
  "near-epoch-manager",
  "near-external-storage",
  "near-jsonrpc",
- "near-jsonrpc-primitives 2.13.0-rc.2",
+ "near-jsonrpc-primitives 2.13.1",
  "near-mainnet-res",
  "near-network",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
  "near-pool",
- "near-primitives 2.13.0-rc.2",
+ "near-primitives 2.13.1",
  "near-rosetta-rpc",
  "near-store",
  "near-telemetry",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "node-runtime",
  "num-rational 0.3.2",
  "parking_lot 0.12.5",
@@ -7732,8 +7732,8 @@ dependencies = [
 
 [[package]]
 name = "node-runtime"
-version = "2.13.0-rc.2"
-source = "git+https://github.com/near/nearcore?tag=2.13.0-rc.2#315524124213463b36ffe6df5822359aacee070e"
+version = "2.13.1"
+source = "git+https://github.com/near/nearcore?tag=2.13.1#9d05464c13dca4794c1802e11f45f163ed9936c2"
 dependencies = [
  "ahash 0.8.12",
  "borsh",
@@ -7741,13 +7741,13 @@ dependencies = [
  "dashmap",
  "itertools 0.14.0",
  "near-async",
- "near-crypto 2.13.0-rc.2",
- "near-o11y 2.13.0-rc.2",
- "near-parameters 2.13.0-rc.2",
- "near-primitives 2.13.0-rc.2",
- "near-primitives-core 2.13.0-rc.2",
+ "near-crypto 2.13.1",
+ "near-o11y 2.13.1",
+ "near-parameters 2.13.1",
+ "near-primitives 2.13.1",
+ "near-primitives-core 2.13.1",
  "near-store",
- "near-vm-runner 2.13.0-rc.2",
+ "near-vm-runner 2.13.1",
  "near-wallet-contract",
  "parking_lot 0.12.5",
  "rand 0.8.6",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -261,16 +261,16 @@ zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 zstd = "0.13.3"
 
 # NEAR CORE DEPENDENCIES:
-near-async = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-client = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-crypto = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-indexer = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-o11y = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-store = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-near-time = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
-nearcore = { git = "https://github.com/near/nearcore", tag = "2.13.0-rc.2" }
+near-async = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-client = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-config-utils = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-crypto = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-indexer = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-indexer-primitives = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-o11y = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-store = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+near-time = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
+nearcore = { git = "https://github.com/near/nearcore", tag = "2.13.1" }
 
 ## Outdated dependencies we cannot upgrade ##
 # Version 0.8.3 requires rustc 1.88

--- a/crates/test-utils/src/lib.rs
+++ b/crates/test-utils/src/lib.rs
@@ -6,4 +6,4 @@ pub mod contract_types;
 /// Single source of truth shared by the e2e-tests crate and the contract test crates.
 /// `scripts/check-sandbox-image-version.sh` enforces that this stays in lockstep with
 /// the workspace's nearcore tag.
-pub const DEFAULT_SANDBOX_VERSION: &str = "2.13.0-rc.2";
+pub const DEFAULT_SANDBOX_VERSION: &str = "2.13.1";


### PR DESCRIPTION
Cherry-pick of #3808 (nearcore `2.13.0-rc.2` → `2.13.1`) onto `release/v3.13` for the 3.13.2 release. `Cargo.toml` + `test-utils` applied as-is; `Cargo.lock` regenerated on the release base (verified with `cargo check --locked`).

2.13.1 (CODE_YELLOW_MAINNET, protocol v85) is compatible with both networks. Part of #3789.