### PR TITLE
refactor: typed propose_update and vote_update on MpcContractHandle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7018,6 +7018,7 @@ dependencies = [
  "near-contract-transport",
  "near-mpc-bounded-collections",
  "near-mpc-crypto-types",
+ "near-sdk",
  "rstest",
  "schemars 0.8.22",
  "serde",

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1333,10 +1333,19 @@ impl MpcContract {
     ) -> Result<UpdateId, Error> {
         // Only voters can propose updates:
         let proposer = self.voter_or_panic();
+        let payload_bytes =
+            args.payload_bytes()
+                .map_err(|err| InvalidParameters::MalformedPayload {
+                    reason: err.to_string(),
+                })?;
         let update: Update = args.try_into()?;
 
         let attached = env::attached_deposit();
-        let required = ProposedUpdates::required_deposit(&update);
+        let required = ProposedUpdates::required_deposit(payload_bytes).map_err(|err| {
+            InvalidParameters::MalformedPayload {
+                reason: err.to_string(),
+            }
+        })?;
         if attached < required {
             return Err(InvalidParameters::InsufficientDeposit {
                 attached: attached.as_yoctonear(),
@@ -2850,6 +2859,7 @@ mod tests {
     use crate::state::resharing::ResharingContractState;
     use crate::state::test_utils::{
         gen_initializing_state, gen_resharing_state, gen_running_state,
+        gen_running_state_with_params,
     };
     use crate::tee::measurements::{
         KeyProviderEventDigest, MrtdHash, Rtmr0Hash, Rtmr1Hash, Rtmr2Hash,
@@ -5809,6 +5819,53 @@ mod tests {
         );
         // then: threshold met (have 2 valid votes, need 2)
         assert!(contract.vote_update(update_id).unwrap());
+    }
+
+    #[test]
+    #[expect(non_snake_case)]
+    fn propose_update__should_charge_a_deposit_covering_the_worst_case_storage_cost() {
+        // Given
+        let running_state = gen_running_state_with_params(1, 129, 129);
+        let voters: Vec<AccountId> = running_state
+            .parameters
+            .participants()
+            .participants()
+            .iter()
+            .map(|(account_id, _, _)| account_id.clone())
+            .collect();
+        let mut contract =
+            MpcContract::new_from_protocol_state(ProtocolContractState::Running(running_state));
+        let code = vec![0xff; 4096];
+        let required_deposit = ProposedUpdates::required_deposit(
+            u128::try_from(code.len()).expect("usize always fits in u128"),
+        )
+        .expect("the deposit for a 4 KiB payload fits in u128");
+
+        // When
+        let mut environment = Environment::new(None, Some(voters[0].clone()), None);
+        environment.set_deposit(required_deposit);
+        let storage_before = env::storage_usage();
+        let id = contract
+            .propose_update(ProposeUpdateArgs {
+                code: Some(code),
+                config: None,
+            })
+            .unwrap();
+        for voter in &voters[1..] {
+            Environment::new(None, Some(voter.clone()), None);
+            assert!(!contract.vote_update(id).unwrap());
+        }
+        // near-sdk `store` collections write their cached changes to storage
+        // in `Drop`; dropping the contract persists the entry and the votes.
+        drop(contract);
+        let bytes_grown = u128::from(env::storage_usage() - storage_before);
+        let storage_cost = env::storage_byte_cost().saturating_mul(bytes_grown);
+
+        // Then
+        assert!(
+            required_deposit >= storage_cost,
+            "deposit {required_deposit} does not cover {storage_cost} of storage"
+        );
     }
 
     /// Callers authorized to drive `remove_non_participant_update_votes`.

--- a/crates/contract/src/update.rs
+++ b/crates/contract/src/update.rs
@@ -117,7 +117,7 @@ impl TryFrom<ProposeUpdateArgs> for Update {
 pub(crate) struct UpdateEntry {
     pub(super) update: Update,
     // TODO(#3965): remove this field, it's not read anywhere.
-    pub bytes_used: u128,
+    bytes_used: u128,
 }
 
 #[derive(Clone, Debug, PartialEq)]

--- a/crates/contract/src/update.rs
+++ b/crates/contract/src/update.rs
@@ -10,6 +10,9 @@ use crate::{
 use borsh::{self, BorshDeserialize, BorshSerialize};
 use derive_more::Deref;
 use near_account_id::AccountId;
+use near_mpc_contract_interface::deposits::{
+    DepositOverflowError, propose_update_required_deposit_yoctonear,
+};
 use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types::{ProposeUpdateArgs, UpdateHash};
 use near_sdk::{
@@ -113,7 +116,8 @@ impl TryFrom<ProposeUpdateArgs> for Update {
 )]
 pub(crate) struct UpdateEntry {
     pub(super) update: Update,
-    pub(super) bytes_used: u128,
+    // TODO(#3965): remove this field, it's not read anywhere.
+    pub bytes_used: u128,
 }
 
 #[derive(Clone, Debug, PartialEq)]
@@ -141,8 +145,12 @@ impl Default for ProposedUpdates {
 }
 
 impl ProposedUpdates {
-    pub fn required_deposit(update: &Update) -> NearToken {
-        required_deposit(bytes_used(update))
+    pub fn required_deposit(payload_bytes: u128) -> Result<NearToken, DepositOverflowError> {
+        propose_update_required_deposit_yoctonear(
+            payload_bytes,
+            env::storage_byte_cost().as_yoctonear(),
+        )
+        .map(NearToken::from_yoctonear)
     }
 
     /// Propose an update given the new contract code and/or config.
@@ -274,10 +282,6 @@ fn bytes_used(update: &Update) -> u128 {
     }
 
     bytes_used
-}
-
-fn required_deposit(bytes_used: u128) -> NearToken {
-    env::storage_byte_cost().saturating_mul(bytes_used)
 }
 
 #[cfg(test)]

--- a/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
+++ b/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
@@ -16,6 +16,9 @@ use crate::sandbox::{
     },
 };
 use mpc_contract::update::UpdateId;
+use near_mpc_contract_interface::deposits::{
+    STORAGE_BYTE_COST_YOCTONEAR, propose_update_required_deposit_yoctonear,
+};
 use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types::{ProposeUpdateArgs, ProtocolContractState};
 use near_workspaces::types::NearToken;
@@ -124,15 +127,26 @@ async fn test_propose_update_config() {
         resolve_verification_tera_gas: 16,
     };
 
+    let propose_args = ProposeUpdateArgs {
+        code: None,
+        config: Some(new_config.clone()),
+    };
+    let deposit = NearToken::from_yoctonear(
+        propose_update_required_deposit_yoctonear(
+            propose_args
+                .payload_bytes()
+                .expect("config serializes to JSON"),
+            STORAGE_BYTE_COST_YOCTONEAR,
+        )
+        .expect("the deposit for a config proposal fits in u128"),
+    );
+
     let mut proposals = Vec::with_capacity(mpc_signer_accounts.len());
     for account in &mpc_signer_accounts {
         let propose_execution = account
             .call(contract.id(), method_names::PROPOSE_UPDATE)
-            .args_borsh((ProposeUpdateArgs {
-                code: None,
-                config: Some(new_config.clone()),
-            },))
-            .deposit(NearToken::from_millinear(100))
+            .args_borsh((propose_args.clone(),))
+            .deposit(deposit)
             .transact()
             .await
             .unwrap();

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -792,17 +792,24 @@ impl MpcCluster {
         Ok(())
     }
 
-    pub fn user_client(&self, account_id: &AccountId) -> anyhow::Result<NearKitCaller> {
+    pub fn client_for(&self, account_id: &AccountId) -> anyhow::Result<NearKitCaller> {
         let key = self
             .user_accounts
             .get(account_id)
-            .with_context(|| format!("unknown user account: {account_id}"))?;
+            .or_else(|| {
+                self.nodes
+                    .iter()
+                    .zip(self.node_keys.iter())
+                    .find(|(node, _)| node.account_id() == account_id)
+                    .map(|(_, key)| key)
+            })
+            .with_context(|| format!("unknown account: {account_id}"))?;
         self.blockchain.client_for(account_id.as_ref(), key)
     }
 
     pub fn contract_handle(&self, account_id: &AccountId) -> MpcContractHandle<NearKitCaller> {
         self.contract
-            .handle_for(self.user_client(account_id).unwrap())
+            .handle_for(self.client_for(account_id).unwrap())
     }
 
     pub fn default_user_account(&self) -> &AccountId {

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -57,8 +57,6 @@ const NODE_MANAGEMENT_DEPOSIT: near_kit::NearToken = near_kit::NearToken::from_y
 // load. Override to 240 blocks (~30 s in sandbox) as a comfortable
 // budget over mainnet's effective headroom.
 const KEY_EVENT_TIMEOUT_BLOCKS: u64 = 240;
-const CONTRACT_UPDATE_DEPOSIT: near_kit::NearToken = near_kit::NearToken::from_millinear(17_000);
-const CONTRACT_UPDATE_GAS: near_kit::Gas = near_kit::Gas::from_tgas(300);
 const VOTE_FOREIGN_CHAIN_GAS: near_kit::Gas = near_kit::Gas::from_tgas(30);
 const CONTRACT_DEPLOY_TIMEOUT: Duration = Duration::from_secs(15);
 const PROPOSER_NODE_INDEX: usize = 0;
@@ -1067,16 +1065,14 @@ impl MpcCluster {
             code: Some(new_wasm.to_vec()),
             config: None,
         };
-        let proposer_client = self.operator_client_for(PROPOSER_NODE_INDEX)?;
+        let proposer_account = self
+            .nodes
+            .get(PROPOSER_NODE_INDEX)
+            .expect("need at least one node")
+            .account_id();
         let outcome = self
-            .contract
-            .call_from_borsh_with_deposit(
-                &proposer_client,
-                method_names::PROPOSE_UPDATE,
-                propose_args,
-                CONTRACT_UPDATE_GAS,
-                CONTRACT_UPDATE_DEPOSIT,
-            )
+            .contract_handle(proposer_account)
+            .propose_update(propose_args)
             .await
             .context("failed to call propose_update")?;
         anyhow::ensure!(
@@ -1084,19 +1080,14 @@ impl MpcCluster {
             "propose_update failed: {:?}",
             outcome.failure_message()
         );
-        let proposal_id: UpdateId = outcome
+        let proposal_id: u64 = outcome
             .json()
-            .context("propose_update did not return a JSON UpdateId")?;
+            .context("propose_update did not return a JSON update id")?;
 
-        for (i, _) in self.nodes.iter().enumerate() {
-            let client = self.operator_client_for(i)?;
+        for (i, node) in self.nodes.iter().enumerate() {
             let vote_outcome = self
-                .contract
-                .call_from(
-                    &client,
-                    method_names::VOTE_UPDATE,
-                    json!({ "id": proposal_id }),
-                )
+                .contract_handle(node.account_id())
+                .vote_update(proposal_id)
                 .await
                 .with_context(|| format!("node {i} failed to call vote_update"))?;
             anyhow::ensure!(
@@ -1460,11 +1451,6 @@ async fn create_user_accounts(
     }
     Ok(map)
 }
-
-/// JSON mirror of the contract's `UpdateId`. `propose_update` returns it and
-/// `vote_update` consumes it via the `id` field; both wire it as a bare u64.
-#[derive(Debug, Clone, Copy, serde::Serialize, serde::Deserialize)]
-struct UpdateId(u64);
 
 fn build_participants(
     indices: &[usize],

--- a/crates/near-mpc-contract-interface/Cargo.toml
+++ b/crates/near-mpc-contract-interface/Cargo.toml
@@ -19,14 +19,8 @@ blstrs = ["near-mpc-crypto-types/blstrs"]
 # Helper to build mpc contract function call arguments
 call-args = []
 # The typed client (`MpcContractHandle`) over the transport traits. Pulls in
-# the transport crate and serde_json.
-client = [
-    "call-args",
-    "dep:near-contract-transport",
-    "near-contract-transport/traits",
-    "dep:serde_json",
-    "dep:thiserror",
-]
+# the transport crate.
+client = ["call-args", "dep:near-contract-transport", "near-contract-transport/traits"]
 ed25519-dalek = ["near-mpc-crypto-types/ed25519-dalek"]
 k256 = ["near-mpc-crypto-types/k256"]
 near = ["near-mpc-crypto-types/near"]
@@ -39,11 +33,11 @@ near-contract-transport = { workspace = true, optional = true }
 near-mpc-bounded-collections = { workspace = true }
 near-mpc-crypto-types = { workspace = true }
 serde = { workspace = true }
-serde_json = { workspace = true, optional = true }
+serde_json = { workspace = true }
 serde_repr = { workspace = true }
 serde_with = { workspace = true }
 sha2 = { workspace = true }
-thiserror = { workspace = true, optional = true }
+thiserror = { workspace = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 schemars = { workspace = true, optional = true }
@@ -53,6 +47,7 @@ assert_matches = { workspace = true }
 borsh = { workspace = true }
 hex = { workspace = true }
 insta = { workspace = true }
+near-sdk = { workspace = true, features = ["non-contract-usage"] }
 rstest = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/crates/near-mpc-contract-interface/src/client.rs
+++ b/crates/near-mpc-contract-interface/src/client.rs
@@ -8,14 +8,19 @@ use near_contract_transport::{CallContract, FunctionCallArgs, NearGas, NearToken
 
 use crate::call_args::{
     RequestAppPrivateKeyArgs, SignArgs, SubmitParticipantInfoArgs, VerifyForeignTransactionArgs,
+    VoteUpdateArgs,
 };
-use crate::deposits::{SIGN_DEPOSIT_YOCTONEAR, SUBMIT_PARTICIPANT_INFO_DEPOSIT_MILLINEAR};
+use crate::deposits::{
+    DepositOverflowError, SIGN_DEPOSIT_YOCTONEAR, STORAGE_BYTE_COST_YOCTONEAR,
+    SUBMIT_PARTICIPANT_INFO_DEPOSIT_MILLINEAR, propose_update_required_deposit_yoctonear,
+};
 use crate::method_names::{
-    REQUEST_APP_PRIVATE_KEY, SIGN, SUBMIT_PARTICIPANT_INFO, VERIFY_FOREIGN_TRANSACTION, VERIFY_TEE,
+    PROPOSE_UPDATE, REQUEST_APP_PRIVATE_KEY, SIGN, SUBMIT_PARTICIPANT_INFO,
+    VERIFY_FOREIGN_TRANSACTION, VERIFY_TEE, VOTE_UPDATE,
 };
 use crate::types::{
-    AccountId, Attestation, CKDAppPublicKey, CKDRequestArgs, Ed25519PublicKey, SignRequestArgs,
-    VerifyForeignTransactionRequestArgs,
+    AccountId, Attestation, CKDAppPublicKey, CKDRequestArgs, Ed25519PublicKey, PayloadBytesError,
+    ProposeUpdateArgs, SignRequestArgs, VerifyForeignTransactionRequestArgs,
 };
 
 /// Default gas for handle-issued calls without a method-specific amount.
@@ -107,6 +112,48 @@ impl<C: CallContract> MpcContractHandle<C> {
             .map_err(MpcContractHandleError::Call)
     }
 
+    pub async fn propose_update(
+        &self,
+        args: ProposeUpdateArgs,
+    ) -> Result<C::Output, MpcContractHandleError<C::Error>> {
+        let deposit = NearToken::from_yoctonear(propose_update_required_deposit_yoctonear(
+            args.payload_bytes()?,
+            STORAGE_BYTE_COST_YOCTONEAR,
+        )?);
+        let args = borsh::to_vec(&args)?;
+        self.caller
+            .call_contract(
+                &self.contract_id,
+                FunctionCallArgs {
+                    method_name: PROPOSE_UPDATE.to_string(),
+                    args,
+                    gas: MAX_GAS,
+                    deposit,
+                },
+            )
+            .await
+            .map_err(MpcContractHandleError::Call)
+    }
+
+    pub async fn vote_update(
+        &self,
+        id: u64,
+    ) -> Result<C::Output, MpcContractHandleError<C::Error>> {
+        let args = serde_json::to_vec(&VoteUpdateArgs::new(id))?;
+        self.caller
+            .call_contract(
+                &self.contract_id,
+                FunctionCallArgs {
+                    method_name: VOTE_UPDATE.to_string(),
+                    args,
+                    gas: MAX_GAS,
+                    deposit: NearToken::from_yoctonear(0),
+                },
+            )
+            .await
+            .map_err(MpcContractHandleError::Call)
+    }
+
     pub async fn submit_participant_info(
         &self,
         proposed_participant_attestation: Attestation,
@@ -150,6 +197,12 @@ impl<C: CallContract> MpcContractHandle<C> {
 pub enum MpcContractHandleError<E> {
     #[error("failed to serialize call arguments: {0}")]
     Serialize(#[from] serde_json::Error),
+    #[error("failed to borsh-encode call arguments: {0}")]
+    Encode(#[from] std::io::Error),
+    #[error("failed to size the call payload: {0}")]
+    Payload(#[from] PayloadBytesError),
+    #[error("failed to compute the required deposit: {0}")]
+    Deposit(#[from] DepositOverflowError),
     #[error("contract call failed: {0}")]
     Call(E),
 }
@@ -162,7 +215,7 @@ mod tests {
         AccountId, Attestation, BitcoinExtractor, BitcoinRpcRequest, BitcoinTxId,
         BlockConfirmations, CKDAppPublicKey, CKDAppPublicKeyPV, CKDRequestArgs, DomainId,
         Ed25519PublicKey, ForeignChainRpcRequest, ForeignTxPayloadVersion, MockAttestation,
-        Payload, SignRequestArgs, VerifyForeignTransactionRequestArgs,
+        Payload, ProposeUpdateArgs, SignRequestArgs, VerifyForeignTransactionRequestArgs,
     };
     use near_contract_transport::{CallContract, FunctionCallArgs};
     use near_mpc_crypto_types::{Bls12381G1PublicKey, Bls12381G2PublicKey};
@@ -195,12 +248,20 @@ mod tests {
     /// Renders a recorded call as its reviewable wire format
     /// (method, gas, deposit, args).
     fn render(contract_id: &AccountId, call: &FunctionCallArgs) -> String {
+        // This is only necessary because our contract takes as input
+        // borsh-arguments (e.g. when proposing updates).
+        // 1. If the args are json, we print them as a string.
+        // 2. if the args are not json, then they are some borsh serialization.
+        //    In this case, we print the hex-encoding.
+        let args = match serde_json::from_slice::<serde_json::Value>(&call.args) {
+            Ok(_) => String::from_utf8(call.args.clone()).expect("JSON args are UTF-8"),
+            Err(_) => format!("0x{}", hex::encode(&call.args)),
+        };
         format!(
-            "contract: {contract_id}\nmethod:   {}\ngas:      {}\ndeposit:  {}\nargs:     {}",
+            "contract: {contract_id}\nmethod:   {}\ngas:      {}\ndeposit:  {}\nargs:     {args}",
             call.method_name,
             call.gas,
             call.deposit.exact_amount_display(),
-            String::from_utf8_lossy(&call.args),
         )
     }
 
@@ -254,6 +315,14 @@ mod tests {
             .await
             .unwrap();
         handle
+            .propose_update(ProposeUpdateArgs {
+                code: Some(vec![7u8; 4]),
+                config: None,
+            })
+            .await
+            .unwrap();
+        handle.vote_update(7).await.unwrap();
+        handle
             .submit_participant_info(
                 Attestation::Mock(MockAttestation::Valid),
                 Ed25519PublicKey::from([7u8; 32]),
@@ -264,7 +333,7 @@ mod tests {
 
         // Then
         let calls = caller.calls.lock().unwrap();
-        assert_eq!(calls.len(), 6);
+        assert_eq!(calls.len(), 8);
         let catalog = calls
             .iter()
             .map(|(contract_id, call)| render(contract_id, call))

--- a/crates/near-mpc-contract-interface/src/client.rs
+++ b/crates/near-mpc-contract-interface/src/client.rs
@@ -116,8 +116,12 @@ impl<C: CallContract> MpcContractHandle<C> {
         &self,
         args: ProposeUpdateArgs,
     ) -> Result<C::Output, MpcContractHandleError<C::Error>> {
+        let payload_bytes = args.payload_bytes().map_err(|err| match err {
+            PayloadBytesError::Serialize(err) => MpcContractHandleError::Serialize(err),
+            PayloadBytesError::Overflow => MpcContractHandleError::Deposit(DepositOverflowError),
+        })?;
         let deposit = NearToken::from_yoctonear(propose_update_required_deposit_yoctonear(
-            args.payload_bytes()?,
+            payload_bytes,
             STORAGE_BYTE_COST_YOCTONEAR,
         )?);
         let args = borsh::to_vec(&args)?;
@@ -199,8 +203,6 @@ pub enum MpcContractHandleError<E> {
     Serialize(#[from] serde_json::Error),
     #[error("failed to borsh-encode call arguments: {0}")]
     Encode(#[from] std::io::Error),
-    #[error("failed to size the call payload: {0}")]
-    Payload(#[from] PayloadBytesError),
     #[error("failed to compute the required deposit: {0}")]
     Deposit(#[from] DepositOverflowError),
     #[error("contract call failed: {0}")]

--- a/crates/near-mpc-contract-interface/src/client.rs
+++ b/crates/near-mpc-contract-interface/src/client.rs
@@ -255,9 +255,9 @@ mod tests {
         // 1. If the args are json, we print them as a string.
         // 2. if the args are not json, then they are some borsh serialization.
         //    In this case, we print the hex-encoding.
-        let args = match serde_json::from_slice::<serde_json::Value>(&call.args) {
-            Ok(_) => String::from_utf8(call.args.clone()).expect("JSON args are UTF-8"),
-            Err(_) => format!("0x{}", hex::encode(&call.args)),
+        let args = match std::str::from_utf8(&call.args) {
+            Ok(text) if serde_json::from_str::<serde_json::Value>(text).is_ok() => text.to_string(),
+            _ => format!("0x{}", hex::encode(&call.args)),
         };
         format!(
             "contract: {contract_id}\nmethod:   {}\ngas:      {}\ndeposit:  {}\nargs:     {args}",

--- a/crates/near-mpc-contract-interface/src/deposits.rs
+++ b/crates/near-mpc-contract-interface/src/deposits.rs
@@ -6,3 +6,51 @@
 pub const SUBMIT_PARTICIPANT_INFO_DEPOSIT_MILLINEAR: u128 = 100;
 
 pub const SIGN_DEPOSIT_YOCTONEAR: u128 = 1;
+
+pub const STORAGE_BYTE_COST_YOCTONEAR: u128 = 10_000_000_000_000_000_000;
+
+pub const PROPOSE_UPDATE_ENTRY_OVERHEAD_BYTES: u128 = 32_768;
+
+#[derive(Debug, PartialEq, Eq, thiserror::Error)]
+#[error("the required deposit exceeds u128::MAX yoctoNEAR")]
+pub struct DepositOverflowError;
+
+pub fn propose_update_required_deposit_yoctonear(
+    payload_bytes: u128,
+    storage_byte_cost_yoctonear: u128,
+) -> Result<u128, DepositOverflowError> {
+    PROPOSE_UPDATE_ENTRY_OVERHEAD_BYTES
+        .checked_add(payload_bytes)
+        .and_then(|bytes| storage_byte_cost_yoctonear.checked_mul(bytes))
+        .ok_or(DepositOverflowError)
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::{
+        DepositOverflowError, STORAGE_BYTE_COST_YOCTONEAR,
+        propose_update_required_deposit_yoctonear,
+    };
+
+    #[test]
+    fn propose_update_required_deposit__should_error_when_the_deposit_overflows() {
+        // Given
+        let payload_bytes = u128::MAX;
+
+        // When
+        let result =
+            propose_update_required_deposit_yoctonear(payload_bytes, STORAGE_BYTE_COST_YOCTONEAR);
+
+        // Then
+        assert_eq!(result, Err(DepositOverflowError));
+    }
+
+    #[test]
+    fn STORAGE_BYTE_COST_YOCTONEAR__should_match_env_storage_byte_cost() {
+        assert_eq!(
+            near_sdk::env::storage_byte_cost().as_yoctonear(),
+            STORAGE_BYTE_COST_YOCTONEAR
+        );
+    }
+}

--- a/crates/near-mpc-contract-interface/src/lib.rs
+++ b/crates/near-mpc-contract-interface/src/lib.rs
@@ -37,7 +37,7 @@ pub mod types {
     };
     pub use tee::{AllowedMpcDockerImageHash, NodeId};
 
-    pub use updates::{ProposeUpdateArgs, ProposedUpdates, UpdateHash};
+    pub use updates::{PayloadBytesError, ProposeUpdateArgs, ProposedUpdates, UpdateHash};
 
     // Re-export hash types used in attestation DTO fields
     pub use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash, Sha384Digest};

--- a/crates/near-mpc-contract-interface/src/snapshots/near_mpc_contract_interface__client__tests__mpc_contract_handle__should_match_the_wire_format_catalog.snap
+++ b/crates/near-mpc-contract-interface/src/snapshots/near_mpc_contract_interface__client__tests__mpc_contract_handle__should_match_the_wire_format_catalog.snap
@@ -27,6 +27,18 @@ deposit:  1 yoctoNEAR
 args:     {"request":{"request":{"Bitcoin":{"tx_id":"0707070707070707070707070707070707070707070707070707070707070707","confirmations":1,"extractors":["BlockHash"]}},"domain_id":0,"payload_version":1}}
 
 contract: mpc.near
+method:   propose_update
+gas:      300.0 Tgas
+deposit:  0.32772 NEAR
+args:     0x01040000000707070700
+
+contract: mpc.near
+method:   vote_update
+gas:      300.0 Tgas
+deposit:  0 NEAR
+args:     {"id":7}
+
+contract: mpc.near
 method:   submit_participant_info
 gas:      300.0 Tgas
 deposit:  0.1 NEAR

--- a/crates/near-mpc-contract-interface/src/types/updates.rs
+++ b/crates/near-mpc-contract-interface/src/types/updates.rs
@@ -60,3 +60,28 @@ pub struct ProposeUpdateArgs {
     pub code: Option<Vec<u8>>,
     pub config: Option<Config>,
 }
+
+impl ProposeUpdateArgs {
+    pub fn payload_bytes(&self) -> Result<u128, PayloadBytesError> {
+        let code_bytes = self.code.as_ref().map_or(0, |code| code.len());
+        let config_bytes = self
+            .config
+            .as_ref()
+            .map(serde_json::to_vec)
+            .transpose()?
+            .map_or(0, |config| config.len());
+        code_bytes
+            .checked_add(config_bytes)
+            .and_then(|payload_bytes| u128::try_from(payload_bytes).ok())
+            .ok_or(PayloadBytesError::Overflow)
+    }
+}
+
+/// Sizing a proposal's payload failed.
+#[derive(Debug, thiserror::Error)]
+pub enum PayloadBytesError {
+    #[error("the config does not serialize to JSON: {0}")]
+    Serialize(#[from] serde_json::Error),
+    #[error("the payload exceeds u128::MAX bytes")]
+    Overflow,
+}


### PR DESCRIPTION
Resolves #3919, part of #3693

This turned out more complex than anticipated, because I wanted the contract and interface to share the logic calculating the required deposit for update proposals.
Since we lacked a test for assessing whether the contract charges the correct deposits for updates, this PR adds that as well.

In the course of this, I discovered that we never use `UpdateEntry::bytes_used`, but deferred deleting that field to later, as it would require migration logic (c.f. #3965).