### PR TITLE
docs: add reproducibility-verification step to the release guide

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -95,19 +95,20 @@ run if any artifact is missing.
 ### 3. Verify the build is reproducible
 
 **Do this before publishing (step 5) — publishing creates the git tag and is
-effectively irreversible.** Confirm the artifacts CI built match a local
+effectively irreversible.** Confirm the CI-built artifacts match a local
 reproducible build, so the released `:X.Y.Z` images and contract WASM are
 exactly what the source produces:
 
 - **Contract WASM** — build via the reproducible path and compare its hash to
-  the CI `contract` artifact:
+  the CI `contract` artifact (builds from committed git state, so commit first):
   ```sh
-  nix develop --command cargo near build reproducible-wasm --manifest-path crates/contract/Cargo.toml
+  cargo near build reproducible-wasm --manifest-path crates/contract/Cargo.toml
   ```
-- **Docker images** — rebuild with `repro-env` and compare the digests to the
-  CI-pushed `nearone/mpc-{node,node-gcp,launcher}:<branch>-<short-sha>`:
+- **Docker images** — compare the digests in the draft release to the ones
+  produced locally (with no flags the script builds and prints digests for all
+  three images):
   ```sh
-  ./deployment/build-images.sh --node --rust-launcher
+  ./deployment/build-images.sh
   ```
 
 See [reproducible builds](./docs/reproducible-builds.md) for the full

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -148,10 +148,7 @@ by GitHub when the draft is published.
 Review the draft and click "Publish release." Publishing creates the
 `3.11.0` git tag at the released commit.
 
-> ⚠️ **Point of no return.** Publishing creates the tag, and once operators
-> consume `:X.Y.Z` the tag can't be cleanly re-pointed (the Release workflow's
-> tag/release-existence checks block it). Only publish after step 3's
-> reproducibility check passes.
+> ⚠️ **Point of no return.** Publishing creates the tag, and once the tag is published it cannot be modified as we are using [immutable releases](https://docs.github.com/en/code-security/concepts/supply-chain-security/immutable-releases).
 
 ### 6. Promote to operator floating tags (optional)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -92,7 +92,28 @@ run if any artifact is missing.
 > smoke-test on testnet before promoting, deploy
 > `nearone/mpc-node-gcp:release-v3.11-<short-sha>` directly.
 
-### 3. Run the Release workflow
+### 3. Verify the build is reproducible
+
+**Do this before publishing (step 5) — publishing creates the git tag and is
+effectively irreversible.** Confirm the artifacts CI built match a local
+reproducible build, so the released `:X.Y.Z` images and contract WASM are
+exactly what the source produces:
+
+- **Contract WASM** — build via the reproducible path and compare its hash to
+  the CI `contract` artifact:
+  ```sh
+  nix develop --command cargo near build reproducible-wasm --manifest-path crates/contract/Cargo.toml
+  ```
+- **Docker images** — rebuild with `repro-env` and compare the digests to the
+  CI-pushed `nearone/mpc-{node,node-gcp,launcher}:<branch>-<short-sha>`:
+  ```sh
+  ./deployment/build-images.sh --node --rust-launcher
+  ```
+
+See [reproducible builds](./docs/reproducible-builds.md) for the full
+procedure. If any hash/digest differs, do **not** publish — investigate first.
+
+### 4. Run the Release workflow
 
 Trigger the [Release workflow](.github/workflows/release.yml) against the
 branch:
@@ -115,7 +136,7 @@ is missing.
 > [Build Contract](.github/workflows/build_contract.yml) workflow
 > manually before triggering the release.
 
-### 4. Edit and publish the draft release
+### 5. Edit and publish the draft release
 
 When the workflow finishes, a draft release named `MPC 3.11.0` appears on
 the [releases page](https://github.com/near/mpc/releases). The draft
@@ -126,7 +147,12 @@ by GitHub when the draft is published.
 Review the draft and click "Publish release." Publishing creates the
 `3.11.0` git tag at the released commit.
 
-### 5. Promote to operator floating tags (optional)
+> ⚠️ **Point of no return.** Publishing creates the tag, and once operators
+> consume `:X.Y.Z` the tag can't be cleanly re-pointed (the Release workflow's
+> tag/release-existence checks block it). Only publish after step 3's
+> reproducibility check passes.
+
+### 6. Promote to operator floating tags (optional)
 
 Some operators consume floating tags like `nearone/mpc-node-gcp:testnet-release`
 and `:mainnet-release`. Promote with the retag workflows:


### PR DESCRIPTION
Closes #3823.

Adds a **"Verify the build is reproducible"** step to `RELEASES.md` before the Release workflow, and a point-of-no-return note on the publish step.

Currently the release guide has no gate to confirm CI artifacts match a local reproducible build before publishing, and doesn't flag that publishing (which creates the tag) is effectively irreversible — it was tribal knowledge (raised during the 3.13.2 prep). `docs/reproducible-builds.md` documents the *how*; this wires it into the flow.

- New step 3: compare CI contract-WASM hash + Docker image digests to a local `repro-env` / `cargo near build reproducible-wasm` build; renumbers the following steps.
- Publish step now notes it's the point of no return (tag can't be cleanly re-pointed once consumed).



