### PR TITLE
refactor(contract): share NodeId/auth test helpers via `primitives::test_utils`

### DIFF
--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -2679,8 +2679,8 @@ mod tests {
     use crate::pending_requests::MAX_PENDING_REQUEST_FAN_OUT;
     use crate::primitives::participants::{ParticipantId, ParticipantInfo, Participants};
     use crate::primitives::test_utils::{
-        NUM_PROTOCOLS, bogus_ed25519_near_public_key, bogus_ed25519_public_key, gen_account_id,
-        gen_participant, gen_participants, infer_purpose_from_protocol,
+        NUM_PROTOCOLS, bogus_ed25519_near_public_key, bogus_ed25519_public_key, create_node_id,
+        gen_account_id, gen_participant, gen_participants, infer_purpose_from_protocol,
     };
     use crate::state::key_event::KeyEvent;
     use crate::state::key_event::tests::Environment;
@@ -5691,11 +5691,7 @@ mod tests {
         let (target_account_id, _, target_participant_info) = &participant_list[2];
 
         // Replace the target's attestation with an expired one
-        let node_id = NodeId {
-            account_id: target_account_id.clone(),
-            tls_public_key: target_participant_info.tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = create_node_id(target_account_id, &target_participant_info.tls_public_key);
         let expiring_attestation = MpcAttestation::Mock(MpcMockAttestation::WithConstraints {
             mpc_docker_image_hash: None,
             launcher_docker_compose_hash: None,
@@ -5810,11 +5806,7 @@ mod tests {
         let participant_list: Vec<_> = participants.participants().to_vec();
         let (target_account_id, _, target_participant_info) =
             &participant_list[PARTICIPANT_COUNT - 1];
-        let node_id = NodeId {
-            account_id: target_account_id.clone(),
-            tls_public_key: target_participant_info.tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = create_node_id(target_account_id, &target_participant_info.tls_public_key);
         let expiring_attestation = MpcAttestation::Mock(MpcMockAttestation::WithConstraints {
             mpc_docker_image_hash: None,
             launcher_docker_compose_hash: None,

--- a/crates/contract/src/primitives/test_utils.rs
+++ b/crates/contract/src/primitives/test_utils.rs
@@ -13,7 +13,8 @@ use crate::{
 use curve25519_dalek::edwards::CompressedEdwardsY;
 use near_account_id::AccountId;
 use near_mpc_contract_interface::types::{
-    DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
+    DomainConfig, DomainId, DomainPurpose, Ed25519PublicKey, NodeId, Protocol,
+    ReconstructionThreshold,
 };
 use near_sdk::{test_utils::VMContextBuilder, testing_env};
 use rand::{Rng, SeedableRng, distributions::Uniform, rngs::StdRng};
@@ -147,17 +148,41 @@ pub fn gen_participants(n: usize) -> Participants {
     participants
 }
 
+/// Builds a [`NodeId`] with a placeholder (bogus) account public key.
+pub fn create_node_id(account_id: &AccountId, tls_public_key: &Ed25519PublicKey) -> NodeId {
+    NodeId {
+        account_id: account_id.clone(),
+        tls_public_key: tls_public_key.clone(),
+        account_public_key: bogus_ed25519_public_key(),
+    }
+}
+
+/// Builds a [`NodeId`] for `account_id` with placeholder (bogus) TLS and account public keys,
+/// for tests that do not exercise those keys.
+pub fn node_id_for(account_id: &AccountId) -> NodeId {
+    create_node_id(account_id, &bogus_ed25519_public_key())
+}
+
+/// Sets `account_id` as the signer and authenticates it against `participants`.
+pub fn authenticate_as(
+    account_id: &AccountId,
+    participants: &Participants,
+) -> AuthenticatedParticipantId {
+    let mut ctx = VMContextBuilder::new();
+    ctx.signer_account_id(account_id.clone());
+    testing_env!(ctx.build());
+    AuthenticatedParticipantId::new(participants).unwrap()
+}
+
 /// Build `n` participants and pre-authenticate each, returning the set alongside
 /// each participant's [`AuthenticatedParticipantId`].
 pub fn gen_authenticated_participants(n: usize) -> (Participants, Vec<AuthenticatedParticipantId>) {
     let participants = gen_participants(n);
-    let mut auth_ids = Vec::with_capacity(n);
-    for (account_id, _, _) in participants.participants() {
-        let mut ctx = VMContextBuilder::new();
-        ctx.signer_account_id(account_id.clone());
-        testing_env!(ctx.build());
-        auth_ids.push(AuthenticatedParticipantId::new(&participants).unwrap());
-    }
+    let auth_ids = participants
+        .participants()
+        .iter()
+        .map(|(account_id, _, _)| authenticate_as(account_id, &participants))
+        .collect();
     (participants, auth_ids)
 }
 

--- a/crates/contract/src/primitives/test_utils.rs
+++ b/crates/contract/src/primitives/test_utils.rs
@@ -148,7 +148,6 @@ pub fn gen_participants(n: usize) -> Participants {
     participants
 }
 
-/// Builds a [`NodeId`] with a fresh random account public key.
 pub fn create_node_id(account_id: &AccountId, tls_public_key: &Ed25519PublicKey) -> NodeId {
     NodeId {
         account_id: account_id.clone(),
@@ -157,12 +156,10 @@ pub fn create_node_id(account_id: &AccountId, tls_public_key: &Ed25519PublicKey)
     }
 }
 
-/// Builds a [`NodeId`] for the given [`AccountId`] with fresh random TLS and account public keys.
 pub fn node_id_for(account_id: &AccountId) -> NodeId {
     create_node_id(account_id, &bogus_ed25519_public_key())
 }
 
-/// Sets the given [`AccountId`] as the signer and authenticates it against the [`Participants`].
 pub fn authenticate_as(
     account_id: &AccountId,
     participants: &Participants,

--- a/crates/contract/src/primitives/test_utils.rs
+++ b/crates/contract/src/primitives/test_utils.rs
@@ -148,7 +148,7 @@ pub fn gen_participants(n: usize) -> Participants {
     participants
 }
 
-/// Builds a [`NodeId`] with a placeholder (bogus) account public key.
+/// Builds a [`NodeId`] with a fresh random account public key.
 pub fn create_node_id(account_id: &AccountId, tls_public_key: &Ed25519PublicKey) -> NodeId {
     NodeId {
         account_id: account_id.clone(),
@@ -157,13 +157,12 @@ pub fn create_node_id(account_id: &AccountId, tls_public_key: &Ed25519PublicKey)
     }
 }
 
-/// Builds a [`NodeId`] for `account_id` with placeholder (bogus) TLS and account public keys,
-/// for tests that do not exercise those keys.
+/// Builds a [`NodeId`] for the given [`AccountId`] with fresh random TLS and account public keys.
 pub fn node_id_for(account_id: &AccountId) -> NodeId {
     create_node_id(account_id, &bogus_ed25519_public_key())
 }
 
-/// Sets `account_id` as the signer and authenticates it against `participants`.
+/// Sets the given [`AccountId`] as the signer and authenticates it against the [`Participants`].
 pub fn authenticate_as(
     account_id: &AccountId,
     participants: &Participants,

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -535,9 +535,9 @@ pub(crate) enum AttestationCheckError {
 #[expect(non_snake_case)]
 mod tests {
     use super::*;
-    use crate::primitives::key_state::AuthenticatedParticipantId;
     use crate::primitives::test_utils::{
-        bogus_ed25519_near_public_key, bogus_ed25519_public_key, gen_participant, gen_participants,
+        authenticate_as, bogus_ed25519_near_public_key, bogus_ed25519_public_key, create_node_id,
+        gen_participant, gen_participants, node_id_for,
     };
     use crate::tee::test_utils::set_block_timestamp;
     use assert_matches::assert_matches;
@@ -572,21 +572,13 @@ mod tests {
         let participant_nodes: Vec<NodeId> = participants
             .participants()
             .iter()
-            .map(|(account_id, _, p_info)| NodeId {
-                account_id: account_id.clone(),
-                tls_public_key: p_info.tls_public_key.clone(),
-                account_public_key: bogus_ed25519_public_key(),
-            })
+            .map(|(account_id, _, p_info)| create_node_id(account_id, &p_info.tls_public_key))
             .collect();
 
         // Add TEE information for all participants and non-participant
         let local_attestation = Attestation::Mock(MockAttestation::Valid);
 
-        let non_participant_uid = NodeId {
-            account_id: non_participant.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-            tls_public_key: bogus_ed25519_public_key(),
-        };
+        let non_participant_uid = node_id_for(&non_participant);
 
         for node_id in &participant_nodes {
             tee_state
@@ -638,16 +630,8 @@ mod tests {
 
         let mut tee_state = TeeState::default();
 
-        let fresh_node = NodeId {
-            account_id: "fresh.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
-        let stale_node = NodeId {
-            account_id: "stale.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let fresh_node = node_id_for(&"fresh.near".parse().unwrap());
+        let stale_node = node_id_for(&"stale.near".parse().unwrap());
 
         let fresh = Attestation::Mock(MockAttestation::WithConstraints {
             mpc_docker_image_hash: None,
@@ -707,11 +691,7 @@ mod tests {
         });
 
         for idx in 0..10 {
-            let node_id = NodeId {
-                account_id: format!("node{idx}.near").parse().unwrap(),
-                tls_public_key: bogus_ed25519_public_key(),
-                account_public_key: bogus_ed25519_public_key(),
-            };
+            let node_id = node_id_for(&format!("node{idx}.near").parse().unwrap());
             tee_state
                 .add_participant(node_id, expired.clone(), Duration::from_secs(0))
                 .unwrap();
@@ -744,11 +724,7 @@ mod tests {
         testing_env!(VMContextBuilder::new().block_timestamp(0).build());
 
         let mut tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"alice.near".parse().unwrap());
         let attestation = Attestation::Mock(MockAttestation::WithConstraints {
             mpc_docker_image_hash: None,
             launcher_docker_compose_hash: None,
@@ -780,11 +756,7 @@ mod tests {
         let participant: AccountId = "dave.near".parse().unwrap();
         let local_attestation = Attestation::Mock(MockAttestation::Valid);
 
-        let participant_id = NodeId {
-            account_id: participant.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-            tls_public_key: bogus_ed25519_public_key(),
-        };
+        let participant_id = node_id_for(&participant);
 
         let insertion_result = tee_state.add_participant(
             participant_id.clone(),
@@ -814,11 +786,7 @@ mod tests {
     fn add_participant_increases_storage_size() {
         // given
         let mut tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"alice.near".parse().unwrap());
         let attestation = Attestation::Mock(MockAttestation::Valid);
 
         // when
@@ -838,11 +806,7 @@ mod tests {
     fn add_participant_indexes_by_tls_key() {
         // given
         let mut tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"alice.near".parse().unwrap());
         let attestation = Attestation::Mock(MockAttestation::Valid);
 
         // when
@@ -863,11 +827,7 @@ mod tests {
     fn add_participant_preserves_node_id_integrity() {
         // given
         let mut tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"alice.near".parse().unwrap());
         let attestation = Attestation::Mock(MockAttestation::Valid);
 
         // when
@@ -892,17 +852,9 @@ mod tests {
         // given
         let mut tee_state = TeeState::default();
 
-        let node_1 = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_1 = node_id_for(&"alice.near".parse().unwrap());
 
-        let node_2 = NodeId {
-            account_id: "bob.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_2 = node_id_for(&"bob.near".parse().unwrap());
 
         // when
         tee_state
@@ -938,11 +890,7 @@ mod tests {
     fn re_verify_validates_fresh_attestation() {
         // given
         let mut tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "fresh.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"fresh.near".parse().unwrap());
 
         const NOW_SECONDS: u64 = 1000;
 
@@ -970,11 +918,7 @@ mod tests {
     fn test_re_verify_rejects_expired_attestation() {
         // given
         let mut tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "about_to_be_expired.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"about_to_be_expired.near".parse().unwrap());
 
         const EXPIRY_TIMESTAMP_SECONDS: u64 = 1000;
         const ELAPSED_SECONDS: u64 = 200;
@@ -1012,11 +956,7 @@ mod tests {
     fn re_verify_succeeds_within_expiry_time() {
         // given
         let mut tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "valid_check.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"valid_check.near".parse().unwrap());
 
         const EXPIRY_TIMESTAMP_SECONDS: u64 = 1000;
 
@@ -1052,11 +992,7 @@ mod tests {
     fn test_re_verify_returns_invalid_for_missing_node() {
         // given
         let tee_state = TeeState::default();
-        let node_id = NodeId {
-            account_id: "ghost.near".parse().unwrap(),
-            tls_public_key: bogus_ed25519_public_key(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let node_id = node_id_for(&"ghost.near".parse().unwrap());
 
         // when
         let status = tee_state.reverify_participants(&node_id, Duration::from_secs(0));
@@ -1206,15 +1142,6 @@ mod tests {
 
     /// Grace period for TEE upgrade deadline used in validate_tee() tests
     const TEST_GRACE_PERIOD: Duration = Duration::from_secs(10);
-
-    /// Helper to create a NodeId from participant data
-    fn create_node_id(account_id: &AccountId, tls_public_key: &Ed25519PublicKey) -> NodeId {
-        NodeId {
-            account_id: account_id.clone(),
-            tls_public_key: tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-        }
-    }
 
     /// Helper to extract account IDs from participants for assertion comparisons
     fn account_ids(participants: &Participants) -> Vec<AccountId> {
@@ -1380,11 +1307,7 @@ mod tests {
         let mut tee_state = TeeState::default();
         let tls_public_key = bogus_ed25519_public_key();
 
-        let alice_node = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key: tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let alice_node = create_node_id(&"alice.near".parse().unwrap(), &tls_public_key);
         tee_state
             .add_participant(
                 alice_node.clone(),
@@ -1394,11 +1317,7 @@ mod tests {
             .expect("initial insertion should succeed");
 
         // When: a different account submits an attestation for the same TLS key.
-        let attacker_node = NodeId {
-            account_id: "attacker.near".parse().unwrap(),
-            tls_public_key: tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let attacker_node = create_node_id(&"attacker.near".parse().unwrap(), &tls_public_key);
         let result = tee_state.add_participant(
             attacker_node,
             Attestation::Mock(MockAttestation::Valid),
@@ -1425,11 +1344,7 @@ mod tests {
         let mut tee_state = TeeState::default();
         let tls_public_key = bogus_ed25519_public_key();
 
-        let initial_node = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key: tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let initial_node = create_node_id(&"alice.near".parse().unwrap(), &tls_public_key);
         tee_state
             .add_participant(
                 initial_node,
@@ -1439,11 +1354,7 @@ mod tests {
             .expect("initial insertion should succeed");
 
         // When: the same account resubmits with a rotated account_public_key.
-        let rotated_node = NodeId {
-            account_id: "alice.near".parse().unwrap(),
-            tls_public_key,
-            account_public_key: bogus_ed25519_public_key(),
-        };
+        let rotated_node = create_node_id(&"alice.near".parse().unwrap(), &tls_public_key);
         let result = tee_state.add_participant(
             rotated_node.clone(),
             Attestation::Mock(MockAttestation::Valid),
@@ -1517,10 +1428,7 @@ mod tests {
         // P0 and P1 vote for a malicious hash before resharing
         let malicious_hash = NodeImageHash::from([0xAA; 32]);
         for account_id in &account_ids[0..2] {
-            let mut ctx = VMContextBuilder::new();
-            ctx.signer_account_id(account_id.clone());
-            testing_env!(ctx.build());
-            let auth_id = AuthenticatedParticipantId::new(&all_participants).unwrap();
+            let auth_id = authenticate_as(account_id, &all_participants);
             tee_state.votes.vote(malicious_hash, &auth_id);
         }
         assert_eq!(tee_state.votes.proposal_by_account.len(), 2);
@@ -1536,10 +1444,7 @@ mod tests {
 
         // P2 votes for the same malicious hash — should be only 1 vote, not 3
         let p2_account = &account_ids[2];
-        let mut ctx = VMContextBuilder::new();
-        ctx.signer_account_id(p2_account.clone());
-        testing_env!(ctx.build());
-        let auth_id = AuthenticatedParticipantId::new(&new_participants).unwrap();
+        let auth_id = authenticate_as(p2_account, &new_participants);
         let vote_count = tee_state.votes.vote(malicious_hash, &auth_id);
         assert_eq!(vote_count, 1, "Only the fresh vote from P2 should count");
     }
@@ -1558,10 +1463,7 @@ mod tests {
         let mut tee_state = TeeState::default();
 
         // P0 votes for a launcher hash
-        let mut ctx = VMContextBuilder::new();
-        ctx.signer_account_id(account_ids[0].clone());
-        testing_env!(ctx.build());
-        let auth_id = AuthenticatedParticipantId::new(&all_participants).unwrap();
+        let auth_id = authenticate_as(&account_ids[0], &all_participants);
         let launcher_action = LauncherVoteAction::Add(LauncherImageHash::from([0xBB; 32]));
         tee_state.launcher_votes.vote(launcher_action, &auth_id);
 

--- a/crates/contract/tests/inprocess/attestation_submission.rs
+++ b/crates/contract/tests/inprocess/attestation_submission.rs
@@ -7,7 +7,7 @@ use mpc_contract::{
     primitives::{
         key_state::{AttemptId, EpochId, KeyForDomain, Keyset},
         participants::{ParticipantId, ParticipantInfo},
-        test_utils::{bogus_ed25519_public_key, gen_participants},
+        test_utils::{create_node_id, gen_participants, node_id_for},
         thresholds::{ProposedThresholdParameters, Threshold, ThresholdParameters},
     },
     tee::tee_state::NodeId,
@@ -141,10 +141,8 @@ impl TestSetupBuilder {
         let all_nodes: Vec<NodeId> = setup
             .participants_list
             .iter()
-            .map(|(account_id, _, participant_info)| NodeId {
-                account_id: account_id.clone(),
-                tls_public_key: participant_info.tls_public_key.clone(),
-                account_public_key: bogus_ed25519_public_key(),
+            .map(|(account_id, _, participant_info)| {
+                create_node_id(account_id, &participant_info.tls_public_key)
             })
             .collect();
 
@@ -250,10 +248,8 @@ impl TestSetup {
     fn get_participant_node_ids(&self) -> Vec<NodeId> {
         self.participants_list
             .iter()
-            .map(|(account_id, _, participant_info)| NodeId {
-                account_id: account_id.clone(),
-                tls_public_key: participant_info.tls_public_key.clone(),
-                account_public_key: bogus_ed25519_public_key(),
+            .map(|(account_id, _, participant_info)| {
+                create_node_id(account_id, &participant_info.tls_public_key)
             })
             .collect()
     }
@@ -320,11 +316,10 @@ fn submit_participant_info__should_reject_overwrite_from_other_account() {
     // When: an unrelated account submits an attestation that targets the victim's TLS key.
     // The attacker context attaches a deposit large enough to cover any storage charge,
     // so the call can only fail due to the ownership check — not `InsufficientDeposit`.
-    let attacker_node = NodeId {
-        account_id: "attacker.near".parse().unwrap(),
-        tls_public_key: victim_node.tls_public_key.clone(),
-        account_public_key: bogus_ed25519_public_key(),
-    };
+    let attacker_node = create_node_id(
+        &"attacker.near".parse().unwrap(),
+        &victim_node.tls_public_key,
+    );
     testing_env!(
         VMContextBuilder::new()
             .signer_account_id(attacker_node.account_id.clone())
@@ -379,10 +374,8 @@ fn clean_tee_status__should_not_touch_attestations() {
         .participants_list
         .iter()
         .take(PARTICIPANT_COUNT)
-        .map(|(account_id, _, participant_info)| NodeId {
-            account_id: account_id.clone(),
-            tls_public_key: participant_info.tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
+        .map(|(account_id, _, participant_info)| {
+            create_node_id(account_id, &participant_info.tls_public_key)
         })
         .collect();
     for node_id in &participant_nodes {
@@ -390,11 +383,7 @@ fn clean_tee_status__should_not_touch_attestations() {
     }
 
     // Add TEE account for someone who is NOT a current participant
-    let removed_participant_node = NodeId {
-        account_id: "removed.participant.near".parse().unwrap(),
-        tls_public_key: bogus_ed25519_public_key(),
-        account_public_key: bogus_ed25519_public_key(),
-    };
+    let removed_participant_node = node_id_for(&"removed.participant.near".parse().unwrap());
     setup.submit_attestation_for_node(&removed_participant_node, valid_attestation);
 
     // Verify initial state: 2 participants but 3 TEE accounts
@@ -470,19 +459,11 @@ fn clean_invalid_attestations__should_remove_expired_entries() {
     // outsider account.
     let participant_node = {
         let (account_id, _, info) = &setup.participants_list[0];
-        NodeId {
-            account_id: account_id.clone(),
-            tls_public_key: info.tls_public_key.clone(),
-            account_public_key: bogus_ed25519_public_key(),
-        }
+        create_node_id(account_id, &info.tls_public_key)
     };
     setup.submit_attestation_for_node(&participant_node, expiring_attestation.clone());
 
-    let stale_node = NodeId {
-        account_id: "stale.near".parse().unwrap(),
-        tls_public_key: bogus_ed25519_public_key(),
-        account_public_key: bogus_ed25519_public_key(),
-    };
+    let stale_node = node_id_for(&"stale.near".parse().unwrap());
     setup.submit_attestation_for_node(&stale_node, expiring_attestation);
 
     const EXPECTED_STORED: usize = PARTICIPANT_COUNT + 1; // original mocks + outsider entry


### PR DESCRIPTION
Closes #3831
