### PR TITLE
build: bump near-sdk to 5.29.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1559,7 +1559,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease 0.2.37",
  "proc-macro2",
@@ -2077,7 +2077,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3097,6 +3097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "digest-io"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2de63d600bc7fab91180bc17385f29b342468dc8ef2af09dceba450a293de3da"
+dependencies = [
+ "digest 0.11.2",
+]
+
+[[package]]
 name = "dirs"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3526,7 +3535,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5099,7 +5108,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6708,19 +6717,6 @@ dependencies = [
 
 [[package]]
 name = "near-crypto-hash"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c203dab49864dd98bb39a849ff78a2191415f2c287b5a1c0845d7ab743539d9"
-dependencies = [
- "borsh",
- "bs58 0.5.1",
- "schemars 0.8.22",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "near-crypto-hash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8fd0822ff3a82bdccda49b787cb11530512a929bfd13fd0d9fbd510b6360200"
@@ -6821,38 +6817,22 @@ dependencies = [
 
 [[package]]
 name = "near-global-contracts"
-version = "0.1.1"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78498a0f092cc6f921032c8ab7792060c3f59cfb16b775d02e62fb56c10f40d"
+checksum = "3380812ba34540085abe428d13d8152eec8b50f6953934f4bd4025c9ec6ea536"
 dependencies = [
  "borsh",
  "cfg_eval",
+ "digest-io",
  "hex",
  "near-account-id",
- "near-crypto-hash 0.1.0",
- "near-primitives-core 0.36.0",
+ "near-crypto-hash",
+ "near-primitives-core 0.37.1",
  "near-sdk-env",
  "schemars 0.8.22",
  "serde",
  "serde_with",
- "sha3 0.10.8",
-]
-
-[[package]]
-name = "near-global-contracts"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9124fca52251d3ecf714ddb50937c39cc3e2b6f4ee03f85e272fa73eb588920e"
-dependencies = [
- "borsh",
- "cfg_eval",
- "hex",
- "near-account-id",
- "near-crypto-hash 0.2.0",
- "near-sdk-env",
- "serde",
- "serde_with",
- "sha3 0.10.8",
+ "sha3 0.11.0",
 ]
 
 [[package]]
@@ -7049,7 +7029,7 @@ dependencies = [
  "ml-dsa",
  "near-account-id",
  "near-gas",
- "near-global-contracts 0.2.0",
+ "near-global-contracts",
  "near-kit-macros",
  "near-token",
  "rand 0.8.6",
@@ -7226,14 +7206,14 @@ dependencies = [
 
 [[package]]
 name = "near-o11y"
-version = "0.36.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d91204ffc16c4f490bc312a29bc1f3a3ab7e2ee612e6acb0c20c0dd75b87411e"
+checksum = "c0627261a90d57b3b55502a445fb0ba18e1dbf9637bc38f221d48e8814ab83f0"
 dependencies = [
  "base64 0.21.7",
  "clap",
- "near-crypto 0.36.0",
- "near-primitives-core 0.36.0",
+ "near-crypto 0.37.1",
+ "near-primitives-core 0.37.1",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-semantic-conventions",
@@ -7657,9 +7637,9 @@ source = "git+https://github.com/near/nearcore?tag=2.13.2#bb3f43910e801c7a58e501
 
 [[package]]
 name = "near-sdk"
-version = "5.28.0"
+version = "5.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b892fe415aed663d56045ded55304ecd7c3ae20acd13705bfd876f900121af73"
+checksum = "7a73792952a259279660613a5fe7a17e9684d20bcb7bb879ea90544c53ae0aaf"
 dependencies = [
  "base64 0.22.1",
  "borsh",
@@ -7667,19 +7647,20 @@ dependencies = [
  "ed25519-dalek",
  "near-abi",
  "near-account-id",
- "near-crypto 0.36.0",
+ "near-crypto 0.37.1",
  "near-gas",
- "near-global-contracts 0.1.1",
- "near-parameters 0.36.0",
- "near-primitives 0.36.0",
- "near-primitives-core 0.36.0",
+ "near-global-contracts",
+ "near-parameters 0.37.1",
+ "near-primitives 0.37.1",
+ "near-primitives-core 0.37.1",
  "near-sdk-core",
  "near-sdk-env",
  "near-sdk-macros",
  "near-sys",
  "near-token",
- "near-vm-runner 0.36.0",
+ "near-vm-runner 0.37.1",
  "once_cell",
+ "p256",
  "schemars 0.8.22",
  "serde",
  "serde_json",
@@ -7690,20 +7671,20 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-core"
-version = "4.1.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4458222343b11d563c011c04e087fbbdbe8ca23acd605aeaffab78faaf0606aa"
+checksum = "a7ff5b3fe050e889000200d4750d73cff60aedab5b52a09f573d527be3683929"
 dependencies = [
  "base64 0.22.1",
  "borsh",
  "bs58 0.5.1",
  "hex",
  "near-account-id",
- "near-crypto 0.36.0",
- "near-crypto-hash 0.1.0",
+ "near-crypto 0.37.1",
+ "near-crypto-hash",
  "near-gas",
- "near-parameters 0.36.0",
- "near-primitives-core 0.36.0",
+ "near-parameters 0.37.1",
+ "near-primitives-core 0.37.1",
  "near-sdk-env",
  "near-token",
  "schemars 0.8.22",
@@ -7715,21 +7696,21 @@ dependencies = [
 
 [[package]]
 name = "near-sdk-env"
-version = "0.1.0"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4f4bf153cf88eadafff20c6d82b16e3cab3fc4d636d3530473079044ddb9bf3"
+checksum = "73a159e55901b3a2fab682896ef8e037a3862d4677e762644be922696de28339"
 dependencies = [
  "near-sys",
  "ripemd",
- "sha2 0.10.9",
- "sha3 0.10.8",
+ "sha2 0.11.0",
+ "sha3 0.11.0",
 ]
 
 [[package]]
 name = "near-sdk-macros"
-version = "5.28.0"
+version = "5.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4880ec9be9f54912938052d0e42299d972020e0ff60ca1efe5aa329da1a212f8"
+checksum = "046d418232eab401e648fea74c5261012fc2649e2154881c6ffc142ef56322a2"
 dependencies = [
  "Inflector",
  "darling 0.20.11",
@@ -7930,9 +7911,9 @@ dependencies = [
 
 [[package]]
 name = "near-vm-runner"
-version = "0.36.0"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48ba8231c6b84f7e8bffd2ffa94f6732f15880d0564ac52eb232efacd455d649"
+checksum = "f46d2e9b9f72344c9cc0645b0fe380e1817d84f621724f144cc4ecc8305a0a22"
 dependencies = [
  "anyhow",
  "blst",
@@ -7944,12 +7925,12 @@ dependencies = [
  "finite-wasm 0.5.1",
  "finite-wasm 0.6.1",
  "lru 0.16.4",
- "near-crypto 0.36.0",
- "near-o11y 0.36.0",
- "near-parameters 0.36.0",
- "near-primitives-core 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "near-stdx 0.36.0",
+ "near-crypto 0.37.1",
+ "near-o11y 0.37.1",
+ "near-parameters 0.37.1",
+ "near-primitives-core 0.37.1",
+ "near-schema-checker-lib 0.37.1",
+ "near-stdx 0.37.1",
  "num-rational 0.3.2",
  "p256",
  "parking_lot 0.12.5",
@@ -9588,7 +9569,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10423,7 +10404,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10436,7 +10417,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10495,7 +10476,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 0.26.11",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -10516,7 +10497,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs 1.0.6",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11725,7 +11706,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13378,7 +13359,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6025,12 +6025,12 @@ dependencies = [
  "hex",
  "mpc-primitives",
  "near-account-id",
- "near-crypto 0.36.0",
- "near-jsonrpc-client 0.21.1",
- "near-jsonrpc-primitives 0.36.0",
+ "near-crypto 0.37.1",
+ "near-jsonrpc-client",
+ "near-jsonrpc-primitives 0.37.1",
  "near-mpc-bounded-collections",
  "near-mpc-contract-interface",
- "near-primitives 0.36.0",
+ "near-primitives 0.37.1",
  "near-sdk",
  "node-types",
  "rand 0.8.6",
@@ -6399,31 +6399,6 @@ dependencies = [
 
 [[package]]
 name = "near-chain-configs"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ad19244d6390aa12020ed3f5971ea452fb54aa8b8f6435d4cf0cbbbc8fbd302"
-dependencies = [
- "anyhow",
- "bytesize",
- "chrono",
- "derive_more 2.1.1",
- "near-config-utils 0.36.0",
- "near-crypto 0.36.0",
- "near-parameters 0.36.0",
- "near-primitives 0.36.0",
- "near-time 0.36.0",
- "num-rational 0.3.2",
- "parking_lot 0.12.5",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "smart-default",
- "time",
- "tracing",
-]
-
-[[package]]
-name = "near-chain-configs"
 version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c040592165e3d2bfc8887976eeac4c933bc91bb43f6fbf88fcf29e77e033378"
@@ -6589,18 +6564,6 @@ dependencies = [
 
 [[package]]
 name = "near-config-utils"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0238af1d79fd3841817e3a5861bb628ba825669f211ca379836ae716da67bb21"
-dependencies = [
- "anyhow",
- "json_comments",
- "thiserror 2.0.19",
- "tracing",
-]
-
-[[package]]
-name = "near-config-utils"
 version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70fe450b1373398e71738321751b606fa10a5461a17e3f5ec84f10e3641c7744"
@@ -6632,32 +6595,6 @@ dependencies = [
  "near-token",
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "near-crypto"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe9390bf0db47f0a34386ef6a30adc1270288874b7eac5cab7fa48d3f89fe03"
-dependencies = [
- "blake2",
- "borsh",
- "bs58 0.4.0",
- "curve25519-dalek",
- "derive_more 2.1.1",
- "ed25519-dalek",
- "hex",
- "near-account-id",
- "near-config-utils 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "near-stdx 0.36.0",
- "primitive-types 0.10.1",
- "rand 0.8.6",
- "secp256k1 0.27.0",
- "serde",
- "serde_json",
- "subtle",
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -6780,15 +6717,6 @@ dependencies = [
 
 [[package]]
 name = "near-fmt"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "503fac5d4e533a6d5e2c642cd22bd2400d1159dd5b2db58072dfc183a288c273"
-dependencies = [
- "near-primitives-core 0.36.0",
-]
-
-[[package]]
-name = "near-fmt"
 version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a831df247238a0b55699065bb024a365fcae1db44a55dd432f97500b200ae4d0"
@@ -6903,25 +6831,6 @@ dependencies = [
 
 [[package]]
 name = "near-jsonrpc-client"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614359c17b9cbf5faf2d82ecfe10d7a79b588c51f5f04517f75eff09f1751cdb"
-dependencies = [
- "borsh",
- "lazy_static",
- "log",
- "near-chain-configs 0.36.0",
- "near-crypto 0.36.0",
- "near-jsonrpc-primitives 0.36.0",
- "near-primitives 0.36.0",
- "reqwest 0.12.28",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
-]
-
-[[package]]
-name = "near-jsonrpc-client"
 version = "0.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d89c387760380551514795ac1d1b9de102fc09d3bc0a6ded75e88ded33d6822"
@@ -6951,24 +6860,6 @@ dependencies = [
  "serde",
  "serde_json",
  "url",
-]
-
-[[package]]
-name = "near-jsonrpc-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "99fa313996117ffead7c6f8eb12bb2b83e6ad569c7c2fd58d406c0f53ed06e01"
-dependencies = [
- "arbitrary",
- "near-chain-configs 0.36.0",
- "near-crypto 0.36.0",
- "near-primitives 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "near-time 0.36.0",
- "serde",
- "serde_json",
- "thiserror 2.0.19",
- "time",
 ]
 
 [[package]]
@@ -7253,25 +7144,6 @@ dependencies = [
 
 [[package]]
 name = "near-parameters"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b89a9337ab742575d6dc9770ee7d4398de8cec8bbe5eaf25f00349f4e13d0173"
-dependencies = [
- "borsh",
- "enum-map",
- "near-account-id",
- "near-primitives-core 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "num-rational 0.3.2",
- "serde",
- "serde_repr",
- "serde_yaml",
- "strum 0.24.1",
- "thiserror 2.0.19",
-]
-
-[[package]]
-name = "near-parameters"
 version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea8b451deb2c7f2c5f5f375d86ac881ea89a7c726fa66d9326d1932a89d5623"
@@ -7317,49 +7189,6 @@ dependencies = [
  "near-o11y 2.13.2",
  "near-primitives 2.13.2",
  "rand 0.8.6",
-]
-
-[[package]]
-name = "near-primitives"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "381f54f821ecdddfaccba5815a8d72bb4bb7abacac79783ce86841518523c591"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "bitvec",
- "borsh",
- "bytes",
- "bytesize",
- "chrono",
- "derive_builder",
- "derive_more 2.1.1",
- "easy-ext",
- "enum-map",
- "hex",
- "itertools 0.14.0",
- "near-crypto 0.36.0",
- "near-fmt 0.36.0",
- "near-parameters 0.36.0",
- "near-primitives-core 0.36.0",
- "near-schema-checker-lib 0.36.0",
- "near-stdx 0.36.0",
- "near-time 0.36.0",
- "num-rational 0.3.2",
- "ordered-float 4.6.0",
- "primitive-types 0.10.1",
- "rand 0.8.6",
- "rand_chacha 0.3.1",
- "serde",
- "serde_json",
- "serde_with",
- "sha3 0.10.8",
- "smallvec",
- "smart-default",
- "strum 0.24.1",
- "thiserror 2.0.19",
- "tracing",
- "zstd",
 ]
 
 [[package]]
@@ -7446,30 +7275,6 @@ dependencies = [
  "thiserror 2.0.19",
  "tracing",
  "zstd",
-]
-
-[[package]]
-name = "near-primitives-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5660ac51d24534bc144e7cc04f702921c22a7e2553072663d4b43a56a8bb1ae7"
-dependencies = [
- "arbitrary",
- "base64 0.21.7",
- "borsh",
- "bs58 0.4.0",
- "derive_more 2.1.1",
- "enum-map",
- "near-account-id",
- "near-gas",
- "near-schema-checker-lib 0.36.0",
- "near-token",
- "num-rational 0.3.2",
- "serde",
- "serde_repr",
- "serde_with",
- "sha2 0.10.9",
- "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -7574,12 +7379,6 @@ dependencies = [
 
 [[package]]
 name = "near-schema-checker-core"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37ad456b1bd9876772d6c0b557d100d518d60dd13e359daca8e0293828e29a05"
-
-[[package]]
-name = "near-schema-checker-core"
 version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b76b929fcd3ca312fad49075e6a69ff007b8d953b94d31b271a00512743735a"
@@ -7588,16 +7387,6 @@ checksum = "1b76b929fcd3ca312fad49075e6a69ff007b8d953b94d31b271a00512743735a"
 name = "near-schema-checker-core"
 version = "2.13.2"
 source = "git+https://github.com/near/nearcore?tag=2.13.2#bb3f43910e801c7a58e5018f3f7ad33644ccd354"
-
-[[package]]
-name = "near-schema-checker-lib"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebdeed0043b2309b306984e4d3eeff6777ba6c66a2f955d34f883fd4ce7f84f2"
-dependencies = [
- "near-schema-checker-core 0.36.0",
- "near-schema-checker-macro 0.36.0",
-]
 
 [[package]]
 name = "near-schema-checker-lib"
@@ -7617,12 +7406,6 @@ dependencies = [
  "near-schema-checker-core 2.13.2",
  "near-schema-checker-macro 2.13.2",
 ]
-
-[[package]]
-name = "near-schema-checker-macro"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "731a7b9cc155e291f149f2f6f8f88f5cab512b772aaf301f9defb4e4bceb1629"
 
 [[package]]
 name = "near-schema-checker-macro"
@@ -7725,12 +7508,6 @@ dependencies = [
 
 [[package]]
 name = "near-stdx"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f35191f9d7a78d5cdca9788e648dce89ebbb74faef4abfa6992ed7f1fb300369"
-
-[[package]]
-name = "near-stdx"
 version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0756fd99704e5ee8a83430a5f914db53aff72e2a593ce2683bcab15886299b96"
@@ -7809,17 +7586,6 @@ dependencies = [
  "serde",
  "serde_json",
  "tracing",
-]
-
-[[package]]
-name = "near-time"
-version = "0.36.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba02806ee8691aaf41717febbe09f8e8b60ff145f09f0fc23438c07a370b3b7"
-dependencies = [
- "parking_lot 0.12.5",
- "serde",
- "time",
 ]
 
 [[package]]
@@ -8063,7 +7829,7 @@ dependencies = [
  "near-account-id",
  "near-crypto 0.37.1",
  "near-gas",
- "near-jsonrpc-client 0.22.0",
+ "near-jsonrpc-client",
  "near-jsonrpc-primitives 0.37.1",
  "near-primitives 0.37.1",
  "near-sandbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -191,7 +191,7 @@ near-jsonrpc-primitives = "0.36.0"
 near-kit = { version = "0.12.1", default-features = false }
 near-primitives = "0.36.0"
 near-sandbox = "0.3.11"
-near-sdk = { version = "5.28.0", features = [
+near-sdk = { version = "5.29.0", features = [
     "legacy",
     "unstable",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -184,12 +184,12 @@ near-account-id = "2.6.0"
 # the git nearcore crate below, which the node's indexer stack requires.
 # Must be bumped in lockstep with `near-primitives`: its types appear in
 # near-primitives' transaction API but are not re-exported there.
-near-crypto-public = { version = "0.36.0", package = "near-crypto" }
+near-crypto-public = { version = "0.37.1", package = "near-crypto" }
 near-gas = "0.3.4"
-near-jsonrpc-client = "0.21.1"
-near-jsonrpc-primitives = "0.36.0"
+near-jsonrpc-client = "0.22.0"
+near-jsonrpc-primitives = "0.37.1"
 near-kit = { version = "0.12.1", default-features = false }
-near-primitives = "0.36.0"
+near-primitives = "0.37.1"
 near-sandbox = "0.3.11"
 near-sdk = { version = "5.29.0", features = [
     "legacy",

--- a/crates/contract/src/crypto_shared/types.rs
+++ b/crates/contract/src/crypto_shared/types.rs
@@ -79,18 +79,14 @@ impl From<PublicKeyExtended> for dtos::PublicKey {
     fn from(public_key_extended: PublicKeyExtended) -> Self {
         match public_key_extended {
             PublicKeyExtended::Secp256k1 { near_public_key } => {
-                let mut bytes = [0u8; 64];
-                bytes.copy_from_slice(&near_public_key.as_bytes()[1..]);
-                dtos::PublicKey::Secp256k1(dtos::Secp256k1PublicKey::from(bytes))
+                dtos::PublicKey::try_from(&near_public_key)
+                    .expect("Secp256k1 variant always has a secp256k1 key")
             }
             PublicKeyExtended::Ed25519 {
                 near_public_key_compressed,
                 ..
-            } => {
-                let mut bytes = [0u8; 32];
-                bytes.copy_from_slice(&near_public_key_compressed.as_bytes()[1..]);
-                dtos::PublicKey::Ed25519(dtos::Ed25519PublicKey::from(bytes))
-            }
+            } => dtos::PublicKey::try_from(&near_public_key_compressed)
+                .expect("Ed25519 variant always has an ed25519 key"),
             PublicKeyExtended::Bls12381 { public_key } => public_key,
         }
     }
@@ -335,8 +331,10 @@ pub mod ed25519_types {
 }
 
 #[cfg(test)]
+#[expect(non_snake_case)]
 mod tests {
     use super::*;
+    use assert_matches::assert_matches;
     use k256::elliptic_curve::PrimeField;
     use rstest::rstest;
 
@@ -377,5 +375,25 @@ mod tests {
             <PublicKeyExtended as BorshDeserialize>::deserialize(&mut slice_ref).unwrap();
 
         assert_eq!(deserialized, public_key_extended);
+    }
+
+    #[test]
+    fn public_key_extended_try_from_near_public_key__should_reject_mldsa65() {
+        // Given
+        const MLDSA65_PUBLIC_KEY_SIZE: usize = 1952;
+        let near_public_key = near_sdk::PublicKey::from_parts(
+            near_sdk::CurveType::MLDSA65,
+            vec![0u8; MLDSA65_PUBLIC_KEY_SIZE],
+        )
+        .unwrap();
+
+        // When
+        let result = PublicKeyExtended::try_from(near_public_key);
+
+        // Then
+        assert_matches!(
+            result,
+            Err(PublicKeyExtendedConversionError::UnsupportedCurve)
+        );
     }
 }

--- a/crates/contract/src/crypto_shared/types.rs
+++ b/crates/contract/src/crypto_shared/types.rs
@@ -79,12 +79,18 @@ impl From<PublicKeyExtended> for dtos::PublicKey {
     fn from(public_key_extended: PublicKeyExtended) -> Self {
         match public_key_extended {
             PublicKeyExtended::Secp256k1 { near_public_key } => {
-                dtos::PublicKey::from(&near_public_key)
+                let mut bytes = [0u8; 64];
+                bytes.copy_from_slice(&near_public_key.as_bytes()[1..]);
+                dtos::PublicKey::Secp256k1(dtos::Secp256k1PublicKey::from(bytes))
             }
             PublicKeyExtended::Ed25519 {
                 near_public_key_compressed,
                 ..
-            } => dtos::PublicKey::from(&near_public_key_compressed),
+            } => {
+                let mut bytes = [0u8; 32];
+                bytes.copy_from_slice(&near_public_key_compressed.as_bytes()[1..]);
+                dtos::PublicKey::Ed25519(dtos::Ed25519PublicKey::from(bytes))
+            }
             PublicKeyExtended::Bls12381 { public_key } => public_key,
         }
     }

--- a/crates/contract/src/crypto_shared/types.rs
+++ b/crates/contract/src/crypto_shared/types.rs
@@ -40,6 +40,7 @@ pub enum PublicKeyExtended {
 pub enum PublicKeyExtendedConversionError {
     PublicKeyLengthMalformed,
     FailedDecompressingToEdwardsPoint,
+    UnsupportedCurve,
 }
 
 impl Display for PublicKeyExtendedConversionError {
@@ -49,6 +50,7 @@ impl Display for PublicKeyExtendedConversionError {
             Self::FailedDecompressingToEdwardsPoint => {
                 "The provided compressed key can not be decompressed to an edwards point."
             }
+            Self::UnsupportedCurve => "The provided curve is not supported.",
         };
 
         f.write_str(message)
@@ -110,6 +112,9 @@ impl TryFrom<near_sdk::PublicKey> for PublicKeyExtended {
                 }
             }
             near_sdk::CurveType::SECP256K1 => Self::Secp256k1 { near_public_key },
+            near_sdk::CurveType::MLDSA65 => {
+                return Err(PublicKeyExtendedConversionError::UnsupportedCurve);
+            }
         };
 
         Ok(extended_key)

--- a/crates/near-mpc-crypto-types/src/conversions/near.rs
+++ b/crates/near-mpc-crypto-types/src/conversions/near.rs
@@ -2,22 +2,21 @@ use super::CryptoConversionError;
 use crate::crypto::{Ed25519PublicKey, PublicKey, PublicKeyExtended, Secp256k1PublicKey};
 use crate::primitives::K256Signature;
 
-impl From<&near_sdk::PublicKey> for PublicKey {
-    fn from(pk: &near_sdk::PublicKey) -> Self {
+impl TryFrom<&near_sdk::PublicKey> for PublicKey {
+    type Error = CryptoConversionError;
+    fn try_from(pk: &near_sdk::PublicKey) -> Result<Self, Self::Error> {
         match pk.curve_type() {
             near_sdk::CurveType::SECP256K1 => {
                 let mut bytes = [0u8; 64];
                 bytes.copy_from_slice(&pk.as_bytes()[1..]);
-                PublicKey::Secp256k1(Secp256k1PublicKey::from(bytes))
+                Ok(PublicKey::Secp256k1(Secp256k1PublicKey::from(bytes)))
             }
             near_sdk::CurveType::ED25519 => {
                 let mut bytes = [0u8; 32];
                 bytes.copy_from_slice(&pk.as_bytes()[1..]);
-                PublicKey::Ed25519(Ed25519PublicKey::from(bytes))
+                Ok(PublicKey::Ed25519(Ed25519PublicKey::from(bytes)))
             }
-            near_sdk::CurveType::MLDSA65 => {
-                unreachable!("MLDSA65 near_sdk::PublicKey has no mapping to dtos::PublicKey")
-            }
+            near_sdk::CurveType::MLDSA65 => Err(CryptoConversionError::UnsupportedCurve),
         }
     }
 }
@@ -150,7 +149,7 @@ mod tests {
             .unwrap();
 
         // when
-        let dto = PublicKey::from(&near_pk);
+        let dto = PublicKey::try_from(&near_pk).unwrap();
         let recovered = near_sdk::PublicKey::try_from(dto).unwrap();
 
         // then
@@ -165,7 +164,7 @@ mod tests {
                 .parse().unwrap();
 
         // when
-        let dto = PublicKey::from(&near_pk);
+        let dto = PublicKey::try_from(&near_pk).unwrap();
         let recovered = near_sdk::PublicKey::try_from(dto).unwrap();
 
         // then

--- a/crates/near-mpc-crypto-types/src/conversions/near.rs
+++ b/crates/near-mpc-crypto-types/src/conversions/near.rs
@@ -106,10 +106,23 @@ impl K256Signature {
 }
 
 #[cfg(test)]
+#[expect(non_snake_case)]
 mod tests {
     use super::*;
     use crate::crypto::Bls12381G2PublicKey;
     use assert_matches::assert_matches;
+    use rstest::rstest;
+
+    const ED25519_PUBLIC_KEY_SIZE: usize = 32;
+    const SECP256K1_PUBLIC_KEY_SIZE: usize = 64;
+    const MLDSA65_PUBLIC_KEY_SIZE: usize = 1952;
+
+    fn encoded_mldsa65_key() -> String {
+        format!(
+            "ml-dsa-65:{}",
+            bs58::encode(vec![0u8; MLDSA65_PUBLIC_KEY_SIZE]).into_string()
+        )
+    }
 
     #[test]
     fn roundtrip_ed25519_public_key() {
@@ -212,32 +225,69 @@ mod tests {
     }
 
     #[test]
-    fn test_assert_near_public_key_sizes() {
-        const ED25519_PUBLIC_KEY_SIZE: usize = 32;
-        const SECP256K1_PUBLIC_KEY_SIZE: usize = 64;
+    fn public_key_try_from_near_public_key__should_reject_mldsa65() {
+        // Given
+        let near_pk = near_sdk::PublicKey::from_parts(
+            near_sdk::CurveType::MLDSA65,
+            vec![0u8; MLDSA65_PUBLIC_KEY_SIZE],
+        )
+        .unwrap();
 
-        let near_public_keys = [
-            "secp256k1:4Ls3DBDeFDaf5zs2hxTBnJpKnfsnjNahpKU9HwQvij8fTXoCP9y5JQqQpe273WgrKhVVj1EH73t5mMJKDFMsxoEd",
-            "secp256k1:3Abs6NwUMErNAftRfipRjWxxqcTPBJTSr2uoHi3bHcthzb4iXqNnNYi86ATKwf4XWHg1JDrX2m1sJgNMYq7ey6cG",
-            "secp256k1:21C8NARZw2tUuULi1tENKi5azgDKLp9cv4FT2U1N6iF5k1W33BbJvsLr6rCZsYZxxUjBtpuWCsKvmv9P5ARzyyyn",
-            "secp256k1:4YbU8ZLEQK7gww1f65ZhtFCYfSxrm67sV9eaQi8oRo1LvCAtznztsiryJrzHg2oz285xN3ADAsGPizmCNe4hn9WR",
-            "ed25519:2XPuwqhg71RXRiTUMKGapd8FYWgXnxVvydYBK9tS1ex2",
-            "ed25519:4upBpJYUrjPBzqNYaY8pvJGQtep7YMT3j9zRsopYQqfG",
-            "ed25519:6sqMFXkswuH9b7Pnn6dGAy1vA1X3N2CSrKDDkdHzTcrv",
-            "ed25519:Fru1RoC6dw1xY2J6C6ZSBUt5PEysxTLX2kDexxqoDN6k",
-        ];
-        for pk in near_public_keys {
-            let near_pk: near_sdk::PublicKey = pk.parse().unwrap();
-            match near_pk.curve_type() {
-                near_sdk::CurveType::ED25519 => {
-                    assert_eq!(near_pk.as_bytes().len(), ED25519_PUBLIC_KEY_SIZE + 1);
-                }
-                near_sdk::CurveType::SECP256K1 => {
-                    assert_eq!(near_pk.as_bytes().len(), SECP256K1_PUBLIC_KEY_SIZE + 1);
-                }
-                near_sdk::CurveType::MLDSA65 => unreachable!(),
-            }
-        }
+        // When
+        let result = PublicKey::try_from(&near_pk);
+
+        // Then
+        assert_matches!(result, Err(CryptoConversionError::UnsupportedCurve));
+    }
+
+    /// The `[1..]` slicing in the conversions above relies on `as_bytes()` being
+    /// the raw key prefixed with a single curve-type byte.
+    #[rstest]
+    #[case::secp256k1_1(
+        "secp256k1:4Ls3DBDeFDaf5zs2hxTBnJpKnfsnjNahpKU9HwQvij8fTXoCP9y5JQqQpe273WgrKhVVj1EH73t5mMJKDFMsxoEd",
+        SECP256K1_PUBLIC_KEY_SIZE
+    )]
+    #[case::secp256k1_2(
+        "secp256k1:3Abs6NwUMErNAftRfipRjWxxqcTPBJTSr2uoHi3bHcthzb4iXqNnNYi86ATKwf4XWHg1JDrX2m1sJgNMYq7ey6cG",
+        SECP256K1_PUBLIC_KEY_SIZE
+    )]
+    #[case::secp256k1_3(
+        "secp256k1:21C8NARZw2tUuULi1tENKi5azgDKLp9cv4FT2U1N6iF5k1W33BbJvsLr6rCZsYZxxUjBtpuWCsKvmv9P5ARzyyyn",
+        SECP256K1_PUBLIC_KEY_SIZE
+    )]
+    #[case::secp256k1_4(
+        "secp256k1:4YbU8ZLEQK7gww1f65ZhtFCYfSxrm67sV9eaQi8oRo1LvCAtznztsiryJrzHg2oz285xN3ADAsGPizmCNe4hn9WR",
+        SECP256K1_PUBLIC_KEY_SIZE
+    )]
+    #[case::ed25519_1(
+        "ed25519:2XPuwqhg71RXRiTUMKGapd8FYWgXnxVvydYBK9tS1ex2",
+        ED25519_PUBLIC_KEY_SIZE
+    )]
+    #[case::ed25519_2(
+        "ed25519:4upBpJYUrjPBzqNYaY8pvJGQtep7YMT3j9zRsopYQqfG",
+        ED25519_PUBLIC_KEY_SIZE
+    )]
+    #[case::ed25519_3(
+        "ed25519:6sqMFXkswuH9b7Pnn6dGAy1vA1X3N2CSrKDDkdHzTcrv",
+        ED25519_PUBLIC_KEY_SIZE
+    )]
+    #[case::ed25519_4(
+        "ed25519:Fru1RoC6dw1xY2J6C6ZSBUt5PEysxTLX2kDexxqoDN6k",
+        ED25519_PUBLIC_KEY_SIZE
+    )]
+    #[case::mldsa65(&encoded_mldsa65_key(), MLDSA65_PUBLIC_KEY_SIZE)]
+    fn near_public_key__should_prefix_the_raw_key_with_one_curve_type_byte(
+        #[case] encoded_key: &str,
+        #[case] expected_key_size: usize,
+    ) {
+        // Given
+        let near_pk: near_sdk::PublicKey = encoded_key.parse().unwrap();
+
+        // When
+        let bytes = near_pk.as_bytes();
+
+        // Then
+        assert_eq!(bytes.len(), expected_key_size + 1);
     }
 
     #[test]

--- a/crates/near-mpc-crypto-types/src/conversions/near.rs
+++ b/crates/near-mpc-crypto-types/src/conversions/near.rs
@@ -15,6 +15,9 @@ impl From<&near_sdk::PublicKey> for PublicKey {
                 bytes.copy_from_slice(&pk.as_bytes()[1..]);
                 PublicKey::Ed25519(Ed25519PublicKey::from(bytes))
             }
+            near_sdk::CurveType::MLDSA65 => {
+                unreachable!("MLDSA65 near_sdk::PublicKey has no mapping to dtos::PublicKey")
+            }
         }
     }
 }
@@ -233,6 +236,7 @@ mod tests {
                 near_sdk::CurveType::SECP256K1 => {
                     assert_eq!(near_pk.as_bytes().len(), SECP256K1_PUBLIC_KEY_SIZE + 1);
                 }
+                near_sdk::CurveType::MLDSA65 => unreachable!(),
             }
         }
     }

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,7 @@ ignore = [
   # TODO(#3732): remove once quick-xml dependency is >= 0.41.0
   "RUSTSEC-2026-0194", # quadratic attribute duplicate-check
   "RUSTSEC-2026-0195", # unbounded namespace-declaration allocation
+  "RUSTSEC-2026-0222", # wasmtime: stores can mix up type indices between engines
 ]
 
 [bans]


### PR DESCRIPTION
This pull request updates the `near-sdk` dependency in the `Cargo.toml` file to a newer version. This is a straightforward dependency version bump.

- Dependency updates:
  * Upgraded `near-sdk` from version `5.28.0` to `5.29.0` in `Cargo.toml` to ensure compatibility with the latest features and fixes.