### PR TITLE
feat: introduce MpcContractHandle as shared contract interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7000,6 +7000,7 @@ dependencies = [
  "hex",
  "insta",
  "mpc-primitives",
+ "near-contract-transport",
  "near-mpc-bounded-collections",
  "near-mpc-crypto-types",
  "rstest",
@@ -7009,6 +7010,8 @@ dependencies = [
  "serde_repr",
  "serde_with",
  "sha2 0.10.9",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/near-mpc-contract-interface/Cargo.toml
+++ b/crates/near-mpc-contract-interface/Cargo.toml
@@ -18,6 +18,15 @@ abi = [
 blstrs = ["near-mpc-crypto-types/blstrs"]
 # Helper to build mpc contract function call arguments
 call-args = []
+# The typed client (`MpcContractHandle`) over the transport traits. Pulls in
+# the transport crate and serde_json.
+client = [
+    "call-args",
+    "dep:near-contract-transport",
+    "near-contract-transport/traits",
+    "dep:serde_json",
+    "dep:thiserror",
+]
 ed25519-dalek = ["near-mpc-crypto-types/ed25519-dalek"]
 k256 = ["near-mpc-crypto-types/k256"]
 near = ["near-mpc-crypto-types/near"]
@@ -26,12 +35,15 @@ near = ["near-mpc-crypto-types/near"]
 borsh = { workspace = true }
 derive_more = { workspace = true }
 mpc-primitives = { workspace = true }
+near-contract-transport = { workspace = true, optional = true }
 near-mpc-bounded-collections = { workspace = true }
 near-mpc-crypto-types = { workspace = true }
 serde = { workspace = true }
+serde_json = { workspace = true, optional = true }
 serde_repr = { workspace = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
+thiserror = { workspace = true, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { workspace = true, optional = true }
@@ -43,6 +55,7 @@ hex = { workspace = true }
 insta = { workspace = true }
 rstest = { workspace = true }
 serde_json = { workspace = true }
+tokio = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/near-mpc-contract-interface/src/client.rs
+++ b/crates/near-mpc-contract-interface/src/client.rs
@@ -78,8 +78,6 @@ impl<C: CallContract> MpcContractHandle<C> {
 pub enum MpcContractHandleError<E> {
     #[error("failed to serialize call arguments: {0}")]
     Serialize(#[from] serde_json::Error),
-    #[error("failed to borsh-encode call arguments: {0}")]
-    Encode(#[from] std::io::Error),
     #[error("contract call failed: {0}")]
     Call(E),
 }

--- a/crates/near-mpc-contract-interface/src/client.rs
+++ b/crates/near-mpc-contract-interface/src/client.rs
@@ -1,0 +1,160 @@
+//! Typed client for the NEAR MPC signer contract.
+//!
+//! [`MpcContractHandle`] is the single source of each method's wire format
+//! (method name, argument struct, gas, deposit), generic over a transport
+//! backend implementing [`CallContract`].
+
+use near_contract_transport::{CallContract, FunctionCallArgs, NearGas, NearToken};
+
+use crate::call_args::SubmitParticipantInfoArgs;
+use crate::method_names::{SUBMIT_PARTICIPANT_INFO, VERIFY_TEE};
+use crate::types::{AccountId, Attestation, Ed25519PublicKey};
+
+/// Gas attached to every handle-issued call.
+// TODO(#166): 300 Tgas is the protocol maximum and higher than most methods
+// need; benchmark per method and reduce.
+pub const MAX_GAS: NearGas = NearGas::from_gas(300_000_000_000_000);
+
+pub const SUBMIT_PARTICIPANT_INFO_DEPOSIT_MILLINEAR: u128 = 100;
+
+/// Typed interface to the MPC signer contract at a fixed account, generic over
+/// the transport backend `C`.
+#[derive(Clone)]
+pub struct MpcContractHandle<C> {
+    caller: C,
+    contract_id: AccountId,
+}
+
+impl<C> MpcContractHandle<C> {
+    pub fn new(caller: C, contract_id: AccountId) -> Self {
+        Self {
+            caller,
+            contract_id,
+        }
+    }
+}
+
+impl<C: CallContract> MpcContractHandle<C> {
+    pub async fn submit_participant_info(
+        &self,
+        proposed_participant_attestation: Attestation,
+        tls_public_key: Ed25519PublicKey,
+    ) -> Result<C::Output, MpcContractHandleError<C::Error>> {
+        let args = serde_json::to_vec(&SubmitParticipantInfoArgs::new(
+            proposed_participant_attestation,
+            tls_public_key,
+        ))?;
+        self.caller
+            .call_contract(
+                &self.contract_id,
+                FunctionCallArgs {
+                    method_name: SUBMIT_PARTICIPANT_INFO.to_string(),
+                    args,
+                    gas: MAX_GAS,
+                    deposit: NearToken::from_millinear(SUBMIT_PARTICIPANT_INFO_DEPOSIT_MILLINEAR),
+                },
+            )
+            .await
+            .map_err(MpcContractHandleError::Call)
+    }
+
+    pub async fn verify_tee(&self) -> Result<C::Output, MpcContractHandleError<C::Error>> {
+        self.caller
+            .call_contract(
+                &self.contract_id,
+                FunctionCallArgs {
+                    method_name: VERIFY_TEE.to_string(),
+                    args: b"{}".to_vec(),
+                    gas: MAX_GAS,
+                    deposit: NearToken::from_yoctonear(0),
+                },
+            )
+            .await
+            .map_err(MpcContractHandleError::Call)
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum MpcContractHandleError<E> {
+    #[error("failed to serialize call arguments: {0}")]
+    Serialize(#[from] serde_json::Error),
+    #[error("failed to borsh-encode call arguments: {0}")]
+    Encode(#[from] std::io::Error),
+    #[error("contract call failed: {0}")]
+    Call(E),
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::MpcContractHandle;
+    use crate::types::{AccountId, Attestation, Ed25519PublicKey, MockAttestation};
+    use near_contract_transport::{CallContract, FunctionCallArgs};
+    use std::sync::Mutex;
+
+    /// A [`CallContract`] that records the calls it is handed, so a test can
+    /// assert the exact wire encoding a handle method produced.
+    #[derive(Default)]
+    struct RecordingCaller {
+        calls: Mutex<Vec<(AccountId, FunctionCallArgs)>>,
+    }
+
+    impl CallContract for RecordingCaller {
+        type Output = ();
+        type Error = ();
+
+        async fn call_contract(
+            &self,
+            contract_id: &AccountId,
+            call_args: FunctionCallArgs,
+        ) -> Result<(), Self::Error> {
+            self.calls
+                .lock()
+                .unwrap()
+                .push((contract_id.clone(), call_args));
+            Ok(())
+        }
+    }
+
+    /// Renders a recorded call as its reviewable wire format
+    /// (method, gas, deposit, args).
+    fn render(contract_id: &AccountId, call: &FunctionCallArgs) -> String {
+        format!(
+            "contract: {contract_id}\nmethod:   {}\ngas:      {}\ndeposit:  {}\nargs:     {}",
+            call.method_name,
+            call.gas,
+            call.deposit,
+            String::from_utf8_lossy(&call.args),
+        )
+    }
+
+    /// One catalog snapshot for the whole handle: every method is called once
+    /// and its wire format becomes a section of the snapshot. New handle
+    /// methods add a call here.
+    #[tokio::test]
+    async fn mpc_contract_handle__should_match_the_wire_format_catalog() {
+        // Given
+        let caller = RecordingCaller::default();
+        let handle = MpcContractHandle::new(&caller, "mpc.near".parse().unwrap());
+
+        // When: every handle method, once, in declaration order
+        handle
+            .submit_participant_info(
+                Attestation::Mock(MockAttestation::Valid),
+                Ed25519PublicKey::from([7u8; 32]),
+            )
+            .await
+            .unwrap();
+        handle.verify_tee().await.unwrap();
+
+        // Then
+        let calls = caller.calls.lock().unwrap();
+        assert_eq!(calls.len(), 2);
+        let catalog = calls
+            .iter()
+            .map(|(contract_id, call)| render(contract_id, call))
+            .collect::<Vec<_>>()
+            .join("\n\n");
+        insta::assert_snapshot!(catalog);
+    }
+}

--- a/crates/near-mpc-contract-interface/src/lib.rs
+++ b/crates/near-mpc-contract-interface/src/lib.rs
@@ -2,6 +2,9 @@
 #[cfg(feature = "call-args")]
 pub mod call_args;
 
+#[cfg(feature = "client")]
+pub mod client;
+
 pub mod method_names;
 pub mod types {
     pub use attestation::{

--- a/crates/near-mpc-contract-interface/src/snapshots/near_mpc_contract_interface__client__tests__mpc_contract_handle__should_match_the_wire_format_catalog.snap
+++ b/crates/near-mpc-contract-interface/src/snapshots/near_mpc_contract_interface__client__tests__mpc_contract_handle__should_match_the_wire_format_catalog.snap
@@ -1,0 +1,15 @@
+---
+source: crates/near-mpc-contract-interface/src/client.rs
+expression: catalog
+---
+contract: mpc.near
+method:   submit_participant_info
+gas:      300.0 Tgas
+deposit:  0.100 NEAR
+args:     {"proposed_participant_attestation":{"Mock":"Valid"},"tls_public_key":"ed25519:US517G5965aydkZ46HS38QLi7UQiSojurfbQfKCELFx"}
+
+contract: mpc.near
+method:   verify_tee
+gas:      300.0 Tgas
+deposit:  0 NEAR
+args:     {}

--- a/crates/tee-context/Cargo.toml
+++ b/crates/tee-context/Cargo.toml
@@ -8,11 +8,10 @@ license = { workspace = true }
 chain-gateway = { workspace = true }
 mpc-primitives = { workspace = true }
 near-contract-transport = { workspace = true }
-near-mpc-contract-interface = { workspace = true, features = ["call-args"] }
+near-mpc-contract-interface = { workspace = true, features = ["client"] }
 
 near-account-id = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
@@ -23,6 +22,7 @@ assert_matches = { workspace = true }
 chain-gateway = { workspace = true, features = ["test-utils"] }
 ed25519-dalek = { workspace = true }
 mpc-primitives = { workspace = true }
+serde_json = { workspace = true }
 tokio = { workspace = true, features = ["test-util", "macros"] }
 
 [lints]

--- a/crates/tee-context/src/errors.rs
+++ b/crates/tee-context/src/errors.rs
@@ -1,7 +1,12 @@
 #[derive(Debug, thiserror::Error)]
 pub enum TeeContextError {
-    #[error("chain gateway error: {0}")]
-    ChainGateway(#[from] chain_gateway::errors::ChainGatewayError),
-    #[error("serialization error: {0}")]
-    Serialization(#[from] serde_json::Error),
+    #[error("allowed-hashes watcher closed before delivering an initial value")]
+    HashWatcherClosed,
+    #[error(transparent)]
+    ContractCall(
+        #[from]
+        near_mpc_contract_interface::client::MpcContractHandleError<
+            chain_gateway::errors::ChainGatewayError,
+        >,
+    ),
 }

--- a/crates/tee-context/src/lib.rs
+++ b/crates/tee-context/src/lib.rs
@@ -6,14 +6,13 @@ pub use types::{AllowedTeeHashes, TeeNodeIdentity};
 
 use chain_gateway::{
     state_viewer::{SubscribeToContractMethod, WatchContractState},
-    transaction_sender::{SubmitFunctionCall, TransactionSigner},
+    transaction_sender::{AccountCaller, SubmitFunctionCall, TransactionSigner},
 };
 use near_account_id::AccountId;
-use near_contract_transport::{FunctionCallArgs, NearGas, NearToken, ViewArgs};
-use near_mpc_contract_interface::call_args as contract_args;
+use near_contract_transport::ViewArgs;
+use near_mpc_contract_interface::client::MpcContractHandle;
 use near_mpc_contract_interface::method_names::{
-    ALLOWED_DOCKER_IMAGE_HASHES, ALLOWED_LAUNCHER_COMPOSE_HASHES, SUBMIT_PARTICIPANT_INFO,
-    VERIFY_TEE,
+    ALLOWED_DOCKER_IMAGE_HASHES, ALLOWED_LAUNCHER_COMPOSE_HASHES,
 };
 use near_mpc_contract_interface::types::{
     AllowedMpcDockerImageHash, Attestation, Ed25519PublicKey,
@@ -23,9 +22,6 @@ use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
 use mpc_primitives::hash::{DockerImageHash, LauncherDockerComposeHash};
-
-const SUBMIT_ATTESTATION_GAS: NearGas = NearGas::from_tgas(300);
-const VERIFY_TEE_GAS: NearGas = NearGas::from_tgas(300);
 
 // TODO(#3751): drop this struct after upgrading the contract.
 #[derive(Clone, Debug, Deserialize)]
@@ -58,13 +54,12 @@ impl AllowedDockerImageHashesResponse {
 /// - Submits attestations.
 /// - Triggers on-chain re-validation of stored attestations.
 pub struct TeeContext<S> {
-    /// Contract that manages TEE attestations and allowed hashes.
-    governance_contract: AccountId,
     /// Allowed TEE hashes from the governance contract.
     allowed_hashes_rx: watch::Receiver<AllowedTeeHashes>,
     /// Cancels the background hash-watcher task when `TeeContext` is dropped.
     _watcher_cancel: CancelOnDrop,
-    submitter: S,
+    /// Typed handle for submitting attestations and triggering re-validation.
+    mpc_contract_handle: MpcContractHandle<AccountCaller<S>>,
 }
 
 /// Cancels the background hash-watcher task when dropped.
@@ -78,7 +73,7 @@ impl Drop for CancelOnDrop {
 
 impl<S> TeeContext<S>
 where
-    S: SubmitFunctionCall + SubscribeToContractMethod + Clone + Send + 'static,
+    S: SubmitFunctionCall + SubscribeToContractMethod + Clone + Send + Sync + 'static,
 {
     /// Creates a new `TeeContext`.
     ///
@@ -89,6 +84,7 @@ where
     pub async fn new(
         chain_gateway: S,
         governance_contract: AccountId,
+        signer: TransactionSigner,
     ) -> Result<Self, TeeContextError> {
         let cancel = CancellationToken::new();
         let rx = spawn_hash_watcher(
@@ -98,11 +94,13 @@ where
         )
         .await?;
 
+        let caller = AccountCaller::new(chain_gateway, [signer].into());
+        let mpc_contract_handle = MpcContractHandle::new(caller, governance_contract);
+
         Ok(Self {
-            governance_contract,
             allowed_hashes_rx: rx,
             _watcher_cancel: CancelOnDrop(cancel),
-            submitter: chain_gateway,
+            mpc_contract_handle,
         })
     }
 
@@ -117,42 +115,20 @@ where
     /// Submits an attestation to the governance contract.
     pub async fn submit_attestation(
         &self,
-        signer: &TransactionSigner,
         attestation: Attestation,
         tls_public_key: Ed25519PublicKey,
     ) -> Result<(), TeeContextError> {
-        let args = contract_args::SubmitParticipantInfoArgs::new(attestation, tls_public_key);
-        let args_json = serde_json::to_vec(&args)?;
-
-        self.submitter
-            .submit_function_call_tx(
-                signer,
-                self.governance_contract.clone(),
-                FunctionCallArgs {
-                    method_name: SUBMIT_PARTICIPANT_INFO.to_string(),
-                    args: args_json,
-                    gas: SUBMIT_ATTESTATION_GAS,
-                    deposit: NearToken::from_yoctonear(0),
-                },
-            )
+        self.mpc_contract_handle
+            .submit_participant_info(attestation, tls_public_key)
             .await
             .map(|_| ())
             .map_err(Into::into)
     }
 
     /// Triggers on-chain re-validation of all stored attestations.
-    pub async fn verify_tee(&self, signer: &TransactionSigner) -> Result<(), TeeContextError> {
-        self.submitter
-            .submit_function_call_tx(
-                signer,
-                self.governance_contract.clone(),
-                FunctionCallArgs {
-                    method_name: VERIFY_TEE.to_string(),
-                    args: b"{}".to_vec(),
-                    gas: VERIFY_TEE_GAS,
-                    deposit: NearToken::from_yoctonear(0),
-                },
-            )
+    pub async fn verify_tee(&self) -> Result<(), TeeContextError> {
+        self.mpc_contract_handle
+            .verify_tee()
             .await
             .map(|_| ())
             .map_err(Into::into)
@@ -170,9 +146,9 @@ async fn spawn_hash_watcher(
 
     tokio::spawn(watch_hashes(chain_gateway, governance_contract, tx, cancel));
 
-    rx.changed().await.map_err(|_| {
-        TeeContextError::ChainGateway(chain_gateway::errors::ChainGatewayError::MonitoringClosed)
-    })?;
+    rx.changed()
+        .await
+        .map_err(|_| TeeContextError::HashWatcherClosed)?;
 
     Ok(rx)
 }
@@ -251,15 +227,24 @@ async fn watch_hashes(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use super::{AllowedTeeHashes, TeeContext, TeeContextError, watch_hashes};
     use assert_matches::assert_matches;
     use chain_gateway::{
+        errors::ChainGatewayError,
         mock::{MockChainState, MockChainStateBuilder, MockError},
+        transaction_sender::TransactionSigner,
         types::LatestFinalBlockInfo,
     };
     use ed25519_dalek::SigningKey;
+    use mpc_primitives::hash::{DockerImageHash, LauncherDockerComposeHash};
+    use near_account_id::AccountId;
     use near_contract_transport::ObservedState;
-    use near_mpc_contract_interface::types::{Attestation, MockAttestation};
+    use near_mpc_contract_interface::client::MpcContractHandleError;
+    use near_mpc_contract_interface::types::{
+        AllowedMpcDockerImageHash, Attestation, Ed25519PublicKey, MockAttestation,
+    };
+    use tokio::sync::watch;
+    use tokio_util::sync::CancellationToken;
     /// Block height returned by [`MockChainState`] view responses.
     const MOCK_BLOCK_HEIGHT: u64 = 1;
 
@@ -328,7 +313,9 @@ mod tests {
             .with_latest_block(latest_block)
             .with_signed_transaction_submitter_response(submit_response)
             .build();
-        TeeContext::new(mock, governance_account()).await.unwrap()
+        TeeContext::new(mock, governance_account(), test_signer())
+            .await
+            .unwrap()
     }
 
     async fn create_test_context() -> (TeeContext<MockChainState>, MockChainState) {
@@ -341,9 +328,13 @@ mod tests {
             .with_latest_block(Ok(default_block_info()))
             .with_signed_transaction_submitter_response(Ok(()))
             .build();
-        let ctx = TeeContext::new(mock_chain_state.clone(), governance_account())
-            .await
-            .unwrap();
+        let ctx = TeeContext::new(
+            mock_chain_state.clone(),
+            governance_account(),
+            test_signer(),
+        )
+        .await
+        .unwrap();
         (ctx, mock_chain_state)
     }
 
@@ -366,10 +357,7 @@ mod tests {
         let (ctx, mock_chain) = create_test_context().await;
         let attestation = Attestation::Mock(MockAttestation::Valid);
         let tls_key = Ed25519PublicKey([0u8; 32]);
-        let signer = test_signer();
-        ctx.submit_attestation(&signer, attestation, tls_key)
-            .await
-            .unwrap();
+        ctx.submit_attestation(attestation, tls_key).await.unwrap();
 
         let txs = mock_chain.signed_transactions().await;
         assert_eq!(txs.len(), 1);
@@ -378,8 +366,7 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn test_verify_tee() {
         let (ctx, mock_chain) = create_test_context().await;
-        let signer = test_signer();
-        ctx.verify_tee(&signer).await.unwrap();
+        ctx.verify_tee().await.unwrap();
 
         let txs = mock_chain.signed_transactions().await;
         assert_eq!(txs.len(), 1);
@@ -390,19 +377,28 @@ mod tests {
         let ctx = create_context_with(Err(MockError::LatestFinalBlockError), Ok(())).await;
         let result = ctx
             .submit_attestation(
-                &test_signer(),
                 Attestation::Mock(MockAttestation::Valid),
                 Ed25519PublicKey([0u8; 32]),
             )
             .await;
-        assert_matches!(result, Err(TeeContextError::ChainGateway(_)));
+        assert_matches!(
+            result,
+            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
+                ChainGatewayError::FetchFinalBlock { .. }
+            )))
+        );
     }
 
     #[tokio::test(start_paused = true)]
     async fn test_verify_tee_propagates_fetch_block_error() {
         let ctx = create_context_with(Err(MockError::LatestFinalBlockError), Ok(())).await;
-        let result = ctx.verify_tee(&test_signer()).await;
-        assert_matches!(result, Err(TeeContextError::ChainGateway(_)));
+        let result = ctx.verify_tee().await;
+        assert_matches!(
+            result,
+            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
+                ChainGatewayError::FetchFinalBlock { .. }
+            )))
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -410,19 +406,28 @@ mod tests {
         let ctx = create_context_with(Ok(default_block_info()), Err(MockError::RpcError)).await;
         let result = ctx
             .submit_attestation(
-                &test_signer(),
                 Attestation::Mock(MockAttestation::Valid),
                 Ed25519PublicKey([0u8; 32]),
             )
             .await;
-        assert_matches!(result, Err(TeeContextError::ChainGateway(_)));
+        assert_matches!(
+            result,
+            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
+                ChainGatewayError::SubmitSignedTransaction { .. }
+            )))
+        );
     }
 
     #[tokio::test(start_paused = true)]
     async fn test_verify_tee_propagates_submit_error() {
         let ctx = create_context_with(Ok(default_block_info()), Err(MockError::RpcError)).await;
-        let result = ctx.verify_tee(&test_signer()).await;
-        assert_matches!(result, Err(TeeContextError::ChainGateway(_)));
+        let result = ctx.verify_tee().await;
+        assert_matches!(
+            result,
+            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
+                ChainGatewayError::SubmitSignedTransaction { .. }
+            )))
+        );
     }
 
     #[tokio::test(start_paused = true)]
@@ -432,7 +437,7 @@ mod tests {
             .with_view_response(Err(MockError::ViewClientError))
             .build();
 
-        let result = TeeContext::new(mock.clone(), governance_account()).await;
+        let result = TeeContext::new(mock.clone(), governance_account(), test_signer()).await;
         assert!(result.is_err());
 
         // The task exited on initial failure — no further polling should happen.

--- a/crates/tee-context/src/lib.rs
+++ b/crates/tee-context/src/lib.rs
@@ -338,6 +338,17 @@ mod tests {
         (ctx, mock_chain_state)
     }
 
+    macro_rules! assert_call_error {
+        ($result:expr, $pattern:pat) => {
+            assert_matches!(
+                $result,
+                Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
+                    $pattern
+                )))
+            )
+        };
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_new_populates_allowed_hashes() {
         let (ctx, _) = create_test_context().await;
@@ -381,24 +392,14 @@ mod tests {
                 Ed25519PublicKey([0u8; 32]),
             )
             .await;
-        assert_matches!(
-            result,
-            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
-                ChainGatewayError::FetchFinalBlock { .. }
-            )))
-        );
+        assert_call_error!(result, ChainGatewayError::FetchFinalBlock { .. });
     }
 
     #[tokio::test(start_paused = true)]
     async fn test_verify_tee_propagates_fetch_block_error() {
         let ctx = create_context_with(Err(MockError::LatestFinalBlockError), Ok(())).await;
         let result = ctx.verify_tee().await;
-        assert_matches!(
-            result,
-            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
-                ChainGatewayError::FetchFinalBlock { .. }
-            )))
-        );
+        assert_call_error!(result, ChainGatewayError::FetchFinalBlock { .. });
     }
 
     #[tokio::test(start_paused = true)]
@@ -410,24 +411,14 @@ mod tests {
                 Ed25519PublicKey([0u8; 32]),
             )
             .await;
-        assert_matches!(
-            result,
-            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
-                ChainGatewayError::SubmitSignedTransaction { .. }
-            )))
-        );
+        assert_call_error!(result, ChainGatewayError::SubmitSignedTransaction { .. });
     }
 
     #[tokio::test(start_paused = true)]
     async fn test_verify_tee_propagates_submit_error() {
         let ctx = create_context_with(Ok(default_block_info()), Err(MockError::RpcError)).await;
         let result = ctx.verify_tee().await;
-        assert_matches!(
-            result,
-            Err(TeeContextError::ContractCall(MpcContractHandleError::Call(
-                ChainGatewayError::SubmitSignedTransaction { .. }
-            )))
-        );
+        assert_call_error!(result, ChainGatewayError::SubmitSignedTransaction { .. });
     }
 
     #[tokio::test(start_paused = true)]


### PR DESCRIPTION
resolves #3868, part of #3693 

This PR introduces the `MpcContractHandle`, which will serve as a single source of truth for making contract calls in all our different back-ends (e2e test,  devnet, node, sandbox,...).

Changes:

- [x] `near-mpc-contract-interface` gains a `client` feature and module: `MpcContractHandle`, `MpcContractHandleError<E>`, wire-format snapshot tests (one catalog snapshot for all methods).
- [x] `TeeContext::new` takes a `TransactionSigner`; `submit_attestation`/`verify_tee` lose the per-call signer parameter.
- [x] `TeeContextError` collapses to `HashWatcherClosed` + `ContractCall`; propagation tests assert the nested error kinds.
- [x] The `client` feature stays out of the contract's wasm build.