### PR TITLE
refactor: THRESHOLD into GOVERNANCE_THRESHOLD

### DIFF
--- a/crates/node/src/keyshare/test_utils.rs
+++ b/crates/node/src/keyshare/test_utils.rs
@@ -8,7 +8,7 @@ use threshold_signatures::frost_secp256k1::Secp256K1Sha256;
 use threshold_signatures::test_utils::{generate_participants_with_random_ids, run_keygen};
 
 const NUM_PARTICIPANTS: usize = 2;
-const GOVERNANCE_THRESHOLD: usize = 2;
+const RECONSTRUCTION_THRESHOLD: usize = 2;
 
 pub fn make_key_id(epoch_id: u64, domain_id: u64, attempt_id: u64) -> KeyEventId {
     KeyEventId::new(
@@ -26,7 +26,7 @@ pub fn generate_dummy_keyshares<R: CryptoRng + RngCore + SeedableRng + Send + 's
 ) -> (Keyshare, Keyshare) {
     let keyshares: std::collections::HashMap<_, _> = run_keygen::<Secp256K1Sha256, _>(
         &generate_participants_with_random_ids(NUM_PARTICIPANTS, rng),
-        GOVERNANCE_THRESHOLD,
+        RECONSTRUCTION_THRESHOLD,
         rng,
     )
     .into_iter()
@@ -67,7 +67,7 @@ pub fn generate_dummy_keyshare<R: CryptoRng + RngCore + SeedableRng + Send + 'st
 ) -> Keyshare {
     let key = run_keygen::<Secp256K1Sha256, _>(
         &generate_participants_with_random_ids(NUM_PARTICIPANTS, rng),
-        GOVERNANCE_THRESHOLD,
+        RECONSTRUCTION_THRESHOLD,
         rng,
     )
     .into_iter()

--- a/crates/node/src/keyshare/test_utils.rs
+++ b/crates/node/src/keyshare/test_utils.rs
@@ -8,7 +8,7 @@ use threshold_signatures::frost_secp256k1::Secp256K1Sha256;
 use threshold_signatures::test_utils::{generate_participants_with_random_ids, run_keygen};
 
 const NUM_PARTICIPANTS: usize = 2;
-const THRESHOLD: usize = 2;
+const GOVERNANCE_THRESHOLD: usize = 2;
 
 pub fn make_key_id(epoch_id: u64, domain_id: u64, attempt_id: u64) -> KeyEventId {
     KeyEventId::new(
@@ -26,7 +26,7 @@ pub fn generate_dummy_keyshares<R: CryptoRng + RngCore + SeedableRng + Send + 's
 ) -> (Keyshare, Keyshare) {
     let keyshares: std::collections::HashMap<_, _> = run_keygen::<Secp256K1Sha256, _>(
         &generate_participants_with_random_ids(NUM_PARTICIPANTS, rng),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         rng,
     )
     .into_iter()
@@ -67,7 +67,7 @@ pub fn generate_dummy_keyshare<R: CryptoRng + RngCore + SeedableRng + Send + 'st
 ) -> Keyshare {
     let key = run_keygen::<Secp256K1Sha256, _>(
         &generate_participants_with_random_ids(NUM_PARTICIPANTS, rng),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         rng,
     )
     .into_iter()

--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -51,11 +51,11 @@ pub trait MeshNetworkTransportSender: Send + Sync + 'static {
     /// Sends a message to everyone on a best-effort basis about the current height of our indexer.
     fn send_indexer_height(&self, height: IndexerHeightMessage);
 
-    /// Waits for `threshold` number of connections (a freebie is included for the node itself)
+    /// Waits for `required_ready_count` number of connections (a freebie is included for the node itself)
     /// to the given `peers` to be bidirectionally established at the same time.
     async fn wait_for_ready(
         &self,
-        threshold: usize,
+        required_ready_count: usize,
         peers_to_consider: &[ParticipantId],
     ) -> anyhow::Result<()>;
 }
@@ -898,7 +898,7 @@ pub mod testing {
 
         async fn wait_for_ready(
             &self,
-            _threshold: usize,
+            _required_ready_count: usize,
             _peers_to_consider: &[ParticipantId],
         ) -> anyhow::Result<()> {
             Ok(())

--- a/crates/node/src/network/conn.rs
+++ b/crates/node/src/network/conn.rs
@@ -300,10 +300,17 @@ impl<I: Send + Sync + 'static, O: Send + Sync + 'static> AllNodeConnectivities<I
         Self { connectivities }
     }
 
-    /// Waits for `threshold` number of connections (a freebie is included for the node itself)
+    /// Waits for `required_ready_count` number of connections (a freebie is included for the node itself)
     /// to the given `peers` to be bidirectionally established at the same time.
-    pub async fn wait_for_ready(&self, threshold: usize, peers_to_consider: &[ParticipantId]) {
-        info!("Waiting for {:?} participants to be ready.", threshold - 1);
+    pub async fn wait_for_ready(
+        &self,
+        required_ready_count: usize,
+        peers_to_consider: &[ParticipantId],
+    ) {
+        info!(
+            "Waiting for {:?} participants to be ready.",
+            required_ready_count - 1
+        );
 
         let mut receivers = self
             .connectivities
@@ -321,7 +328,7 @@ impl<I: Send + Sync + 'static, O: Send + Sync + 'static> AllNodeConnectivities<I
                     connected_count += 1;
                 }
             }
-            if connected_count + 1 >= threshold {
+            if connected_count + 1 >= required_ready_count {
                 break;
             }
 

--- a/crates/node/src/network/conn.rs
+++ b/crates/node/src/network/conn.rs
@@ -308,6 +308,7 @@ impl<I: Send + Sync + 'static, O: Send + Sync + 'static> AllNodeConnectivities<I
         peers_to_consider: &[ParticipantId],
     ) {
         info!(
+            // Subtract the freebie for this node itself, so the count reflects the peers we still wait on.
             "Waiting for {:?} participants to be ready.",
             required_ready_count - 1
         );

--- a/crates/node/src/p2p.rs
+++ b/crates/node/src/p2p.rs
@@ -943,11 +943,11 @@ impl MeshNetworkTransportSender for TlsMeshSender {
 
     async fn wait_for_ready(
         &self,
-        threshold: usize,
+        required_ready_count: usize,
         peers_to_consider: &[ParticipantId],
     ) -> anyhow::Result<()> {
         self.connectivities
-            .wait_for_ready(threshold, peers_to_consider)
+            .wait_for_ready(required_ready_count, peers_to_consider)
             .await;
         Ok(())
     }
@@ -1014,7 +1014,7 @@ pub mod testing {
 
     pub fn generate_test_p2p_configs(
         participant_accounts: &[AccountId],
-        threshold: usize,
+        governance_threshold: usize,
         // this is a hack to make sure that when tests run in parallel, they don't
         // collide on the same port.
         ports: &TestPorts,
@@ -1041,7 +1041,7 @@ pub mod testing {
         let mut configs = Vec::new();
         for (i, singing_key) in p2p_keypairs.into_iter().enumerate() {
             let participants = ParticipantsConfig {
-                threshold: threshold as u64,
+                threshold: governance_threshold as u64,
                 participants: participants.clone(),
             };
 

--- a/crates/node/src/tests.rs
+++ b/crates/node/src/tests.rs
@@ -190,13 +190,13 @@ impl IntegrationTestSetup {
         clock: Clock,
         temp_dir: &Path,
         participant_accounts: Vec<AccountId>,
-        threshold: usize,
+        governance_threshold: usize,
         txn_delay_blocks: u64,
         ports: TestPorts,
         block_time: std::time::Duration,
     ) -> IntegrationTestSetup {
         let p2p_configs =
-            generate_test_p2p_configs(&participant_accounts, threshold, &ports).unwrap();
+            generate_test_p2p_configs(&participant_accounts, governance_threshold, &ports).unwrap();
         let participants = p2p_configs[0].0.participants.clone();
         let mut indexer_manager =
             FakeIndexerManager::new(clock.clone(), txn_delay_blocks, block_time);

--- a/crates/node/src/tests/asset_generation_signing_contention.rs
+++ b/crates/node/src/tests/asset_generation_signing_contention.rs
@@ -69,7 +69,8 @@ use near_time::Clock;
 use std::time::Duration;
 
 const NUM_PARTICIPANTS: usize = 4;
-const THRESHOLD: usize = 3;
+const GOVERNANCE_THRESHOLD: usize = 3;
+const RECONSTRUCTION_THRESHOLD: usize = 3;
 const TXN_DELAY_BLOCKS: u64 = 1;
 
 // The only knob that differs between the two scenarios is the desired triple
@@ -195,7 +196,7 @@ async fn measure_signing_latency(
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{i}").parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::ASSET_GENERATION_SIGNING_CONTENTION_TEST.with_case(case),
         DEFAULT_BLOCK_TIME,
@@ -204,7 +205,7 @@ async fn measure_signing_latency(
     let ecdsa_domain = DomainConfig {
         id: DomainId(0),
         protocol: Protocol::CaitSith,
-        reconstruction_threshold: ReconstructionThreshold::new(THRESHOLD as u64),
+        reconstruction_threshold: ReconstructionThreshold::new(RECONSTRUCTION_THRESHOLD as u64),
         purpose: DomainPurpose::Sign,
     };
 

--- a/crates/node/src/tests/basic_cluster.rs
+++ b/crates/node/src/tests/basic_cluster.rs
@@ -18,7 +18,7 @@ use near_time::Clock;
 #[test_log::test]
 async fn test_basic_cluster() {
     const NUM_PARTICIPANTS: usize = 4;
-    const THRESHOLD: usize = 3;
+    const GOVERNANCE_THRESHOLD: usize = 3;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup: IntegrationTestSetup = IntegrationTestSetup::new(
@@ -27,7 +27,7 @@ async fn test_basic_cluster() {
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::BASIC_CLUSTER_TEST,
         DEFAULT_BLOCK_TIME,

--- a/crates/node/src/tests/changing_participant_details.rs
+++ b/crates/node/src/tests/changing_participant_details.rs
@@ -23,7 +23,7 @@ use near_time::Clock;
 #[test_log::test]
 async fn test_changing_participant_set_test_keyshare_import() {
     const NUM_PARTICIPANTS: usize = 2;
-    const THRESHOLD: usize = 2;
+    const GOVERNANCE_THRESHOLD: usize = 2;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut account_ids: Vec<_> = (0..NUM_PARTICIPANTS)
@@ -34,7 +34,7 @@ async fn test_changing_participant_set_test_keyshare_import() {
         Clock::real(),
         temp_dir.path(),
         account_ids,
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::RECOVERY_TEST,
         DEFAULT_BLOCK_TIME,

--- a/crates/node/src/tests/faulty.rs
+++ b/crates/node/src/tests/faulty.rs
@@ -21,7 +21,7 @@ use rand::Rng;
 #[test_log::test]
 async fn test_faulty_cluster() {
     const NUM_PARTICIPANTS: usize = 4;
-    const THRESHOLD: usize = 3;
+    const GOVERNANCE_THRESHOLD: usize = 3;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let accounts = (0..NUM_PARTICIPANTS)
@@ -31,7 +31,7 @@ async fn test_faulty_cluster() {
         Clock::real(),
         temp_dir.path(),
         accounts.clone(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::FAULTY_CLUSTER_TEST,
         DEFAULT_BLOCK_TIME,
@@ -169,7 +169,7 @@ async fn test_faulty_cluster() {
 #[test_log::test]
 async fn test_indexer_stuck() {
     const NUM_PARTICIPANTS: usize = 4;
-    const THRESHOLD: usize = 3;
+    const GOVERNANCE_THRESHOLD: usize = 3;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let accounts = (0..NUM_PARTICIPANTS)
@@ -179,7 +179,7 @@ async fn test_indexer_stuck() {
         Clock::real(),
         temp_dir.path(),
         accounts.clone(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::FAULTY_STUCK_INDEXER_TEST,
         std::time::Duration::from_millis(100),

--- a/crates/node/src/tests/foreign_chain_configuration.rs
+++ b/crates/node/src/tests/foreign_chain_configuration.rs
@@ -19,7 +19,8 @@ use std::time::Duration;
 async fn foreign_chain_configuration_auto_registered_to_contract_on_startup__should_use_local_config()
  {
     // Given
-    const THRESHOLD: usize = 2;
+    const GOVERNANCE_THRESHOLD: usize = 2;
+    const RECONSTRUCTION_THRESHOLD: usize = 2;
     const TXN_DELAY_BLOCKS: u64 = 1;
 
     let temp_dir = tempfile::tempdir().unwrap();
@@ -27,7 +28,7 @@ async fn foreign_chain_configuration_auto_registered_to_contract_on_startup__sho
         Clock::real(),
         temp_dir.path(),
         vec!["test0".parse().unwrap(), "test1".parse().unwrap()],
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::FOREIGN_CHAIN_POLICY_TEST,
         DEFAULT_BLOCK_TIME,
@@ -75,7 +76,7 @@ async fn foreign_chain_configuration_auto_registered_to_contract_on_startup__sho
         contract.add_domains(vec![DomainConfig {
             id: DomainId(0),
             protocol: Protocol::CaitSith,
-            reconstruction_threshold: ReconstructionThreshold::new(THRESHOLD as u64),
+            reconstruction_threshold: ReconstructionThreshold::new(RECONSTRUCTION_THRESHOLD as u64),
             purpose: DomainPurpose::ForeignTx,
         }]);
     }

--- a/crates/node/src/tests/multidomain.rs
+++ b/crates/node/src/tests/multidomain.rs
@@ -16,7 +16,7 @@ use near_time::Clock;
 #[test_log::test]
 async fn test_basic_multidomain() {
     const NUM_PARTICIPANTS: usize = 4;
-    const THRESHOLD: usize = 3;
+    const GOVERNANCE_THRESHOLD: usize = 3;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup = IntegrationTestSetup::new(
@@ -25,14 +25,14 @@ async fn test_basic_multidomain() {
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::BASIC_MULTIDOMAIN_TEST,
         std::time::Duration::from_millis(600), // helps to avoid flaky test
     );
 
     // TODO(#1689): in this test it would be desirable to add DamgardEtAl.
-    // That requires having NUM_PARTICIPANTS = 5 and THRESHOLD = 5
+    // That requires having NUM_PARTICIPANTS = 5 and GOVERNANCE_THRESHOLD = 5
     // which makes this test too slow to pass in CI, which should be fixed
     let mut domains = vec![
         sign_domain(0, Protocol::CaitSith, 3),

--- a/crates/node/src/tests/onboarding.rs
+++ b/crates/node/src/tests/onboarding.rs
@@ -70,7 +70,7 @@ impl MigrationTestNodeInfo {
 #[test_log::test]
 async fn test_onboarding() {
     const NUM_PARTICIPANTS: usize = 2;
-    const THRESHOLD: usize = 2;
+    const GOVERNANCE_THRESHOLD: usize = 2;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut account_ids: Vec<_> = (0..NUM_PARTICIPANTS)
@@ -81,7 +81,7 @@ async fn test_onboarding() {
         Clock::real(),
         temp_dir.path(),
         account_ids,
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::ONBOARDING_TEST,
         DEFAULT_BLOCK_TIME,

--- a/crates/node/src/tests/reconstruction_thresholds.rs
+++ b/crates/node/src/tests/reconstruction_thresholds.rs
@@ -71,7 +71,7 @@ async fn per_domain_reconstruction_threshold__should_gate_signing_availability_w
  {
     // Given a 5-node cluster with three domains at distinct thresholds.
     const NUM_PARTICIPANTS: usize = 5;
-    const THRESHOLD: usize = 3;
+    const GOVERNANCE_THRESHOLD: usize = 3;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup = IntegrationTestSetup::new(
@@ -80,7 +80,7 @@ async fn per_domain_reconstruction_threshold__should_gate_signing_availability_w
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::RECONSTRUCTION_THRESHOLD_AVAILABILITY_TEST,
         DEFAULT_BLOCK_TIME,
@@ -166,7 +166,7 @@ async fn per_domain_reconstruction_threshold__should_gate_signing_availability_w
 async fn resharing__should_apply_updated_thresholds_while_preserving_unchanged_ones() {
     // Given a cluster starting with 4 of an eventual 5 participants.
     const NUM_PARTICIPANTS: usize = 5;
-    const THRESHOLD: usize = 3;
+    const GOVERNANCE_THRESHOLD: usize = 3;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup = IntegrationTestSetup::new(
@@ -175,7 +175,7 @@ async fn resharing__should_apply_updated_thresholds_while_preserving_unchanged_o
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::RECONSTRUCTION_THRESHOLD_RESHARING_TEST,
         DEFAULT_BLOCK_TIME,

--- a/crates/node/src/tests/resharing.rs
+++ b/crates/node/src/tests/resharing.rs
@@ -35,9 +35,9 @@ fn infer_purpose_from_protocol(protocol: Protocol) -> DomainPurpose {
 async fn test_key_resharing_simple(
     #[case] case: u16,
     #[case] protocol: Protocol,
-    #[case] threshold: usize,
+    #[case] governance_threshold: usize,
 ) {
-    let num_participants: usize = threshold + 1;
+    let num_participants: usize = governance_threshold + 1;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup = IntegrationTestSetup::new(
@@ -46,7 +46,7 @@ async fn test_key_resharing_simple(
         (0..num_participants)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        threshold,
+        governance_threshold,
         TXN_DELAY_BLOCKS,
         port_seed::KEY_RESHARING_SIMPLE_TEST.with_case(case),
         DEFAULT_BLOCK_TIME,
@@ -166,7 +166,7 @@ async fn test_key_resharing_simple(
 #[test_log::test]
 async fn test_key_resharing_multistage() {
     const NUM_PARTICIPANTS: usize = 6;
-    const THRESHOLD: usize = 4;
+    const GOVERNANCE_THRESHOLD: usize = 4;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup = IntegrationTestSetup::new(
@@ -175,7 +175,7 @@ async fn test_key_resharing_multistage() {
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::KEY_RESHARING_MULTISTAGE_TEST,
         std::time::Duration::from_millis(600),
@@ -384,7 +384,7 @@ async fn test_key_resharing_multistage() {
 #[test_log::test]
 async fn test_signature_requests_in_resharing_are_processed() {
     const NUM_PARTICIPANTS: usize = 5;
-    const THRESHOLD: usize = 3;
+    const GOVERNANCE_THRESHOLD: usize = 3;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup = IntegrationTestSetup::new(
@@ -393,7 +393,7 @@ async fn test_signature_requests_in_resharing_are_processed() {
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::KEY_RESHARING_SIGNATURE_BUFFERING_TEST,
         DEFAULT_BLOCK_TIME,

--- a/crates/node/src/tests/update_participant_url.rs
+++ b/crates/node/src/tests/update_participant_url.rs
@@ -22,7 +22,7 @@ use near_time::Clock;
 async fn update_participant_url__should_keep_signing_when_peer_address_moved_to_dead_address() {
     // Given
     const NUM_PARTICIPANTS: usize = 2;
-    const THRESHOLD: usize = 2;
+    const GOVERNANCE_THRESHOLD: usize = 2;
     const TXN_DELAY_BLOCKS: u64 = 1;
     let temp_dir = tempfile::tempdir().unwrap();
     let mut setup = IntegrationTestSetup::new(
@@ -31,7 +31,7 @@ async fn update_participant_url__should_keep_signing_when_peer_address_moved_to_
         (0..NUM_PARTICIPANTS)
             .map(|i| format!("test{}", i).parse().unwrap())
             .collect(),
-        THRESHOLD,
+        GOVERNANCE_THRESHOLD,
         TXN_DELAY_BLOCKS,
         port_seed::UPDATE_PARTICIPANT_URL_TEST,
         DEFAULT_BLOCK_TIME,


### PR DESCRIPTION
Closes part of #3903. This PR is meant to change the THRESHOLD into GOVERNANCE_THRESHOLD. It also modifies the term threshold in generic functions into `required_ready_count`

Upcoming PR will touch upon Contract internal-only renames.