### PR TITLE
fix: report computations lead metrics after finishing computations + more labels

### DIFF
--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -409,10 +409,6 @@ pub const MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL: &str = "succeeded";
 pub const MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL: &str = "failed";
 pub const MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL: &str = "deadline_exceeded";
 
-/// Records the outcome of a finished leader-side computation attempt: bumps exactly one of
-/// `succeeded`, `failed`, or `deadline_exceeded`, plus `total`, so the labels stay consistent
-/// at every scrape. `deadline_exceeded` means the node's own deadline (`timeout_sec`) elapsed
-/// and the attempt was aborted, not the on-chain request timeout.
 pub fn record_led_computation_outcome<T>(
     metric: &prometheus::IntCounterVec,
     result: &Result<anyhow::Result<T>, tokio::time::error::Elapsed>,

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -177,7 +177,7 @@ pub static MPC_NUM_SIGNATURE_COMPUTATIONS_LED: LazyLock<prometheus::IntCounterVe
     || {
         prometheus::register_int_counter_vec!(
             "mpc_num_signature_computations_led",
-            "Number of finished signature computation attempts that this node led. Attempts that never finish (e.g. node restart) are not counted.",
+            "Number of finished signature computation attempts that this node led. Attempts interrupted before completion (e.g. node restart) are not counted.",
             &["result"],
         )
         .unwrap()
@@ -188,7 +188,7 @@ pub static MPC_NUM_CKD_COMPUTATIONS_LED: LazyLock<prometheus::IntCounterVec> = L
     || {
         prometheus::register_int_counter_vec!(
             "mpc_num_ckd_computations_led",
-            "Number of finished ckd computation attempts that this node led. Attempts that never finish (e.g. node restart) are not counted.",
+            "Number of finished ckd computation attempts that this node led. Attempts interrupted before completion (e.g. node restart) are not counted.",
             &["result"],
         )
         .unwrap()
@@ -199,7 +199,7 @@ pub static MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED: LazyLock<prometheus::IntC
     LazyLock::new(|| {
         prometheus::register_int_counter_vec!(
             "mpc_num_verify_foreign_tx_computations_led",
-            "Number of finished verify foreign tx computation attempts that this node led. Attempts that never finish (e.g. node restart) are not counted.",
+            "Number of finished verify foreign tx computation attempts that this node led. Attempts interrupted before completion (e.g. node restart) are not counted.",
             &["result"],
         )
         .unwrap()

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -173,31 +173,33 @@ pub static MPC_NUM_TIMEOUTS_INDEXED: LazyLock<prometheus::IntCounter> = LazyLock
     .unwrap()
 });
 
-pub static MPC_NUM_SIGNATURE_COMPUTATIONS_LED: LazyLock<prometheus::IntCounterVec> =
-    LazyLock::new(|| {
+pub static MPC_NUM_SIGNATURE_COMPUTATIONS_LED: LazyLock<prometheus::IntCounterVec> = LazyLock::new(
+    || {
         prometheus::register_int_counter_vec!(
             "mpc_num_signature_computations_led",
-            "Number of signature computations that this node led",
+            "Number of finished signature computation attempts that this node led. Attempts that never finish (e.g. node restart) are not counted.",
             &["result"],
         )
         .unwrap()
-    });
+    },
+);
 
-pub static MPC_NUM_CKD_COMPUTATIONS_LED: LazyLock<prometheus::IntCounterVec> =
-    LazyLock::new(|| {
+pub static MPC_NUM_CKD_COMPUTATIONS_LED: LazyLock<prometheus::IntCounterVec> = LazyLock::new(
+    || {
         prometheus::register_int_counter_vec!(
             "mpc_num_ckd_computations_led",
-            "Number of ckd computations that this node led",
+            "Number of finished ckd computation attempts that this node led. Attempts that never finish (e.g. node restart) are not counted.",
             &["result"],
         )
         .unwrap()
-    });
+    },
+);
 
 pub static MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED: LazyLock<prometheus::IntCounterVec> =
     LazyLock::new(|| {
         prometheus::register_int_counter_vec!(
             "mpc_num_verify_foreign_tx_computations_led",
-            "Number of verify foreign tx computations that this node led",
+            "Number of finished verify foreign tx computation attempts that this node led. Attempts that never finish (e.g. node restart) are not counted.",
             &["result"],
         )
         .unwrap()
@@ -404,6 +406,27 @@ pub static PARTICIPANT_TOTAL_TIMES_SEEN_IN_FAILED_SIGNATURE_COMPUTATION_FOLLOWER
 
 pub const MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL: &str = "total";
 pub const MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL: &str = "succeeded";
+pub const MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL: &str = "failed";
+pub const MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL: &str = "deadline_exceeded";
+
+/// Records the outcome of a finished leader-side computation attempt: bumps exactly one of
+/// `succeeded`, `failed`, or `deadline_exceeded`, plus `total`, so the labels stay consistent
+/// at every scrape. `deadline_exceeded` means the node's own deadline (`timeout_sec`) elapsed
+/// and the attempt was aborted, not the on-chain request timeout.
+pub fn record_led_computation_outcome<T>(
+    metric: &prometheus::IntCounterVec,
+    result: &Result<anyhow::Result<T>, tokio::time::error::Elapsed>,
+) {
+    let outcome_label = match result {
+        Ok(Ok(_)) => MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
+        Ok(Err(_)) => MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL,
+        Err(_) => MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
+    };
+    metric.with_label_values(&[outcome_label]).inc();
+    metric
+        .with_label_values(&[MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL])
+        .inc();
+}
 
 pub static MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL: LazyLock<prometheus::IntCounterVec> =
     LazyLock::new(|| {

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -409,21 +409,6 @@ pub const MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL: &str = "succeeded";
 pub const MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL: &str = "failed";
 pub const MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL: &str = "deadline_exceeded";
 
-pub fn record_led_computation_outcome<T>(
-    metric: &prometheus::IntCounterVec,
-    result: &Result<anyhow::Result<T>, tokio::time::error::Elapsed>,
-) {
-    let outcome_label = match result {
-        Ok(Ok(_)) => MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
-        Ok(Err(_)) => MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL,
-        Err(_) => MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
-    };
-    metric.with_label_values(&[outcome_label]).inc();
-    metric
-        .with_label_values(&[MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL])
-        .inc();
-}
-
 pub static MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL: LazyLock<prometheus::IntCounterVec> =
     LazyLock::new(|| {
         prometheus::register_int_counter_vec!(

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -383,74 +383,10 @@ where
                             .clone();
                         let response = match existing_response {
                             None => {
-                                let computation = async {
-                                    match this
-                                        .domain_to_protocol
-                                        .get(&signature_attempt.request.domain)
-                                    {
-                                        Some(Protocol::CaitSith) => {
-                                            let (signature, public_key) = this
-                                                .ecdsa_signature_provider
-                                                .clone()
-                                                .make_signature(signature_attempt.request.id)
-                                                .await?;
-
-                                            let response =
-                                                contract_args::SignatureRespondArgs::from_ecdsa(
-                                                    &signature_attempt.request,
-                                                    &signature,
-                                                    &public_key,
-                                                )?;
-
-                                            Ok(response)
-                                        }
-                                        Some(Protocol::Frost) => {
-                                            let (signature, _) = this
-                                                .eddsa_signature_provider
-                                                .clone()
-                                                .make_signature(signature_attempt.request.id)
-                                                .await?;
-
-                                            let response =
-                                                contract_args::SignatureRespondArgs::from_eddsa(
-                                                    &signature_attempt.request,
-                                                    &signature,
-                                                )?;
-
-                                            Ok(response)
-                                        }
-                                        Some(Protocol::ConfidentialKeyDerivation) => {
-                                            Err(anyhow::anyhow!(
-                                                "Incorrect protocol for domain: {:?}",
-                                                signature_attempt.request.domain.clone()
-                                            ))
-                                        }
-                                        Some(Protocol::DamgardEtAl) => {
-                                            let (signature, public_key) = this
-                                                .robust_ecdsa_signature_provider
-                                                .clone()
-                                                .make_signature(signature_attempt.request.id)
-                                                .await?;
-
-                                            let response =
-                                                contract_args::SignatureRespondArgs::from_ecdsa(
-                                                    &signature_attempt.request,
-                                                    &signature,
-                                                    &public_key,
-                                                )?;
-
-                                            Ok(response)
-                                        }
-                                        None => Err(anyhow::anyhow!(
-                                            "Signature scheme is not found for domain: {:?}",
-                                            signature_attempt.request.domain.clone()
-                                        )),
-                                    }
-                                };
                                 let response = run_led_computation(
                                     &metrics::MPC_NUM_SIGNATURE_COMPUTATIONS_LED,
                                     Duration::from_secs(this.config.signature.timeout_sec),
-                                    computation,
+                                    this.compute_signature_response(&signature_attempt.request),
                                 )
                                 .await?;
 
@@ -494,45 +430,10 @@ where
                             .clone();
                         let response = match existing_response {
                             None => {
-                                let computation = async {
-                                    match this
-                                        .domain_to_protocol
-                                        .get(&ckd_attempt.request.domain_id)
-                                    {
-                                        Some(Protocol::ConfidentialKeyDerivation) => {
-                                            let response = this
-                                                .ckd_provider
-                                                .clone()
-                                                .make_signature(ckd_attempt.request.id)
-                                                .await?;
-
-                                            let response = contract_args::CKDRespondArgs::new(
-                                                (&ckd_attempt.request)
-                                                    .into_contract_interface_type(),
-                                                CKDResponse {
-                                                    big_y: (&response.0.0).into(),
-                                                    big_c: (&response.0.1).into(),
-                                                },
-                                            );
-
-                                            Ok(response)
-                                        }
-                                        Some(Protocol::CaitSith)
-                                        | Some(Protocol::DamgardEtAl)
-                                        | Some(Protocol::Frost) => Err(anyhow::anyhow!(
-                                            "Signature scheme is not allowed for domain: {:?}",
-                                            ckd_attempt.request.domain_id.clone()
-                                        )),
-                                        None => Err(anyhow::anyhow!(
-                                            "Signature scheme is not found for domain: {:?}",
-                                            ckd_attempt.request.domain_id.clone()
-                                        )),
-                                    }
-                                };
                                 let response = run_led_computation(
                                     &metrics::MPC_NUM_CKD_COMPUTATIONS_LED,
                                     Duration::from_secs(this.config.ckd.timeout_sec),
-                                    computation,
+                                    this.compute_ckd_response(&ckd_attempt.request),
                                 )
                                 .await?;
 
@@ -580,45 +481,12 @@ where
                             .clone();
                         let response = match existing_response {
                             None => {
-                                let computation = async {
-                                    match this
-                                        .domain_to_protocol
-                                        .get(&verify_foreign_tx_attempt.request.domain_id)
-                                    {
-                                        Some(Protocol::CaitSith) => {
-                                            let response = this
-                                                .verify_foreign_tx_provider
-                                                .make_verify_foreign_tx_leader(
-                                                    verify_foreign_tx_attempt.request.id,
-                                                )
-                                                .await?;
-
-                                            let payload_hash = response.0.0.compute_msg_hash()?;
-                                            let response = contract_args::VerifyForeignTransactionRespondArgs::from_signature(
-                                                verify_foreign_tx_attempt.request.clone(),
-                                                payload_hash,
-                                                response.0.1,
-                                                response.1,
-                                            )?;
-
-                                            Ok(response)
-                                        }
-                                        Some(Protocol::ConfidentialKeyDerivation)
-                                        | Some(Protocol::DamgardEtAl)
-                                        | Some(Protocol::Frost) => Err(anyhow::anyhow!(
-                                            "Signature scheme is not allowed for domain: {:?}",
-                                            verify_foreign_tx_attempt.request.domain_id.clone()
-                                        )),
-                                        None => Err(anyhow::anyhow!(
-                                            "Signature scheme is not found for domain: {:?}",
-                                            verify_foreign_tx_attempt.request.domain_id.clone()
-                                        )),
-                                    }
-                                };
                                 let response = run_led_computation(
                                     &metrics::MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED,
                                     Duration::from_secs(this.config.signature.timeout_sec),
-                                    computation,
+                                    this.compute_verify_foreign_tx_response(
+                                        &verify_foreign_tx_attempt.request,
+                                    ),
                                 )
                                 .await?;
 
@@ -648,6 +516,129 @@ where
                     },
                 );
             }
+        }
+    }
+
+    async fn compute_signature_response(
+        &self,
+        request: &SignatureRequest,
+    ) -> anyhow::Result<contract_args::SignatureRespondArgs> {
+        match self.domain_to_protocol.get(&request.domain) {
+            Some(Protocol::CaitSith) => {
+                let (signature, public_key) = self
+                    .ecdsa_signature_provider
+                    .clone()
+                    .make_signature(request.id)
+                    .await?;
+
+                let response = contract_args::SignatureRespondArgs::from_ecdsa(
+                    request,
+                    &signature,
+                    &public_key,
+                )?;
+
+                Ok(response)
+            }
+            Some(Protocol::Frost) => {
+                let (signature, _) = self
+                    .eddsa_signature_provider
+                    .clone()
+                    .make_signature(request.id)
+                    .await?;
+
+                let response =
+                    contract_args::SignatureRespondArgs::from_eddsa(request, &signature)?;
+
+                Ok(response)
+            }
+            Some(Protocol::ConfidentialKeyDerivation) => Err(anyhow::anyhow!(
+                "Incorrect protocol for domain: {:?}",
+                request.domain.clone()
+            )),
+            Some(Protocol::DamgardEtAl) => {
+                let (signature, public_key) = self
+                    .robust_ecdsa_signature_provider
+                    .clone()
+                    .make_signature(request.id)
+                    .await?;
+
+                let response = contract_args::SignatureRespondArgs::from_ecdsa(
+                    request,
+                    &signature,
+                    &public_key,
+                )?;
+
+                Ok(response)
+            }
+            None => Err(anyhow::anyhow!(
+                "Signature scheme is not found for domain: {:?}",
+                request.domain.clone()
+            )),
+        }
+    }
+
+    async fn compute_ckd_response(
+        &self,
+        request: &CKDRequest,
+    ) -> anyhow::Result<contract_args::CKDRespondArgs> {
+        match self.domain_to_protocol.get(&request.domain_id) {
+            Some(Protocol::ConfidentialKeyDerivation) => {
+                let response = self.ckd_provider.clone().make_signature(request.id).await?;
+
+                let response = contract_args::CKDRespondArgs::new(
+                    request.into_contract_interface_type(),
+                    CKDResponse {
+                        big_y: (&response.0.0).into(),
+                        big_c: (&response.0.1).into(),
+                    },
+                );
+
+                Ok(response)
+            }
+            Some(Protocol::CaitSith) | Some(Protocol::DamgardEtAl) | Some(Protocol::Frost) => {
+                Err(anyhow::anyhow!(
+                    "Signature scheme is not allowed for domain: {:?}",
+                    request.domain_id.clone()
+                ))
+            }
+            None => Err(anyhow::anyhow!(
+                "Signature scheme is not found for domain: {:?}",
+                request.domain_id.clone()
+            )),
+        }
+    }
+
+    async fn compute_verify_foreign_tx_response(
+        &self,
+        request: &VerifyForeignTxRequest,
+    ) -> anyhow::Result<contract_args::VerifyForeignTransactionRespondArgs> {
+        match self.domain_to_protocol.get(&request.domain_id) {
+            Some(Protocol::CaitSith) => {
+                let response = self
+                    .verify_foreign_tx_provider
+                    .make_verify_foreign_tx_leader(request.id)
+                    .await?;
+
+                let payload_hash = response.0.0.compute_msg_hash()?;
+                let response = contract_args::VerifyForeignTransactionRespondArgs::from_signature(
+                    request.clone(),
+                    payload_hash,
+                    response.0.1,
+                    response.1,
+                )?;
+
+                Ok(response)
+            }
+            Some(Protocol::ConfidentialKeyDerivation)
+            | Some(Protocol::DamgardEtAl)
+            | Some(Protocol::Frost) => Err(anyhow::anyhow!(
+                "Signature scheme is not allowed for domain: {:?}",
+                request.domain_id.clone()
+            )),
+            None => Err(anyhow::anyhow!(
+                "Signature scheme is not found for domain: {:?}",
+                request.domain_id.clone()
+            )),
         }
     }
 

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -523,13 +523,15 @@ where
         &self,
         request: &SignatureRequest,
     ) -> anyhow::Result<contract_args::SignatureRespondArgs> {
+        macro_rules! make_signature {
+            ($provider:expr) => {
+                $provider.make_signature(request.id).await?
+            };
+        }
+
         match self.domain_to_protocol.get(&request.domain) {
             Some(Protocol::CaitSith) => {
-                let (signature, public_key) = self
-                    .ecdsa_signature_provider
-                    .clone()
-                    .make_signature(request.id)
-                    .await?;
+                let (signature, public_key) = make_signature!(self.ecdsa_signature_provider);
 
                 let response = contract_args::SignatureRespondArgs::from_ecdsa(
                     request,
@@ -540,11 +542,7 @@ where
                 Ok(response)
             }
             Some(Protocol::Frost) => {
-                let (signature, _) = self
-                    .eddsa_signature_provider
-                    .clone()
-                    .make_signature(request.id)
-                    .await?;
+                let (signature, _) = make_signature!(self.eddsa_signature_provider);
 
                 let response =
                     contract_args::SignatureRespondArgs::from_eddsa(request, &signature)?;
@@ -556,11 +554,7 @@ where
                 request.domain
             )),
             Some(Protocol::DamgardEtAl) => {
-                let (signature, public_key) = self
-                    .robust_ecdsa_signature_provider
-                    .clone()
-                    .make_signature(request.id)
-                    .await?;
+                let (signature, public_key) = make_signature!(self.robust_ecdsa_signature_provider);
 
                 let response = contract_args::SignatureRespondArgs::from_ecdsa(
                     request,
@@ -583,7 +577,7 @@ where
     ) -> anyhow::Result<contract_args::CKDRespondArgs> {
         match self.domain_to_protocol.get(&request.domain_id) {
             Some(Protocol::ConfidentialKeyDerivation) => {
-                let response = self.ckd_provider.clone().make_signature(request.id).await?;
+                let response = self.ckd_provider.make_signature(request.id).await?;
 
                 let response = contract_args::CKDRespondArgs::new(
                     request.into_contract_interface_type(),
@@ -841,8 +835,12 @@ mod tests {
         .unwrap()
     }
 
-    fn label_value(metric: &prometheus::IntCounterVec, label: &str) -> u64 {
-        metric.with_label_values(&[label]).get()
+    fn assert_label_value(metric: &prometheus::IntCounterVec, label: &str, expected: u64) {
+        assert_eq!(
+            metric.with_label_values(&[label]).get(),
+            expected,
+            "unexpected count for result label {label:?}",
+        );
     }
 
     #[tokio::test]
@@ -857,24 +855,17 @@ mod tests {
 
         // Then
         assert_eq!(result.unwrap(), 42);
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL),
-            1
+        assert_label_value(
+            &metric,
+            metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
+            1,
         );
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL),
-            1
-        );
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL),
-            0
-        );
-        assert_eq!(
-            label_value(
-                &metric,
-                metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL
-            ),
-            0
+        assert_label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL, 1);
+        assert_label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL, 0);
+        assert_label_value(
+            &metric,
+            metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
+            0,
         );
     }
 
@@ -892,24 +883,17 @@ mod tests {
 
         // Then
         assert_eq!(result.unwrap_err().to_string(), "computation failed");
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL),
-            1
+        assert_label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL, 1);
+        assert_label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL, 1);
+        assert_label_value(
+            &metric,
+            metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
+            0,
         );
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL),
-            1
-        );
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL),
-            0
-        );
-        assert_eq!(
-            label_value(
-                &metric,
-                metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL
-            ),
-            0
+        assert_label_value(
+            &metric,
+            metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
+            0,
         );
     }
 
@@ -929,24 +913,17 @@ mod tests {
 
         // Then
         result.unwrap_err();
-        assert_eq!(
-            label_value(
-                &metric,
-                metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL
-            ),
-            1
+        assert_label_value(
+            &metric,
+            metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
+            1,
         );
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL),
-            1
+        assert_label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL, 1);
+        assert_label_value(
+            &metric,
+            metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
+            0,
         );
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL),
-            0
-        );
-        assert_eq!(
-            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL),
-            0
-        );
+        assert_label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL, 0);
     }
 }

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -32,6 +32,7 @@ use mpc_primitives::domain::{DomainId, Protocol};
 use near_mpc_contract_interface::types::CKDResponse;
 use near_time::Clock;
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -43,6 +44,27 @@ use tokio::time::{sleep, timeout};
 /// responded to multiple times. It doesn't affect correctness, but can make tests less flaky and
 /// production runs experience fewer redundant signatures/ckds.
 const INITIAL_STARTUP_PROCESSING_DELAY: Duration = Duration::from_secs(2);
+
+async fn run_led_computation<T>(
+    metric: &prometheus::IntCounterVec,
+    deadline: Duration,
+    computation: impl Future<Output = anyhow::Result<T>>,
+) -> anyhow::Result<T> {
+    let (outcome_label, result) = match timeout(deadline, computation).await {
+        Ok(Ok(value)) => (metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL, Ok(value)),
+        Ok(Err(error)) => (metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL, Err(error)),
+        Err(elapsed) => (
+            metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
+            Err(elapsed.into()),
+        ),
+    };
+    metric.with_label_values(&[outcome_label]).inc();
+    metric
+        .with_label_values(&[metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL])
+        .inc();
+    result
+}
+
 const TEE_CONTRACT_VERIFICATION_INVOCATION_INTERVAL_DURATION: Duration =
     Duration::from_secs(60 * 60 * 24 * 2);
 
@@ -425,16 +447,12 @@ where
                                         )),
                                     }
                                 };
-                                let result = timeout(
+                                let response = run_led_computation(
+                                    &metrics::MPC_NUM_SIGNATURE_COMPUTATIONS_LED,
                                     Duration::from_secs(this.config.signature.timeout_sec),
                                     computation,
                                 )
-                                .await;
-                                metrics::record_led_computation_outcome(
-                                    &metrics::MPC_NUM_SIGNATURE_COMPUTATIONS_LED,
-                                    &result,
-                                );
-                                let response = result??;
+                                .await?;
 
                                 signature_attempt
                                     .computation_progress
@@ -511,16 +529,12 @@ where
                                         )),
                                     }
                                 };
-                                let result = timeout(
+                                let response = run_led_computation(
+                                    &metrics::MPC_NUM_CKD_COMPUTATIONS_LED,
                                     Duration::from_secs(this.config.ckd.timeout_sec),
                                     computation,
                                 )
-                                .await;
-                                metrics::record_led_computation_outcome(
-                                    &metrics::MPC_NUM_CKD_COMPUTATIONS_LED,
-                                    &result,
-                                );
-                                let response = result??;
+                                .await?;
 
                                 ckd_attempt
                                     .computation_progress
@@ -601,16 +615,12 @@ where
                                         )),
                                     }
                                 };
-                                let result = timeout(
+                                let response = run_led_computation(
+                                    &metrics::MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED,
                                     Duration::from_secs(this.config.signature.timeout_sec),
                                     computation,
                                 )
-                                .await;
-                                metrics::record_led_computation_outcome(
-                                    &metrics::MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED,
-                                    &result,
-                                );
-                                let response = result??;
+                                .await?;
 
                                 verify_foreign_tx_attempt
                                     .computation_progress

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -553,7 +553,7 @@ where
             }
             Some(Protocol::ConfidentialKeyDerivation) => Err(anyhow::anyhow!(
                 "Incorrect protocol for domain: {:?}",
-                request.domain.clone()
+                request.domain
             )),
             Some(Protocol::DamgardEtAl) => {
                 let (signature, public_key) = self
@@ -572,7 +572,7 @@ where
             }
             None => Err(anyhow::anyhow!(
                 "Signature scheme is not found for domain: {:?}",
-                request.domain.clone()
+                request.domain
             )),
         }
     }
@@ -598,12 +598,12 @@ where
             Some(Protocol::CaitSith) | Some(Protocol::DamgardEtAl) | Some(Protocol::Frost) => {
                 Err(anyhow::anyhow!(
                     "Signature scheme is not allowed for domain: {:?}",
-                    request.domain_id.clone()
+                    request.domain_id
                 ))
             }
             None => Err(anyhow::anyhow!(
                 "Signature scheme is not found for domain: {:?}",
-                request.domain_id.clone()
+                request.domain_id
             )),
         }
     }
@@ -633,11 +633,11 @@ where
             | Some(Protocol::DamgardEtAl)
             | Some(Protocol::Frost) => Err(anyhow::anyhow!(
                 "Signature scheme is not allowed for domain: {:?}",
-                request.domain_id.clone()
+                request.domain_id
             )),
             None => Err(anyhow::anyhow!(
                 "Signature scheme is not found for domain: {:?}",
-                request.domain_id.clone()
+                request.domain_id
             )),
         }
     }
@@ -831,5 +831,122 @@ mod tests {
                 "unexpected classification for {task_id:?}",
             );
         }
+    }
+
+    fn led_computations_metric() -> prometheus::IntCounterVec {
+        prometheus::IntCounterVec::new(
+            prometheus::Opts::new("test_computations_led", "test"),
+            &["result"],
+        )
+        .unwrap()
+    }
+
+    fn label_value(metric: &prometheus::IntCounterVec, label: &str) -> u64 {
+        metric.with_label_values(&[label]).get()
+    }
+
+    #[tokio::test]
+    #[expect(non_snake_case)]
+    async fn run_led_computation__should_record_succeeded_and_total_on_success() {
+        // Given
+        let metric = led_computations_metric();
+
+        // When
+        let result =
+            run_led_computation(&metric, Duration::from_secs(1), async { anyhow::Ok(42) }).await;
+
+        // Then
+        assert_eq!(result.unwrap(), 42);
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL),
+            1
+        );
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL),
+            1
+        );
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL),
+            0
+        );
+        assert_eq!(
+            label_value(
+                &metric,
+                metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL
+            ),
+            0
+        );
+    }
+
+    #[tokio::test]
+    #[expect(non_snake_case)]
+    async fn run_led_computation__should_record_failed_and_total_on_error() {
+        // Given
+        let metric = led_computations_metric();
+
+        // When
+        let result: anyhow::Result<u32> = run_led_computation(&metric, Duration::from_secs(1), {
+            async { Err(anyhow::anyhow!("computation failed")) }
+        })
+        .await;
+
+        // Then
+        assert_eq!(result.unwrap_err().to_string(), "computation failed");
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL),
+            1
+        );
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL),
+            1
+        );
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL),
+            0
+        );
+        assert_eq!(
+            label_value(
+                &metric,
+                metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL
+            ),
+            0
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    #[expect(non_snake_case)]
+    async fn run_led_computation__should_record_deadline_exceeded_and_total_on_timeout() {
+        // Given
+        let metric = led_computations_metric();
+
+        // When
+        let result: anyhow::Result<u32> = run_led_computation(
+            &metric,
+            Duration::ZERO,
+            std::future::pending::<anyhow::Result<u32>>(),
+        )
+        .await;
+
+        // Then
+        result.unwrap_err();
+        assert_eq!(
+            label_value(
+                &metric,
+                metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL
+            ),
+            1
+        );
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL),
+            1
+        );
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL),
+            0
+        );
+        assert_eq!(
+            label_value(&metric, metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL),
+            0
+        );
     }
 }

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -45,26 +45,6 @@ use tokio::time::{sleep, timeout};
 /// production runs experience fewer redundant signatures/ckds.
 const INITIAL_STARTUP_PROCESSING_DELAY: Duration = Duration::from_secs(2);
 
-async fn run_led_computation<T>(
-    metric: &prometheus::IntCounterVec,
-    deadline: Duration,
-    computation: impl Future<Output = anyhow::Result<T>>,
-) -> anyhow::Result<T> {
-    let (outcome_label, result) = match timeout(deadline, computation).await {
-        Ok(Ok(value)) => (metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL, Ok(value)),
-        Ok(Err(error)) => (metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL, Err(error)),
-        Err(elapsed) => (
-            metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
-            Err(elapsed.into()),
-        ),
-    };
-    metric.with_label_values(&[outcome_label]).inc();
-    metric
-        .with_label_values(&[metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL])
-        .inc();
-    result
-}
-
 const TEE_CONTRACT_VERIFICATION_INVOCATION_INTERVAL_DURATION: Duration =
     Duration::from_secs(60 * 60 * 24 * 2);
 
@@ -107,6 +87,26 @@ fn is_heavy_generation_task(task_id: &MpcTaskId) -> bool {
         | MpcTaskId::CKDTaskId(_)
         | MpcTaskId::VerifyForeignTxTaskId(_) => false,
     }
+}
+
+async fn run_led_computation<T>(
+    metric: &prometheus::IntCounterVec,
+    deadline: Duration,
+    computation: impl Future<Output = anyhow::Result<T>>,
+) -> anyhow::Result<T> {
+    let (outcome_label, result) = match timeout(deadline, computation).await {
+        Ok(Ok(value)) => (metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL, Ok(value)),
+        Ok(Err(error)) => (metrics::MPC_NUM_COMPUTATIONS_LED_FAILED_LABEL, Err(error)),
+        Err(elapsed) => (
+            metrics::MPC_NUM_COMPUTATIONS_LED_DEADLINE_EXCEEDED_LABEL,
+            Err(elapsed.into()),
+        ),
+    };
+    metric.with_label_values(&[outcome_label]).inc();
+    metric
+        .with_label_values(&[metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL])
+        .inc();
+    result
 }
 
 impl<ForeignChainPolicyReader> MpcClient<ForeignChainPolicyReader>

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -102,10 +102,10 @@ async fn run_led_computation<T>(
             Err(elapsed.into()),
         ),
     };
-    metric.with_label_values(&[outcome_label]).inc();
     metric
         .with_label_values(&[metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL])
         .inc();
+    metric.with_label_values(&[outcome_label]).inc();
     result
 }
 

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -361,86 +361,80 @@ where
                             .clone();
                         let response = match existing_response {
                             None => {
-                                metrics::MPC_NUM_SIGNATURE_COMPUTATIONS_LED
-                                    .with_label_values(&[
-                                        metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL,
-                                    ])
-                                    .inc();
-
-                                let response = match this
-                                    .domain_to_protocol
-                                    .get(&signature_attempt.request.domain)
-                                {
-                                    Some(Protocol::CaitSith) => {
-                                        let (signature, public_key) = timeout(
-                                            Duration::from_secs(this.config.signature.timeout_sec),
-                                            this.ecdsa_signature_provider
+                                let computation = async {
+                                    match this
+                                        .domain_to_protocol
+                                        .get(&signature_attempt.request.domain)
+                                    {
+                                        Some(Protocol::CaitSith) => {
+                                            let (signature, public_key) = this
+                                                .ecdsa_signature_provider
                                                 .clone()
-                                                .make_signature(signature_attempt.request.id),
-                                        )
-                                        .await??;
+                                                .make_signature(signature_attempt.request.id)
+                                                .await?;
 
-                                        let response =
-                                            contract_args::SignatureRespondArgs::from_ecdsa(
-                                                &signature_attempt.request,
-                                                &signature,
-                                                &public_key,
-                                            )?;
+                                            let response =
+                                                contract_args::SignatureRespondArgs::from_ecdsa(
+                                                    &signature_attempt.request,
+                                                    &signature,
+                                                    &public_key,
+                                                )?;
 
-                                        Ok(response)
-                                    }
-                                    Some(Protocol::Frost) => {
-                                        let (signature, _) = timeout(
-                                            Duration::from_secs(this.config.signature.timeout_sec),
-                                            this.eddsa_signature_provider
+                                            Ok(response)
+                                        }
+                                        Some(Protocol::Frost) => {
+                                            let (signature, _) = this
+                                                .eddsa_signature_provider
                                                 .clone()
-                                                .make_signature(signature_attempt.request.id),
-                                        )
-                                        .await??;
+                                                .make_signature(signature_attempt.request.id)
+                                                .await?;
 
-                                        let response =
-                                            contract_args::SignatureRespondArgs::from_eddsa(
-                                                &signature_attempt.request,
-                                                &signature,
-                                            )?;
+                                            let response =
+                                                contract_args::SignatureRespondArgs::from_eddsa(
+                                                    &signature_attempt.request,
+                                                    &signature,
+                                                )?;
 
-                                        Ok(response)
-                                    }
-                                    Some(Protocol::ConfidentialKeyDerivation) => {
-                                        Err(anyhow::anyhow!(
-                                            "Incorrect protocol for domain: {:?}",
+                                            Ok(response)
+                                        }
+                                        Some(Protocol::ConfidentialKeyDerivation) => {
+                                            Err(anyhow::anyhow!(
+                                                "Incorrect protocol for domain: {:?}",
+                                                signature_attempt.request.domain.clone()
+                                            ))
+                                        }
+                                        Some(Protocol::DamgardEtAl) => {
+                                            let (signature, public_key) = this
+                                                .robust_ecdsa_signature_provider
+                                                .clone()
+                                                .make_signature(signature_attempt.request.id)
+                                                .await?;
+
+                                            let response =
+                                                contract_args::SignatureRespondArgs::from_ecdsa(
+                                                    &signature_attempt.request,
+                                                    &signature,
+                                                    &public_key,
+                                                )?;
+
+                                            Ok(response)
+                                        }
+                                        None => Err(anyhow::anyhow!(
+                                            "Signature scheme is not found for domain: {:?}",
                                             signature_attempt.request.domain.clone()
-                                        ))
+                                        )),
                                     }
-                                    Some(Protocol::DamgardEtAl) => {
-                                        let (signature, public_key) = timeout(
-                                            Duration::from_secs(this.config.signature.timeout_sec),
-                                            this.robust_ecdsa_signature_provider
-                                                .clone()
-                                                .make_signature(signature_attempt.request.id),
-                                        )
-                                        .await??;
-
-                                        let response =
-                                            contract_args::SignatureRespondArgs::from_ecdsa(
-                                                &signature_attempt.request,
-                                                &signature,
-                                                &public_key,
-                                            )?;
-
-                                        Ok(response)
-                                    }
-                                    None => Err(anyhow::anyhow!(
-                                        "Signature scheme is not found for domain: {:?}",
-                                        signature_attempt.request.domain.clone()
-                                    )),
-                                }?;
-
-                                metrics::MPC_NUM_SIGNATURE_COMPUTATIONS_LED
-                                    .with_label_values(&[
-                                        metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
-                                    ])
-                                    .inc();
+                                };
+                                let result = timeout(
+                                    Duration::from_secs(this.config.signature.timeout_sec),
+                                    computation,
+                                )
+                                .await;
+                                metrics::record_led_computation_outcome(
+                                    &metrics::MPC_NUM_SIGNATURE_COMPUTATIONS_LED,
+                                    &result,
+                                );
+                                let response = result??;
 
                                 signature_attempt
                                     .computation_progress
@@ -482,52 +476,51 @@ where
                             .clone();
                         let response = match existing_response {
                             None => {
-                                metrics::MPC_NUM_CKD_COMPUTATIONS_LED
-                                    .with_label_values(&[
-                                        metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL,
-                                    ])
-                                    .inc();
-
-                                let response = match this
-                                    .domain_to_protocol
-                                    .get(&ckd_attempt.request.domain_id)
-                                {
-                                    Some(Protocol::ConfidentialKeyDerivation) => {
-                                        let response = timeout(
-                                            Duration::from_secs(this.config.ckd.timeout_sec),
-                                            this.ckd_provider
+                                let computation = async {
+                                    match this
+                                        .domain_to_protocol
+                                        .get(&ckd_attempt.request.domain_id)
+                                    {
+                                        Some(Protocol::ConfidentialKeyDerivation) => {
+                                            let response = this
+                                                .ckd_provider
                                                 .clone()
-                                                .make_signature(ckd_attempt.request.id),
-                                        )
-                                        .await??;
+                                                .make_signature(ckd_attempt.request.id)
+                                                .await?;
 
-                                        let response = contract_args::CKDRespondArgs::new(
-                                            (&ckd_attempt.request).into_contract_interface_type(),
-                                            CKDResponse {
-                                                big_y: (&response.0.0).into(),
-                                                big_c: (&response.0.1).into(),
-                                            },
-                                        );
+                                            let response = contract_args::CKDRespondArgs::new(
+                                                (&ckd_attempt.request)
+                                                    .into_contract_interface_type(),
+                                                CKDResponse {
+                                                    big_y: (&response.0.0).into(),
+                                                    big_c: (&response.0.1).into(),
+                                                },
+                                            );
 
-                                        Ok(response)
+                                            Ok(response)
+                                        }
+                                        Some(Protocol::CaitSith)
+                                        | Some(Protocol::DamgardEtAl)
+                                        | Some(Protocol::Frost) => Err(anyhow::anyhow!(
+                                            "Signature scheme is not allowed for domain: {:?}",
+                                            ckd_attempt.request.domain_id.clone()
+                                        )),
+                                        None => Err(anyhow::anyhow!(
+                                            "Signature scheme is not found for domain: {:?}",
+                                            ckd_attempt.request.domain_id.clone()
+                                        )),
                                     }
-                                    Some(Protocol::CaitSith)
-                                    | Some(Protocol::DamgardEtAl)
-                                    | Some(Protocol::Frost) => Err(anyhow::anyhow!(
-                                        "Signature scheme is not allowed for domain: {:?}",
-                                        ckd_attempt.request.domain_id.clone()
-                                    )),
-                                    None => Err(anyhow::anyhow!(
-                                        "Signature scheme is not found for domain: {:?}",
-                                        ckd_attempt.request.domain_id.clone()
-                                    )),
-                                }?;
-
-                                metrics::MPC_NUM_CKD_COMPUTATIONS_LED
-                                    .with_label_values(&[
-                                        metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
-                                    ])
-                                    .inc();
+                                };
+                                let result = timeout(
+                                    Duration::from_secs(this.config.ckd.timeout_sec),
+                                    computation,
+                                )
+                                .await;
+                                metrics::record_led_computation_outcome(
+                                    &metrics::MPC_NUM_CKD_COMPUTATIONS_LED,
+                                    &result,
+                                );
+                                let response = result??;
 
                                 ckd_attempt
                                     .computation_progress
@@ -573,53 +566,51 @@ where
                             .clone();
                         let response = match existing_response {
                             None => {
-                                metrics::MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED
-                                    .with_label_values(&[
-                                        metrics::MPC_NUM_COMPUTATIONS_LED_TOTAL_LABEL,
-                                    ])
-                                    .inc();
-
-                                let response = match this
-                                    .domain_to_protocol
-                                    .get(&verify_foreign_tx_attempt.request.domain_id)
-                                {
-                                    Some(Protocol::CaitSith) => {
-                                        let response = timeout(
-                                            Duration::from_secs(this.config.signature.timeout_sec),
-                                            this.verify_foreign_tx_provider
+                                let computation = async {
+                                    match this
+                                        .domain_to_protocol
+                                        .get(&verify_foreign_tx_attempt.request.domain_id)
+                                    {
+                                        Some(Protocol::CaitSith) => {
+                                            let response = this
+                                                .verify_foreign_tx_provider
                                                 .make_verify_foreign_tx_leader(
                                                     verify_foreign_tx_attempt.request.id,
-                                                ),
-                                        )
-                                        .await??;
+                                                )
+                                                .await?;
 
-                                        let payload_hash = response.0.0.compute_msg_hash()?;
-                                        let response = contract_args::VerifyForeignTransactionRespondArgs::from_signature(
-                                            verify_foreign_tx_attempt.request.clone(),
-                                            payload_hash,
-                                            response.0.1,
-                                            response.1,
-                                        )?;
+                                            let payload_hash = response.0.0.compute_msg_hash()?;
+                                            let response = contract_args::VerifyForeignTransactionRespondArgs::from_signature(
+                                                verify_foreign_tx_attempt.request.clone(),
+                                                payload_hash,
+                                                response.0.1,
+                                                response.1,
+                                            )?;
 
-                                        Ok(response)
+                                            Ok(response)
+                                        }
+                                        Some(Protocol::ConfidentialKeyDerivation)
+                                        | Some(Protocol::DamgardEtAl)
+                                        | Some(Protocol::Frost) => Err(anyhow::anyhow!(
+                                            "Signature scheme is not allowed for domain: {:?}",
+                                            verify_foreign_tx_attempt.request.domain_id.clone()
+                                        )),
+                                        None => Err(anyhow::anyhow!(
+                                            "Signature scheme is not found for domain: {:?}",
+                                            verify_foreign_tx_attempt.request.domain_id.clone()
+                                        )),
                                     }
-                                    Some(Protocol::ConfidentialKeyDerivation)
-                                    | Some(Protocol::DamgardEtAl)
-                                    | Some(Protocol::Frost) => Err(anyhow::anyhow!(
-                                        "Signature scheme is not allowed for domain: {:?}",
-                                        verify_foreign_tx_attempt.request.domain_id.clone()
-                                    )),
-                                    None => Err(anyhow::anyhow!(
-                                        "Signature scheme is not found for domain: {:?}",
-                                        verify_foreign_tx_attempt.request.domain_id.clone()
-                                    )),
-                                }?;
-
-                                metrics::MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED
-                                    .with_label_values(&[
-                                        metrics::MPC_NUM_COMPUTATIONS_LED_SUCCEEDED_LABEL,
-                                    ])
-                                    .inc();
+                                };
+                                let result = timeout(
+                                    Duration::from_secs(this.config.signature.timeout_sec),
+                                    computation,
+                                )
+                                .await;
+                                metrics::record_led_computation_outcome(
+                                    &metrics::MPC_NUM_VERIFY_FOREIGN_TX_COMPUTATIONS_LED,
+                                    &result,
+                                );
+                                let response = result??;
 
                                 verify_foreign_tx_attempt
                                     .computation_progress


### PR DESCRIPTION
closes #3835 

Note: This also adds an `deadline_exceeded` label which is not mentioned in the issue. I think it's a strict improvement to be able to distinguish between the different failure types in our metrics.