### PR TITLE
feat(near-contract-transport): Introducing `CallContract` trait enabling different back-ends to share the same contract interface.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "near-crypto 2.13.1",
  "near-indexer",
  "near-indexer-primitives",
+ "near-mpc-bounded-collections",
  "near-o11y 2.13.1",
  "near-sdk",
  "near-store",

--- a/crates/chain-gateway/Cargo.toml
+++ b/crates/chain-gateway/Cargo.toml
@@ -18,6 +18,7 @@ near-contract-transport = { workspace = true, features = ["traits"] }
 near-crypto = { workspace = true }
 near-indexer = { workspace = true }
 near-indexer-primitives = { workspace = true }
+near-mpc-bounded-collections = { workspace = true }
 near-o11y = { workspace = true }
 nearcore = { workspace = true }
 prometheus = { workspace = true }

--- a/crates/chain-gateway/src/transaction_sender.rs
+++ b/crates/chain-gateway/src/transaction_sender.rs
@@ -1,8 +1,10 @@
+mod caller;
 mod signer;
 mod traits;
 
 #[cfg(test)]
 mod test_utils;
 
+pub use caller::AccountCaller;
 pub use signer::TransactionSigner;
 pub use traits::SubmitFunctionCall;

--- a/crates/chain-gateway/src/transaction_sender/caller.rs
+++ b/crates/chain-gateway/src/transaction_sender/caller.rs
@@ -1,0 +1,140 @@
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use near_account_id::AccountId;
+use near_contract_transport::{CallContract, FunctionCallArgs};
+use near_indexer_primitives::CryptoHash;
+use near_mpc_bounded_collections::NonEmptyVec;
+
+use crate::errors::ChainGatewayError;
+use crate::transaction_sender::{SubmitFunctionCall, TransactionSigner};
+
+pub struct AccountCaller<T> {
+    submitter: T,
+    signers: NonEmptyVec<TransactionSigner>,
+    next: AtomicUsize,
+}
+
+impl<T> AccountCaller<T> {
+    pub fn new(submitter: T, signers: NonEmptyVec<TransactionSigner>) -> Self {
+        Self {
+            submitter,
+            signers,
+            next: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl<T: SubmitFunctionCall + Sync> CallContract for AccountCaller<T> {
+    type Output = CryptoHash;
+    type Error = ChainGatewayError;
+
+    async fn call_contract(
+        &self,
+        contract_id: &AccountId,
+        call_args: FunctionCallArgs,
+    ) -> Result<CryptoHash, ChainGatewayError> {
+        let signer = &self.signers[self.next.fetch_add(1, Ordering::Relaxed) % self.signers.len()];
+        self.submitter
+            .submit_function_call_tx(signer, contract_id.clone(), call_args)
+            .await
+    }
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::AccountCaller;
+    use crate::errors::{ChainGatewayError, ChainGatewayOp};
+    use crate::mock::{MockChainStateBuilder, MockError};
+    use crate::transaction_sender::TransactionSigner;
+    use crate::types::LatestFinalBlockInfo;
+    use ed25519_dalek::{SigningKey, Verifier, VerifyingKey};
+    use near_account_id::AccountId;
+    use near_contract_transport::{CallContract, FunctionCallArgs, NearGas, NearToken};
+    use near_indexer::near_primitives::transaction::SignedTransaction;
+    use near_indexer_primitives::CryptoHash;
+
+    fn test_call() -> FunctionCallArgs {
+        FunctionCallArgs {
+            method_name: "do_something".to_string(),
+            args: b"{}".to_vec(),
+            gas: NearGas::from_gas(1),
+            deposit: NearToken::from_yoctonear(0),
+        }
+    }
+
+    fn signed_by(tx: &SignedTransaction, verifying_key: &VerifyingKey) -> bool {
+        match &tx.signature {
+            near_crypto::Signature::ED25519(sig) => {
+                verifying_key.verify(&tx.get_hash().0, sig).is_ok()
+            }
+            _ => false,
+        }
+    }
+
+    #[tokio::test]
+    async fn account_caller__should_round_robin_across_the_signer_pool() {
+        // Given
+        let account: AccountId = "signer.near".parse().unwrap();
+        let signer0 =
+            TransactionSigner::from_key(account.clone(), SigningKey::from_bytes(&[1u8; 32]));
+        let signer1 = TransactionSigner::from_key(account, SigningKey::from_bytes(&[2u8; 32]));
+        let (key0, key1) = (signer0.public_key(), signer1.public_key());
+        let mock = MockChainStateBuilder::new()
+            .with_latest_block(Ok(LatestFinalBlockInfo {
+                observed_at: 100.into(),
+                value: CryptoHash::hash_bytes(b"blk"),
+            }))
+            .with_signed_transaction_submitter_response(Ok(()))
+            .build();
+        let contract: AccountId = "contract.near".parse().unwrap();
+        let caller = AccountCaller::new(mock.clone(), vec![signer0, signer1].try_into().unwrap());
+
+        // When
+        let first_hash = caller.call_contract(&contract, test_call()).await.unwrap();
+        caller.call_contract(&contract, test_call()).await.unwrap();
+        caller.call_contract(&contract, test_call()).await.unwrap();
+
+        // Then
+        let submitted = mock.signed_transactions().await;
+        assert_eq!(submitted.len(), 3);
+        assert!(signed_by(&submitted[0], &key0));
+        assert!(signed_by(&submitted[1], &key1));
+        assert!(signed_by(&submitted[2], &key0));
+        assert_eq!(first_hash, submitted[0].get_hash());
+    }
+
+    #[tokio::test]
+    async fn account_caller__should_map_a_submit_failure_to_call_error() {
+        // Given
+        let account: AccountId = "signer.near".parse().unwrap();
+        let signer =
+            TransactionSigner::from_key(account.clone(), SigningKey::from_bytes(&[1u8; 32]));
+        let expected_source = MockError::LatestFinalBlockError;
+        let mock = MockChainStateBuilder::new()
+            .with_latest_block(Err(expected_source.clone()))
+            .build();
+        let contract: AccountId = "contract.near".parse().unwrap();
+        let caller = AccountCaller::new(mock, vec![signer].try_into().unwrap());
+
+        // When
+        let call = test_call();
+        let err = caller
+            .call_contract(&contract, call.clone())
+            .await
+            .unwrap_err();
+
+        // Then
+        assert_eq!(
+            err,
+            ChainGatewayError::FetchFinalBlock {
+                op: ChainGatewayOp::SubmitFunctionCallTransaction {
+                    signer: account.to_string(),
+                    receiver_id: contract.to_string(),
+                    method_name: call.method_name
+                },
+                message: expected_source.to_string()
+            }
+        );
+    }
+}

--- a/crates/chain-gateway/src/transaction_sender/caller.rs
+++ b/crates/chain-gateway/src/transaction_sender/caller.rs
@@ -33,7 +33,11 @@ impl<T: SubmitFunctionCall + Sync> CallContract for AccountCaller<T> {
         contract_id: &AccountId,
         call_args: FunctionCallArgs,
     ) -> Result<CryptoHash, ChainGatewayError> {
-        let signer = &self.signers[self.next.fetch_add(1, Ordering::Relaxed) % self.signers.len()];
+        let index = self.next.fetch_add(1, Ordering::Relaxed) % self.signers.len();
+        let signer = self
+            .signers
+            .get(index)
+            .expect("cannot fail because index is taken modulo signers.len()");
         self.submitter
             .submit_function_call_tx(signer, contract_id.clone(), call_args)
             .await

--- a/crates/near-contract-transport/src/lib.rs
+++ b/crates/near-contract-transport/src/lib.rs
@@ -1,11 +1,12 @@
 //! NEAR contract transport: the payload and vocabulary types of contract
-//! calls and views, plus the `ViewContract` trait, implemented once per
-//! transport backend. The trait lives behind the opt-in `traits` feature.
+//! calls and views, plus the `CallContract`/`ViewContract` traits,
+//! implemented once per transport backend. The traits live behind the
+//! opt-in `traits` feature.
 
 #[cfg(feature = "traits")]
 mod traits;
 mod types;
 
 #[cfg(feature = "traits")]
-pub use traits::ViewContract;
+pub use traits::{CallContract, ViewContract};
 pub use types::{BlockHeight, FunctionCallArgs, NearGas, NearToken, ObservedState, ViewArgs};

--- a/crates/near-contract-transport/src/traits.rs
+++ b/crates/near-contract-transport/src/traits.rs
@@ -2,8 +2,34 @@ use std::future::Future;
 
 use near_account_id::AccountId;
 
+use crate::FunctionCallArgs;
 use crate::ViewArgs;
 use crate::types::ObservedState;
+
+pub trait CallContract {
+    /// Backend-specific successful call outcome.
+    type Output;
+    type Error;
+
+    fn call_contract(
+        &self,
+        contract_id: &AccountId,
+        call_args: FunctionCallArgs,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send;
+}
+
+impl<T: CallContract> CallContract for &T {
+    type Output = T::Output;
+    type Error = T::Error;
+
+    fn call_contract(
+        &self,
+        contract_id: &AccountId,
+        call_args: FunctionCallArgs,
+    ) -> impl Future<Output = Result<Self::Output, Self::Error>> + Send {
+        T::call_contract(self, contract_id, call_args)
+    }
+}
 
 /// A backend executing NEAR view calls against a contract.
 ///

--- a/crates/tee-context/Cargo.toml
+++ b/crates/tee-context/Cargo.toml
@@ -7,9 +7,10 @@ license = { workspace = true }
 [dependencies]
 chain-gateway = { workspace = true }
 mpc-primitives = { workspace = true }
-near-account-id = { workspace = true }
 near-contract-transport = { workspace = true }
 near-mpc-contract-interface = { workspace = true, features = ["call-args"] }
+
+near-account-id = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
resolves #3867, part of #3693 

Introduces the `CallContract` trait in the `near-contract-transport` crate and implements the trait for the chain-gateway crate. Implementations for our other back-ends is to follow (e2e test, devnet, sandbox, chain-gateway, node, tee-context,...).

We will then implement the contract-interface over `CallContract`. This has two benefits:
- it will allow us to finally achieve #3693;
- integrating the chain-gateway with the node will become much easier, as they will share the same interface.

Changes:
- [x] `CallContract { type Output; type Error; }` in `near-contract-transport` (behind the `traits` feature), with a `&T` blanket impl
- [x] `AccountCaller<T: SubmitFunctionCall>` in chain-gateway over an owned `NonEmptyVec<TransactionSigner>` (signers are `!Clone` — one nonce counter per key by construction)
- [x] Unit tests: round-robin across the pool; backend error propagation.