### PR TITLE
refactor(chain-gateway): unify view calls behind a single ViewContract trait

### DIFF
--- a/crates/chain-gateway/src/chain_gateway.rs
+++ b/crates/chain-gateway/src/chain_gateway.rs
@@ -1,6 +1,8 @@
 use std::future::Future;
 use std::path::Path;
 
+use crate::primitives::ViewContract;
+use crate::types::ViewArgs;
 use near_account_id::AccountId;
 use near_async::ActorSystem;
 use near_indexer::StreamerMessage;
@@ -15,9 +17,7 @@ use crate::event_subscriber::subscriber::BlockEventSubscriptions;
 use crate::near_internals_wrapper::{
     NearClientActorHandle, NearRpcActorHandle, NearViewClientActorHandle,
 };
-use crate::primitives::{
-    FetchLatestFinalBlockInfo, IsSyncing, QueryViewFunction, SubmitSignedTransaction,
-};
+use crate::primitives::{FetchLatestFinalBlockInfo, IsSyncing, SubmitSignedTransaction};
 use crate::types::ObservedState;
 
 #[derive(Clone)]
@@ -37,17 +37,14 @@ impl IsSyncing for ChainGateway {
     }
 }
 
-impl QueryViewFunction for ChainGateway {
+impl ViewContract for ChainGateway {
     type Error = NearViewClientError;
-    async fn query_view_function(
+    async fn view_contract(
         &self,
         contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
+        view_args: ViewArgs,
     ) -> Result<ObservedState, Self::Error> {
-        self.view_client
-            .query_view_function(contract_id, method_name, args)
-            .await
+        self.view_client.view_contract(contract_id, view_args).await
     }
 }
 

--- a/crates/chain-gateway/src/errors.rs
+++ b/crates/chain-gateway/src/errors.rs
@@ -112,9 +112,6 @@ pub enum ChainGatewayError {
     #[error("starting neard node failed with {msg}")]
     StartupFailed { msg: String },
 
-    #[error("serialization error while {op}: {message}")]
-    Serialization { op: ChainGatewayOp, message: String },
-
     #[error("failed to submit signed transaction while {op}: {message}")]
     SubmitSignedTransaction { op: ChainGatewayOp, message: String },
 

--- a/crates/chain-gateway/src/lib.rs
+++ b/crates/chain-gateway/src/lib.rs
@@ -9,6 +9,7 @@ pub mod types;
 
 pub use chain_gateway::{ChainGateway, NodeHandle};
 pub use mpc_call_args::{FunctionCallArgs, NearGas, NearToken};
+pub use types::ViewArgs;
 
 #[cfg(any(test, feature = "test-utils"))]
 pub mod mock;

--- a/crates/chain-gateway/src/mock.rs
+++ b/crates/chain-gateway/src/mock.rs
@@ -1,6 +1,6 @@
-use crate::primitives::{
-    FetchLatestFinalBlockInfo, IsSyncing, QueryViewFunction, SubmitSignedTransaction,
-};
+use crate::primitives::ViewContract;
+use crate::primitives::{FetchLatestFinalBlockInfo, IsSyncing, SubmitSignedTransaction};
+use crate::types::ViewArgs;
 use crate::types::{LatestFinalBlockInfo, ObservedState};
 use near_account_id::AccountId;
 use near_indexer::near_primitives::transaction::SignedTransaction;
@@ -12,13 +12,13 @@ use tokio::sync::Notify;
 #[derive(Clone)]
 pub struct MockChainState {
     sync_response: Arc<Mutex<Result<bool, MockError>>>,
-    query_view_function_submitter_state: Arc<Mutex<MockQueryViewFunctionState>>,
+    view_state: Arc<Mutex<MockViewState>>,
     latest_final_block: Arc<Mutex<Result<LatestFinalBlockInfo, MockError>>>,
     signed_transaction_submitter_state: Arc<Mutex<MockSignedTransactionSubmitterState>>,
     read_notify: Arc<Notify>,
 }
 
-pub struct MockQueryViewFunctionState {
+pub struct MockViewState {
     pub response: Result<ObservedState, MockError>,
     pub submitted: Vec<Call>,
 }
@@ -46,11 +46,11 @@ impl MockChainState {
 
     /// Update the view function query response.
     pub async fn set_view_response(&self, value: Result<ObservedState, MockError>) {
-        let mut inner = self.query_view_function_submitter_state.lock().unwrap();
+        let mut inner = self.view_state.lock().unwrap();
         inner.response = value;
     }
 
-    /// Wait for the next query_view_function call (polls submitted.len() every 10ms).
+    /// Wait for the next view_contract call (polls submitted.len() every 10ms).
     pub async fn await_next_view_call(&self, max_wait_duration: Duration) -> Result<(), MockError> {
         tokio::time::timeout(max_wait_duration, self.read_notify.notified())
             .await
@@ -59,7 +59,7 @@ impl MockChainState {
 
     /// Returns a snapshot of all recorded view function calls.
     pub async fn view_calls(&self) -> Vec<Call> {
-        let inner = self.query_view_function_submitter_state.lock().unwrap();
+        let inner = self.view_state.lock().unwrap();
         inner.submitted.clone()
     }
 
@@ -72,7 +72,7 @@ impl MockChainState {
 
 pub struct MockChainStateBuilder {
     sync_response: Result<bool, MockError>,
-    query_view_function_response: Result<ObservedState, MockError>,
+    view_response: Result<ObservedState, MockError>,
     latest_final_block: Result<LatestFinalBlockInfo, MockError>,
     signed_transaction_submitter_response: Result<(), MockError>,
 }
@@ -87,7 +87,7 @@ impl MockChainStateBuilder {
     pub fn new() -> Self {
         Self {
             sync_response: Err(MockError::NotInitialized),
-            query_view_function_response: Err(MockError::NotInitialized),
+            view_response: Err(MockError::NotInitialized),
             latest_final_block: Err(MockError::NotInitialized),
             signed_transaction_submitter_response: Err(MockError::NotInitialized),
         }
@@ -108,19 +108,16 @@ impl MockChainStateBuilder {
         self
     }
 
-    pub fn with_query_view_function_response(
-        mut self,
-        r: Result<ObservedState, MockError>,
-    ) -> Self {
-        self.query_view_function_response = r;
+    pub fn with_view_response(mut self, r: Result<ObservedState, MockError>) -> Self {
+        self.view_response = r;
         self
     }
 
     pub fn build(self) -> MockChainState {
         MockChainState {
             sync_response: Arc::new(Mutex::new(self.sync_response)),
-            query_view_function_submitter_state: Arc::new(Mutex::new(MockQueryViewFunctionState {
-                response: self.query_view_function_response,
+            view_state: Arc::new(Mutex::new(MockViewState {
+                response: self.view_response,
                 submitted: Vec::new(),
             })),
             read_notify: Arc::new(Notify::new()),
@@ -142,19 +139,18 @@ impl IsSyncing for MockChainState {
     }
 }
 
-impl QueryViewFunction for MockChainState {
+impl ViewContract for MockChainState {
     type Error = MockError;
-    async fn query_view_function(
+    async fn view_contract(
         &self,
         contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
+        view_args: ViewArgs,
     ) -> Result<ObservedState, Self::Error> {
-        let mut inner = self.query_view_function_submitter_state.lock().unwrap();
+        let mut inner = self.view_state.lock().unwrap();
         inner.submitted.push(Call {
             contract_id: contract_id.clone(),
-            method_name: method_name.to_string(),
-            args: args.to_vec(),
+            method_name: view_args.method_name,
+            args: view_args.args,
         });
         let response = inner.response.clone();
         drop(inner);

--- a/crates/chain-gateway/src/near_internals_wrapper/view_client.rs
+++ b/crates/chain-gateway/src/near_internals_wrapper/view_client.rs
@@ -6,8 +6,8 @@ use near_async::messaging::CanSendAsync as _;
 
 use crate::{
     errors::{NearViewClientError, NearViewClientQuery},
-    primitives::{FetchLatestFinalBlockInfo, QueryViewFunction},
-    types::ObservedState,
+    primitives::{FetchLatestFinalBlockInfo, ViewContract},
+    types::{ObservedState, ViewArgs},
 };
 
 /// Arc-wrapper around near-internal struct
@@ -29,23 +29,23 @@ impl NearViewClientActorHandle {
     }
 }
 
-impl QueryViewFunction for NearViewClientActorHandle {
+impl ViewContract for NearViewClientActorHandle {
     type Error = NearViewClientError;
     /// calls view method contract_id::method_name(args) and returns the result
-    async fn query_view_function(
+    async fn view_contract(
         &self,
         contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
+        view_args: ViewArgs,
     ) -> Result<ObservedState, Self::Error> {
+        let method_name = view_args.method_name;
         let query = near_client::Query {
             block_reference: near_indexer_primitives::types::BlockReference::Finality(
                 near_indexer_primitives::types::Finality::Final,
             ),
             request: near_indexer_primitives::views::QueryRequest::CallFunction {
                 account_id: contract_id.clone(),
-                method_name: method_name.to_string(),
-                args: args.to_vec().into(),
+                method_name: method_name.clone(),
+                args: view_args.args.into(),
             },
         };
 

--- a/crates/chain-gateway/src/primitives.rs
+++ b/crates/chain-gateway/src/primitives.rs
@@ -2,7 +2,7 @@
 //!     - IsSyncing --> checks whether the node is fully synced
 //!     - ViewContract --> can call view methods on a contract
 //!     - FetchLatestFinalBlockInfo-> fetches height and hash of the latest final block
-//!     - SubmitSignedTransaction --> submits  asigned transaction to the blockchain
+//!     - SubmitSignedTransaction --> submits a signed transaction to the blockchain
 use crate::types::LatestFinalBlockInfo;
 use crate::types::{ObservedState, ViewArgs};
 use near_account_id::AccountId;

--- a/crates/chain-gateway/src/primitives.rs
+++ b/crates/chain-gateway/src/primitives.rs
@@ -1,10 +1,10 @@
 //! This file contains the primitives we need to interact with the NEAR blockchain:
 //!     - IsSyncing --> checks whether the node is fully synced
-//!     - QueryViewFunction --> can call view methods on a contract
+//!     - ViewContract --> can call view methods on a contract
 //!     - FetchLatestFinalBlockInfo-> fetches height and hash of the latest final block
 //!     - SubmitSignedTransaction --> submits  asigned transaction to the blockchain
 use crate::types::LatestFinalBlockInfo;
-use crate::types::ObservedState;
+use crate::types::{ObservedState, ViewArgs};
 use near_account_id::AccountId;
 use near_indexer::near_primitives::transaction::SignedTransaction;
 use std::future::Future;
@@ -40,13 +40,12 @@ pub(crate) trait IsSyncing: Send + Sync + 'static {
     }
 }
 
-pub(crate) trait QueryViewFunction: Send + Sync + 'static {
+pub(crate) trait ViewContract: Send + Sync + 'static {
     type Error: std::error::Error + Send + Sync + 'static;
-    fn query_view_function(
+    fn view_contract(
         &self,
         contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
+        view_args: ViewArgs,
     ) -> impl Future<Output = Result<ObservedState, Self::Error>> + Send;
 }
 

--- a/crates/chain-gateway/src/state_viewer/monitoring.rs
+++ b/crates/chain-gateway/src/state_viewer/monitoring.rs
@@ -1,5 +1,6 @@
 use crate::errors::ChainGatewayError;
 use crate::types::ObservedState;
+use crate::types::ViewArgs;
 use near_account_id::AccountId;
 use std::time::Duration;
 use tokio::task::JoinHandle;
@@ -25,13 +26,12 @@ impl Drop for MonitoringTask {
 pub(crate) async fn make_monitoring_task<V>(
     viewer: V,
     contract_id: AccountId,
-    method_name: &str,
-    args: Vec<u8>,
+    view_args: ViewArgs,
 ) -> MonitoringTask
 where
     V: ViewRaw,
 {
-    let observed_state = viewer.view_raw(&contract_id, method_name, &args).await;
+    let observed_state = viewer.view_raw(&contract_id, view_args.clone()).await;
 
     let (sender, last_observed) = tokio::sync::watch::channel(observed_state.clone());
 
@@ -39,8 +39,7 @@ where
     let _task_handle = tokio::spawn(monitor(
         viewer,
         contract_id,
-        method_name.to_string(),
-        args,
+        view_args,
         sender,
         cancel_token.clone(),
     ));
@@ -57,8 +56,7 @@ pub const POLL_INTERVAL: Duration = Duration::from_millis(200);
 async fn monitor<V: ViewRaw>(
     viewer: V,
     contract_id: AccountId,
-    method_name: String,
-    args: Vec<u8>,
+    view_args: ViewArgs,
     sender: tokio::sync::watch::Sender<Result<ObservedState, ChainGatewayError>>,
     cancel: CancellationToken,
 ) {
@@ -70,20 +68,20 @@ async fn monitor<V: ViewRaw>(
             _ = cancel.cancelled() => {
                 tracing::info!(
                     contract_id = ?contract_id,
-                    method_name = ?method_name,
+                    method_name = ?view_args.method_name,
                     "contract monitoring task cancelled"
                 );
                 break;
             }
             _ = ticker.tick() => {
                 let val = viewer
-                    .view_raw(&contract_id, &method_name, &args)
+                    .view_raw(&contract_id, view_args.clone())
                     .await;
 
                 if sender.send_if_modified(|existing| modify(existing, val)) {
                     tracing::debug!(
                         contract_id = ?contract_id,
-                        method_name = ?method_name,
+                        method_name = ?view_args.method_name,
                         "updated value"
                     );
                 }
@@ -114,6 +112,7 @@ fn modify(
 
 #[cfg(test)]
 mod tests {
+    use crate::types::ViewArgs;
     use crate::{
         errors::{ChainGatewayError, ChainGatewayOp},
         mock::{Call, MockChainState, MockError},
@@ -414,14 +413,13 @@ mod tests {
     ) -> (MockChainState, MonitoringTask) {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(mock_response)
+            .with_view_response(mock_response)
             .build();
 
         let task = make_monitoring_task(
             viewer.clone(),
             call.contract_id.clone(),
-            &call.method_name,
-            call.args,
+            ViewArgs::new(call.method_name, call.args),
         )
         .await;
 
@@ -438,7 +436,7 @@ mod tests {
     ) {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(mock_response.clone())
+            .with_view_response(mock_response.clone())
             .build();
 
         // Initial channel value matches what view_raw would return (wrapping errors)
@@ -457,8 +455,7 @@ mod tests {
         let _handle = tokio::spawn(monitor(
             viewer.clone(),
             call.contract_id.clone(),
-            call.method_name,
-            call.args,
+            ViewArgs::new(call.method_name, call.args),
             sender,
             cancel.clone(),
         ));

--- a/crates/chain-gateway/src/state_viewer/subscription.rs
+++ b/crates/chain-gateway/src/state_viewer/subscription.rs
@@ -2,6 +2,7 @@ use super::monitoring::{MonitoringTask, make_monitoring_task};
 use super::traits::{ViewRaw, WatchContractState};
 use crate::errors::ChainGatewayError;
 use crate::types::ObservedState;
+use crate::types::ViewArgs;
 use near_account_id::AccountId;
 use serde::de::DeserializeOwned;
 
@@ -58,10 +59,9 @@ where
     pub(super) async fn new<V: ViewRaw>(
         viewer: V,
         contract_id: AccountId,
-        method_name: &str,
-        args: Vec<u8>,
+        view_args: ViewArgs,
     ) -> Self {
-        let mut task = make_monitoring_task(viewer, contract_id, method_name, args).await;
+        let mut task = make_monitoring_task(viewer, contract_id, view_args).await;
         let cached: Result<ObservedState<Res>, ChainGatewayError> = task
             .last_observed
             .borrow_and_update()
@@ -76,6 +76,7 @@ where
 
 #[cfg(test)]
 mod tests {
+    use crate::types::ViewArgs;
     use assert_matches::assert_matches;
     use near_account_id::AccountId;
 
@@ -91,7 +92,7 @@ mod tests {
     async fn test_subscription_constructor_deserializes_initial_value() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: 42.into(),
                 value: serde_json::to_vec(&"hello").unwrap(),
             }))
@@ -100,8 +101,7 @@ mod tests {
         let mut sub = ContractMethodSubscription::<String>::new(
             viewer,
             "test.testnet".parse().unwrap(),
-            "get_value",
-            b"{}".to_vec(),
+            ViewArgs::no_args("get_value"),
         )
         .await;
 
@@ -116,14 +116,13 @@ mod tests {
         let method_name = "get_value".to_string();
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Err(MockError::ViewClientError))
+            .with_view_response(Err(MockError::ViewClientError))
             .build();
 
         let mut sub = ContractMethodSubscription::<String>::new(
             viewer,
             account_id.clone(),
-            &method_name,
-            b"{}".to_vec(),
+            ViewArgs::no_args(&method_name),
         )
         .await;
 
@@ -143,7 +142,7 @@ mod tests {
     async fn test_subscription_constructor_returns_deserialization_error_on_bad_json() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: 1.into(),
                 value: b"not json".to_vec(),
             }))
@@ -154,8 +153,7 @@ mod tests {
         let mut sub = ContractMethodSubscription::<String>::new(
             viewer,
             contract_id.clone(),
-            &method_name,
-            b"{}".to_vec(),
+            ViewArgs::no_args(&method_name),
         )
         .await;
 
@@ -167,7 +165,7 @@ mod tests {
     async fn test_subscription_latest_updates_on_value_change() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: 1.into(),
                 value: serde_json::to_vec(&"initial").unwrap(),
             }))
@@ -176,8 +174,7 @@ mod tests {
         let mut sub = ContractMethodSubscription::<String>::new(
             viewer.clone(),
             "test.testnet".parse().unwrap(),
-            "get_value",
-            b"{}".to_vec(),
+            ViewArgs::no_args("get_value"),
         )
         .await;
         assert_eq!(sub.latest().unwrap().value, "initial");
@@ -204,7 +201,7 @@ mod tests {
     async fn test_subscription_changed_resolves_and_updates_cache() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: 1.into(),
                 value: serde_json::to_vec(&"before").unwrap(),
             }))
@@ -213,8 +210,7 @@ mod tests {
         let mut sub = ContractMethodSubscription::<String>::new(
             viewer.clone(),
             "test.testnet".parse().unwrap(),
-            "get_value",
-            b"{}".to_vec(),
+            ViewArgs::no_args("get_value"),
         )
         .await;
         assert_eq!(sub.latest().unwrap().value, "before");

--- a/crates/chain-gateway/src/state_viewer/traits.rs
+++ b/crates/chain-gateway/src/state_viewer/traits.rs
@@ -1,10 +1,12 @@
 use std::future::Future;
 
 use crate::errors::{ChainGatewayError, ChainGatewayOp};
-use crate::primitives::{IsSyncing, QueryViewFunction};
+use crate::primitives::IsSyncing;
+use crate::primitives::ViewContract;
 use crate::types::ObservedState;
+use crate::types::ViewArgs;
 use near_account_id::AccountId;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::de::DeserializeOwned;
 
 use super::subscription::ContractMethodSubscription;
 
@@ -15,6 +17,7 @@ use super::subscription::ContractMethodSubscription;
 /// # Example
 ///
 /// ```
+/// use chain_gateway::ViewArgs;
 /// use chain_gateway::mock::{MockChainState, Call};
 /// use chain_gateway::state_viewer::{WatchContractState, SubscribeToContractMethod};
 /// use chain_gateway::types::ObservedState;
@@ -23,14 +26,17 @@ use super::subscription::ContractMethodSubscription;
 /// async fn main() {
 ///     let viewer = MockChainState::builder()
 ///         .with_syncing_status(Ok(false))
-///         .with_query_view_function_response(Ok(ObservedState {
+///         .with_view_response(Ok(ObservedState {
 ///             observed_at: 1.into(),
 ///             value: br#""hello""#.to_vec(),
 ///         }))
 ///         .build();
 ///
 ///     let mut stream = viewer
-///         .subscribe_to_contract_method::<String>("contract.near".parse().unwrap(), "get_greeting")
+///         .subscribe_to_contract_method::<String>(
+///             "contract.near".parse().unwrap(),
+///             ViewArgs::no_args("get_greeting"),
+///         )
 ///         .await;
 ///
 ///     let state = stream.latest().unwrap();
@@ -48,34 +54,38 @@ pub trait SubscribeToContractMethod {
     fn subscribe_to_contract_method<T>(
         &self,
         contract: AccountId,
-        view_method: &str,
+        view_args: ViewArgs,
     ) -> impl Future<Output = impl WatchContractState<T> + Send> + Send
     where
         T: DeserializeOwned + Send + Clone;
 }
 
-/// Performs a typed view call: serializes `args` as JSON, calls the
-/// contract and deserializes the response.
+/// Performs a typed view call: calls the contract and deserializes the
+/// JSON response.
 ///
 /// # Example
 ///
 /// ```
+/// use chain_gateway::ViewArgs;
 /// use chain_gateway::mock::{MockChainState, Call};
 /// use chain_gateway::state_viewer::ViewMethod;
-/// use chain_gateway::types::{NoArgs, ObservedState};
+/// use chain_gateway::types::ObservedState;
 ///
 /// #[tokio::main]
 /// async fn main() {
 ///     let viewer = MockChainState::builder()
 ///         .with_syncing_status(Ok(false))
-///         .with_query_view_function_response(Ok(ObservedState {
+///         .with_view_response(Ok(ObservedState {
 ///             observed_at: 1.into(),
 ///             value: br#""hello""#.to_vec(),
 ///         }))
 ///         .build();
 ///
 ///     let result: ObservedState<String> = viewer
-///         .view_method("contract.near".parse().unwrap(), "get_greeting", &NoArgs {})
+///         .view_method(
+///             "contract.near".parse().unwrap(),
+///             ViewArgs::no_args("get_greeting"),
+///         )
 ///         .await
 ///         .unwrap();
 ///
@@ -84,25 +94,22 @@ pub trait SubscribeToContractMethod {
 /// }
 /// ```
 pub trait ViewMethod {
-    fn view_method<Arg, Res>(
+    fn view_method<Res>(
         &self,
         contract_id: AccountId,
-        method_name: &str,
-        args: &Arg,
+        view_args: ViewArgs,
     ) -> impl Future<Output = Result<ObservedState<Res>, ChainGatewayError>> + Send
     where
-        Arg: Serialize + Sync,
         Res: DeserializeOwned + Send + Clone;
 }
 
 /// All other viewer traits are derived from this one
-pub(crate) trait ViewRaw: IsSyncing + QueryViewFunction {
+pub(crate) trait ViewRaw: IsSyncing + ViewContract {
     // waits until self is synced and then queries the view function
     fn view_raw(
         &self,
         contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
+        view_args: ViewArgs,
     ) -> impl Future<Output = Result<ObservedState, ChainGatewayError>> + Send;
 }
 
@@ -120,20 +127,20 @@ pub trait WatchContractState<Res> {
     fn changed(&mut self) -> impl Future<Output = Result<(), ChainGatewayError>> + Send;
 }
 
-impl<T: IsSyncing + QueryViewFunction> ViewRaw for T {
+impl<T: IsSyncing + ViewContract> ViewRaw for T {
     async fn view_raw(
         &self,
         contract_id: &AccountId,
-        method_name: &str,
-        args: &[u8],
+        view_args: ViewArgs,
     ) -> Result<ObservedState, ChainGatewayError> {
         self.wait_for_full_sync().await;
-        self.query_view_function(contract_id, method_name, args)
+        let method_name = view_args.method_name.clone();
+        self.view_contract(contract_id, view_args)
             .await
             .map_err(|err| ChainGatewayError::ViewError {
                 op: ChainGatewayOp::ViewQuery {
                     account_id: contract_id.to_string(),
-                    method_name: method_name.to_string(),
+                    method_name,
                 },
                 message: err.to_string(),
             })
@@ -144,35 +151,25 @@ impl<V: ViewRaw + Clone> SubscribeToContractMethod for V {
     fn subscribe_to_contract_method<T>(
         &self,
         contract: AccountId,
-        view_method: &str,
+        view_args: ViewArgs,
     ) -> impl Future<Output = impl WatchContractState<T> + Send> + Send
     where
         T: DeserializeOwned + Send + Clone,
     {
-        ContractMethodSubscription::new(self.clone(), contract, view_method, b"{}".to_vec())
+        ContractMethodSubscription::new(self.clone(), contract, view_args)
     }
 }
 
 impl<T: ViewRaw> ViewMethod for T {
-    async fn view_method<Arg, Res>(
+    async fn view_method<Res>(
         &self,
         contract_id: AccountId,
-        method_name: &str,
-        args: &Arg,
+        view_args: ViewArgs,
     ) -> Result<ObservedState<Res>, ChainGatewayError>
     where
-        Arg: Serialize + Sync,
         Res: DeserializeOwned + Send + Clone,
     {
-        let args: Vec<u8> =
-            serde_json::to_vec(args).map_err(|err| ChainGatewayError::Serialization {
-                op: ChainGatewayOp::ViewQuery {
-                    account_id: contract_id.to_string(),
-                    method_name: method_name.to_string(),
-                },
-                message: err.to_string(),
-            })?;
-        let res = self.view_raw(&contract_id, method_name, &args).await?;
+        let res = self.view_raw(&contract_id, view_args).await?;
         let value = serde_json::from_slice::<Res>(&res.value).map_err(|err| {
             ChainGatewayError::Deserialization {
                 message: err.to_string(),
@@ -192,7 +189,8 @@ mod tests {
     use crate::errors::{ChainGatewayError, ChainGatewayOp};
     use crate::mock::{Call, MockChainState, MockError};
     use crate::state_viewer::{SubscribeToContractMethod, ViewMethod, WatchContractState};
-    use crate::types::{NoArgs, ObservedState};
+    use crate::types::ObservedState;
+    use crate::types::ViewArgs;
     use assert_matches::assert_matches;
     use near_account_id::AccountId;
     use rand::distributions::{Alphanumeric, DistString};
@@ -231,11 +229,14 @@ mod tests {
         let (call, response) = random_view_params(&mut rng);
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(response.clone()))
+            .with_view_response(Ok(response.clone()))
             .build();
 
         let state = viewer
-            .view_raw(&call.contract_id, &call.method_name, &call.args)
+            .view_raw(
+                &call.contract_id,
+                ViewArgs::new(call.method_name.clone(), call.args.clone()),
+            )
             .await
             .unwrap();
 
@@ -249,11 +250,14 @@ mod tests {
         let (call, response) = random_view_params(&mut rng);
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(response))
+            .with_view_response(Ok(response))
             .build();
 
         viewer
-            .view_raw(&call.contract_id, &call.method_name, &call.args)
+            .view_raw(
+                &call.contract_id,
+                ViewArgs::new(call.method_name.clone(), call.args.clone()),
+            )
             .await
             .unwrap();
 
@@ -266,11 +270,11 @@ mod tests {
         let (call, _response) = random_view_params(&mut rng);
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Err(MockError::SyncError))
+            .with_view_response(Err(MockError::SyncError))
             .build();
 
         let err = viewer
-            .view_raw(&call.contract_id, &call.method_name, b"{}")
+            .view_raw(&call.contract_id, ViewArgs::no_args(&call.method_name))
             .await
             .unwrap_err();
 
@@ -292,14 +296,14 @@ mod tests {
         let (call, response) = random_view_params(&mut rng);
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(true))
-            .with_query_view_function_response(Ok(response))
+            .with_view_response(Ok(response))
             .build();
 
         let v = viewer.clone();
         let cid = call.contract_id.clone();
         let mn = call.method_name.clone();
         let a = call.args.clone();
-        let handle = tokio::spawn(async move { v.view_raw(&cid, &mn, &a).await });
+        let handle = tokio::spawn(async move { v.view_raw(&cid, ViewArgs::new(mn, a)).await });
 
         // wait_for_full_sync polls every 500ms; advance past one interval
         tokio::time::sleep(std::time::Duration::from_millis(1000)).await;
@@ -321,14 +325,14 @@ mod tests {
 
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: block_height.into(),
                 value: json_bytes,
             }))
             .build();
 
         let result = viewer
-            .view_method::<NoArgs, String>("a.testnet".parse().unwrap(), "m", &NoArgs {})
+            .view_method::<String>("a.testnet".parse().unwrap(), ViewArgs::no_args("m"))
             .await
             .unwrap();
 
@@ -340,13 +344,13 @@ mod tests {
     async fn test_view_method_propagates_view_error() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Err(MockError::ViewClientError))
+            .with_view_response(Err(MockError::ViewClientError))
             .build();
 
         let account_id: AccountId = "a.testnet".parse().unwrap();
         let method_name = "m".to_string();
         let err = viewer
-            .view_method::<NoArgs, String>(account_id.clone(), &method_name, &NoArgs {})
+            .view_method::<String>(account_id.clone(), ViewArgs::no_args(&method_name))
             .await
             .unwrap_err();
 
@@ -366,7 +370,7 @@ mod tests {
     async fn test_view_returns_deserialization_error_on_bad_bytes() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: 1.into(),
                 value: b"not valid json".to_vec(),
             }))
@@ -375,7 +379,7 @@ mod tests {
         let contract_id: AccountId = "a.testnet".parse().unwrap();
         let method_name: String = "m".into();
         let err = viewer
-            .view_method::<NoArgs, String>(contract_id, &method_name, &NoArgs {})
+            .view_method::<String>(contract_id, ViewArgs::no_args(&method_name))
             .await
             .unwrap_err();
 
@@ -391,14 +395,17 @@ mod tests {
 
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: block_height.into(),
                 value: json_bytes,
             }))
             .build();
 
         let mut sub = viewer
-            .subscribe_to_contract_method::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_to_contract_method::<String>(
+                "a.testnet".parse().unwrap(),
+                ViewArgs::no_args("m"),
+            )
             .await;
 
         let state = sub.latest().unwrap();
@@ -410,7 +417,7 @@ mod tests {
     async fn test_subscribe_latest_returns_deserialization_error() {
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: 1.into(),
                 value: b"not json".to_vec(),
             }))
@@ -420,7 +427,10 @@ mod tests {
         let method_name: String = "m".into();
         let err = {
             let mut sub = viewer
-                .subscribe_to_contract_method::<String>(contract_id.clone(), &method_name)
+                .subscribe_to_contract_method::<String>(
+                    contract_id.clone(),
+                    ViewArgs::no_args(&method_name),
+                )
                 .await;
 
             sub.latest().unwrap_err()
@@ -436,14 +446,17 @@ mod tests {
 
         let viewer = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: 1.into(),
                 value: serde_json::to_vec(&initial).unwrap(),
             }))
             .build();
 
         let mut sub = viewer
-            .subscribe_to_contract_method::<String>("a.testnet".parse().unwrap(), "m")
+            .subscribe_to_contract_method::<String>(
+                "a.testnet".parse().unwrap(),
+                ViewArgs::no_args("m"),
+            )
             .await;
         assert_eq!(sub.latest().unwrap().value, initial);
 

--- a/crates/chain-gateway/src/types.rs
+++ b/crates/chain-gateway/src/types.rs
@@ -92,11 +92,20 @@ impl ObservedState<Vec<u8>> {
 }
 
 #[cfg(test)]
+#[expect(non_snake_case)]
 mod tests {
     use assert_matches::assert_matches;
     use serde::Deserialize;
 
-    use crate::{errors::ChainGatewayError, types::ObservedState};
+    use crate::{
+        errors::ChainGatewayError,
+        types::{ObservedState, ViewArgs},
+    };
+
+    #[test]
+    fn no_args__should_encode_an_empty_json_object() {
+        assert_eq!(ViewArgs::no_args("m").args, b"{}");
+    }
 
     #[derive(Debug, Deserialize, PartialEq, Eq)]
     struct Num {

--- a/crates/chain-gateway/src/types.rs
+++ b/crates/chain-gateway/src/types.rs
@@ -12,9 +12,26 @@ pub(crate) fn to_action_gas(gas: NearGas) -> Gas {
     Gas::from_gas(gas.as_gas())
 }
 
-/// An empty argument struct for contract view calls that take no arguments.
-#[derive(Serialize)]
-pub struct NoArgs {}
+/// A NEAR view-function request: method name and encoded args.
+#[derive(Debug, Clone)]
+pub struct ViewArgs {
+    pub method_name: String,
+    pub args: Vec<u8>,
+}
+
+impl ViewArgs {
+    pub fn new(method_name: impl Into<String>, args: Vec<u8>) -> Self {
+        Self {
+            method_name: method_name.into(),
+            args,
+        }
+    }
+
+    /// A view call taking no arguments (an empty JSON object).
+    pub fn no_args(method_name: impl Into<String>) -> Self {
+        Self::new(method_name, b"{}".to_vec())
+    }
+}
 
 #[derive(
     Into, From, Copy, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Debug, Display,
@@ -79,10 +96,7 @@ mod tests {
     use assert_matches::assert_matches;
     use serde::Deserialize;
 
-    use crate::{
-        errors::ChainGatewayError,
-        types::{NoArgs, ObservedState},
-    };
+    use crate::{errors::ChainGatewayError, types::ObservedState};
 
     #[derive(Debug, Deserialize, PartialEq, Eq)]
     struct Num {
@@ -111,11 +125,5 @@ mod tests {
 
         let err = observed.deserialize::<Num>().unwrap_err();
         assert_matches!(err, ChainGatewayError::Deserialization { .. });
-    }
-
-    #[test]
-    fn test_no_args_serializes_to_empty_json_object() {
-        let json = serde_json::to_string(&NoArgs {}).unwrap();
-        assert_eq!(json, "{}");
     }
 }

--- a/crates/chain-gateway/tests/common/localnet.rs
+++ b/crates/chain-gateway/tests/common/localnet.rs
@@ -3,7 +3,9 @@ use std::time::{Duration, Instant};
 use chain_gateway::event_subscriber::block_events::BlockUpdate;
 use chain_gateway::event_subscriber::subscriber::BlockEventSubscriptions;
 use chain_gateway::state_viewer::ViewMethod;
-use chain_gateway::types::{NoArgs, ObservedState};
+use chain_gateway::types::ObservedState;
+
+use chain_gateway::ViewArgs;
 use chain_gateway_test_contract::consts::VIEW_VALUE;
 use ed25519_dalek::SigningKey;
 
@@ -120,7 +122,10 @@ impl LocalnetBuilder {
             let state: ObservedState<String> = localnet
                 .observer
                 .chain_gateway
-                .view_method(localnet.contract.account_id.clone(), VIEW_VALUE, &NoArgs {})
+                .view_method(
+                    localnet.contract.account_id.clone(),
+                    ViewArgs::no_args(VIEW_VALUE),
+                )
                 .await
                 .expect("view call should succeed during startup wait");
             if u64::from(state.observed_at) > 0 {

--- a/crates/chain-gateway/tests/event_subscriber_integration.rs
+++ b/crates/chain-gateway/tests/event_subscriber_integration.rs
@@ -2,6 +2,7 @@ use std::time::Duration;
 
 use super::common::localnet::Localnet;
 use crate::common::{accounts::TestAccount, localnet::LocalnetBuilder};
+use chain_gateway::ViewArgs;
 use chain_gateway::{
     event_subscriber::{
         block_events::{
@@ -145,7 +146,7 @@ async fn test_event_subscriber_executor_function_call_success_failure_calls_are_
         .unwrap();
 
     let mut watch_value = observer_gw
-        .subscribe_to_contract_method::<String>(contract_id, VIEW_VALUE)
+        .subscribe_to_contract_method::<String>(contract_id, ViewArgs::no_args(VIEW_VALUE))
         .await;
 
     loop {
@@ -327,7 +328,7 @@ async fn test_event_subscriber_channel_buffer_handles_backpressure(
     let observer_gw = &localnet.observer.chain_gateway;
 
     let mut watch_value = observer_gw
-        .subscribe_to_contract_method::<String>(contract_id.clone(), VIEW_VALUE)
+        .subscribe_to_contract_method::<String>(contract_id.clone(), ViewArgs::no_args(VIEW_VALUE))
         .await;
 
     for target in ["first", "second"] {
@@ -391,7 +392,7 @@ async fn test_block_status_handle_becomes_final() {
 
     // Sync on the state viewer observing the finalised state change.
     let mut watch_value = observer_gw
-        .subscribe_to_contract_method::<String>(contract_id, VIEW_VALUE)
+        .subscribe_to_contract_method::<String>(contract_id, ViewArgs::no_args(VIEW_VALUE))
         .await;
     loop {
         if watch_value

--- a/crates/chain-gateway/tests/sender_integration.rs
+++ b/crates/chain-gateway/tests/sender_integration.rs
@@ -1,11 +1,11 @@
 use std::time::{Duration, Instant};
 
-use chain_gateway::types::NoArgs;
 use chain_gateway::{state_viewer::ViewMethod, transaction_sender::SubmitFunctionCall};
 use chain_gateway_test_contract::args::make_set_value_args;
 use chain_gateway_test_contract::consts::{DEFAULT_VALUE, VIEW_VALUE};
 
 use crate::common::localnet::LocalnetBuilder;
+use chain_gateway::ViewArgs;
 
 /// This integration test uses the `ChainGateway` struct to spin up two neard nodes
 /// for a localnet. One of the nodes is an observer node (what the MPC node would be running),
@@ -28,7 +28,7 @@ async fn test_submit_set_value_and_read_back() {
 
     // Verify initial state: get_value should return DEFAULT_VALUE
     let initial: chain_gateway::types::ObservedState<String> = observer_gw
-        .view_method(contract_id.clone(), VIEW_VALUE, &NoArgs {})
+        .view_method(contract_id.clone(), ViewArgs::no_args(VIEW_VALUE))
         .await
         .expect("initial view call should succeed");
 
@@ -50,7 +50,7 @@ async fn test_submit_set_value_and_read_back() {
         localnet.assert_nodes_alive();
 
         let result: chain_gateway::types::ObservedState<String> = observer_gw
-            .view_method(contract_id.clone(), VIEW_VALUE, &NoArgs {})
+            .view_method(contract_id.clone(), ViewArgs::no_args(VIEW_VALUE))
             .await
             .expect("view call should succeed");
 

--- a/crates/chain-gateway/tests/state_viewer_integration.rs
+++ b/crates/chain-gateway/tests/state_viewer_integration.rs
@@ -2,8 +2,9 @@ use assert_matches::assert_matches;
 use chain_gateway::errors::ChainGatewayError;
 use chain_gateway::state_viewer::WatchContractState;
 use chain_gateway::state_viewer::{SubscribeToContractMethod, ViewMethod};
-use chain_gateway::types::NoArgs;
 use chain_gateway::types::ObservedState;
+
+use chain_gateway::ViewArgs;
 use chain_gateway_test_contract::consts::{DEFAULT_VALUE, VIEW_VALUE};
 
 use crate::common::localnet::Localnet;
@@ -16,7 +17,7 @@ async fn test_view_method_contract_state() {
     let observer_gw = &localnet.observer.chain_gateway;
 
     let value: ObservedState<String> = observer_gw
-        .view_method(contract_id, VIEW_VALUE, &NoArgs {})
+        .view_method(contract_id, ViewArgs::no_args(VIEW_VALUE))
         .await
         .expect("view call should succeed");
 
@@ -32,7 +33,7 @@ async fn test_view_method_nonexistent_method_returns_error() {
     let observer_gw = &localnet.observer.chain_gateway;
 
     let result = observer_gw
-        .view_method::<NoArgs, String>(contract_id, "nonexistent", &NoArgs {})
+        .view_method::<String>(contract_id, ViewArgs::no_args("nonexistent"))
         .await;
 
     let err = result.expect_err("calling a nonexistent method should fail");
@@ -49,7 +50,7 @@ async fn test_subscription_receives_initial_value() {
 
     {
         let mut sub = observer_gw
-            .subscribe_to_contract_method::<String>(contract_id, VIEW_VALUE)
+            .subscribe_to_contract_method::<String>(contract_id, ViewArgs::no_args(VIEW_VALUE))
             .await;
 
         let res = sub.latest().expect("subscription latest should succeed");

--- a/crates/chain-gateway/tests/view_subscription.rs
+++ b/crates/chain-gateway/tests/view_subscription.rs
@@ -10,6 +10,7 @@ use chain_gateway_test_contract::{
 };
 
 use crate::common::localnet::LocalnetBuilder;
+use chain_gateway::ViewArgs;
 
 /// Checks if subscribing to the state succeeds
 #[tokio::test]
@@ -23,7 +24,7 @@ async fn test_subscription() {
     let contract_id = localnet.contract.account_id.clone();
 
     let mut sub = observer_gw
-        .subscribe_to_contract_method::<String>(contract_id.clone(), VIEW_VALUE)
+        .subscribe_to_contract_method::<String>(contract_id.clone(), ViewArgs::no_args(VIEW_VALUE))
         .await;
 
     let res = sub.latest().expect("subscription latest should succeed");

--- a/crates/tee-context/src/lib.rs
+++ b/crates/tee-context/src/lib.rs
@@ -5,7 +5,7 @@ pub use errors::TeeContextError;
 pub use types::{AllowedTeeHashes, TeeNodeIdentity};
 
 use chain_gateway::{
-    NearGas, NearToken,
+    NearGas, NearToken, ViewArgs,
     state_viewer::{SubscribeToContractMethod, WatchContractState},
     transaction_sender::{SubmitFunctionCall, TransactionSigner},
     types::FunctionCallArgs,
@@ -191,14 +191,14 @@ async fn watch_hashes(
     let mut image_sub = chain_gateway
         .subscribe_to_contract_method::<AllowedDockerImageHashesResponse>(
             governance_contract.clone(),
-            ALLOWED_DOCKER_IMAGE_HASHES,
+            ViewArgs::no_args(ALLOWED_DOCKER_IMAGE_HASHES),
         )
         .await;
 
     let mut launcher_sub = chain_gateway
         .subscribe_to_contract_method::<Vec<LauncherDockerComposeHash>>(
             governance_contract,
-            ALLOWED_LAUNCHER_COMPOSE_HASHES,
+            ViewArgs::no_args(ALLOWED_LAUNCHER_COMPOSE_HASHES),
         )
         .await;
 
@@ -296,7 +296,7 @@ mod tests {
     fn mock_chain() -> MockChainState {
         MockChainStateBuilder::new()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: MOCK_BLOCK_HEIGHT.into(),
                 value: serde_json::to_vec(&allowed_image_hashes()).unwrap(),
             }))
@@ -321,7 +321,7 @@ mod tests {
     ) -> TeeContext<MockChainState> {
         let mock = MockChainStateBuilder::new()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: MOCK_BLOCK_HEIGHT.into(),
                 value: serde_json::to_vec(&allowed_image_hashes()).unwrap(),
             }))
@@ -334,7 +334,7 @@ mod tests {
     async fn create_test_context() -> (TeeContext<MockChainState>, MockChainState) {
         let mock_chain_state = MockChainStateBuilder::new()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Ok(ObservedState {
+            .with_view_response(Ok(ObservedState {
                 observed_at: MOCK_BLOCK_HEIGHT.into(),
                 value: serde_json::to_vec(&allowed_image_hashes()).unwrap(),
             }))
@@ -429,7 +429,7 @@ mod tests {
     async fn test_new_fails_when_view_errors() {
         let mock = MockChainStateBuilder::new()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Err(MockError::ViewClientError))
+            .with_view_response(Err(MockError::ViewClientError))
             .build();
 
         let result = TeeContext::new(mock.clone(), governance_account()).await;
@@ -469,7 +469,7 @@ mod tests {
     async fn test_watch_hashes_exits_on_initial_error() {
         let mock = MockChainState::builder()
             .with_syncing_status(Ok(false))
-            .with_query_view_function_response(Err(MockError::ViewClientError))
+            .with_view_response(Err(MockError::ViewClientError))
             .build();
         let (tx, mut rx) = watch::channel(AllowedTeeHashes::default());
 


### PR DESCRIPTION
resolves #3865, part of https://github.com/near/mpc/issues/3693

- [x] `ViewArgs { method_name, args }` with `new`/`no_args` constructors is the input to `view_raw`, `view_method`, and `subscribe_to_contract_method`.
- [x] `QueryViewFunction` is renamed to `ViewContract` (owned `ViewArgs` parameter); exactly one view impl per backend (`ChainGateway`, `NearViewClientActorHandle`, `MockChainState`).
- [x] `NoArgs` and the now-unused `ChainGatewayError::Serialization` variant are removed.
- [x] chain-gateway unit, doc, and integration tests pass.