### PR TITLE
refactor: Renaming per-domain reconstruction-threshold identifiers

### DIFF
--- a/crates/node/src/assets/cleanup.rs
+++ b/crates/node/src/assets/cleanup.rs
@@ -168,7 +168,8 @@ mod tests {
     #[test]
     fn test_delete_triples_and_presignatures() {
         // setup
-        let (mut start_data, my_participant_id, threshold) = test_utils::gen_four_participants();
+        let (mut start_data, my_participant_id, reconstruction_threshold) =
+            test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
         let subset: Vec<_> = all_participants.iter().take(3).cloned().collect();
         let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
@@ -189,7 +190,7 @@ mod tests {
             start_data.clone(),
             my_participant_id,
             [DomainId(0), DomainId(1)].to_vec(),
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
         ctx.assert_owned(2);
@@ -207,7 +208,7 @@ mod tests {
             start_data.clone(),
             my_participant_id,
             [DomainId(0), DomainId(1)].to_vec(),
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
         ctx.assert_owned(1);
@@ -221,7 +222,7 @@ mod tests {
             end_data.clone(),
             my_participant_id,
             [DomainId(0), DomainId(1)].to_vec(),
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
 
@@ -237,7 +238,8 @@ mod tests {
     #[expect(non_snake_case)]
     fn delete_stale_triples_and_presignatures__should_clean_stale_triple_in_v2_column() {
         // Given a node has written a stale triple via TripleStorage.
-        let (mut start_data, my_participant_id, threshold) = test_utils::gen_four_participants();
+        let (mut start_data, my_participant_id, reconstruction_threshold) =
+            test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
         let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
         let dir = tempfile::tempdir().unwrap();
@@ -250,12 +252,12 @@ mod tests {
                 let alive = alive_participants.clone();
                 Arc::new(move || alive.lock().unwrap().clone())
             },
-            threshold,
+            reconstruction_threshold,
         )
         .unwrap();
         let id = triple_store.generate_and_reserve_id();
         triple_store.add_owned(id, make_triple(&all_participants));
-        let v2_key = triple_v2_key(threshold, id);
+        let v2_key = triple_v2_key(reconstruction_threshold, id);
         // Sanity: the row really is in the TripleV2 column.
         assert!(db.get(DBCol::TripleV2, &v2_key).unwrap().is_some());
 
@@ -266,7 +268,7 @@ mod tests {
             start_data.clone(),
             my_participant_id,
             vec![DomainId(0)],
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
         assert!(db.get(DBCol::TripleV2, &v2_key).unwrap().is_some());
@@ -285,7 +287,7 @@ mod tests {
             start_data.clone(),
             my_participant_id,
             vec![DomainId(0)],
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
 
@@ -298,7 +300,8 @@ mod tests {
     #[test]
     #[expect(non_snake_case)]
     fn delete_stale_triples_and_presignatures__should_keep_active_triple() {
-        let (mut start_data, my_participant_id, threshold) = test_utils::gen_four_participants();
+        let (mut start_data, my_participant_id, reconstruction_threshold) =
+            test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
         // Triple uses everyone EXCEPT the last participant (whose TLS we'll change
         // below), so the participant set stays fully within the persistent set.
@@ -318,12 +321,12 @@ mod tests {
                 let alive = alive_participants.clone();
                 Arc::new(move || alive.lock().unwrap().clone())
             },
-            threshold,
+            reconstruction_threshold,
         )
         .unwrap();
         let id = triple_store.generate_and_reserve_id();
         triple_store.add_owned(id, make_triple(&active_subset));
-        let v2_key = triple_v2_key(threshold, id);
+        let v2_key = triple_v2_key(reconstruction_threshold, id);
 
         // Seed epoch_data, then run cleanup with one participant's TLS rotated
         // (the one our triple does not depend on).
@@ -332,7 +335,7 @@ mod tests {
             start_data.clone(),
             my_participant_id,
             vec![DomainId(0)],
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
         start_data
@@ -346,7 +349,7 @@ mod tests {
             start_data.clone(),
             my_participant_id,
             vec![DomainId(0)],
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
 
@@ -359,7 +362,8 @@ mod tests {
     #[test]
     #[expect(non_snake_case)]
     fn delete_stale_triples_and_presignatures__should_keep_peer_owned_triple() {
-        let (mut start_data, my_participant_id, threshold) = test_utils::gen_four_participants();
+        let (mut start_data, my_participant_id, reconstruction_threshold) =
+            test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
         let peer = *all_participants
             .iter()
@@ -376,21 +380,21 @@ mod tests {
                 let alive = alive_participants.clone();
                 Arc::new(move || alive.lock().unwrap().clone())
             },
-            threshold,
+            reconstruction_threshold,
         )
         .unwrap();
         // Even an outright-stale peer-owned triple stays put — the peer cleans
         // its own.
         let peer_id = UniqueId::new(peer, 100, 0);
         triple_store.add_unowned(peer_id, make_triple(&all_participants));
-        let v2_key = triple_v2_key(threshold, peer_id);
+        let v2_key = triple_v2_key(reconstruction_threshold, peer_id);
 
         delete_stale_triples_and_presignatures(
             &db,
             start_data.clone(),
             my_participant_id,
             vec![DomainId(0)],
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
         start_data
@@ -404,7 +408,7 @@ mod tests {
             start_data.clone(),
             my_participant_id,
             vec![DomainId(0)],
-            BTreeSet::from([threshold]),
+            BTreeSet::from([reconstruction_threshold]),
         )
         .unwrap();
 

--- a/crates/node/src/assets/test_utils.rs
+++ b/crates/node/src/assets/test_utils.rs
@@ -46,10 +46,13 @@ pub fn triple_v2_key(t: ReconstructionThreshold, id: UniqueId) -> Vec<u8> {
 /// data, the local participant's ID, and the reconstruction threshold so
 /// callers don't have to restate the magic number alongside the fixture.
 pub fn gen_four_participants() -> (EpochData, ParticipantId, ReconstructionThreshold) {
-    let threshold = ReconstructionThreshold::new(3);
+    let reconstruction_threshold = ReconstructionThreshold::new(3);
     let epoch_id = EpochId::new(rand::thread_rng().next_u64());
-    let parameters =
-        ThresholdParameters::new(gen_participants(4), Threshold::new(threshold.inner())).unwrap();
+    let parameters = ThresholdParameters::new(
+        gen_participants(4),
+        Threshold::new(reconstruction_threshold.inner()),
+    )
+    .unwrap();
     let parameters_dto: near_mpc_contract_interface::types::ThresholdParameters = parameters.into();
     let participants: ParticipantsConfig = convert_participant_infos(parameters_dto, None).unwrap();
     let epoch_data = EpochData {
@@ -57,7 +60,7 @@ pub fn gen_four_participants() -> (EpochData, ParticipantId, ReconstructionThres
         participants,
     };
     let my_participant_id = epoch_data.participants.participants.first().unwrap().id;
-    (epoch_data, my_participant_id, threshold)
+    (epoch_data, my_participant_id, reconstruction_threshold)
 }
 
 pub fn get_participant_ids(epoch_data: EpochData) -> Vec<ParticipantId> {

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -50,7 +50,7 @@ pub async fn keygen_computation_inner(
     // The reconstruction threshold `t` is the per-domain source of truth. For
     // every protocol (including robust-ECDSA, whose reconstruction lower bound
     // equals `t`) the keygen runs with lower bound `t`.
-    let threshold =
+    let reconstruction_threshold =
         TSReconstructionThreshold::from(usize::try_from(domain.reconstruction_threshold.inner())?);
     let keyshare_handle = keyshare_storage
         .write()
@@ -65,7 +65,8 @@ pub async fn keygen_computation_inner(
     let (keyshare, public_key) = match domain.protocol {
         Protocol::CaitSith => {
             let keyshare =
-                EcdsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
+                EcdsaSignatureProvider::run_key_generation_client(reconstruction_threshold, channel)
+                    .await?;
             let public_key = dtos::PublicKey::Secp256k1(dtos::Secp256k1PublicKey::try_from(
                 keyshare.public_key.to_element().to_affine(),
             )?);
@@ -73,7 +74,11 @@ pub async fn keygen_computation_inner(
         }
         Protocol::DamgardEtAl => {
             let keyshare =
-                RobustEcdsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
+                RobustEcdsaSignatureProvider::run_key_generation_client(
+                    reconstruction_threshold,
+                    channel,
+                )
+                .await?;
             let public_key = dtos::PublicKey::Secp256k1(dtos::Secp256k1PublicKey::try_from(
                 keyshare.public_key.to_element().to_affine(),
             )?);
@@ -81,14 +86,16 @@ pub async fn keygen_computation_inner(
         }
         Protocol::Frost => {
             let keyshare =
-                EddsaSignatureProvider::run_key_generation_client(threshold, channel).await?;
+                EddsaSignatureProvider::run_key_generation_client(reconstruction_threshold, channel)
+                    .await?;
             let public_key = dtos::PublicKey::Ed25519(dtos::Ed25519PublicKey::from(
                 keyshare.public_key.to_element().compress(),
             ));
             (KeyshareData::Ed25519(keyshare), public_key)
         }
         Protocol::ConfidentialKeyDerivation => {
-            let keyshare = CKDProvider::run_key_generation_client(threshold, channel).await?;
+            let keyshare =
+                CKDProvider::run_key_generation_client(reconstruction_threshold, channel).await?;
             let public_key = dtos::PublicKey::Bls12381(dtos::Bls12381G2PublicKey::from(
                 &keyshare.public_key.to_element(),
             ));
@@ -183,9 +190,9 @@ async fn resharing_computation_inner(
 ) -> anyhow::Result<()> {
     anyhow::ensure!(key_id.domain_id == domain.id, "Domain mismatch");
 
-    let new_threshold =
+    let new_reconstruction_threshold =
         TSReconstructionThreshold::from(usize::try_from(domain.reconstruction_threshold.inner())?);
-    let old_threshold = TSReconstructionThreshold::from(usize::try_from(
+    let old_reconstruction_threshold = TSReconstructionThreshold::from(usize::try_from(
         args.old_reconstruction_thresholds
             .get(&key_id.domain_id)
             .ok_or_else(|| {
@@ -240,8 +247,8 @@ async fn resharing_computation_inner(
                 })
                 .transpose()?;
             let res = EcdsaSignatureProvider::run_key_resharing_client(
-                new_threshold,
-                old_threshold,
+                new_reconstruction_threshold,
+                old_reconstruction_threshold,
                 my_share,
                 public_key,
                 &args.old_participants,
@@ -263,8 +270,8 @@ async fn resharing_computation_inner(
                 })
                 .transpose()?;
             let res = RobustEcdsaSignatureProvider::run_key_resharing_client(
-                new_threshold,
-                old_threshold,
+                new_reconstruction_threshold,
+                old_reconstruction_threshold,
                 my_share,
                 public_key,
                 &args.old_participants,
@@ -285,8 +292,8 @@ async fn resharing_computation_inner(
                 })
                 .transpose()?;
             let res = EddsaSignatureProvider::run_key_resharing_client(
-                new_threshold,
-                old_threshold,
+                new_reconstruction_threshold,
+                old_reconstruction_threshold,
                 my_share,
                 public_key,
                 &args.old_participants,
@@ -304,8 +311,8 @@ async fn resharing_computation_inner(
                 })
                 .transpose()?;
             let res = CKDProvider::run_key_resharing_client(
-                new_threshold,
-                old_threshold,
+                new_reconstruction_threshold,
+                old_reconstruction_threshold,
                 my_share,
                 public_key,
                 &args.old_participants,

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -64,30 +64,33 @@ pub async fn keygen_computation_inner(
 
     let (keyshare, public_key) = match domain.protocol {
         Protocol::CaitSith => {
-            let keyshare =
-                EcdsaSignatureProvider::run_key_generation_client(reconstruction_threshold, channel)
-                    .await?;
+            let keyshare = EcdsaSignatureProvider::run_key_generation_client(
+                reconstruction_threshold,
+                channel,
+            )
+            .await?;
             let public_key = dtos::PublicKey::Secp256k1(dtos::Secp256k1PublicKey::try_from(
                 keyshare.public_key.to_element().to_affine(),
             )?);
             (KeyshareData::Secp256k1(keyshare), public_key)
         }
         Protocol::DamgardEtAl => {
-            let keyshare =
-                RobustEcdsaSignatureProvider::run_key_generation_client(
-                    reconstruction_threshold,
-                    channel,
-                )
-                .await?;
+            let keyshare = RobustEcdsaSignatureProvider::run_key_generation_client(
+                reconstruction_threshold,
+                channel,
+            )
+            .await?;
             let public_key = dtos::PublicKey::Secp256k1(dtos::Secp256k1PublicKey::try_from(
                 keyshare.public_key.to_element().to_affine(),
             )?);
             (KeyshareData::Secp256k1(keyshare), public_key)
         }
         Protocol::Frost => {
-            let keyshare =
-                EddsaSignatureProvider::run_key_generation_client(reconstruction_threshold, channel)
-                    .await?;
+            let keyshare = EddsaSignatureProvider::run_key_generation_client(
+                reconstruction_threshold,
+                channel,
+            )
+            .await?;
             let public_key = dtos::PublicKey::Ed25519(dtos::Ed25519PublicKey::from(
                 keyshare.public_key.to_element().compress(),
             ));

--- a/crates/node/src/providers.rs
+++ b/crates/node/src/providers.rs
@@ -72,7 +72,7 @@ pub trait SignatureProvider {
     ///
     /// It drains `channel_receiver` until the required task is found, meaning these clients must not be run in parallel.
     async fn run_key_generation_client(
-        threshold: ReconstructionThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput>;
 
@@ -80,8 +80,8 @@ pub trait SignatureProvider {
     /// Both leaders and followers call this function.
     /// It drains `channel_receiver` until the required task is found, meaning these clients must not be run in parallel.
     async fn run_key_resharing_client(
-        new_threshold: ReconstructionThreshold,
-        old_threshold: ReconstructionThreshold,
+        new_reconstruction_threshold: ReconstructionThreshold,
+        old_reconstruction_threshold: ReconstructionThreshold,
         key_share: Option<Self::SecretShare>,
         public_key: Self::PublicKey,
         old_participants: &ParticipantsConfig,

--- a/crates/node/src/providers/ckd.rs
+++ b/crates/node/src/providers/ckd.rs
@@ -88,23 +88,23 @@ impl SignatureProvider for CKDProvider {
     }
 
     async fn run_key_generation_client(
-        threshold: TSReconstructionThreshold,
+        reconstruction_threshold: TSReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
-        Self::run_key_generation_client_internal(threshold, channel).await
+        Self::run_key_generation_client_internal(reconstruction_threshold, channel).await
     }
 
     async fn run_key_resharing_client(
-        new_threshold: TSReconstructionThreshold,
-        old_threshold: TSReconstructionThreshold,
+        new_reconstruction_threshold: TSReconstructionThreshold,
+        old_reconstruction_threshold: TSReconstructionThreshold,
         key_share: Option<SigningShare>,
         public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
         Self::run_key_resharing_client_internal(
-            new_threshold,
-            old_threshold,
+            new_reconstruction_threshold,
+            old_reconstruction_threshold,
             key_share,
             public_key,
             old_participants,

--- a/crates/node/src/providers/ckd/key_generation.rs
+++ b/crates/node/src/providers/ckd/key_generation.rs
@@ -16,8 +16,8 @@ impl CKDProvider {
         let key = KeyGenerationComputation {
             reconstruction_threshold,
         }
-            .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
-            .await?;
+        .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
+        .await?;
         tracing::info!("CKD key generation completed");
 
         Ok(key)

--- a/crates/node/src/providers/ckd/key_generation.rs
+++ b/crates/node/src/providers/ckd/key_generation.rs
@@ -10,10 +10,12 @@ use threshold_signatures::participants::Participant;
 
 impl CKDProvider {
     pub(super) async fn run_key_generation_client_internal(
-        threshold: ReconstructionThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<KeygenOutput> {
-        let key = KeyGenerationComputation { threshold }
+        let key = KeyGenerationComputation {
+            reconstruction_threshold,
+        }
             .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
             .await?;
         tracing::info!("CKD key generation completed");
@@ -25,7 +27,7 @@ impl CKDProvider {
 /// Runs the key generation protocol, returning the key generated.
 /// This protocol is identical for the leader and the followers.
 pub struct KeyGenerationComputation {
-    threshold: ReconstructionThreshold,
+    reconstruction_threshold: ReconstructionThreshold,
 }
 
 #[async_trait::async_trait]
@@ -41,7 +43,7 @@ impl MpcLeaderCentricComputation<KeygenOutput> for KeyGenerationComputation {
         let protocol = threshold_signatures::keygen::<BLS12381SHA256, _, _>(
             &cs_participants,
             me.into(),
-            self.threshold,
+            self.reconstruction_threshold,
             OsRng,
         )?;
         run_protocol("CKD key generation", channel, protocol).await
@@ -120,7 +122,7 @@ mod tests {
                 .ok_or_else(|| anyhow::anyhow!("No channel"))?
         };
         let key = KeyGenerationComputation {
-            threshold: ReconstructionThreshold::from(3),
+            reconstruction_threshold: ReconstructionThreshold::from(3),
         }
         .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
         .await?;

--- a/crates/node/src/providers/ckd/key_resharing.rs
+++ b/crates/node/src/providers/ckd/key_resharing.rs
@@ -13,17 +13,17 @@ use threshold_signatures::participants::Participant;
 
 impl CKDProvider {
     pub(super) async fn run_key_resharing_client_internal(
-        new_threshold: ReconstructionThreshold,
-        old_threshold: ReconstructionThreshold,
+        new_reconstruction_threshold: ReconstructionThreshold,
+        old_reconstruction_threshold: ReconstructionThreshold,
         my_share: Option<SigningShare>,
         public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<KeygenOutput> {
         let new_keyshare = KeyResharingComputation {
-            threshold: new_threshold,
+            reconstruction_threshold: new_reconstruction_threshold,
             old_participants: old_participants.participants.iter().map(|p| p.id).collect(),
-            old_threshold,
+            old_reconstruction_threshold,
             my_share,
             public_key,
         }
@@ -49,9 +49,9 @@ impl CKDProvider {
 ///       the old threshold; or
 ///     - the threshold is larger than the number of participants.
 pub struct KeyResharingComputation {
-    threshold: ReconstructionThreshold,
+    reconstruction_threshold: ReconstructionThreshold,
     old_participants: Vec<ParticipantId>,
-    old_threshold: ReconstructionThreshold,
+    old_reconstruction_threshold: ReconstructionThreshold,
     my_share: Option<SigningShare>,
     public_key: VerifyingKey,
 }
@@ -75,11 +75,11 @@ impl MpcLeaderCentricComputation<KeygenOutput> for KeyResharingComputation {
 
         let protocol = threshold_signatures::reshare::<BLS12381SHA256, _, _, _>(
             &old_participants,
-            self.old_threshold,
+            self.old_reconstruction_threshold,
             self.my_share,
             self.public_key,
             &new_participants,
-            self.threshold,
+            self.reconstruction_threshold,
             me.into(),
             OsRng,
         )?;
@@ -155,9 +155,9 @@ mod tests {
                             .ok_or_else(|| anyhow::anyhow!("No channel"))?
                     };
                     let key = KeyResharingComputation {
-                        threshold: ReconstructionThreshold::from(THRESHOLD),
+                        reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
                         old_participants,
-                        old_threshold: ReconstructionThreshold::from(THRESHOLD),
+                        old_reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
                         my_share: keyshare,
                         public_key: pubkey,
                     }

--- a/crates/node/src/providers/ckd/sign.rs
+++ b/crates/node/src/providers/ckd/sign.rs
@@ -30,8 +30,9 @@ impl CKDProvider {
         let ckd_request = self.ckd_request_store.get(id).await?;
 
         let keyshare = self.keyshare(ckd_request.domain_id)?;
-        let threshold: usize = keyshare.reconstruction_threshold.inner().try_into()?;
-        let threshold = ReconstructionThreshold::from(threshold);
+        let reconstruction_threshold: usize =
+            keyshare.reconstruction_threshold.inner().try_into()?;
+        let reconstruction_threshold = ReconstructionThreshold::from(reconstruction_threshold);
         let running_participants: Vec<_> = self
             .mpc_config
             .participants
@@ -43,7 +44,7 @@ impl CKDProvider {
         let participants = self
             .client
             .select_random_active_participants_including_me(
-                threshold.value(),
+                reconstruction_threshold.value(),
                 &running_participants,
             )
             .context("Could not choose active participants for a ckd")?;

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -96,17 +96,21 @@ impl EcdsaSignatureProvider {
     /// follower protocol with an unexpected `t`).
     pub(super) fn triple_store_for_t(
         &self,
-        threshold: ReconstructionThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
     ) -> anyhow::Result<Arc<TripleStorage>> {
-        self.triple_stores.get(&threshold).cloned().ok_or_else(|| {
-            let mut configured: Vec<u64> = self.triple_stores.keys().map(|t| t.inner()).collect();
-            configured.sort();
-            anyhow::anyhow!(
-                "No triple store configured for t = {} (configured: {:?})",
-                threshold.inner(),
-                configured,
-            )
-        })
+        self.triple_stores
+            .get(&reconstruction_threshold)
+            .cloned()
+            .ok_or_else(|| {
+                let mut configured: Vec<u64> =
+                    self.triple_stores.keys().map(|t| t.inner()).collect();
+                configured.sort();
+                anyhow::anyhow!(
+                    "No triple store configured for t = {} (configured: {:?})",
+                    reconstruction_threshold.inner(),
+                    configured,
+                )
+            })
     }
 
     pub(super) fn new_channel_for_task(
@@ -165,23 +169,27 @@ impl SignatureProvider for EcdsaSignatureProvider {
     }
 
     async fn run_key_generation_client(
-        threshold: TSReconstructionThreshold,
+        reconstruction_threshold: TSReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
-        EcdsaSignatureProvider::run_key_generation_client_internal(threshold, channel).await
+        EcdsaSignatureProvider::run_key_generation_client_internal(
+            reconstruction_threshold,
+            channel,
+        )
+        .await
     }
 
     async fn run_key_resharing_client(
-        new_threshold: TSReconstructionThreshold,
-        old_threshold: TSReconstructionThreshold,
+        new_reconstruction_threshold: TSReconstructionThreshold,
+        old_reconstruction_threshold: TSReconstructionThreshold,
         my_share: Option<SigningShare>,
         public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
         EcdsaSignatureProvider::run_key_resharing_client_internal(
-            new_threshold,
-            old_threshold,
+            new_reconstruction_threshold,
+            old_reconstruction_threshold,
             my_share,
             public_key,
             old_participants,
@@ -245,8 +253,9 @@ impl SignatureProvider for EcdsaSignatureProvider {
         // by a generator running at its own threshold.
         let mut generate_triples = Vec::new();
         for (&t, triple_store) in &self.triple_stores {
-            let threshold_usize: usize = t.inner().try_into()?;
-            let threshold_bound = TSReconstructionThreshold::from(threshold_usize);
+            let reconstruction_threshold_usize: usize = t.inner().try_into()?;
+            let reconstruction_threshold_bound =
+                TSReconstructionThreshold::from(reconstruction_threshold_usize);
             generate_triples.push(tracking::spawn(
                 &format!("generate triples for t={}", t.inner()),
                 Self::run_background_triple_generation(
@@ -254,7 +263,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
                     self.mpc_config.clone(),
                     self.config.triple.clone().into(),
                     triple_store.clone(),
-                    threshold_bound,
+                    reconstruction_threshold_bound,
                 ),
             ));
         }

--- a/crates/node/src/providers/ecdsa/key_generation.rs
+++ b/crates/node/src/providers/ecdsa/key_generation.rs
@@ -9,10 +9,12 @@ use threshold_signatures::participants::Participant;
 
 impl EcdsaSignatureProvider {
     pub(crate) async fn run_key_generation_client_internal(
-        threshold: ReconstructionThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<KeygenOutput> {
-        let key = KeyGenerationComputation { threshold }
+        let key = KeyGenerationComputation {
+            reconstruction_threshold,
+        }
             .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
             .await?;
         tracing::info!("Ecdsa secp256k1 key generation completed");
@@ -24,7 +26,7 @@ impl EcdsaSignatureProvider {
 /// Runs the key generation protocol, returning the key generated.
 /// This protocol is identical for the leader and the followers.
 pub struct KeyGenerationComputation {
-    threshold: ReconstructionThreshold,
+    reconstruction_threshold: ReconstructionThreshold,
 }
 
 #[async_trait::async_trait]
@@ -40,7 +42,7 @@ impl MpcLeaderCentricComputation<KeygenOutput> for KeyGenerationComputation {
         let protocol = threshold_signatures::keygen::<Secp256K1Sha256, _, _>(
             &cs_participants,
             me.into(),
-            self.threshold,
+            self.reconstruction_threshold,
             OsRng,
         )?;
         run_protocol("ecdsa key generation", channel, protocol).await
@@ -106,7 +108,7 @@ mod tests {
                 .ok_or_else(|| anyhow::anyhow!("No channel"))?
         };
         let key = KeyGenerationComputation {
-            threshold: ReconstructionThreshold::from(3),
+            reconstruction_threshold: ReconstructionThreshold::from(3),
         }
         .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
         .await?;

--- a/crates/node/src/providers/ecdsa/key_generation.rs
+++ b/crates/node/src/providers/ecdsa/key_generation.rs
@@ -15,8 +15,8 @@ impl EcdsaSignatureProvider {
         let key = KeyGenerationComputation {
             reconstruction_threshold,
         }
-            .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
-            .await?;
+        .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
+        .await?;
         tracing::info!("Ecdsa secp256k1 key generation completed");
 
         Ok(key)

--- a/crates/node/src/providers/ecdsa/key_resharing.rs
+++ b/crates/node/src/providers/ecdsa/key_resharing.rs
@@ -12,17 +12,17 @@ use threshold_signatures::participants::Participant;
 
 impl EcdsaSignatureProvider {
     pub(crate) async fn run_key_resharing_client_internal(
-        new_threshold: ReconstructionThreshold,
-        old_threshold: ReconstructionThreshold,
+        new_reconstruction_threshold: ReconstructionThreshold,
+        old_reconstruction_threshold: ReconstructionThreshold,
         my_share: Option<SigningShare>,
         public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<KeygenOutput> {
         let new_keyshare = KeyResharingComputation {
-            threshold: new_threshold,
+            reconstruction_threshold: new_reconstruction_threshold,
             old_participants: old_participants.participants.iter().map(|p| p.id).collect(),
-            old_threshold,
+            old_reconstruction_threshold,
             my_share,
             public_key,
         }
@@ -48,9 +48,9 @@ impl EcdsaSignatureProvider {
 ///       the old threshold; or
 ///     - the threshold is larger than the number of participants.
 pub struct KeyResharingComputation {
-    threshold: ReconstructionThreshold,
+    reconstruction_threshold: ReconstructionThreshold,
     old_participants: Vec<ParticipantId>,
-    old_threshold: ReconstructionThreshold,
+    old_reconstruction_threshold: ReconstructionThreshold,
     my_share: Option<SigningShare>,
     public_key: VerifyingKey,
 }
@@ -74,11 +74,11 @@ impl MpcLeaderCentricComputation<KeygenOutput> for KeyResharingComputation {
 
         let protocol = threshold_signatures::reshare::<Secp256K1Sha256, _, _, _>(
             &old_participants,
-            self.old_threshold,
+            self.old_reconstruction_threshold,
             self.my_share,
             self.public_key,
             &new_participants,
-            self.threshold,
+            self.reconstruction_threshold,
             me.into(),
             OsRng,
         )?;
@@ -150,9 +150,9 @@ mod tests {
                             .ok_or_else(|| anyhow::anyhow!("No channel"))?
                     };
                     let key = KeyResharingComputation {
-                        threshold: ReconstructionThreshold::from(THRESHOLD),
+                        reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
                         old_participants,
-                        old_threshold: ReconstructionThreshold::from(THRESHOLD),
+                        old_reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
                         my_share: keyshare,
                         public_key: pubkey,
                     }

--- a/crates/node/src/providers/ecdsa/presign.rs
+++ b/crates/node/src/providers/ecdsa/presign.rs
@@ -46,12 +46,13 @@ impl EcdsaSignatureProvider {
     ) -> ! {
         let keygen_out = keyshare.keygen_output;
         let presignature_store = keyshare.presignature_store;
-        let threshold_usize: usize = keyshare
+        let reconstruction_threshold_usize: usize = keyshare
             .reconstruction_threshold
             .inner()
             .try_into()
             .expect("contract validation guarantees a valid threshold");
-        let threshold = TSReconstructionThreshold::from(threshold_usize);
+        let reconstruction_threshold =
+            TSReconstructionThreshold::from(reconstruction_threshold_usize);
 
         let in_flight_generations = InFlightGenerationTracker::new();
         let progress_tracker = Arc::new(PresignatureGenerationProgressTracker {
@@ -112,7 +113,7 @@ impl EcdsaSignatureProvider {
                             let _in_flight = in_flight;
                             let _semaphore_guard = parallelism_limiter.acquire().await?;
                             let presignature = PresignComputation {
-                                threshold,
+                                reconstruction_threshold,
                                 triple0,
                                 triple1,
                                 keygen_out,
@@ -162,21 +163,23 @@ impl EcdsaSignatureProvider {
         // The triple store is keyed by the domain's reconstruction threshold
         // `t`. For cait-sith the leader pairs exactly `t` participants, so the
         // channel participant count must match — cross-check it.
-        let threshold = keyshare.reconstruction_threshold;
-        let threshold_usize: usize = threshold.inner().try_into()?;
-        if channel.participants().len() != threshold_usize {
+        let reconstruction_threshold = keyshare.reconstruction_threshold;
+        let reconstruction_threshold_usize: usize = reconstruction_threshold.inner().try_into()?;
+        if channel.participants().len() != reconstruction_threshold_usize {
             metrics::MPC_NUM_BAD_PEER_PRESIGN_REQUESTS
                 .with_label_values(&[&domain_id.to_string()])
                 .inc();
             anyhow::bail!(
                 "CaitSith presign participant count ({}) does not match domain threshold t={}",
                 channel.participants().len(),
-                threshold_usize,
+                reconstruction_threshold_usize,
             );
         }
-        let triple_store = self.triple_store_for_t(threshold)?;
+        let triple_store = self.triple_store_for_t(reconstruction_threshold)?;
         FollowerPresignComputation {
-            threshold: TSReconstructionThreshold::from(threshold_usize),
+            reconstruction_threshold: TSReconstructionThreshold::from(
+                reconstruction_threshold_usize,
+            ),
             keygen_out: keyshare.keygen_output,
             triple_store,
             paired_triple_id,
@@ -196,7 +199,7 @@ impl EcdsaSignatureProvider {
 /// Performs an MPC presignature operation. This is shared for the initiator
 /// and for passive participants.
 pub struct PresignComputation {
-    threshold: TSReconstructionThreshold,
+    reconstruction_threshold: TSReconstructionThreshold,
     triple0: TripleGenerationOutput,
     triple1: TripleGenerationOutput,
     keygen_out: KeygenOutput,
@@ -219,7 +222,7 @@ impl MpcLeaderCentricComputation<PresignOutput> for PresignComputation {
                 triple0: self.triple0,
                 triple1: self.triple1,
                 keygen_out: self.keygen_out,
-                threshold: self.threshold,
+                threshold: self.reconstruction_threshold,
             },
         )?;
         let _timer = metrics::MPC_PRE_SIGNATURE_TIME_ELAPSED.start_timer();
@@ -236,7 +239,7 @@ impl MpcLeaderCentricComputation<PresignOutput> for PresignComputation {
 /// The difference is: we need to read the triples from the triple store (which may fail),
 /// and we need to write the presignature to the presignature store before completing.
 pub struct FollowerPresignComputation {
-    pub threshold: TSReconstructionThreshold,
+    pub reconstruction_threshold: TSReconstructionThreshold,
     pub paired_triple_id: UniqueId,
     pub keygen_out: KeygenOutput,
     pub triple_store: Arc<TripleStorage>,
@@ -250,7 +253,7 @@ impl MpcLeaderCentricComputation<()> for FollowerPresignComputation {
     async fn compute(self, channel: &mut NetworkTaskChannel) -> anyhow::Result<()> {
         let (triple0, triple1) = self.triple_store.take_unowned(self.paired_triple_id)?;
         let presignature = PresignComputation {
-            threshold: self.threshold,
+            reconstruction_threshold: self.reconstruction_threshold,
             triple0,
             triple1,
             keygen_out: self.keygen_out,

--- a/crates/node/src/providers/ecdsa/sign.rs
+++ b/crates/node/src/providers/ecdsa/sign.rs
@@ -31,12 +31,13 @@ impl EcdsaSignatureProvider {
     ) -> anyhow::Result<(Signature, VerifyingKey)> {
         let keyshare = self.keyshare(sign_request.domain)?;
         let participants = presignature.participants.clone();
-        let threshold: usize = keyshare.reconstruction_threshold.inner().try_into()?;
-        let threshold = ReconstructionThreshold::from(threshold);
+        let reconstruction_threshold: usize =
+            keyshare.reconstruction_threshold.inner().try_into()?;
+        let reconstruction_threshold = ReconstructionThreshold::from(reconstruction_threshold);
 
         let (signature, public_key) = SignComputation {
             keygen_out: keyshare.keygen_output,
-            threshold,
+            reconstruction_threshold,
             presign_out: presignature.presignature,
             msg_hash: *sign_request
                 .payload
@@ -92,13 +93,14 @@ impl EcdsaSignatureProvider {
         // The presignature must be owned by the leader, never one of ours.
         presignature_id.validate_owned_by(channel.sender().get_leader())?;
         let keyshare = self.keyshare(sign_request.domain)?;
-        let threshold: usize = keyshare.reconstruction_threshold.inner().try_into()?;
-        let threshold = ReconstructionThreshold::from(threshold);
+        let reconstruction_threshold: usize =
+            keyshare.reconstruction_threshold.inner().try_into()?;
+        let reconstruction_threshold = ReconstructionThreshold::from(reconstruction_threshold);
 
         let participants = channel.participants().to_vec();
         FollowerSignComputation {
             keygen_out: keyshare.keygen_output,
-            threshold,
+            reconstruction_threshold,
             presignature_store: keyshare.presignature_store.clone(),
             presignature_id,
             msg_hash: *sign_request
@@ -149,7 +151,7 @@ impl EcdsaSignatureProvider {
 /// The tweak allows key derivation
 pub struct SignComputation {
     pub keygen_out: KeygenOutput,
-    pub threshold: ReconstructionThreshold,
+    pub reconstruction_threshold: ReconstructionThreshold,
     pub presign_out: PresignOutput,
     pub msg_hash: [u8; 32],
     pub tweak: Tweak,
@@ -198,7 +200,7 @@ impl MpcLeaderCentricComputation<(SignatureOption, VerifyingKey)> for SignComput
         let protocol = threshold_signatures::ecdsa::ot_based_ecdsa::sign::sign(
             &cs_participants,
             channel.sender().get_leader().into(),
-            self.threshold,
+            self.reconstruction_threshold,
             channel.my_participant_id().into(),
             derived_public_key,
             rerandomized_presignature,
@@ -218,7 +220,7 @@ impl MpcLeaderCentricComputation<(SignatureOption, VerifyingKey)> for SignComput
 /// The difference is that the follower needs to look up the presignature, which may fail.
 pub struct FollowerSignComputation {
     pub keygen_out: KeygenOutput,
-    pub threshold: ReconstructionThreshold,
+    pub reconstruction_threshold: ReconstructionThreshold,
     pub presignature_id: UniqueId,
     pub presignature_store: Arc<PresignatureStorage>,
     pub msg_hash: [u8; 32],
@@ -235,7 +237,7 @@ impl MpcLeaderCentricComputation<()> for FollowerSignComputation {
             .presignature;
         SignComputation {
             keygen_out: self.keygen_out,
-            threshold: self.threshold,
+            reconstruction_threshold: self.reconstruction_threshold,
             presign_out,
             msg_hash: self.msg_hash,
             tweak: self.tweak,

--- a/crates/node/src/providers/ecdsa/triple.rs
+++ b/crates/node/src/providers/ecdsa/triple.rs
@@ -57,13 +57,13 @@ impl TripleStorage {
         db: Arc<SecretDB>,
         my_participant_id: ParticipantId,
         alive_participant_ids_query: Arc<dyn Fn() -> Vec<ParticipantId> + Send + Sync>,
-        threshold: ReconstructionThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
     ) -> anyhow::Result<Self> {
         Ok(Self(DistributedAssetStorage::<PairedTriple>::new(
             clock,
             db,
             DBCol::TripleV2,
-            threshold.inner().to_be_bytes().to_vec(),
+            reconstruction_threshold.inner().to_be_bytes().to_vec(),
             my_participant_id,
             |participants, pair| pair.is_subset_of_active_participants(participants),
             alive_participant_ids_query,
@@ -119,7 +119,7 @@ impl EcdsaSignatureProvider {
         mpc_config: Arc<MpcConfig>,
         config: Arc<TripleConfig>,
         triple_store: Arc<TripleStorage>,
-        threshold: TSReconstructionThreshold,
+        reconstruction_threshold: TSReconstructionThreshold,
     ) -> ! {
         let in_flight_generations = InFlightGenerationTracker::new();
         let parallelism_limiter = Arc::new(tokio::sync::Semaphore::new(config.concurrency));
@@ -143,7 +143,7 @@ impl EcdsaSignatureProvider {
                 < config.concurrency * 2 * SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE
             {
                 let participants = match client.select_random_active_participants_including_me(
-                    threshold.value(),
+                    reconstruction_threshold.value(),
                     &running_participants,
                 ) {
                     Ok(participants) => participants,
@@ -190,7 +190,7 @@ impl EcdsaSignatureProvider {
                             let triples = (ManyTripleGenerationComputation::<
                                 SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE,
                             > {
-                                threshold,
+                                reconstruction_threshold,
                             })
                             .perform_leader_centric_computation(
                                 channel,
@@ -244,11 +244,14 @@ impl EcdsaSignatureProvider {
         // Cait-sith triple generation runs with exactly `t` participants, so we
         // can derive the store's `t` from the channel's participant list
         // without a wire-format change to `EcdsaTaskId::ManyTriples`.
-        let threshold_usize: usize = channel.participants().len();
-        let threshold = ReconstructionThreshold::new(threshold_usize.try_into()?);
-        let triple_store = self.triple_store_for_t(threshold)?;
+        let reconstruction_threshold_usize: usize = channel.participants().len();
+        let reconstruction_threshold =
+            ReconstructionThreshold::new(reconstruction_threshold_usize.try_into()?);
+        let triple_store = self.triple_store_for_t(reconstruction_threshold)?;
         FollowerManyTripleGenerationComputation::<SUPPORTED_TRIPLE_GENERATION_BATCH_SIZE> {
-            threshold: TSReconstructionThreshold::from(threshold_usize),
+            reconstruction_threshold: TSReconstructionThreshold::from(
+                reconstruction_threshold_usize,
+            ),
             out_triple_id_start: start,
             out_triple_store: triple_store,
         }
@@ -276,7 +279,7 @@ impl HasParticipants for PairedTriple {
 /// Generates many cait-sith triples at once. This can significantly save the
 /// *number* of network messages.
 pub struct ManyTripleGenerationComputation<const N: usize> {
-    pub threshold: TSReconstructionThreshold,
+    pub reconstruction_threshold: TSReconstructionThreshold,
 }
 
 #[async_trait::async_trait]
@@ -300,7 +303,7 @@ impl<const N: usize> MpcLeaderCentricComputation<Vec<PairedTriple>>
             N,
             _,
             _,
-        >(&cs_participants, me.into(), self.threshold, OsRng)?;
+        >(&cs_participants, me.into(), self.reconstruction_threshold, OsRng)?;
         let _timer = metrics::MPC_TRIPLES_GENERATION_TIME_ELAPSED.start_timer();
         let triples = run_protocol("many triple gen", channel, protocol).await?;
         metrics::MPC_NUM_TRIPLES_GENERATED.inc_by(N as u64);
@@ -324,7 +327,7 @@ impl<const N: usize> MpcLeaderCentricComputation<Vec<PairedTriple>>
 /// The follower version of the triple generation. The difference is that the follower will only
 /// complete the computation after successfully persisting the triples to storage.
 pub struct FollowerManyTripleGenerationComputation<const N: usize> {
-    pub threshold: TSReconstructionThreshold,
+    pub reconstruction_threshold: TSReconstructionThreshold,
     pub out_triple_store: Arc<TripleStorage>,
     pub out_triple_id_start: UniqueId,
 }
@@ -335,7 +338,7 @@ impl<const N: usize> MpcLeaderCentricComputation<()>
 {
     async fn compute(self, channel: &mut NetworkTaskChannel) -> anyhow::Result<()> {
         let triples = ManyTripleGenerationComputation::<N> {
-            threshold: self.threshold,
+            reconstruction_threshold: self.reconstruction_threshold,
         }
         .compute(channel)
         .await?;
@@ -392,7 +395,7 @@ mod tests {
     use tokio::sync::mpsc;
 
     const NUM_PARTICIPANTS: usize = 4;
-    const THRESHOLD: usize = 3;
+    const RECONSTRUCTION_THRESHOLD: usize = 3;
     const PARALLELISM_PER_CLIENT: usize = 4;
     const TRIPLES_PER_BATCH: usize = 10;
     const BATCHES_TO_GENERATE_PER_CLIENT: usize = 10;
@@ -436,7 +439,7 @@ mod tests {
             .unwrap();
 
             // Sanity check that we generated the right number of triples, and
-            // each triple has THRESHOLD participants.
+            // each triple has RECONSTRUCTION_THRESHOLD participants.
             let mut id_to_triple_count = HashMap::new();
 
             for triples in &all_triples {
@@ -449,7 +452,7 @@ mod tests {
                 NUM_PARTICIPANTS * BATCHES_TO_GENERATE_PER_CLIENT * TRIPLES_PER_BATCH / 2,
             );
             for count in id_to_triple_count.values() {
-                assert_eq!(*count, THRESHOLD);
+                assert_eq!(*count, RECONSTRUCTION_THRESHOLD);
             }
         })
         .await;
@@ -461,7 +464,7 @@ mod tests {
     ) -> anyhow::Result<HashMap<UniqueId, PairedTriple>> {
         let passive_triples = tracking::spawn("monitor passive channels", async move {
             let mut tasks = Vec::new();
-            for _ in 0..BATCHES_TO_GENERATE_PER_CLIENT * (THRESHOLD - 1) {
+            for _ in 0..BATCHES_TO_GENERATE_PER_CLIENT * (RECONSTRUCTION_THRESHOLD - 1) {
                 let channel = channel_receiver.recv().await.unwrap();
                 tasks.push(tracking::spawn(
                     &format!("passive task {:?}", channel.task_id()),
@@ -472,7 +475,9 @@ mod tests {
                             panic!("Unexpected task id");
                         };
                         let triples = ManyTripleGenerationComputation::<TRIPLES_PER_BATCH> {
-                            threshold: TSReconstructionThreshold::from(THRESHOLD),
+                            reconstruction_threshold: TSReconstructionThreshold::from(
+                                RECONSTRUCTION_THRESHOLD,
+                            ),
                         }
                         .perform_leader_centric_computation(
                             channel,
@@ -513,14 +518,16 @@ mod tests {
                             .position(|&p| p == participant_id)
                             .unwrap();
                         participants.rotate_left(my_index);
-                        participants.truncate(THRESHOLD);
+                        participants.truncate(RECONSTRUCTION_THRESHOLD);
                         participants
                     };
                     let channel = client.new_channel_for_task(task_id, participants).unwrap();
                     let result = tracking::spawn(
                         &format!("task {:?}", task_id),
                         ManyTripleGenerationComputation::<TRIPLES_PER_BATCH> {
-                            threshold: TSReconstructionThreshold::from(THRESHOLD),
+                            reconstruction_threshold: TSReconstructionThreshold::from(
+                                RECONSTRUCTION_THRESHOLD,
+                            ),
                         }
                         .perform_leader_centric_computation(
                             channel,
@@ -555,7 +562,7 @@ mod tests {
     fn new_triple_store(
         db: Arc<SecretDB>,
         my_participant_id: ParticipantId,
-        threshold: ReconstructionThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
         alive: Vec<ParticipantId>,
     ) -> TripleStorage {
         TripleStorage::new(
@@ -563,7 +570,7 @@ mod tests {
             db,
             my_participant_id,
             Arc::new(move || alive.clone()),
-            threshold,
+            reconstruction_threshold,
         )
         .unwrap()
     }

--- a/crates/node/src/providers/ecdsa/triple.rs
+++ b/crates/node/src/providers/ecdsa/triple.rs
@@ -299,11 +299,13 @@ impl<const N: usize> MpcLeaderCentricComputation<Vec<PairedTriple>>
             .map(Participant::from)
             .collect::<Vec<_>>();
         let me = channel.my_participant_id();
-        let protocol = threshold_signatures::ecdsa::ot_based_ecdsa::triples::generate_triple_many::<
-            N,
-            _,
-            _,
-        >(&cs_participants, me.into(), self.reconstruction_threshold, OsRng)?;
+        let protocol =
+            threshold_signatures::ecdsa::ot_based_ecdsa::triples::generate_triple_many::<N, _, _>(
+                &cs_participants,
+                me.into(),
+                self.reconstruction_threshold,
+                OsRng,
+            )?;
         let _timer = metrics::MPC_TRIPLES_GENERATION_TIME_ELAPSED.start_timer();
         let triples = run_protocol("many triple gen", channel, protocol).await?;
         metrics::MPC_NUM_TRIPLES_GENERATED.inc_by(N as u64);

--- a/crates/node/src/providers/eddsa.rs
+++ b/crates/node/src/providers/eddsa.rs
@@ -94,23 +94,23 @@ impl SignatureProvider for EddsaSignatureProvider {
     }
 
     async fn run_key_generation_client(
-        threshold: TSReconstructionThreshold,
+        reconstruction_threshold: TSReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
-        Self::run_key_generation_client_internal(threshold, channel).await
+        Self::run_key_generation_client_internal(reconstruction_threshold, channel).await
     }
 
     async fn run_key_resharing_client(
-        new_threshold: TSReconstructionThreshold,
-        old_threshold: TSReconstructionThreshold,
+        new_reconstruction_threshold: TSReconstructionThreshold,
+        old_reconstruction_threshold: TSReconstructionThreshold,
         key_share: Option<SigningShare>,
         public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
         Self::run_key_resharing_client_internal(
-            new_threshold,
-            old_threshold,
+            new_reconstruction_threshold,
+            old_reconstruction_threshold,
             key_share,
             public_key,
             old_participants,

--- a/crates/node/src/providers/eddsa/key_generation.rs
+++ b/crates/node/src/providers/eddsa/key_generation.rs
@@ -10,10 +10,12 @@ use threshold_signatures::participants::Participant;
 
 impl EddsaSignatureProvider {
     pub(super) async fn run_key_generation_client_internal(
-        threshold: ReconstructionThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<KeygenOutput> {
-        let key = KeyGenerationComputation { threshold }
+        let key = KeyGenerationComputation {
+            reconstruction_threshold,
+        }
             .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
             .await?;
         tracing::info!("Eddsa key generation completed");
@@ -25,7 +27,7 @@ impl EddsaSignatureProvider {
 /// Runs the key generation protocol, returning the key generated.
 /// This protocol is identical for the leader and the followers.
 pub struct KeyGenerationComputation {
-    threshold: ReconstructionThreshold,
+    reconstruction_threshold: ReconstructionThreshold,
 }
 
 #[async_trait::async_trait]
@@ -41,7 +43,7 @@ impl MpcLeaderCentricComputation<KeygenOutput> for KeyGenerationComputation {
         let protocol = threshold_signatures::keygen::<Ed25519Sha512, _, _>(
             &cs_participants,
             me.into(),
-            self.threshold,
+            self.reconstruction_threshold,
             OsRng,
         )?;
         run_protocol("eddsa key generation", channel, protocol).await
@@ -108,7 +110,7 @@ mod tests {
                 .ok_or_else(|| anyhow::anyhow!("No channel"))?
         };
         let key = KeyGenerationComputation {
-            threshold: ReconstructionThreshold::from(3),
+            reconstruction_threshold: ReconstructionThreshold::from(3),
         }
         .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
         .await?;

--- a/crates/node/src/providers/eddsa/key_generation.rs
+++ b/crates/node/src/providers/eddsa/key_generation.rs
@@ -16,8 +16,8 @@ impl EddsaSignatureProvider {
         let key = KeyGenerationComputation {
             reconstruction_threshold,
         }
-            .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
-            .await?;
+        .perform_leader_centric_computation(channel, std::time::Duration::from_secs(60))
+        .await?;
         tracing::info!("Eddsa key generation completed");
 
         Ok(key)

--- a/crates/node/src/providers/eddsa/key_resharing.rs
+++ b/crates/node/src/providers/eddsa/key_resharing.rs
@@ -13,17 +13,17 @@ use threshold_signatures::participants::Participant;
 
 impl EddsaSignatureProvider {
     pub(super) async fn run_key_resharing_client_internal(
-        new_threshold: ReconstructionThreshold,
-        old_threshold: ReconstructionThreshold,
+        new_reconstruction_threshold: ReconstructionThreshold,
+        old_reconstruction_threshold: ReconstructionThreshold,
         my_share: Option<SigningShare>,
         public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<KeygenOutput> {
         let new_keyshare = KeyResharingComputation {
-            threshold: new_threshold,
+            reconstruction_threshold: new_reconstruction_threshold,
             old_participants: old_participants.participants.iter().map(|p| p.id).collect(),
-            old_threshold,
+            old_reconstruction_threshold,
             my_share,
             public_key,
         }
@@ -49,9 +49,9 @@ impl EddsaSignatureProvider {
 ///       the old threshold; or
 ///     - the threshold is larger than the number of participants.
 pub struct KeyResharingComputation {
-    threshold: ReconstructionThreshold,
+    reconstruction_threshold: ReconstructionThreshold,
     old_participants: Vec<ParticipantId>,
-    old_threshold: ReconstructionThreshold,
+    old_reconstruction_threshold: ReconstructionThreshold,
     my_share: Option<SigningShare>,
     public_key: VerifyingKey,
 }
@@ -75,11 +75,11 @@ impl MpcLeaderCentricComputation<KeygenOutput> for KeyResharingComputation {
 
         let protocol = threshold_signatures::reshare::<Ed25519Sha512, _, _, _>(
             &old_participants,
-            self.old_threshold,
+            self.old_reconstruction_threshold,
             self.my_share,
             self.public_key,
             &new_participants,
-            self.threshold,
+            self.reconstruction_threshold,
             me.into(),
             OsRng,
         )?;
@@ -152,9 +152,9 @@ mod tests {
                             .ok_or_else(|| anyhow::anyhow!("No channel"))?
                     };
                     let key = KeyResharingComputation {
-                        threshold: ReconstructionThreshold::from(THRESHOLD),
+                        reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
                         old_participants,
-                        old_threshold: ReconstructionThreshold::from(THRESHOLD),
+                        old_reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
                         my_share: keyshare,
                         public_key: pubkey,
                     }

--- a/crates/node/src/providers/eddsa/sign.rs
+++ b/crates/node/src/providers/eddsa/sign.rs
@@ -25,8 +25,9 @@ impl EddsaSignatureProvider {
         let sign_request = self.sign_request_store.get(id).await?;
 
         let keyshare = self.keyshare(sign_request.domain)?;
-        let threshold: usize = keyshare.reconstruction_threshold.inner().try_into()?;
-        let threshold = ReconstructionThreshold::from(threshold);
+        let reconstruction_threshold: usize =
+            keyshare.reconstruction_threshold.inner().try_into()?;
+        let reconstruction_threshold = ReconstructionThreshold::from(reconstruction_threshold);
         let running_participants: Vec<_> = self
             .mpc_config
             .participants
@@ -38,7 +39,7 @@ impl EddsaSignatureProvider {
         let participants = self
             .client
             .select_random_active_participants_including_me(
-                threshold.value(),
+                reconstruction_threshold.value(),
                 &running_participants,
             )
             .context("Can't choose active participants for a eddsa signature")?;
@@ -49,7 +50,7 @@ impl EddsaSignatureProvider {
 
         let result = SignComputation {
             keygen_output: keyshare.keygen_output,
-            threshold,
+            reconstruction_threshold,
             message: sign_request
                 .payload
                 .as_eddsa()
@@ -93,13 +94,14 @@ impl EddsaSignatureProvider {
         metrics::MPC_NUM_PASSIVE_SIGN_REQUESTS_LOOKUP_SUCCEEDED.inc();
 
         let keyshare = self.keyshare(sign_request.domain)?;
-        let threshold: usize = keyshare.reconstruction_threshold.inner().try_into()?;
-        let threshold = ReconstructionThreshold::from(threshold);
+        let reconstruction_threshold: usize =
+            keyshare.reconstruction_threshold.inner().try_into()?;
+        let reconstruction_threshold = ReconstructionThreshold::from(reconstruction_threshold);
 
         let participants = channel.participants().to_vec();
         let _ = SignComputation {
             keygen_output: keyshare.keygen_output,
-            threshold,
+            reconstruction_threshold,
             message: sign_request
                 .payload
                 .as_eddsa()
@@ -131,7 +133,7 @@ impl EddsaSignatureProvider {
 /// The tweak allows key derivation
 pub struct SignComputation {
     pub keygen_output: KeygenOutput,
-    pub threshold: ReconstructionThreshold,
+    pub reconstruction_threshold: ReconstructionThreshold,
     pub message: Vec<u8>,
     pub tweak: Tweak,
 }
@@ -158,7 +160,7 @@ impl MpcLeaderCentricComputation<Option<(Signature, VerifyingKey)>> for SignComp
 
         let protocol = sign(
             cs_participants.as_slice(),
-            self.threshold,
+            self.reconstruction_threshold,
             channel.my_participant_id().into(),
             channel.sender().get_leader().into(),
             derived_keygen_output.clone(),

--- a/crates/node/src/providers/robust_ecdsa.rs
+++ b/crates/node/src/providers/robust_ecdsa.rs
@@ -118,23 +118,27 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
     }
 
     async fn run_key_generation_client(
-        threshold: TSReconstructionThreshold,
+        reconstruction_threshold: TSReconstructionThreshold,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
-        EcdsaSignatureProvider::run_key_generation_client_internal(threshold, channel).await
+        EcdsaSignatureProvider::run_key_generation_client_internal(
+            reconstruction_threshold,
+            channel,
+        )
+        .await
     }
 
     async fn run_key_resharing_client(
-        new_threshold: TSReconstructionThreshold,
-        old_threshold: TSReconstructionThreshold,
+        new_reconstruction_threshold: TSReconstructionThreshold,
+        old_reconstruction_threshold: TSReconstructionThreshold,
         my_share: Option<SigningShare>,
         public_key: VerifyingKey,
         old_participants: &ParticipantsConfig,
         channel: NetworkTaskChannel,
     ) -> anyhow::Result<Self::KeygenOutput> {
         EcdsaSignatureProvider::run_key_resharing_client_internal(
-            new_threshold,
-            old_threshold,
+            new_reconstruction_threshold,
+            old_reconstruction_threshold,
             my_share,
             public_key,
             old_participants,
@@ -211,9 +215,9 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
 /// reconstruction threshold `t`. Returns an error if `t < 2`,
 /// which the contract's threshold validation already rejects.
 pub(super) fn compute_thresholds(
-    threshold: ReconstructionThreshold,
+    reconstruction_threshold: ReconstructionThreshold,
 ) -> anyhow::Result<(usize, MaxMalicious)> {
-    let t: usize = threshold.inner().try_into()?;
+    let t: usize = reconstruction_threshold.inner().try_into()?;
     anyhow::ensure!(
         t >= 2,
         "robust-ECDSA requires a reconstruction threshold of at least 2, got {t}"

--- a/crates/node/src/providers/robust_ecdsa/presign.rs
+++ b/crates/node/src/providers/robust_ecdsa/presign.rs
@@ -43,7 +43,7 @@ pub(super) async fn run_background_presignature_generation(
 ) -> ! {
     let keygen_out = keyshare.keygen_output;
     let presignature_store = keyshare.presignature_store;
-    let threshold = keyshare.reconstruction_threshold;
+    let reconstruction_threshold = keyshare.reconstruction_threshold;
 
     let in_flight_generations = InFlightGenerationTracker::new();
     let progress_tracker = Arc::new(PresignatureGenerationProgressTracker {
@@ -62,7 +62,8 @@ pub(super) async fn run_background_presignature_generation(
         .collect();
 
     let (num_signers, damgard_et_al_threshold) =
-        compute_thresholds(threshold).expect("contract validation guarantees a valid threshold");
+        compute_thresholds(reconstruction_threshold)
+            .expect("contract validation guarantees a valid threshold");
 
     loop {
         progress_tracker.update_progress();

--- a/crates/node/src/providers/robust_ecdsa/presign.rs
+++ b/crates/node/src/providers/robust_ecdsa/presign.rs
@@ -61,9 +61,8 @@ pub(super) async fn run_background_presignature_generation(
         .map(|p| p.id)
         .collect();
 
-    let (num_signers, damgard_et_al_threshold) =
-        compute_thresholds(reconstruction_threshold)
-            .expect("contract validation guarantees a valid threshold");
+    let (num_signers, damgard_et_al_threshold) = compute_thresholds(reconstruction_threshold)
+        .expect("contract validation guarantees a valid threshold");
 
     loop {
         progress_tracker.update_progress();


### PR DESCRIPTION
Close partly #3903 .
This PR is meant to introduce changes namely renaming the threshold to reconstruction_threshold.
This one should not impose any risk or any migration problems 