### PR TITLE
feat: probe Starknet by chain id and a recent transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3752,8 +3752,10 @@ dependencies = [
  "hex",
  "http",
  "httpmock",
+ "jsonrpsee",
  "mpc-node-config",
  "near-mpc-bounded-collections",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/crates/foreign-chain-config-tester/README.md
+++ b/crates/foreign-chain-config-tester/README.md
@@ -7,11 +7,31 @@ production.
 
 For each configured provider it runs a fixed request against a known reference
 transaction — the same inspector and auth handling the node uses — and compares
-the result against a known-good value. Sui is the exception: its providers prune
-transactions after a few weeks, so the check instead verifies the provider's
-chain identity and inspects a transaction from its latest checkpoint. Every
-provider is checked independently: one bad provider does not stop the others
-from being reported.
+the result against a known-good value. Sui and Starknet are the exceptions: they
+verify the provider's chain identity (a genesis-derived constant that is never
+pruned) and then inspect a recently produced transaction — Sui from its latest
+checkpoint, Starknet from its latest L1-accepted block (requires provider JSON-RPC
+v0.9+) — so the check never depends on
+months-old archived history. Every provider is checked independently: one bad
+provider does not stop the others from being reported.
+
+The expected identity of each identity-probed chain comes from configuration —
+there are no built-in values, so the check works for any network, including
+local or custom ones. A configured chain without an identity fails its check:
+
+```yaml
+foreign_chain_health_check:
+  identities:
+    starknet: "0x534e5f4d41494e"                              # felt; decode hex as ASCII
+    sui: "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S"       # base58 genesis checkpoint digest
+```
+
+Well-known values:
+
+| Chain    | Identity                | Mainnet                                        | Testnet                                        |
+|----------|-------------------------|------------------------------------------------|------------------------------------------------|
+| starknet | `starknet_chainId` felt | `0x534e5f4d41494e` (`SN_MAIN`)                 | `0x534e5f5345504f4c4941` (`SN_SEPOLIA`)        |
+| sui      | genesis digest (base58) | `4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S` | `69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD` |
 
 ## Usage
 

--- a/crates/foreign-chain-config-tester/src/config.rs
+++ b/crates/foreign-chain-config-tester/src/config.rs
@@ -12,7 +12,7 @@ use serde::Deserialize;
 use serde::de::IntoDeserializer;
 use serde::de::value::{Error as ValueError, StrDeserializer};
 
-use foreign_chain_health_check::Network;
+use foreign_chain_health_check::{ExpectedIdentities, Network};
 
 /// Paths where `foreign_chains` may live, most-nested first so a wrapped config
 /// matches before a barer one.
@@ -31,6 +31,19 @@ const CONTRACT_ID_PATHS: &[&[&str]] = &[
     &["mpc_node_config", "node", "indexer", "mpc_contract_id"],
     &["node", "indexer", "mpc_contract_id"],
     &["indexer", "mpc_contract_id"],
+];
+
+/// Where the per-chain expected identities live: an `identities` map (chain label ->
+/// expected identity) under a sibling of `foreign_chains`.
+const EXPECTED_IDENTITY_PATHS: &[&[&str]] = &[
+    &[
+        "mpc_node_config",
+        "node",
+        "foreign_chain_health_check",
+        "identities",
+    ],
+    &["node", "foreign_chain_health_check", "identities"],
+    &["foreign_chain_health_check", "identities"],
 ];
 
 fn classify_network(chain_id: Option<&str>, contract_id: Option<&str>) -> Option<Network> {
@@ -63,33 +76,47 @@ fn format_from_path(path: &Path) -> anyhow::Result<Format> {
     }
 }
 
-/// Empty when no `foreign_chains` section is present.
-pub fn parse_foreign_chains(contents: &str, path: &Path) -> anyhow::Result<ForeignChainsConfig> {
+/// Deserializes the subtree at the first of `paths` present in the config into `T`;
+/// `T::default()` when none matches.
+fn find_and_parse<T>(
+    contents: &str,
+    path: &Path,
+    paths: &[&[&str]],
+    what: &str,
+) -> anyhow::Result<T>
+where
+    T: serde::de::DeserializeOwned + Default,
+{
     match format_from_path(path)? {
         Format::Yaml => {
             let root: serde_yaml::Value =
                 serde_yaml::from_str(contents).context("parse YAML config")?;
-            for keys in FOREIGN_CHAINS_PATHS {
+            for keys in paths {
                 if let Some(section) = keys.iter().try_fold(&root, |v, k| v.get(k)) {
                     return serde_yaml::from_value(section.clone())
-                        .context("parse foreign_chains section");
+                        .with_context(|| format!("parse {what} section"));
                 }
             }
-            Ok(ForeignChainsConfig::default())
+            Ok(T::default())
         }
         Format::Toml => {
             let root: toml::Value = toml::from_str(contents).context("parse TOML config")?;
-            for keys in FOREIGN_CHAINS_PATHS {
+            for keys in paths {
                 if let Some(section) = keys.iter().try_fold(&root, |v, k| v.get(*k)) {
                     return section
                         .clone()
                         .try_into()
-                        .context("parse foreign_chains section");
+                        .with_context(|| format!("parse {what} section"));
                 }
             }
-            Ok(ForeignChainsConfig::default())
+            Ok(T::default())
         }
     }
+}
+
+/// Empty when no `foreign_chains` section is present.
+pub fn parse_foreign_chains(contents: &str, path: &Path) -> anyhow::Result<ForeignChainsConfig> {
+    find_and_parse(contents, path, FOREIGN_CHAINS_PATHS, "foreign_chains")
 }
 
 fn toml_str<'a>(root: &'a toml::Value, path: &[&str]) -> Option<&'a str> {
@@ -98,6 +125,20 @@ fn toml_str<'a>(root: &'a toml::Value, path: &[&str]) -> Option<&'a str> {
 
 fn yaml_str<'a>(root: &'a serde_yaml::Value, path: &[&str]) -> Option<&'a str> {
     path.iter().try_fold(root, |v, k| v.get(k))?.as_str()
+}
+
+/// Per-chain expected identities from config. Absent chains stay `None` (their check then
+/// fails until configured); an unknown chain key or non-string value is a hard error.
+pub fn detect_expected_identities(
+    contents: &str,
+    path: &Path,
+) -> anyhow::Result<ExpectedIdentities> {
+    find_and_parse(
+        contents,
+        path,
+        EXPECTED_IDENTITY_PATHS,
+        "foreign_chain_health_check.identities",
+    )
 }
 
 /// `None` when the config carries no conclusive network signal.
@@ -265,5 +306,58 @@ foreign_chains:
 
         // Then
         assert_eq!(network, None);
+    }
+
+    #[test]
+    fn detect_expected_identities__should_read_seeded_value_from_dstack_toml() {
+        // Given an `identities` map nested under the dstack `mpc_node_config.node` prefix
+        let toml = "[mpc_node_config.node.foreign_chain_health_check.identities]\n\
+                    starknet = \"0x534e5f4d41494e\"\n";
+
+        // When
+        let ids = detect_expected_identities(toml, Path::new("user-config.toml")).unwrap();
+
+        // Then
+        assert_eq!(ids.starknet.as_deref(), Some("0x534e5f4d41494e"));
+    }
+
+    #[test]
+    fn detect_expected_identities__should_read_seeded_value_from_top_level_yaml() {
+        // Given
+        let yaml = "foreign_chain_health_check:\n  identities:\n    starknet: \"0x534e5f5345504f4c4941\"\n";
+
+        // When
+        let ids = detect_expected_identities(yaml, Path::new("config.yaml")).unwrap();
+
+        // Then
+        assert_eq!(ids.starknet.as_deref(), Some("0x534e5f5345504f4c4941"));
+    }
+
+    #[test]
+    fn detect_expected_identities__should_reject_non_string_value() {
+        // Given a known chain's identity mistyped as a number (easy to do in TOML)
+        let toml = "[foreign_chain_health_check.identities]\nstarknet = 1\n";
+
+        // When / Then — a loud parse error, not a silently dropped entry
+        detect_expected_identities(toml, Path::new("config.toml")).unwrap_err();
+    }
+
+    #[test]
+    fn detect_expected_identities__should_reject_unknown_chain_key() {
+        // Given a misspelled chain label
+        let toml = "[foreign_chain_health_check.identities]\nstartknet = \"0x1\"\n";
+
+        // When / Then — the typo errors instead of silently doing nothing
+        detect_expected_identities(toml, Path::new("config.toml")).unwrap_err();
+    }
+
+    #[test]
+    fn detect_expected_identities__should_be_empty_when_absent() {
+        // Given / When
+        let ids =
+            detect_expected_identities("home_dir = \"/data\"\n", Path::new("config.toml")).unwrap();
+
+        // Then
+        assert!(ids.starknet.is_none() && ids.sui.is_none());
     }
 }

--- a/crates/foreign-chain-config-tester/src/main.rs
+++ b/crates/foreign-chain-config-tester/src/main.rs
@@ -1,6 +1,7 @@
 //! Foreign-chain RPC config tester: probe every configured provider with a fixed
 //! golden request so operators can verify their config without running the node.
-//! Sui is probed differently — see the README.
+//! Sui and Starknet are probed by chain identity plus a dynamically discovered
+//! transaction instead — see the README.
 
 mod config;
 mod report;
@@ -15,7 +16,7 @@ use foreign_chain_health_check::{Network, check_all_providers};
 
 /// Verify a node's foreign-chain RPC provider configuration.
 ///
-/// Probes every configured provider with a fixed golden request.
+/// Probes every configured provider against a known reference value.
 #[derive(Parser)]
 #[command(about, long_about = None)]
 struct Args {
@@ -23,7 +24,7 @@ struct Args {
     #[arg(long)]
     config: PathBuf,
 
-    /// Network the reference transactions belong to. Auto-detected from
+    /// Network the reference values belong to. Auto-detected from
     /// the config (`chain_id` / `mpc_contract_id`) when omitted.
     #[arg(long, value_enum)]
     network: Option<Network>,
@@ -35,6 +36,7 @@ async fn main() -> anyhow::Result<ExitCode> {
     let contents = fs::read_to_string(&args.config)
         .with_context(|| format!("failed to read {}", args.config.display()))?;
     let foreign_chains = config::parse_foreign_chains(&contents, &args.config)?;
+    let identities = config::detect_expected_identities(&contents, &args.config)?;
     let network = match args.network {
         Some(network) => network,
         None => config::detect_network(&contents, &args.config)?.ok_or_else(|| {
@@ -45,7 +47,7 @@ async fn main() -> anyhow::Result<ExitCode> {
         })?,
     };
 
-    let results = check_all_providers(&foreign_chains, network).await;
+    let results = check_all_providers(&foreign_chains, network, &identities).await;
     print!("{}", report::render(&results));
 
     Ok(if report::any_failed(&results) {

--- a/crates/foreign-chain-health-check/Cargo.toml
+++ b/crates/foreign-chain-health-check/Cargo.toml
@@ -16,13 +16,16 @@ foreign-chain-rpc-auth = { workspace = true }
 foreign-chain-rpc-interfaces = { workspace = true }
 hex = { workspace = true }
 http = { workspace = true }
+jsonrpsee = { workspace = true }
 mpc-node-config = { workspace = true }
+serde = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
 httpmock = { workspace = true }
 near-mpc-bounded-collections = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 
 [lints]

--- a/crates/foreign-chain-health-check/src/checks.rs
+++ b/crates/foreign-chain-health-check/src/checks.rs
@@ -1,4 +1,6 @@
-//! Per-provider golden checks: run a fixed request and verify the extracted value.
+//! Per-provider checks. Golden-transaction chains run a fixed request and verify the
+//! extracted value; identity-based chains (Sui, Starknet) verify the chain identity and
+//! inspect a dynamically discovered recent transaction instead.
 
 use std::time::Duration;
 
@@ -17,7 +19,7 @@ use foreign_chain_inspector::{
     evm::inspector::{EvmChain, EvmExtractedValue, EvmExtractor, EvmInspector},
     http_client::HttpClient,
     starknet::{
-        StarknetExtractedValue, StarknetTransactionHash,
+        StarknetTransactionHash,
         inspector::{StarknetExtractor, StarknetFinality, StarknetInspector},
     },
     sui::{
@@ -26,8 +28,10 @@ use foreign_chain_inspector::{
     },
 };
 use foreign_chain_rpc_interfaces::aptos::ReqwestAptosClient;
+use foreign_chain_rpc_interfaces::starknet::{BlockId, BlockTag};
 use foreign_chain_rpc_interfaces::sui::SuiRpcClient;
 use http::{HeaderName, HeaderValue};
+use jsonrpsee::core::client::ClientT;
 
 use crate::golden;
 
@@ -122,25 +126,92 @@ pub async fn check_bitcoin(
     }
 }
 
-pub async fn check_starknet(
-    client: HttpClient,
-    tx: [u8; 32],
-    expected_block_hash: [u8; 32],
-) -> anyhow::Result<()> {
+/// Where probing starts: this many blocks below the L1-accepted head.
+const HEAD_PROBE_OFFSET: u64 = 10;
+
+/// Cap on the exponential walk-back (the step doubles each try) before giving up.
+const MAX_WALKBACK_BLOCKS: u64 = 1024;
+
+/// Verifies the network via `starknet_chainId`, then runs the inspector at `AcceptedOnL1`
+/// over a transaction from a recent block — walking back past empty or not-yet-final ones.
+/// Requires provider JSON-RPC v0.9+ (the `l1_accepted` block tag).
+pub async fn check_starknet<C>(client: C, expected_chain_id: &str) -> anyhow::Result<()>
+where
+    C: ClientT + Send + Sync,
+{
     let inspector = StarknetInspector::new(client);
-    let values = inspector
-        .extract(
-            StarknetTransactionHash::from(tx),
-            StarknetFinality::AcceptedOnL1,
-            vec![StarknetExtractor::BlockHash],
-        )
-        .await?;
-    match values.into_iter().next().context("RPC returned no value")? {
-        StarknetExtractedValue::BlockHash(hash) => {
-            let got: [u8; 32] = hash.into();
-            verify_block_hash(expected_block_hash, got)
+
+    let chain_id = inspector
+        .chain_id()
+        .await
+        .context("failed to fetch chain id")?;
+    let expected = golden::felt32(expected_chain_id).context("invalid expected chain id")?;
+    if *chain_id.as_fixed_bytes() != expected {
+        return Err(Mismatch::ChainId {
+            expected: expected_chain_id.to_string(),
+            got: format!("{chain_id:#x}"),
         }
-        StarknetExtractedValue::Log(_) => bail!("expected a block hash, got a log"),
+        .into());
+    }
+
+    let head = inspector
+        .block_with_tx_hashes(BlockId::Tag(BlockTag::L1Accepted))
+        .await
+        .context("failed to fetch the latest L1-accepted block")?;
+    let probe_number = head
+        .block_number
+        .checked_sub(HEAD_PROBE_OFFSET)
+        .with_context(|| {
+            format!(
+                "chain height {} is below the probe offset {HEAD_PROBE_OFFSET}",
+                head.block_number
+            )
+        })?;
+    let mut block = inspector
+        .block_with_tx_hashes(BlockId::Number {
+            block_number: probe_number,
+        })
+        .await
+        .context("failed to fetch the probe block")?;
+
+    // Walk back until a transaction verifies. An empty block or a `NotFinalized` receipt (a
+    // lagging load-balanced backend) steps earlier; any other error is a real failure.
+    let mut step = 1;
+    let mut walked_back = 0;
+    loop {
+        if let Some(tx) = block.transactions.first() {
+            let tx_hash = StarknetTransactionHash::from(*tx.as_fixed_bytes());
+            match inspector
+                .extract(
+                    tx_hash,
+                    StarknetFinality::AcceptedOnL1,
+                    vec![StarknetExtractor::Log { log_index: 0 }],
+                )
+                .await
+            {
+                Ok(_)
+                | Err(ForeignChainInspectionError::TransactionFailed)
+                | Err(ForeignChainInspectionError::LogIndexOutOfBounds) => return Ok(()),
+                Err(ForeignChainInspectionError::NotFinalized) => {}
+                Err(e) => {
+                    return Err(e).context("failed to inspect a transaction from a recent block");
+                }
+            }
+        }
+        walked_back += step;
+        if walked_back > MAX_WALKBACK_BLOCKS {
+            bail!("no L1-final transaction within {MAX_WALKBACK_BLOCKS} blocks of the probe block");
+        }
+        let earlier = block.block_number.checked_sub(step).context(
+            "walked back past the genesis block without finding an L1-final transaction",
+        )?;
+        block = inspector
+            .block_with_tx_hashes(BlockId::Number {
+                block_number: earlier,
+            })
+            .await
+            .context("failed to fetch an earlier block")?;
+        step *= 2;
     }
 }
 
@@ -254,7 +325,252 @@ mod tests {
     use crate::golden;
     use crate::network::Network;
     use assert_matches::assert_matches;
+    use foreign_chain_rpc_interfaces::starknet::{
+        GetBlockWithTxHashesResponse, GetTransactionReceiptResponse, H256, StarknetEvent,
+        StarknetExecutionStatus, StarknetFinalityStatus,
+    };
     use httpmock::prelude::*;
+    use jsonrpsee::core::client::{BatchResponse, error::Error as RpcError};
+    use jsonrpsee::core::params::BatchRequestBuilder;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// A [`ClientT`] that returns queued JSON values in call order, ignoring method and params
+    /// (mirrors the inspector crate's sequential mock). Lets `check_starknet`'s fixed call
+    /// sequence — chainId, L1-accepted head, probe block, receipt, canonical block — be scripted.
+    struct SequentialMockClient {
+        responses: Vec<serde_json::Value>,
+        calls: AtomicUsize,
+    }
+
+    impl SequentialMockClient {
+        fn new(responses: Vec<serde_json::Value>) -> Self {
+            Self {
+                responses,
+                calls: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl ClientT for SequentialMockClient {
+        async fn request<R, Params>(&self, _method: &str, _params: Params) -> Result<R, RpcError>
+        where
+            R: serde::de::DeserializeOwned,
+        {
+            let i = self.calls.fetch_add(1, Ordering::SeqCst);
+            let value = self.responses.get(i).cloned().unwrap_or_else(|| {
+                panic!(
+                    "mock received call #{} but only {} responses were queued",
+                    i + 1,
+                    self.responses.len()
+                )
+            });
+            serde_json::from_value(value).map_err(RpcError::ParseError)
+        }
+
+        async fn notification<Params>(
+            &self,
+            _method: &str,
+            _params: Params,
+        ) -> Result<(), RpcError> {
+            unimplemented!("notification() not used in tests")
+        }
+
+        async fn batch_request<'a, R>(
+            &self,
+            _batch: BatchRequestBuilder<'a>,
+        ) -> Result<BatchResponse<'a, R>, RpcError>
+        where
+            R: serde::de::DeserializeOwned + std::fmt::Debug + 'a,
+        {
+            unimplemented!("batch_request() not used in tests")
+        }
+    }
+
+    const STARKNET_MAINNET_CHAIN_ID: &str = "0x534e5f4d41494e";
+
+    fn starknet_receipt() -> GetTransactionReceiptResponse {
+        GetTransactionReceiptResponse {
+            block_hash: H256::from([4; 32]),
+            block_number: 842_750,
+            events: vec![StarknetEvent {
+                data: vec![H256::from([0xab; 32])],
+                from_address: H256::from([0x11; 32]),
+                keys: vec![H256::from([0xcc; 32])],
+            }],
+            finality_status: StarknetFinalityStatus::AcceptedOnL1,
+            execution_status: StarknetExecutionStatus::Succeeded,
+        }
+    }
+
+    fn json(value: impl serde::Serialize) -> serde_json::Value {
+        serde_json::to_value(value).unwrap()
+    }
+
+    #[tokio::test]
+    async fn check_starknet__should_pass_when_chain_id_matches_and_a_recent_tx_verifies() {
+        // Given a provider on the expected network whose probe block (10 below the latest
+        // L1-accepted head) carries a transaction the inspector can verify (final, canonical, succeeded).
+        let receipt = starknet_receipt();
+        let head = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([9; 32]),
+            block_number: 900_000,
+            transactions: vec![],
+        };
+        let probe = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([8; 32]),
+            block_number: 899_990,
+            transactions: vec![H256::from([3; 32])],
+        };
+        let canonical = GetBlockWithTxHashesResponse {
+            block_hash: receipt.block_hash,
+            block_number: receipt.block_number,
+            transactions: vec![],
+        };
+        let client = SequentialMockClient::new(vec![
+            json(STARKNET_MAINNET_CHAIN_ID),
+            json(&head),
+            json(&probe),
+            json(&receipt),
+            json(&canonical),
+        ]);
+
+        // When
+        let result = check_starknet(client, STARKNET_MAINNET_CHAIN_ID).await;
+
+        // Then
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_starknet__should_fail_when_chain_id_differs() {
+        // Given a provider reporting a different network's chain id; the probe must reject it
+        // before spending any further calls.
+        let client = SequentialMockClient::new(vec![json("0x534e5f5345504f4c4941")]);
+
+        // When
+        let result = check_starknet(client, STARKNET_MAINNET_CHAIN_ID).await;
+
+        // Then
+        assert_matches!(
+            result.unwrap_err().downcast_ref::<Mismatch>(),
+            Some(Mismatch::ChainId { .. })
+        );
+    }
+
+    #[tokio::test]
+    async fn check_starknet__should_walk_back_when_the_probe_block_is_empty() {
+        // Given the right network, an empty probe block, and a verifiable transaction in the
+        // block before it.
+        let receipt = starknet_receipt();
+        let head = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([9; 32]),
+            block_number: 900_000,
+            transactions: vec![],
+        };
+        let empty_probe = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([8; 32]),
+            block_number: 899_990,
+            transactions: vec![],
+        };
+        let earlier = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([7; 32]),
+            block_number: 899_989,
+            transactions: vec![H256::from([3; 32])],
+        };
+        let canonical = GetBlockWithTxHashesResponse {
+            block_hash: receipt.block_hash,
+            block_number: receipt.block_number,
+            transactions: vec![],
+        };
+        let client = SequentialMockClient::new(vec![
+            json(STARKNET_MAINNET_CHAIN_ID),
+            json(&head),
+            json(&empty_probe),
+            json(&earlier),
+            json(&receipt),
+            json(&canonical),
+        ]);
+
+        // When
+        let result = check_starknet(client, STARKNET_MAINNET_CHAIN_ID).await;
+
+        // Then
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_starknet__should_walk_back_when_the_probe_tx_is_not_yet_l1_final() {
+        // Given the right network: the probe block's tx is only L2-accepted (as a lagging
+        // load-balanced backend would report), but a tx in an earlier block is L1-final.
+        let l2_receipt = GetTransactionReceiptResponse {
+            finality_status: StarknetFinalityStatus::AcceptedOnL2,
+            ..starknet_receipt()
+        };
+        let l1_receipt = starknet_receipt();
+        let head = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([9; 32]),
+            block_number: 900_000,
+            transactions: vec![],
+        };
+        let probe = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([8; 32]),
+            block_number: 899_990,
+            transactions: vec![H256::from([3; 32])],
+        };
+        let earlier = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([7; 32]),
+            block_number: 899_989,
+            transactions: vec![H256::from([4; 32])],
+        };
+        let canonical = GetBlockWithTxHashesResponse {
+            block_hash: l1_receipt.block_hash,
+            block_number: l1_receipt.block_number,
+            transactions: vec![],
+        };
+        let client = SequentialMockClient::new(vec![
+            json(STARKNET_MAINNET_CHAIN_ID),
+            json(&head),
+            json(&probe),
+            json(&l2_receipt), // probe tx: not yet L1-final -> walk back
+            json(&earlier),
+            json(&l1_receipt), // earlier tx: L1-final -> pass
+            json(&canonical),
+        ]);
+
+        // When
+        let result = check_starknet(client, STARKNET_MAINNET_CHAIN_ID).await;
+
+        // Then
+        result.unwrap();
+    }
+
+    #[tokio::test]
+    async fn check_starknet__should_fail_when_no_l1_final_tx_within_the_walkback_cap() {
+        // Given the right network but every block within the walk-back cap is empty.
+        let head = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([9; 32]),
+            block_number: 1_000_000,
+            transactions: vec![],
+        };
+        let empty = GetBlockWithTxHashesResponse {
+            block_hash: H256::from([8; 32]),
+            block_number: 1_000_000,
+            transactions: vec![],
+        };
+        // More empty blocks than the exponential walk-back can consume before hitting the cap.
+        let responses = [json(STARKNET_MAINNET_CHAIN_ID), json(&head)]
+            .into_iter()
+            .chain(std::iter::repeat_with(|| json(&empty)).take(16))
+            .collect();
+        let client = SequentialMockClient::new(responses);
+
+        // When
+        let result = check_starknet(client, STARKNET_MAINNET_CHAIN_ID).await;
+
+        // Then
+        let error = format!("{:#}", result.unwrap_err());
+        assert!(error.contains("no L1-final transaction"), "{error}");
+    }
 
     fn golden_aptos_body(tx: &str, type_tag: &str, sequence_number: u64) -> serde_json::Value {
         serde_json::json!({
@@ -356,16 +672,18 @@ mod tests {
         }
     }
 
+    /// Sui mainnet's genesis checkpoint digest (`get_service_info` chain id).
+    const SUI_MAINNET_CHAIN_ID: &str = "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S";
+
     #[tokio::test]
     async fn check_sui__should_pass_when_provider_is_on_the_expected_network() {
         // Given
-        let sui = golden::golden_set(Network::Mainnet).sui.unwrap();
         let client = MockSuiClient {
-            chain_id: sui.chain_id.to_string(),
+            chain_id: SUI_MAINNET_CHAIN_ID.to_string(),
         };
 
         // When
-        let result = check_sui(client, sui.chain_id).await;
+        let result = check_sui(client, SUI_MAINNET_CHAIN_ID).await;
 
         // Then
         result.unwrap();
@@ -373,18 +691,13 @@ mod tests {
 
     #[tokio::test]
     async fn check_sui__should_fail_when_chain_id_differs() {
-        // Given — a provider on a different network.
+        // Given — a provider on a different network (the testnet genesis digest).
         let client = MockSuiClient {
-            chain_id: golden::golden_set(Network::Testnet)
-                .sui
-                .unwrap()
-                .chain_id
-                .to_string(),
+            chain_id: "69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD".to_string(),
         };
-        let expected = golden::golden_set(Network::Mainnet).sui.unwrap();
 
         // When
-        let result = check_sui(client, expected.chain_id).await;
+        let result = check_sui(client, SUI_MAINNET_CHAIN_ID).await;
 
         // Then
         assert_matches!(

--- a/crates/foreign-chain-health-check/src/golden.rs
+++ b/crates/foreign-chain-health-check/src/golden.rs
@@ -1,6 +1,8 @@
-//! Per-network reference transactions and the value an inspector must extract
-//! from each. A mainnet transaction does not exist on testnet (and vice versa),
-//! so the vectors are network-specific; `None` means the chain is skipped.
+//! Per-network golden transactions for the chains still probed against a pinned
+//! reference, plus decoding helpers. A mainnet transaction does not exist on testnet
+//! (and vice versa), so the vectors are network-specific; `None` means the chain is
+//! skipped. Identity-probed chains (Sui, Starknet) carry no built-in reference — their
+//! expected identities come from configuration.
 
 use anyhow::Context;
 
@@ -20,17 +22,6 @@ pub struct AptosVector {
     pub event_sequence_number: u64,
 }
 
-/// Unlike other chains, Sui is verified by chain identity rather than a pinned
-/// reference transaction — see [`check_sui`](crate::checks::check_sui).
-#[derive(Clone, Copy)]
-pub struct SuiVector {
-    /// Base58 of the 32-byte genesis checkpoint digest, exactly as `get_service_info`
-    /// returns it (`sui.rpc.v2`: "the digest of the genesis checkpoint"). Its 4-byte
-    /// prefix is the well-known Sui chain identifier — mainnet `0x35834a8a`, testnet
-    /// `0x4c78adac` — which is the value to grep against Sui docs to verify these.
-    pub chain_id: &'static str,
-}
-
 pub struct GoldenSet {
     pub base: Option<BlockHashVector>,
     pub bnb: Option<BlockHashVector>,
@@ -39,9 +30,7 @@ pub struct GoldenSet {
     pub hyper_evm: Option<BlockHashVector>,
     pub abstract_chain: Option<BlockHashVector>,
     pub bitcoin: Option<BlockHashVector>,
-    pub starknet: Option<BlockHashVector>,
     pub aptos: Option<AptosVector>,
-    pub sui: Option<SuiVector>,
 }
 
 pub fn golden_set(network: Network) -> GoldenSet {
@@ -80,17 +69,10 @@ const MAINNET: GoldenSet = GoldenSet {
         tx: "58ee376171bcc4e2cc040c13848d420b5eaf2f634872055b0a08c1fc2ec6453c",
         block_hash: "00000000000000000001fadaf3f8591e071c202762193cf78e389ea691f2ecab",
     }),
-    starknet: Some(BlockHashVector {
-        tx: "0x52a6c2b9d1d1b77dbc322b298fd91f39e3cca9bf1db4a7aa79f14a90efa633e",
-        block_hash: "0x1b716b05027567f9f4a2fe37f8769dc3b04a2e5a3893f6e0ed45f24c7c0ffa5",
-    }),
     aptos: Some(AptosVector {
         tx: "adc6b85a0931fc7f0d7e3839b52d63105e22cec1cb1cdee48aa2065773098c3c",
         event_type_tag: "0x1::block::NewBlockEvent",
         event_sequence_number: 822_198_006,
-    }),
-    sui: Some(SuiVector {
-        chain_id: "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S",
     }),
 };
 
@@ -108,17 +90,10 @@ const TESTNET: GoldenSet = GoldenSet {
         tx: "5acaa0890f8c1f1b2ac114c25b38d376f23beda1b59e9bcba33256d6e11d7e8e",
         block_hash: "000000000000021f43445ab447b3fc85e93eca26b56a4f23ef6c017682038ca2",
     }),
-    starknet: Some(BlockHashVector {
-        tx: "0x115b24c74eade5ee4c01e63cce5aa462fc2d59d040f5b088a31ad44c9aa58dc",
-        block_hash: "0x1f33823b145e92ca069b90d3cfb012277762d9dd1dc2efb975b10a7c3d92875",
-    }),
     aptos: Some(AptosVector {
         tx: "b463d73b3a2e9c684caf9b27eb66a147348130c50fc8fa74a3f56e712c942773",
         event_type_tag: "0x1::block::NewBlockEvent",
         event_sequence_number: 302_761_912,
-    }),
-    sui: Some(SuiVector {
-        chain_id: "69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD",
     }),
 };
 
@@ -205,15 +180,8 @@ mod tests {
                 hex32(v.tx).unwrap();
                 hex32(v.block_hash).unwrap();
             }
-            if let Some(v) = set.starknet {
-                felt32(v.tx).unwrap();
-                felt32(v.block_hash).unwrap();
-            }
             if let Some(v) = set.aptos {
                 hex32(v.tx).unwrap();
-            }
-            if let Some(v) = set.sui {
-                base58_32(v.chain_id).unwrap();
             }
         }
     }

--- a/crates/foreign-chain-health-check/src/lib.rs
+++ b/crates/foreign-chain-health-check/src/lib.rs
@@ -1,6 +1,6 @@
-//! Foreign-chain RPC provider health checks: probe every configured provider
-//! with a fixed golden request and report a per-provider result. Sui is the
-//! exception — see `run_sui`.
+//! Foreign-chain RPC provider health checks: probe every configured provider and report a
+//! per-provider result. Most chains run a fixed golden request; identity-based chains (Sui,
+//! Starknet) verify the chain identity and a recent transaction instead — see `checks`.
 
 mod checks;
 mod golden;
@@ -28,16 +28,27 @@ use mpc_node_config::{ForeignChainConfig, ForeignChainProviderConfig, ForeignCha
 pub use network::Network;
 pub use results::{ProviderResult, Status};
 
-use crate::golden::{AptosVector, BlockHashVector, SuiVector};
+use crate::golden::{AptosVector, BlockHashVector};
 
-/// Probe every configured provider against `network`'s golden reference
-/// transaction, one [`ProviderResult`] per provider, each checked independently.
-/// Chains with no reference for `network`, or configured but unsupported, are
-/// [`Status::Skipped`]; a chain absent from the config still yields a single
-/// placeholder `Skipped` result so its absence stays visible.
+/// Expected chain identities from `foreign_chain_health_check.identities`, one field per
+/// identity-probed chain.
+#[derive(Debug, Default, serde::Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ExpectedIdentities {
+    pub starknet: Option<String>,
+    pub sui: Option<String>,
+}
+
+/// Probe every configured provider against its reference (a configured identity, or for the
+/// chains still using pinned golden transactions, `network`'s golden vector), one
+/// [`ProviderResult`] per provider, each checked independently.
+/// Golden chains with no reference for `network`, or configured but unsupported chains, are
+/// [`Status::Skipped`]; a chain absent from the config still yields a single placeholder
+/// `Skipped` result so its absence stays visible.
 pub async fn check_all_providers(
     fc: &ForeignChainsConfig,
     network: Network,
+    identities: &ExpectedIdentities,
 ) -> Vec<ProviderResult> {
     let golden = golden::golden_set(network);
     let mut out = Vec::new();
@@ -78,7 +89,7 @@ pub async fn check_all_providers(
         mark_not_configured("bitcoin", &mut out);
     }
     if let Some(cfg) = &fc.starknet {
-        run_starknet(cfg, golden.starknet, network, &mut out).await;
+        run_starknet(cfg, identities.starknet.as_deref(), &mut out).await;
     } else {
         mark_not_configured("starknet", &mut out);
     }
@@ -88,7 +99,7 @@ pub async fn check_all_providers(
         mark_not_configured("aptos", &mut out);
     }
     if let Some(cfg) = &fc.sui {
-        run_sui(cfg, golden.sui, network, &mut out).await;
+        run_sui(cfg, identities.sui.as_deref(), &mut out).await;
     } else {
         mark_not_configured("sui", &mut out);
     }
@@ -109,10 +120,7 @@ pub async fn check_all_providers(
 }
 
 fn no_reference_reason(network: Network) -> String {
-    format!(
-        "no {} reference transaction for this chain",
-        network.label()
-    )
+    format!("no {} reference for this chain", network.label())
 }
 
 fn timeout_of(cfg: &ForeignChainConfig) -> Duration {
@@ -213,23 +221,19 @@ async fn run_bitcoin(
 
 async fn run_starknet(
     cfg: &ForeignChainConfig,
-    vector: Option<BlockHashVector>,
-    network: Network,
+    expected_chain_id: Option<&str>,
     out: &mut Vec<ProviderResult>,
 ) {
-    let Some(vector) = vector else {
-        mark_skipped("starknet", cfg, &no_reference_reason(network), out);
+    let Some(expected_chain_id) = expected_chain_id else {
+        mark_missing_identity("starknet", cfg, out);
         return;
     };
     let timeout = timeout_of(cfg);
-    let parsed = golden::felt32(vector.tx)
-        .and_then(|tx| golden::felt32(vector.block_hash).map(|bh| (tx, bh)));
     for (name, provider) in cfg.providers.iter() {
-        let status = match (&parsed, prepare_jsonrpc(provider)) {
-            (Err(e), _) => Status::Failed(format!("invalid golden vector: {e:#}")),
-            (Ok(_), Err(e)) => Status::Failed(format!("{e:#}")),
-            (Ok((tx, bh)), Ok(client)) => {
-                run_check(timeout, checks::check_starknet(client, *tx, *bh)).await
+        let status = match prepare_jsonrpc(provider) {
+            Err(e) => Status::Failed(format!("{e:#}")),
+            Ok(client) => {
+                run_check(timeout, checks::check_starknet(client, expected_chain_id)).await
             }
         };
         out.push(ProviderResult {
@@ -285,19 +289,18 @@ async fn run_aptos(
 /// [`checks::check_sui`] for the mechanism.
 async fn run_sui(
     cfg: &ForeignChainConfig,
-    vector: Option<SuiVector>,
-    network: Network,
+    expected_chain_id: Option<&str>,
     out: &mut Vec<ProviderResult>,
 ) {
-    let Some(vector) = vector else {
-        mark_skipped("sui", cfg, &no_reference_reason(network), out);
+    let Some(expected) = expected_chain_id else {
+        mark_missing_identity("sui", cfg, out);
         return;
     };
     let timeout = timeout_of(cfg);
     for (name, provider) in cfg.providers.iter() {
         let status = match prepare_sui(provider, timeout) {
             Err(e) => Status::Failed(format!("{e:#}")),
-            Ok(client) => run_check(timeout, checks::check_sui(client, vector.chain_id)).await,
+            Ok(client) => run_check(timeout, checks::check_sui(client, expected)).await,
         };
         out.push(ProviderResult {
             chain: "sui",
@@ -322,6 +325,24 @@ fn prepare_sui(
     };
     GrpcSuiClient::new(url, header, timeout)
         .map_err(|e| anyhow::anyhow!("failed to build the Sui gRPC client: {e}"))
+}
+
+/// A configured identity-probed chain without an expected identity is a config error:
+/// every provider row fails until `foreign_chain_health_check.identities.<chain>` is set.
+fn mark_missing_identity(
+    chain: &'static str,
+    cfg: &ForeignChainConfig,
+    out: &mut Vec<ProviderResult>,
+) {
+    for name in cfg.providers.keys() {
+        out.push(ProviderResult {
+            chain,
+            provider: provider_name(name),
+            status: Status::Failed(format!(
+                "no expected identity configured: set foreign_chain_health_check.identities.{chain}"
+            )),
+        });
+    }
 }
 
 fn mark_skipped(
@@ -370,6 +391,30 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn check_all_providers__should_fail_identity_chain_without_configured_identity() {
+        // Given a configured identity-probed chain but no expected identity in config
+        let fc = ForeignChainsConfig {
+            starknet: Some(config_with_provider(AuthConfig::None)),
+            ..Default::default()
+        };
+
+        // When
+        let results =
+            check_all_providers(&fc, Network::Mainnet, &ExpectedIdentities::default()).await;
+
+        // Then the provider fails with a pointer to the config key, without being probed
+        let starknet = results
+            .iter()
+            .find(|r| r.chain == "starknet")
+            .expect("starknet row");
+        assert_matches!(
+            &starknet.status,
+            Status::Failed(reason)
+                if reason.contains("foreign_chain_health_check.identities.starknet")
+        );
+    }
+
+    #[tokio::test]
     async fn check_all_providers__should_skip_configured_but_unsupported_chains() {
         // Given a configured but not-yet-supported chain
         let fc = ForeignChainsConfig {
@@ -378,7 +423,8 @@ mod tests {
         };
 
         // When
-        let results = check_all_providers(&fc, Network::Mainnet).await;
+        let results =
+            check_all_providers(&fc, Network::Mainnet, &ExpectedIdentities::default()).await;
 
         // Then it is reported skipped as unsupported, not probed
         let ethereum = results
@@ -397,7 +443,8 @@ mod tests {
         let fc = ForeignChainsConfig::default();
 
         // When
-        let results = check_all_providers(&fc, Network::Mainnet).await;
+        let results =
+            check_all_providers(&fc, Network::Mainnet, &ExpectedIdentities::default()).await;
 
         // Then every known chain still appears, each with a "not configured" placeholder
         let expected = [
@@ -443,7 +490,8 @@ mod tests {
         };
 
         // When
-        let results = check_all_providers(&fc, Network::Mainnet).await;
+        let results =
+            check_all_providers(&fc, Network::Mainnet, &ExpectedIdentities::default()).await;
 
         // Then
         assert_eq!(results[0].chain, "base");
@@ -524,7 +572,8 @@ mod tests {
         };
 
         // When
-        let results = check_all_providers(&fc, Network::Mainnet).await;
+        let results =
+            check_all_providers(&fc, Network::Mainnet, &ExpectedIdentities::default()).await;
 
         // Then — the broken provider does not suppress the healthy one; pass,
         // fail, and skip all coexist in a single run.

--- a/crates/foreign-chain-inspector/src/starknet/inspector.rs
+++ b/crates/foreign-chain-inspector/src/starknet/inspector.rs
@@ -1,14 +1,16 @@
 use crate::starknet::{StarknetExtractedValue, StarknetTransactionHash};
 use crate::{ForeignChainInspectionError, ForeignChainInspector};
 use foreign_chain_rpc_interfaces::starknet::{
-    BlockId, GetBlockWithTxHashesArgs, GetBlockWithTxHashesResponse, GetTransactionReceiptArgs,
-    GetTransactionReceiptResponse, H256, StarknetExecutionStatus, StarknetFinalityStatus,
+    BlockId, ChainIdArgs, GetBlockWithTxHashesArgs, GetBlockWithTxHashesResponse,
+    GetTransactionReceiptArgs, GetTransactionReceiptResponse, H256, StarknetExecutionStatus,
+    StarknetFinalityStatus, parse_felt,
 };
 use jsonrpsee::core::client::ClientT;
 use near_mpc_contract_interface::types::{StarknetFelt, StarknetLog};
 
 const GET_TRANSACTION_RECEIPT_METHOD: &str = "starknet_getTransactionReceipt";
 const GET_BLOCK_WITH_TX_HASHES_METHOD: &str = "starknet_getBlockWithTxHashes";
+const CHAIN_ID_METHOD: &str = "starknet_chainId";
 
 #[derive(Clone)]
 pub struct StarknetInspector<Client> {
@@ -80,6 +82,26 @@ where
         Self { client }
     }
 
+    /// The network's chain identifier (`starknet_chainId`) as a felt, e.g. `0x534e5f4d41494e`
+    /// (`SN_MAIN`). The RPC returns a possibly-short felt string; it is padded to a full felt.
+    pub async fn chain_id(&self) -> Result<H256, ForeignChainInspectionError> {
+        let felt: String = self.client.request(CHAIN_ID_METHOD, &ChainIdArgs).await?;
+        parse_felt(&felt).map_err(ForeignChainInspectionError::MalformedRpcResponse)
+    }
+
+    /// Fetches a block and its transaction hashes by id (e.g. `BlockId::Tag(Latest)` for the
+    /// head).
+    pub async fn block_with_tx_hashes(
+        &self,
+        block_id: BlockId,
+    ) -> Result<GetBlockWithTxHashesResponse, ForeignChainInspectionError> {
+        let args = GetBlockWithTxHashesArgs { block_id };
+        Ok(self
+            .client
+            .request(GET_BLOCK_WITH_TX_HASHES_METHOD, &args)
+            .await?)
+    }
+
     /// Checks that the receipt's block is on the canonical chain by re-fetching the canonical
     /// block at `receipt_block_number` and comparing hashes. `starknet_getBlockWithTxHashes`
     /// only ever resolves to a canonical block, so a mismatch means the receipt was indexed
@@ -94,14 +116,10 @@ where
         receipt_block_number: u64,
         receipt_block_hash: H256,
     ) -> Result<(), ForeignChainInspectionError> {
-        let args = GetBlockWithTxHashesArgs {
-            block_id: BlockId::Number {
+        let canonical = self
+            .block_with_tx_hashes(BlockId::Number {
                 block_number: receipt_block_number,
-            },
-        };
-        let canonical: GetBlockWithTxHashesResponse = self
-            .client
-            .request(GET_BLOCK_WITH_TX_HASHES_METHOD, &args)
+            })
             .await?;
 
         let hash_matches = canonical.block_hash == receipt_block_hash;

--- a/crates/foreign-chain-inspector/tests/starknet_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/starknet_inspector.rs
@@ -46,6 +46,7 @@ fn canonical_block_for(receipt: &GetTransactionReceiptResponse) -> GetBlockWithT
     GetBlockWithTxHashesResponse {
         block_hash: receipt.block_hash,
         block_number: receipt.block_number,
+        transactions: vec![],
     }
 }
 
@@ -413,6 +414,7 @@ async fn extract__should_return_non_canonical_block_when_receipt_block_hash_diff
     let canonical_block = GetBlockWithTxHashesResponse {
         block_hash: H256::from(canonical_hash_bytes),
         block_number,
+        transactions: vec![],
     };
 
     let mock_client = SequentialResponseMockClientBuilder::new()

--- a/crates/foreign-chain-rpc-interfaces/src/starknet.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/starknet.rs
@@ -62,12 +62,20 @@ impl ToRpcParams for &GetTransactionReceiptArgs {
     to_rpc_params_impl!();
 }
 
-/// Block identifier accepted by Starknet block-lookup RPCs. The inspector's canonical-chain
-/// check uses `Number`; add more variants only when a caller actually needs them.
+/// Block identifier accepted by Starknet block-lookup RPCs: a height or a named tag.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum BlockId {
+    Tag(BlockTag),
     Number { block_number: u64 },
+}
+
+/// A named Starknet block, serialized as the bare string the JSON-RPC spec expects.
+/// `L1Accepted` (the latest block settled on Ethereum L1) requires provider JSON-RPC v0.9+.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BlockTag {
+    L1Accepted,
 }
 
 /// Partial RPC response for `starknet_getBlockWithTxHashes`.
@@ -77,6 +85,9 @@ pub struct GetBlockWithTxHashesResponse {
     #[serde(deserialize_with = "deserialize_starknet_felt")]
     pub block_hash: H256,
     pub block_number: u64,
+    /// Transaction hashes in block order; empty if the response omitted them.
+    #[serde(default, deserialize_with = "deserialize_starknet_felt_vec")]
+    pub transactions: Vec<H256>,
 }
 
 /// Request args for `starknet_getBlockWithTxHashes`.
@@ -99,10 +110,19 @@ impl ToRpcParams for &GetBlockWithTxHashesArgs {
     to_rpc_params_impl!();
 }
 
+/// `starknet_chainId` takes no parameters.
+pub struct ChainIdArgs;
+
+impl ToRpcParams for &ChainIdArgs {
+    fn to_rpc_params(self) -> Result<Option<Box<serde_json::value::RawValue>>, serde_json::Error> {
+        Ok(None)
+    }
+}
+
 /// Starknet felt values use `0x`-prefixed hex like Ethereum, but may omit leading
 /// zeros (e.g. `"0x5"` instead of `"0x0000…0005"`). This function zero-pads
 /// short representations so they can be parsed as an [`H256`].
-fn parse_felt(s: &str) -> Result<H256, String> {
+pub fn parse_felt(s: &str) -> Result<H256, String> {
     let stripped = s.strip_prefix("0x").unwrap_or(s);
 
     if stripped.len() > 64 {
@@ -136,7 +156,7 @@ where
 #[expect(non_snake_case)]
 mod tests {
     use super::{
-        BlockId, GetBlockWithTxHashesArgs, GetBlockWithTxHashesResponse,
+        BlockId, BlockTag, GetBlockWithTxHashesArgs, GetBlockWithTxHashesResponse,
         GetTransactionReceiptResponse, StarknetExecutionStatus, StarknetFinalityStatus, parse_felt,
     };
 
@@ -216,6 +236,20 @@ mod tests {
     }
 
     #[test]
+    fn serialize_block_id__should_render_l1_accepted_tag_as_bare_string() {
+        // given
+        let args = GetBlockWithTxHashesArgs {
+            block_id: BlockId::Tag(BlockTag::L1Accepted),
+        };
+
+        // when
+        let serialized = serde_json::to_value(&args).unwrap();
+
+        // then — a named tag is a bare string, not a `{ block_number }` object.
+        assert_eq!(serialized, serde_json::json!(["l1_accepted"]));
+    }
+
+    #[test]
     fn deserialize_get_block_with_tx_hashes_response__should_accept_short_hex_block_hash() {
         let json = serde_json::json!({
             "block_hash": SHORT_HEX_BLOCK_HASH,
@@ -229,6 +263,7 @@ mod tests {
             GetBlockWithTxHashesResponse {
                 block_hash: parse_felt(SHORT_HEX_BLOCK_HASH).unwrap(),
                 block_number: TEST_BLOCK_NUMBER,
+                transactions: vec![],
             }
         );
     }

--- a/deployment/cvm-deployment/user-config.toml
+++ b/deployment/cvm-deployment/user-config.toml
@@ -148,3 +148,16 @@ max_retries = 3
 
 [mpc_node_config.node.foreign_chains.starknet.providers.publicnode]
 rpc_url = "https://starknet-sepolia-rpc.publicnode.com"
+
+[mpc_node_config.node.foreign_chains.sui]
+timeout_sec = 30
+max_retries = 3
+
+[mpc_node_config.node.foreign_chains.sui.providers.fullnode]
+rpc_url = "https://fullnode.testnet.sui.io:443"
+
+# Expected identity per chain for the provider health check — see
+# crates/foreign-chain-config-tester/README.md for the well-known values.
+[mpc_node_config.node.foreign_chain_health_check.identities]
+starknet = "0x534e5f5345504f4c4941" # mainnet: "0x534e5f4d41494e"
+sui = "69WiPg3DAQiwdxfncX6wYQ2siKwAe6L9BZthQea3JNMD" # mainnet: "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S"

--- a/docs/localnet/mpc-config.template.toml
+++ b/docs/localnet/mpc-config.template.toml
@@ -104,3 +104,7 @@ rpc_url = "https://archive.mainnet.sui.io"
 
 [node.foreign_chains.sui.providers.public.auth]
 kind = "none"
+
+[node.foreign_chain_health_check.identities]
+starknet = "0x534e5f4d41494e"
+sui = "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S"

--- a/docs/localnet/mpc-configs/config.yaml.template
+++ b/docs/localnet/mpc-configs/config.yaml.template
@@ -69,3 +69,7 @@ foreign_chains:
         rpc_url: "https://archive.mainnet.sui.io"
         auth:
           kind: none
+foreign_chain_health_check:
+  identities:
+    starknet: "0x534e5f4d41494e"
+    sui: "4btiuiMPvEENsttpZC7CZ53DruC3MAgfznDbASZ7DR6S"


### PR DESCRIPTION
Part of #3764; rationale: #3969. Stacked, merge bottom-up:

1. **#3932 (this PR)** — Starknet: chain id + a recent L1-accepted tx
2. #3962 — 6 EVM chains: `eth_chainId` + a recent finalized tx
3. #3963 — Bitcoin: genesis hash + a recent tx
4. #3964 — Aptos: ledger chain id + a recent tx

Replaces Starknet's pinned golden tx with the Sui-style probe: verify `starknet_chainId`, then inspect a real tx from a recent `l1_accepted` block at `AcceptedOnL1` (walks back past empty/not-yet-final blocks; needs provider JSON-RPC v0.9+).

Identities come from config (`foreign_chain_health_check.identities`), no built-ins — so any network is checkable, and a configured chain fails until its identity is set. Also lands the shared scaffolding the rest of the stack reuses.