### PR TITLE
chore: bump nearkit from 0.12.1 to 0.14.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6900,9 +6900,9 @@ dependencies = [
 
 [[package]]
 name = "near-kit"
-version = "0.12.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e09f8896690046f5e20b455592555ce408a07257b96d7f9ac6eed6210307ad2"
+checksum = "e542f3e8a8705fc55b69802db8fc3ec4c3eba6012e4e5ce7a21d9f1d42f9d477"
 dependencies = [
  "base64 0.22.1",
  "bip39",
@@ -6929,10 +6929,9 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.11.0",
- "sha3 0.11.0",
+ "sha3 0.12.0",
  "thiserror 2.0.19",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -10853,6 +10852,17 @@ checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
 dependencies = [
  "digest 0.11.2",
  "keccak 0.2.0",
+]
+
+[[package]]
+name = "sha3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc9bad02c26382724b2d2692c6f179285e4b54eeecd7968f52a50059c3c11759"
+dependencies = [
+ "digest 0.11.2",
+ "keccak 0.2.0",
+ "sponge-cursor",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -188,7 +188,7 @@ near-crypto-public = { version = "0.37.1", package = "near-crypto" }
 near-gas = "0.3.4"
 near-jsonrpc-client = "0.22.0"
 near-jsonrpc-primitives = "0.37.1"
-near-kit = { version = "0.12.1", default-features = false }
+near-kit = { version = "0.14.0", default-features = false, features = ["rpc"] }
 near-primitives = "0.37.1"
 near-sandbox = "0.3.11"
 near-sdk = { version = "5.29.0", features = [

--- a/crates/e2e-tests/src/blockchain.rs
+++ b/crates/e2e-tests/src/blockchain.rs
@@ -1,6 +1,6 @@
 use ed25519_dalek::SigningKey;
 use near_contract_transport::{CallContract, FunctionCallArgs};
-use near_kit::FinalExecutionOutcome;
+use near_kit::{Final, FinalExecutionOutcome};
 use near_mpc_contract_interface::client::MpcContractHandle;
 use near_mpc_contract_interface::types::ProtocolContractState;
 use serde::de::DeserializeOwned;
@@ -78,7 +78,7 @@ impl NearBlockchain {
             tx = tx.add_full_access_key(key.to_near_public_key());
         }
 
-        tx.wait_until(near_kit::Final)
+        tx.wait_until::<Final>()
             .await
             .map_err(|e| anyhow::anyhow!("failed to create account {name}: {e}"))?;
         Ok(())
@@ -97,7 +97,7 @@ impl NearBlockchain {
             .transfer(near_kit::NearToken::from_near(balance_near))
             .add_full_access_key(key.to_near_public_key())
             .deploy(wasm.to_vec())
-            .wait_until(near_kit::Final)
+            .wait_until::<Final>()
             .await
             .map_err(|e| anyhow::anyhow!("failed to create account and deploy to {name}: {e}"))?;
 


### PR DESCRIPTION
The previous PR (#4040) created by dependabot to upgrade nearkit didn't compile, this is a follow up to correct this.