### PR TITLE
chore: bump claude review and fix env overflow for big PRs

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -1,7 +1,7 @@
 You are reviewing a Rust pull request. Produce a thorough, actionable review using the structure below.
 
 **IMPORTANT - CONTEXT AWARENESS:**
-- Review any existing PR comments and discussions provided alongside this prompt before giving feedback
+- `Read` the existing-discussion file named in `<existing_discussions>` before giving feedback
 - Do not duplicate points already raised in existing discussions
 - If a resolved thread addressed an issue, do not re-raise it
 - You have read access to the checked-out repository — use `Read`, `Grep`, and `Glob` to verify how changes interact with surrounding code, look up referenced types/functions/tests, and consult [CLAUDE.md], [AGENTS.md], [CONTRIBUTING.md], and [engineering-standards.md] for project conventions

--- a/.github/workflows/claude-pr-review.yml
+++ b/.github/workflows/claude-pr-review.yml
@@ -30,12 +30,6 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: symlink fix workaround
-        run: |
-          # see https://github.com/anthropics/claude-code-action/issues/1205#issuecomment-4248704481
-          rm CLAUDE.md
-          cp AGENTS.md CLAUDE.md
-
       - name: Fetch PR Comments Context
         id: fetch-comments
         env:
@@ -58,7 +52,10 @@ jobs:
             echo '</pr_context>'
             echo ''
             echo '<existing_discussions>'
-            cat /tmp/pr_comments_context.txt
+            echo 'Existing PR comments, reviews, and review threads are in'
+            echo '/tmp/pr_comments_context.txt (JSON). Read that file first, before'
+            echo 'reviewing, so you do not re-raise points already made. If it is'
+            echo 'absent, or holds a ⚠️ line rather than JSON, proceed without it.'
             echo '</existing_discussions>'
             echo ''
             echo '<review_instructions>'
@@ -69,11 +66,11 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@2cc1ac1331eac7a6a96d716dd204dd2888d0fcd2 # main @ Claude Code 2.1.128 / Agent SDK 0.2.128 (needed for --effort xhigh)
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API }}
           prompt: ${{ env.REVIEW_PROMPT }}
           claude_args: >-
-            --model claude-opus-4-7
+            --model claude-opus-5
             --effort xhigh
             --allowed-tools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Validate title type matches changes
         env:
           GH_TOKEN: ${{ github.token }}
-        uses: anthropics/claude-code-action@6062f3709600659be5e47fcddf2cf76993c235c2 #v1.0.76
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API }}
           prompt: ${{ env.TITLE_CHECK_PROMPT }}


### PR DESCRIPTION
Closes #3987 

Notice I added also a small fix not mentioned in the issue, so that reviews work in PRs where comments overflow env vars, like this one https://github.com/near/mpc/actions/runs/30337485870