### PR TITLE
fix(tee-verifier): inherit repository for reproducible builds

### DIFF
--- a/crates/tee-verifier/Cargo.toml
+++ b/crates/tee-verifier/Cargo.toml
@@ -3,6 +3,7 @@ name = "tee-verifier"
 version = { workspace = true }
 license = { workspace = true }
 edition = { workspace = true }
+repository = { workspace = true }
 
 [package.metadata.cargo-shear]
 ignored = ["borsh"]


### PR DESCRIPTION
Fixes #3884.

`cargo near build reproducible-wasm` embeds NEP-330 provenance and requires a non-empty `[package.repository]`.