### PR TITLE
fix(attestation): revert DEFAULT_EXPIRATION_DURATION_SECONDS to 7 days

### DIFF
--- a/crates/mpc-attestation/src/attestation.rs
+++ b/crates/mpc-attestation/src/attestation.rs
@@ -25,7 +25,7 @@ use crate::alloc::string::{String, ToString};
 /// re-verified via [`VerifiedAttestation::re_verify`]. Nodes resubmit hourly,
 /// well within this window, so valid attestations refresh in time.
 // TODO(#1639): extract timestamp from certificate itself
-pub const DEFAULT_EXPIRATION_DURATION_SECONDS: u64 = 60 * 60 * 24; // 1 day
+pub const DEFAULT_EXPIRATION_DURATION_SECONDS: u64 = 60 * 60 * 24 * 7; // 7 days
 
 // `large_enum_variant` fires only where `usize` is 64-bit; under the contract's
 // wasm32 build the variants are close enough in size that it doesn't, so gate the


### PR DESCRIPTION
## What

Reverts `DEFAULT_EXPIRATION_DURATION_SECONDS` (`crates/mpc-attestation/src/attestation.rs`) from **1 day back to 7 days**, and fixes the stale `// 1 day` inline comment.

## Why

The contract stamps each accepted attestation with `expiry = block_timestamp + DEFAULT_EXPIRATION_DURATION_SECONDS` (`TeeState::add_participant`). The value was dropped from 7d to 1d in #3626, which leaves almost no margin: if a node can't refresh its attestation for ~24h it gets dropped. This bit us during an Intel PCS incident where the PCK CRL went stale (>7 days without re-sign) and node-side collateral freshness rejected fresh quote generation — with a 1-day expiry, nodes are ~24h from being kicked; the previous 7-day window would have given a week of runway. Nodes re-attest hourly, well within 7 days.

## Safety — no node/contract version-skew hazard

Made safe by #3736 (`fix(node): confirm submit_participant_info via advancing attestation expiry`, already on `main`). The node used to confirm its submission by reconstructing the attestation's creation time as `stored_expiry − DEFAULT_EXPIRATION_DURATION_SECONDS`; under skew (contract stamping 7d while a node still assumes 1d) the reconstructed age (~6d) exceeds the 120s freshness bound, so every submission is treated as `NotExecuted` and retried indefinitely. #3736 replaced that with an *expiry-advanced* check that doesn't depend on the constant's value, so this 1d→7d change cannot trigger that retry loop. (Holds provided nodes are on the #3736 build.)

## Notes

- Takes effect for **new** submissions after redeploy; does **not** retroactively extend attestations already stored on-chain.
- Node-side confirmation is independent of this constant since #3736 (it now checks the expiry *advanced* rather than reconstructing from the value), so contract and node no longer need to agree on it. The only remaining reference in the node is a doc comment.
- The node-side collateral freshness fix (relaxing `MAX_COLLATERAL_AGE` / per-field PCK CRL handling) is a separate PR.

Closes #3947
