### PR TITLE
refactor(ops): move prepare-release.sh under scripts/ops/

### DIFF
--- a/.cliffignore
+++ b/.cliffignore
@@ -1,5 +1,5 @@
 # Commits to exclude from the changelog (read by git-cliff via cliff.toml,
-# invoked from scripts/prepare-release.sh and the manual flow in RELEASES.md).
+# invoked from scripts/ops/prepare-release.sh and the manual flow in RELEASES.md).
 # The block below is the 502 commits from the threshold-signatures repo that
 # were merged in 59037a57 ("Merge threshold-signatures repo"). Their full
 # pre-merge history would otherwise pollute the changelog.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -53,19 +53,19 @@ with whatever version you're releasing.
 ### 1. Prepare the release PR
 
 Create a working branch off the release-source branch, then run
-[`scripts/prepare-release.sh`](./scripts/prepare-release.sh) to apply the
+[`scripts/ops/prepare-release.sh`](./scripts/ops/prepare-release.sh) to apply the
 release boilerplate (changelog, version bump, ABI snapshot, licenses):
 
 ```sh
 # For a minor/major release:
 git checkout main && git pull
 git checkout -b release-prep/v3.11.0
-./scripts/prepare-release.sh 3.11.0
+./scripts/ops/prepare-release.sh 3.11.0
 
 # For a patch release:
 git checkout release/v3.11 && git pull
 git checkout -b release-prep/v3.11.1
-./scripts/prepare-release.sh 3.11.1
+./scripts/ops/prepare-release.sh 3.11.1
 ```
 
 Push the working branch and open a PR against `main` (for minor releases)
@@ -233,7 +233,7 @@ We follow [Semantic Versioning](https://semver.org/) with these compatibility ru
 ## Changelog conventions
 
 We use [`git-cliff`](https://git-cliff.org/) to maintain `CHANGELOG.md`.
-The `prepare-release.sh` script invokes `git-cliff -t <VERSION>
+The `scripts/ops/prepare-release.sh` script invokes `git-cliff -t <VERSION>
 <BASE_TAG>..<HEAD-SHA>`, where `BASE_TAG` is the most recent **semver**
 tag (`X.Y.Z`) reachable from `HEAD`, found via `git describe` with a
 `--match` glob that skips stray non-semver tags. The range head is a

--- a/scripts/ops/prepare-release.sh
+++ b/scripts/ops/prepare-release.sh
@@ -14,8 +14,8 @@
 #   4. Regenerate third-party licenses
 #   5. Commit the release changes
 #
-# Usage:  ./scripts/prepare-release.sh <VERSION>
-# Example: ./scripts/prepare-release.sh 3.6.0
+# Usage:  ./scripts/ops/prepare-release.sh <VERSION>
+# Example: ./scripts/ops/prepare-release.sh 3.6.0
 #
 
 set -euo pipefail
@@ -67,7 +67,8 @@ require_cmds git-cliff cargo-about cargo-insta
 if [[ -z "${GITHUB_TOKEN:-}" ]]; then
     if command -v gh &>/dev/null && gh auth status &>/dev/null; then
         echo "==> GITHUB_TOKEN not set, obtaining from 'gh auth token'."
-        export GITHUB_TOKEN=$(gh auth token)
+        GITHUB_TOKEN=$(gh auth token)
+        export GITHUB_TOKEN
     else
         echo "WARNING: GITHUB_TOKEN is not set and 'gh' CLI is not authenticated."
         echo "         PR links in the changelog may be missing. Fix: export GITHUB_TOKEN=<token> or 'gh auth login'."


### PR DESCRIPTION
Establishes scripts/ops/ as the home for operator-run tooling and relocates the release-cutting script there. Updates the path references in RELEASES.md and .cliffignore; the CHANGELOG.md mention is left as a historical entry.

Upcoming PR will introduce more automation of the ops processes