### PR TITLE
chore: bump up rkyv as per RUSTSEC 2026-0233/0234/0235

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11475,7 +11475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9855,9 +9855,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73389e0c99e664f919275ab5b5b0471391fe9a8de61e1dff9b1eaf56a90f16e3"
+checksum = "815cc8a37159a463064825246cadb07961e25cd9885908606f6d08a98d8f8874"
 dependencies = [
  "bytecheck",
  "bytes",
@@ -9874,9 +9874,9 @@ dependencies = [
 
 [[package]]
 name = "rkyv_derive"
-version = "0.8.16"
+version = "0.8.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d2ed0b54125315fb36bd021e82d314d1c126548f871634b483f46b31d13cac6"
+checksum = "c0ed1a78a1b19d184b0daa629dd9a024573173ec7d485b287cb369fb3607cc1c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11475,7 +11475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
  "windows-sys 0.61.2",

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,13 @@ ignore = [
   # has no patched release. Only reachable through near-vm-runner, which never
   # shares a Store across Engines.
   "RUSTSEC-2026-0222", # wasmtime stores can mix up type indices between engines
+  # Package rkyv pulled from near-vm-compiler (nearcore) 
+  # Patched >=0.8.17, 
+  # TODO(#3732): drop once nearcore is bumped to version that doesn't pull in
+  # vulnerable version.
+  "RUSTSEC-2026-0233",
+  "RUSTSEC-2026-0234",
+  "RUSTSEC-2026-0235",
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -33,8 +33,7 @@ ignore = [
   # has no patched release. Only reachable through near-vm-runner, which never
   # shares a Store across Engines.
   "RUSTSEC-2026-0222", # wasmtime stores can mix up type indices between engines
-  # Package rkyv pulled from near-vm-compiler (nearcore)
-  # Patched >=0.8.17,
+  # Package rkyv pulled from near-vm-compiler (nearcore), patched >=0.8.17
   # TODO(#3732): drop once nearcore is bumped to version that doesn't pull in
   # vulnerable version.
   "RUSTSEC-2026-0233",

--- a/deny.toml
+++ b/deny.toml
@@ -33,12 +33,6 @@ ignore = [
   # has no patched release. Only reachable through near-vm-runner, which never
   # shares a Store across Engines.
   "RUSTSEC-2026-0222", # wasmtime stores can mix up type indices between engines
-  # Package rkyv pulled from near-vm-compiler (nearcore), patched >=0.8.17
-  # TODO(#3732): drop once nearcore is bumped to version that doesn't pull in
-  # vulnerable version.
-  "RUSTSEC-2026-0233",
-  "RUSTSEC-2026-0234",
-  "RUSTSEC-2026-0235",
 ]
 
 [bans]

--- a/deny.toml
+++ b/deny.toml
@@ -33,8 +33,8 @@ ignore = [
   # has no patched release. Only reachable through near-vm-runner, which never
   # shares a Store across Engines.
   "RUSTSEC-2026-0222", # wasmtime stores can mix up type indices between engines
-  # Package rkyv pulled from near-vm-compiler (nearcore) 
-  # Patched >=0.8.17, 
+  # Package rkyv pulled from near-vm-compiler (nearcore)
+  # Patched >=0.8.17,
   # TODO(#3732): drop once nearcore is bumped to version that doesn't pull in
   # vulnerable version.
   "RUSTSEC-2026-0233",


### PR DESCRIPTION
These were issued today. Adding to exclude as it's failing CI in other PR's.