### PR TITLE
refactor: Contract internal-only renames from threshold to reconstruction threshold

### DIFF
--- a/crates/contract/src/errors.rs
+++ b/crates/contract/src/errors.rs
@@ -267,8 +267,13 @@ pub enum DomainError {
         MIN_RECONSTRUCTION_THRESHOLD
     )]
     ReconstructionThresholdTooLow,
-    #[error("Reconstruction threshold {threshold} exceeds participant count {participants}.")]
-    ReconstructionThresholdExceedsParticipants { threshold: u64, participants: u64 },
+    #[error(
+        "Reconstruction threshold {reconstruction_threshold} exceeds participant count {participants}."
+    )]
+    ReconstructionThresholdExceedsParticipants {
+        reconstruction_threshold: u64,
+        participants: u64,
+    },
     #[error(
         "Protocol {protocol:?} requires at least {required} participants, found {participants}."
     )]
@@ -278,9 +283,9 @@ pub enum DomainError {
         participants: u64,
     },
     #[error(
-        "Reconstruction threshold {threshold} overflowed when computing the DamgardEtAl bound."
+        "Reconstruction threshold {reconstruction_threshold} overflowed when computing the DamgardEtAl bound."
     )]
-    ReconstructionThresholdOverflow { threshold: u64 },
+    ReconstructionThresholdOverflow { reconstruction_threshold: u64 },
     #[error(
         "Resharing proposal references domain ID {domain_id}, which is not in the current registry."
     )]

--- a/crates/contract/src/foreign_chains_metadata.rs
+++ b/crates/contract/src/foreign_chains_metadata.rs
@@ -41,7 +41,7 @@ impl ForeignChainsMetadata {
     pub(crate) fn update_available_chains_config_cache(
         &mut self,
         active_tls_keys: &BTreeSet<dtos::Ed25519PublicKey>,
-        threshold: u64,
+        reconstruction_threshold: u64,
     ) {
         let mut chain_to_supporter_count: std::collections::BTreeMap<dtos::ForeignChain, u64> =
             std::collections::BTreeMap::new();
@@ -60,7 +60,7 @@ impl ForeignChainsMetadata {
         }
         self.available_foreign_chains = chain_to_supporter_count
             .into_iter()
-            .filter_map(|(chain, count)| (count >= threshold).then_some(chain))
+            .filter_map(|(chain, count)| (count >= reconstruction_threshold).then_some(chain))
             .collect::<BTreeSet<_>>()
             .into();
     }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -1057,13 +1057,15 @@ impl MpcContract {
         };
         // TODO(#3556): replace this with a per-scheme
         // `required_active_signers(protocol, reconstruction_threshold)`.
-        let Some(threshold) = self.protocol_state.domain_registry().ok().and_then(|r| {
-            r.domains()
-                .iter()
-                .filter(|d| d.purpose == DomainPurpose::ForeignTx)
-                .map(|d| d.reconstruction_threshold.inner())
-                .max()
-        }) else {
+        let Some(reconstruction_threshold) =
+            self.protocol_state.domain_registry().ok().and_then(|r| {
+                r.domains()
+                    .iter()
+                    .filter(|d| d.purpose == DomainPurpose::ForeignTx)
+                    .map(|d| d.reconstruction_threshold.inner())
+                    .max()
+            })
+        else {
             // No op if contract isn't in Running or Resharing state, or
             // there is no foreign tx domain registered.
             // Not panicking is intentional.
@@ -1078,7 +1080,7 @@ impl MpcContract {
             .collect();
         self.foreign_chains
             .get_mut()
-            .update_available_chains_config_cache(&active_tls_keys, threshold);
+            .update_available_chains_config_cache(&active_tls_keys, reconstruction_threshold);
     }
 
     #[deprecated(
@@ -2024,7 +2026,10 @@ impl MpcContract {
         let domains = DomainRegistry::from_raw_validated(domains, next_domain_id)?;
         let num_participants = parameters.participants().len() as u64;
         for domain in domains.domains() {
-            crate::primitives::domain::validate_domain_threshold(domain, num_participants)?;
+            crate::primitives::domain::validate_domain_reconstruction_threshold(
+                domain,
+                num_participants,
+            )?;
         }
         // Keep the GovernanceThreshold at least as large as the largest ReconstructionThreshold.
         ThresholdParameters::validate_governance_against_reconstruction(
@@ -4359,7 +4364,7 @@ mod tests {
         assert_matches!(
             result.unwrap_err(),
             Error::DomainError(DomainError::ReconstructionThresholdExceedsParticipants {
-                threshold: 4,
+                reconstruction_threshold: 4,
                 participants: 3,
             })
         );

--- a/crates/contract/src/primitives/domain.rs
+++ b/crates/contract/src/primitives/domain.rs
@@ -39,7 +39,7 @@ pub fn validate_domain_purpose(domain: &DomainConfig) -> Result<(), Error> {
 /// Validates the per-domain reconstruction threshold against the participant
 /// count. Universal bound `2 <= t <= n` plus, for `DamgardEtAl`, the
 /// honest-majority bound `2t - 1 <= n`.
-pub fn validate_domain_threshold(
+pub fn validate_domain_reconstruction_threshold(
     domain: &DomainConfig,
     num_participants: u64,
 ) -> Result<(), Error> {
@@ -49,16 +49,17 @@ pub fn validate_domain_threshold(
     }
     if t > num_participants {
         return Err(DomainError::ReconstructionThresholdExceedsParticipants {
-            threshold: t,
+            reconstruction_threshold: t,
             participants: num_participants,
         }
         .into());
     }
     if domain.protocol == Protocol::DamgardEtAl {
-        let required = t
-            .checked_mul(2)
-            .and_then(|x| x.checked_sub(1))
-            .ok_or(DomainError::ReconstructionThresholdOverflow { threshold: t })?;
+        let required = t.checked_mul(2).and_then(|x| x.checked_sub(1)).ok_or(
+            DomainError::ReconstructionThresholdOverflow {
+                reconstruction_threshold: t,
+            },
+        )?;
         if required > num_participants {
             return Err(DomainError::InsufficientParticipantsForProtocol {
                 protocol: domain.protocol,

--- a/crates/contract/src/primitives/test_utils.rs
+++ b/crates/contract/src/primitives/test_utils.rs
@@ -30,7 +30,7 @@ const ALL_PROTOCOLS: [Protocol; 4] = [
 pub const NUM_PROTOCOLS: usize = ALL_PROTOCOLS.len();
 
 /// Default per-domain reconstruction threshold used by test fixtures. `2` is
-/// the minimum valid value (`validate_domain_threshold` requires `t >= 2`).
+/// the minimum valid value (`validate_domain_reconstruction_threshold` requires `t >= 2`).
 /// Works for participant counts `>= 3`, which is what `gen_threshold_params`
 /// produces — needed because fixtures may include `DamgardEtAl` domains,
 /// whose `2t - 1 <= n` bound becomes `n >= 3` at `t = 2`.

--- a/crates/contract/src/primitives/thresholds.rs
+++ b/crates/contract/src/primitives/thresholds.rs
@@ -357,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn validate_threshold__should_not_produce_empty_window_for_small_n() {
+    fn validate_governance_threshold__should_not_produce_empty_window_for_small_n() {
         // The relative upper cap is clamped up to the ceil(0.6n) lower bound, so the
         // feasible window must always hold at least one valid threshold.
         for n in 2..=12u64 {

--- a/crates/contract/src/primitives/thresholds.rs
+++ b/crates/contract/src/primitives/thresholds.rs
@@ -38,7 +38,7 @@ impl ThresholdParameters {
     /// Constructs Threshold parameters from `participants` and `threshold` if the
     /// threshold meets the absolute and relative validation criteria.
     pub fn new(participants: Participants, threshold: Threshold) -> Result<Self, Error> {
-        match Self::validate_threshold(participants.len() as u64, threshold) {
+        match Self::validate_governance_threshold(participants.len() as u64, threshold) {
             Ok(_) => Ok(ThresholdParameters {
                 participants,
                 threshold,
@@ -53,7 +53,7 @@ impl ThresholdParameters {
     /// - threshold can not exceed the number of shares `n_shares`.
     /// - threshold must be at least 60% of the number of shares (rounded upwards).
     /// - threshold must not exceed the upper bound (now set to 100%)
-    fn validate_threshold(n_shares: u64, k: Threshold) -> Result<(), Error> {
+    fn validate_governance_threshold(n_shares: u64, k: Threshold) -> Result<(), Error> {
         if k.value() > n_shares {
             return Err(InvalidThreshold::MaxRequirementFailed {
                 max: n_shares,
@@ -85,7 +85,7 @@ impl ThresholdParameters {
 
     /// Validates the GovernanceThreshold `k` against both the participant count and the
     /// largest ReconstructionThreshold across all domains. Layers the cross-domain rule
-    /// `GovernanceThreshold >= max(ReconstructionThreshold)` on top of `validate_threshold`:
+    /// `GovernanceThreshold >= max(ReconstructionThreshold)` on top of `validate_governance_threshold`:
     /// the network must never be able to govern with fewer parties than are required to
     /// reconstruct any domain's key. Call this at every point where the GovernanceThreshold,
     /// a ReconstructionThreshold, or the participant set changes.
@@ -94,7 +94,7 @@ impl ThresholdParameters {
         governance: Threshold,
         max_reconstruction_threshold: Option<ReconstructionThreshold>,
     ) -> Result<(), Error> {
-        Self::validate_threshold(num_participants, governance)?;
+        Self::validate_governance_threshold(num_participants, governance)?;
         if let Some(max_reconstruction_threshold) = max_reconstruction_threshold
             && governance.value() < max_reconstruction_threshold.inner()
         {
@@ -108,7 +108,7 @@ impl ThresholdParameters {
     }
 
     pub fn validate(&self) -> Result<(), Error> {
-        Self::validate_threshold(self.participants.len() as u64, self.threshold())?;
+        Self::validate_governance_threshold(self.participants.len() as u64, self.threshold())?;
         self.participants.validate()
     }
 
@@ -301,19 +301,21 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_threshold() {
+    fn test_validate_governance_threshold() {
         let n = rand::thread_rng().gen_range(2..600) as u64;
         let min_threshold = governance_threshold_lower_relative_bound(n);
         let max_threshold = governance_threshold_upper_relative_bound(n);
         for k in 0..min_threshold {
-            let _ = ThresholdParameters::validate_threshold(n, Threshold::new(k)).unwrap_err();
+            let _ = ThresholdParameters::validate_governance_threshold(n, Threshold::new(k))
+                .unwrap_err();
         }
         for k in min_threshold..=max_threshold {
-            ThresholdParameters::validate_threshold(n, Threshold::new(k)).unwrap();
+            ThresholdParameters::validate_governance_threshold(n, Threshold::new(k)).unwrap();
         }
         // Anything above the upper cap (up to and beyond n) must be rejected.
         for k in (max_threshold + 1)..=(n + 1) {
-            let _ = ThresholdParameters::validate_threshold(n, Threshold::new(k)).unwrap_err();
+            let _ = ThresholdParameters::validate_governance_threshold(n, Threshold::new(k))
+                .unwrap_err();
         }
     }
 
@@ -363,7 +365,7 @@ mod tests {
             let upper = governance_threshold_upper_relative_bound(n);
             assert!(upper >= lower, "empty window at n={n}: [{lower}, {upper}]");
             // The clamped boundary value must validate.
-            ThresholdParameters::validate_threshold(n, Threshold::new(upper)).unwrap();
+            ThresholdParameters::validate_governance_threshold(n, Threshold::new(upper)).unwrap();
         }
     }
 
@@ -590,7 +592,7 @@ mod tests {
                 .cloned()
                 .collect(),
         );
-        // Use a valid threshold for the doubled size so validate_threshold passes
+        // Use a valid threshold for the doubled size so validate_governance_threshold passes
         // and the duplicate check in participants.validate() is reached.
         let tampered_params = ThresholdParameters::new_unvalidated(
             tampered_participants,

--- a/crates/contract/src/state/running.rs
+++ b/crates/contract/src/state/running.rs
@@ -5,7 +5,7 @@ use crate::errors::{DomainError, Error, InvalidParameters, VoteError};
 use crate::primitives::{
     domain::{
         AddDomainsVotes, DomainRegistry, max_reconstruction_threshold, validate_domain_purpose,
-        validate_domain_threshold,
+        validate_domain_reconstruction_threshold,
     },
     key_state::{AuthenticatedAccountId, AuthenticatedParticipantId, EpochId, Keyset},
     threshold_votes::ThresholdParametersVotes,
@@ -177,7 +177,7 @@ impl RunningContractState {
             })
             .collect();
         for domain in &effective_domains {
-            validate_domain_threshold(domain, new_num_participants)?;
+            validate_domain_reconstruction_threshold(domain, new_num_participants)?;
         }
 
         // The GovernanceThreshold must dominate every domain's effective ReconstructionThreshold;
@@ -222,7 +222,7 @@ impl RunningContractState {
             .expect("participant count fits in u64");
         for domain in &domains {
             validate_domain_purpose(domain)?;
-            validate_domain_threshold(domain, num_participants)?;
+            validate_domain_reconstruction_threshold(domain, num_participants)?;
         }
         // Keep trust assumptions consistent: a domain must never require more shares to
         // reconstruct than the GovernanceThreshold demands to govern. Route through the

--- a/docs/design/domain-separation.md
+++ b/docs/design/domain-separation.md
@@ -932,7 +932,7 @@ Resolved: the `GovernanceThreshold` is now constrained relative to the cryptogra
 - `ceil(0.6*n) <= GovernanceThreshold <= n` — the existing 60% lower bound. A relative upper cap is retained in the code but currently set to 100%
 (effectively disabled due to non-convergence of opinions on what would be a good upper bound).
 
-These are enforced at every mutation point (governance threshold updates, reconstruction threshold updates, participant add, participant kick) and re-validated once on migration, where a violation hard-blocks the upgrade (panic) — state that breaks the relation must be corrected via `vote_new_parameters` before upgrading. See `ThresholdParameters::validate_threshold` and `validate_governance_against_reconstruction` in `crates/contract/src/primitives/thresholds.rs`.
+These are enforced at every mutation point (governance threshold updates, reconstruction threshold updates, participant add, participant kick) and re-validated once on migration, where a violation hard-blocks the upgrade (panic) — state that breaks the relation must be corrected via `vote_new_parameters` before upgrading. See `ThresholdParameters::validate_governance_threshold` and `validate_governance_against_reconstruction` in `crates/contract/src/primitives/thresholds.rs`.
 
 ### 7.2 Backward-Compatible View Methods
 

--- a/docs/design/domain-separation.md
+++ b/docs/design/domain-separation.md
@@ -246,7 +246,7 @@ Each protocol has different constraints on `ReconstructionThreshold` relative to
 ```rust
 /// Validates that the reconstruction threshold is achievable
 /// given the number of participants.
-pub fn validate_threshold(config: &DistributedKeyConfig, num_participants: u64) -> Result<(), Error> {
+pub fn validate_domain_reconstruction_threshold(config: &DistributedKeyConfig, num_participants: u64) -> Result<(), Error> {
     let t = config.reconstruction_threshold.inner();
 
     // Universal constraints
@@ -289,7 +289,7 @@ pub fn validate_for_participant_count(
     num_participants: u64,
 ) -> Result<(), Error> {
     for key in keys.iter() {
-        validate_threshold(key, num_participants).map_err(|e| {
+        validate_domain_reconstruction_threshold(key, num_participants).map_err(|e| {
             Error::ThresholdIncompatibleWithNewParticipants { distributed_key_id: key.id, inner: e }
         })?;
     }
@@ -507,7 +507,7 @@ Note: Migration needs a `From<Curve> for Protocol` (the reverse direction) to in
 **Precondition**: PR 4 landed. `DistributedKeyConfig.reconstruction_threshold` exists but is populated from the global threshold during migration.
 
 **Changes**:
-- Add `validate_threshold(config: &DistributedKeyConfig, num_participants)` with protocol-specific rules:
+- Add `validate_domain_reconstruction_threshold(config: &DistributedKeyConfig, num_participants)` with protocol-specific rules:
   - CaitSith/Frost/CKD: `t <= n` (same as current).
   - DamgardEtAl: `2t - 1 <= n`.
 - Add `min_active_participants(protocol, reconstruction_threshold)` helper (see §3.1).
@@ -520,7 +520,7 @@ Note: Migration needs a `From<Curve> for Protocol` (the reverse direction) to in
 
 **Key behavioral change**: This is where `DistributedKeyConfig` gains real per-key threshold semantics. Before this PR, the `reconstruction_threshold` was always the global value.
 
-**Tests**: Unit tests for `validate_threshold` edge cases: DamgardEtAl with `2t-1 == n` (boundary), `2t-1 > n` (reject), `t < 2` (reject). Resharing validation tests: propose new participant set that violates one domain's threshold. Verify `vote_add_domains` rejects invalid thresholds.
+**Tests**: Unit tests for `validate_domain_reconstruction_threshold` edge cases: DamgardEtAl with `2t-1 == n` (boundary), `2t-1 > n` (reject), `t < 2` (reject). Resharing validation tests: propose new participant set that violates one domain's threshold. Verify `vote_add_domains` rejects invalid thresholds.
 
 ---
 
@@ -814,7 +814,7 @@ mpc-contract/
   primitives/
     domain.rs       → DistributedKeyRegistry, AddDomainsVotes, validation logic
     key_state.rs    → KeyForDomain, Keyset (with NEAR-specific storage)
-    thresholds.rs   → Validation logic (validate_threshold, etc.)
+    thresholds.rs   → Validation logic (validate_domain_reconstruction_threshold, etc.)
   state/            → ProtocolContractState, RunningContractState, etc.
 ```
 


### PR DESCRIPTION
Fixes part of #3903. Namely the contract internals. This does not create migration "problems".

Upcoming PR: Cross-crate TYPE renames