### PR TITLE
ci: stop the review bot demanding license notices on dependency bumps

### DIFF
--- a/.github/prompts/pr-review.prompt.md
+++ b/.github/prompts/pr-review.prompt.md
@@ -56,6 +56,7 @@ REVIEW STYLE:
 - Flag code-comment quality issues per [engineering-standards.md]. The goal is to avoid comments that may become stale or add little value to the reader.
 - Do NOT comment on style, formatting, or naming unless it causes a bug.
 - Do NOT restate what the diff already shows
+- Do NOT ask for `third-party-licenses/licenses.html` to be regenerated on a dependency or lockfile change. Those notices are refreshed during release preparation by [prepare-release.sh]; drift between releases is expected and no CI job gates it. Stale notices are only a finding on a release PR, where that script should already have refreshed them.
 - If no critical issues found: approve with a one-line summary
 - Sign off with: ✅ (approved) or ⚠️ (issues found)
 
@@ -108,3 +109,4 @@ Please always use `gh pr comment` to post your review instead.
 [AGENTS.md]: ../../AGENTS.md
 [CONTRIBUTING.md]: ../../CONTRIBUTING.md
 [engineering-standards.md]: ../../docs/engineering-standards.md
+[prepare-release.sh]: ../../scripts/ops/prepare-release.sh


### PR DESCRIPTION
Closes #4020

Scoped to "not on a dependency or lockfile change" rather than a blanket exemption, so stale notices remain a finding on a release PR
