### PR TITLE
ci: fix nightly build sed branch OR tags

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -28,7 +28,7 @@ jobs:
         env:
           NEARCORE_BRANCH: ${{ inputs.nearcore-branch || 'master' }}
         run: |
-          sed -i "s|\({ git = \"https://github.com/near/nearcore\", branch = \"\)[^\"]*|\1${NEARCORE_BRANCH}|g" Cargo.toml
+          sed -i -E "s#(\{ git = \"https://github.com/near/nearcore\", )(tag|branch) = \"[^\"]*\"#\1branch = \"${NEARCORE_BRANCH}\"#g" Cargo.toml
 
       - name: Build MPC
         id: build-mpc


### PR DESCRIPTION
because Cargo.toml uses tag instead of branch, this CI does not properly replace the branch on nightly runs