### PR TITLE
feat: EVM chains RPC probing logic

### DIFF
--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -249,7 +249,7 @@ mod tests {
             self.chain_id.to_string()
         }
 
-        /// The form `eth_chainId` answers.
+        /// The `0xXXX` hex quantity an RPC provider answers to an `eth_chainId` request.
         fn answered(&self) -> String {
             format!("{:#x}", self.chain_id)
         }

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -831,7 +831,13 @@ mod tests {
         else {
             panic!("expected the flood to read as the wrong network");
         };
-        assert!(observed.to_string().chars().count() < 100);
+        let observed = observed.to_string();
+        assert!(observed.ends_with("_TRUNCATED"), "{observed}");
+        assert_eq!(
+            observed.chars().count(),
+            NetworkFingerprint::MAX_CHARS,
+            "{observed}"
+        );
     }
 
     #[test]

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -4,6 +4,13 @@
 use std::collections::BTreeMap;
 use std::time::Duration;
 
+use foreign_chain_inspector::abstract_chain::inspector::Abstract;
+use foreign_chain_inspector::arbitrum::inspector::Arbitrum;
+use foreign_chain_inspector::base::inspector::Base;
+use foreign_chain_inspector::bnb::inspector::Bnb;
+use foreign_chain_inspector::evm::inspector::{EvmChain, EvmInspector};
+use foreign_chain_inspector::hyperevm::inspector::HyperEvm;
+use foreign_chain_inspector::polygon::inspector::Polygon;
 use foreign_chain_inspector::starknet::inspector::StarknetInspector;
 use foreign_chain_inspector::{
     FanOut, ForeignChainInspectionError, NetworkFingerprint, ProviderFailure,
@@ -95,13 +102,31 @@ pub async fn probe_all_providers(config: &ForeignChainsConfig) -> ProbeReport {
                     })
                     .await
                 }
-                // TODO(#4003): probe the remaining chains.
+                ForeignChain::Abstract => probe_evm::<Abstract>(chain, chain_config).await,
+                ForeignChain::Arbitrum => probe_evm::<Arbitrum>(chain, chain_config).await,
+                ForeignChain::Base => probe_evm::<Base>(chain, chain_config).await,
+                ForeignChain::Bnb => probe_evm::<Bnb>(chain, chain_config).await,
+                ForeignChain::HyperEvm => probe_evm::<HyperEvm>(chain, chain_config).await,
+                ForeignChain::Polygon => probe_evm::<Polygon>(chain, chain_config).await,
+                // TODO(#4003): probe Bitcoin, Aptos and Sui. Ethereum, Solana and Ton have no
+                // inspector, so there is nothing to probe them with.
                 _ => rows_of(chain, chain_config, ProviderStatus::ProbeNotImplemented),
             }
         });
 
     let report_rows = futures::future::join_all(probe_attempts).await.concat();
     ProbeReport { rows: report_rows }
+}
+
+/// The chain marker only types the inspector; `eth_chainId` is the same call for all of them.
+async fn probe_evm<Chain>(chain: ForeignChain, config: &ForeignChainConfig) -> Vec<ProviderHealth>
+where
+    Chain: EvmChain + Clone + Send + Sync + 'static,
+{
+    probe_chain(chain, config, |provider| {
+        Ok(EvmInspector::<_, Chain>::new(prepare_jsonrpc(provider)?))
+    })
+    .await
 }
 
 async fn probe_chain<I>(
@@ -224,6 +249,19 @@ mod tests {
     const PADDED_UPPERCASE_MAINNET: &str = "0x00534E5F4D41494E";
     /// Reserved as "discard", so nothing listens there.
     const CLOSED_PORT_URL: &str = "http://127.0.0.1:9";
+    /// For a chain with no probe: the value is never read, only whether it is set at all.
+    const ANY_FINGERPRINT: &str = "any-fingerprint";
+
+    /// Every EVM chain the probe covers: what `eth_chainId` answers on mainnet, and the decimal
+    /// chain id an operator configures.
+    const EVM_MAINNETS: [(ForeignChain, &str, &str); 6] = [
+        (ForeignChain::Abstract, "0xab5", "2741"),
+        (ForeignChain::Arbitrum, "0xa4b1", "42161"),
+        (ForeignChain::Base, "0x2105", "8453"),
+        (ForeignChain::Bnb, "0x38", "56"),
+        (ForeignChain::HyperEvm, "0x3e7", "999"),
+        (ForeignChain::Polygon, "0x89", "137"),
+    ];
 
     fn provider(rpc_url: &str) -> ForeignChainProviderConfig {
         ForeignChainProviderConfig {
@@ -269,6 +307,30 @@ mod tests {
             starknet: Some(config),
             ..Default::default()
         }
+    }
+
+    fn bitcoin_only(config: ForeignChainConfig) -> ForeignChainsConfig {
+        ForeignChainsConfig {
+            bitcoin: Some(config),
+            ..Default::default()
+        }
+    }
+
+    fn must_put_chain(
+        chains: &mut ForeignChainsConfig,
+        chain: ForeignChain,
+        config: ForeignChainConfig,
+    ) {
+        let slot = match chain {
+            ForeignChain::Abstract => &mut chains.abstract_chain,
+            ForeignChain::Arbitrum => &mut chains.arbitrum,
+            ForeignChain::Base => &mut chains.base,
+            ForeignChain::Bnb => &mut chains.bnb,
+            ForeignChain::HyperEvm => &mut chains.hyper_evm,
+            ForeignChain::Polygon => &mut chains.polygon,
+            other => panic!("no config slot wired for `{other:?}`"),
+        };
+        *slot = Some(config);
     }
 
     async fn mock_chain_id<'a>(
@@ -635,20 +697,17 @@ mod tests {
     async fn probe_all_providers__should_report_a_chain_with_no_fingerprint_probe_as_not_implemented()
      {
         // Given
-        let config = ForeignChainsConfig {
-            base: Some(chain_config(
-                Some("8453"),
-                one_provider("publicnode", CLOSED_PORT_URL),
-            )),
-            ..Default::default()
-        };
+        let config = bitcoin_only(chain_config(
+            Some(ANY_FINGERPRINT),
+            one_provider("publicnode", CLOSED_PORT_URL),
+        ));
 
         // When
         let report = probe_all_providers(&config).await;
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Base, "publicnode"),
+            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
             ProviderStatus::ProbeNotImplemented
         );
     }
@@ -663,8 +722,8 @@ mod tests {
                 Some(MAINNET),
                 one_provider("publicnode", &server.base_url()),
             )),
-            base: Some(chain_config(
-                Some("8453"),
+            bitcoin: Some(chain_config(
+                Some(ANY_FINGERPRINT),
                 one_provider("publicnode", CLOSED_PORT_URL),
             )),
             ..Default::default()
@@ -679,10 +738,70 @@ mod tests {
             ProviderStatus::Healthy
         );
         assert_eq!(
-            must_status_of(&report, ForeignChain::Base, "publicnode"),
+            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
             ProviderStatus::ProbeNotImplemented
         );
         assert_eq!(report.counts_per_chain().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn probe_all_providers__should_report_every_evm_chain_on_its_expected_network_as_healthy()
+    {
+        // Given
+        // Each chain gets its own mock, all of which have to outlive the probe.
+        let mut servers = Vec::new();
+        let mut config = ForeignChainsConfig::default();
+        for (chain, answered, expected) in EVM_MAINNETS {
+            let server = httpmock::MockServer::start_async().await;
+            mock_chain_id(&server, answered).await;
+            must_put_chain(
+                &mut config,
+                chain,
+                chain_config(
+                    Some(expected),
+                    one_provider("publicnode", &server.base_url()),
+                ),
+            );
+            servers.push(server);
+        }
+
+        // When
+        let report = probe_all_providers(&config).await;
+
+        // Then
+        for (chain, _, _) in EVM_MAINNETS {
+            assert_eq!(
+                must_status_of(&report, chain, "publicnode"),
+                ProviderStatus::Healthy,
+                "{chain:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn probe_all_providers__should_report_an_evm_provider_on_another_network_as_wrong_network()
+     {
+        // Given
+        let server = httpmock::MockServer::start_async().await;
+        mock_chain_id(&server, "0x14a34").await;
+        let mut config = ForeignChainsConfig::default();
+        must_put_chain(
+            &mut config,
+            ForeignChain::Base,
+            chain_config(Some("8453"), one_provider("publicnode", &server.base_url())),
+        );
+
+        // When
+        let report = probe_all_providers(&config).await;
+
+        // Then
+        assert_eq!(
+            must_status_of(&report, ForeignChain::Base, "publicnode"),
+            ProviderStatus::WrongNetwork {
+                expected: NetworkFingerprint::from("8453".to_string()),
+                observed: NetworkFingerprint::from("84532".to_string()),
+            }
+        );
     }
 
     #[tokio::test]

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -238,15 +238,49 @@ mod tests {
     /// For a chain with no probe: the value is never read, only whether it is set at all.
     const ANY_FINGERPRINT: &str = "any-fingerprint";
 
-    /// Every EVM chain the probe covers: what `eth_chainId` answers on mainnet, and the decimal
-    /// chain id an operator configures.
-    const EVM_MAINNETS: [(ForeignChain, &str, &str); 6] = [
-        (ForeignChain::Abstract, "0xab5", "2741"),
-        (ForeignChain::Arbitrum, "0xa4b1", "42161"),
-        (ForeignChain::Base, "0x2105", "8453"),
-        (ForeignChain::Bnb, "0x38", "56"),
-        (ForeignChain::HyperEvm, "0x3e7", "999"),
-        (ForeignChain::Polygon, "0x89", "137"),
+    struct EvmMainnet {
+        chain: ForeignChain,
+        chain_id: u64,
+    }
+
+    impl EvmMainnet {
+        /// The form an operator configures.
+        fn expected(&self) -> String {
+            self.chain_id.to_string()
+        }
+
+        /// The form `eth_chainId` answers.
+        fn answered(&self) -> String {
+            format!("{:#x}", self.chain_id)
+        }
+    }
+
+    /// Every EVM chain the probe covers, with its mainnet chain id.
+    const EVM_MAINNETS: [EvmMainnet; 6] = [
+        EvmMainnet {
+            chain: ForeignChain::Abstract,
+            chain_id: 2741,
+        },
+        EvmMainnet {
+            chain: ForeignChain::Arbitrum,
+            chain_id: 42161,
+        },
+        EvmMainnet {
+            chain: ForeignChain::Base,
+            chain_id: 8453,
+        },
+        EvmMainnet {
+            chain: ForeignChain::Bnb,
+            chain_id: 56,
+        },
+        EvmMainnet {
+            chain: ForeignChain::HyperEvm,
+            chain_id: 999,
+        },
+        EvmMainnet {
+            chain: ForeignChain::Polygon,
+            chain_id: 137,
+        },
     ];
 
     fn provider(rpc_url: &str) -> ForeignChainProviderConfig {
@@ -736,14 +770,14 @@ mod tests {
         // Given
         let mut servers = Vec::new();
         let mut config = ForeignChainsConfig::default();
-        for (chain, answered, expected) in EVM_MAINNETS {
+        for mainnet in EVM_MAINNETS {
             let server = httpmock::MockServer::start_async().await;
-            mock_chain_id(&server, answered).await;
+            mock_chain_id(&server, &mainnet.answered()).await;
             must_put_chain(
                 &mut config,
-                chain,
+                mainnet.chain,
                 chain_config(
-                    Some(expected),
+                    Some(&mainnet.expected()),
                     one_provider("publicnode", &server.base_url()),
                 ),
             );
@@ -754,7 +788,7 @@ mod tests {
         let report = probe_all_providers(&config).await;
 
         // Then
-        for (chain, _, _) in EVM_MAINNETS {
+        for EvmMainnet { chain, .. } in EVM_MAINNETS {
             assert_eq!(
                 must_status_of(&report, chain, "publicnode"),
                 ProviderStatus::Healthy,

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -117,7 +117,6 @@ pub async fn probe_all_providers(config: &ForeignChainsConfig) -> ProbeReport {
     ProbeReport { rows: report_rows }
 }
 
-/// The chain marker only types the inspector; `eth_chainId` is the same call for all of them.
 async fn probe_evm<Chain>(chain: ForeignChain, config: &ForeignChainConfig) -> Vec<ProviderHealth>
 where
     Chain: EvmChain + Clone + Send + Sync + 'static,

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -72,7 +72,6 @@ impl ProbeReport {
         &self.rows
     }
 
-    /// Only configured chains appear, never reports on a chain the operator did not configure.
     pub fn counts_per_chain(&self) -> BTreeMap<ForeignChain, ProviderCounts> {
         let mut counts: BTreeMap<ForeignChain, ProviderCounts> = BTreeMap::new();
         for row in &self.rows {

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -200,18 +200,6 @@ fn rows_of(
         .collect()
 }
 
-/// A provider answers what it likes and the report reaches logs and metric labels, so the length is
-/// capped well clear of the longest real fingerprint: Bitcoin's genesis hash, at 66 characters.
-fn bounded(observed: NetworkFingerprint) -> NetworkFingerprint {
-    const MAX_CHARS: usize = 96;
-
-    let observed = observed.to_string();
-    match observed.char_indices().nth(MAX_CHARS) {
-        None => NetworkFingerprint::from(observed),
-        Some((cutoff, _)) => NetworkFingerprint::from(format!("{}…", &observed[..cutoff])),
-    }
-}
-
 fn classify(
     expected: &NetworkFingerprint,
     reported: Result<NetworkFingerprint, ForeignChainInspectionError>,
@@ -220,7 +208,7 @@ fn classify(
         Ok(observed) if &observed == expected => ProviderStatus::Healthy,
         Ok(observed) => ProviderStatus::WrongNetwork {
             expected: expected.clone(),
-            observed: bounded(observed),
+            observed,
         },
         Err(error) => match error.provider_failure() {
             Some(ProviderFailure::Unreachable) => ProviderStatus::Unreachable,
@@ -448,8 +436,8 @@ mod tests {
         assert_eq!(
             must_status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::WrongNetwork {
-                expected: NetworkFingerprint::from(MAINNET.to_string()),
-                observed: NetworkFingerprint::from(SEPOLIA.to_string()),
+                expected: NetworkFingerprint::new(MAINNET),
+                observed: NetworkFingerprint::new(SEPOLIA),
             }
         );
     }
@@ -748,7 +736,6 @@ mod tests {
     async fn probe_all_providers__should_report_every_evm_chain_on_its_expected_network_as_healthy()
     {
         // Given
-        // Each chain gets its own mock, all of which have to outlive the probe.
         let mut servers = Vec::new();
         let mut config = ForeignChainsConfig::default();
         for (chain, answered, expected) in EVM_MAINNETS {
@@ -798,8 +785,8 @@ mod tests {
         assert_eq!(
             must_status_of(&report, ForeignChain::Base, "publicnode"),
             ProviderStatus::WrongNetwork {
-                expected: NetworkFingerprint::from("8453".to_string()),
-                observed: NetworkFingerprint::from("84532".to_string()),
+                expected: NetworkFingerprint::new("8453"),
+                observed: NetworkFingerprint::new("84532"),
             }
         );
     }
@@ -851,7 +838,7 @@ mod tests {
     #[test]
     fn classify__should_report_a_transaction_level_error_as_malformed() {
         // Given
-        let expected = NetworkFingerprint::from(MAINNET.to_string());
+        let expected = NetworkFingerprint::new(MAINNET);
 
         // When
         let status = classify(

--- a/crates/foreign-chain-inspector/src/evm/inspector.rs
+++ b/crates/foreign-chain-inspector/src/evm/inspector.rs
@@ -52,7 +52,7 @@ where
             .request(CHAIN_ID_METHOD, NO_PARAMS)
             .await
             .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
-        Ok(NetworkFingerprint::new(chain_id.canonical_text()))
+        Ok(Self::canonical_fingerprint(&chain_id.0))
     }
 
     fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {

--- a/crates/foreign-chain-inspector/src/evm/inspector.rs
+++ b/crates/foreign-chain-inspector/src/evm/inspector.rs
@@ -54,13 +54,11 @@ where
             .request(CHAIN_ID_METHOD, NO_PARAMS)
             .await
             .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
-        Ok(chain_id.canonical_text().into())
+        Ok(NetworkFingerprint::new(chain_id.canonical_text()))
     }
 
     fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {
-        ChainIdResponse(fingerprint.to_owned())
-            .canonical_text()
-            .into()
+        NetworkFingerprint::new(ChainIdResponse(fingerprint.to_owned()).canonical_text())
     }
 }
 

--- a/crates/foreign-chain-inspector/src/evm/inspector.rs
+++ b/crates/foreign-chain-inspector/src/evm/inspector.rs
@@ -52,7 +52,7 @@ where
             .request(CHAIN_ID_METHOD, NO_PARAMS)
             .await
             .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
-        Ok(Self::canonical_fingerprint(&chain_id.0))
+        Ok(NetworkFingerprint::new(chain_id.canonical_text()))
     }
 
     fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {

--- a/crates/foreign-chain-inspector/src/evm/inspector.rs
+++ b/crates/foreign-chain-inspector/src/evm/inspector.rs
@@ -3,16 +3,22 @@ use std::hash::Hash;
 
 use jsonrpsee::core::client::ClientT;
 
-use crate::{EthereumFinality, ForeignChainInspectionError, ForeignChainInspector};
+use crate::{
+    EthereumFinality, ForeignChainInspectionError, ForeignChainInspector, NetworkFingerprint,
+    NetworkFingerprintInspector,
+};
 
 use foreign_chain_rpc_interfaces::evm::{
-    BlockNumberOrTag, FinalityTag, GetBlockByNumberArgs, GetBlockByNumberResponse,
+    BlockNumberOrTag, ChainIdResponse, FinalityTag, GetBlockByNumberArgs, GetBlockByNumberResponse,
     GetTransactionReceiptARgs, GetTransactionReceiptResponse, H256, Log,
     ReturnFullTransactionObjects, U64,
 };
 
 const GET_TRANSACTION_RECEIPT_METHOD: &str = "eth_getTransactionReceipt";
 const GET_BLOCK_BY_NUMBER_METHOD: &str = "eth_getBlockByNumber";
+const CHAIN_ID_METHOD: &str = "eth_chainId";
+/// `eth_chainId` takes no arguments. Sent as an explicit empty array.
+const NO_PARAMS: [(); 0] = [];
 
 /// Marker trait for EVM-compatible chain type parameters.
 ///
@@ -35,6 +41,27 @@ pub trait EvmChain {
 pub struct EvmInspector<Client, Chain> {
     client: Client,
     _chain: std::marker::PhantomData<Chain>,
+}
+
+impl<Client, Chain> NetworkFingerprintInspector for EvmInspector<Client, Chain>
+where
+    Client: ClientT + Send + Sync,
+    Chain: Send + Sync,
+{
+    async fn network_fingerprint(&self) -> Result<NetworkFingerprint, ForeignChainInspectionError> {
+        let chain_id: ChainIdResponse = self
+            .client
+            .request(CHAIN_ID_METHOD, NO_PARAMS)
+            .await
+            .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
+        Ok(chain_id.canonical_text().into())
+    }
+
+    fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {
+        ChainIdResponse(fingerprint.to_owned())
+            .canonical_text()
+            .into()
+    }
 }
 
 impl<Client, Chain> ForeignChainInspector for EvmInspector<Client, Chain>

--- a/crates/foreign-chain-inspector/src/evm/inspector.rs
+++ b/crates/foreign-chain-inspector/src/evm/inspector.rs
@@ -4,8 +4,8 @@ use std::hash::Hash;
 use jsonrpsee::core::client::ClientT;
 
 use crate::{
-    EthereumFinality, ForeignChainInspectionError, ForeignChainInspector, NetworkFingerprint,
-    NetworkFingerprintInspector,
+    EthereumFinality, ForeignChainInspectionError, ForeignChainInspector, NO_PARAMS,
+    NetworkFingerprint, NetworkFingerprintInspector,
 };
 
 use foreign_chain_rpc_interfaces::evm::{
@@ -17,8 +17,6 @@ use foreign_chain_rpc_interfaces::evm::{
 const GET_TRANSACTION_RECEIPT_METHOD: &str = "eth_getTransactionReceipt";
 const GET_BLOCK_BY_NUMBER_METHOD: &str = "eth_getBlockByNumber";
 const CHAIN_ID_METHOD: &str = "eth_chainId";
-/// `eth_chainId` takes no arguments. Sent as an explicit empty array.
-const NO_PARAMS: [(); 0] = [];
 
 /// Marker trait for EVM-compatible chain type parameters.
 ///

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -41,24 +41,35 @@ pub trait ForeignChainInspector {
     ) -> impl Future<Output = Result<Vec<Self::ExtractedValue>, ForeignChainInspectionError>> + Send;
 }
 
+/// Parameters for an RPC that takes none. Sent as an explicit empty array.
+pub(crate) const NO_PARAMS: [(); 0] = [];
+
 /// The network a provider serves, as the chain itself reports it: a chain id or a genesis hash, in
 /// one canonical text form per chain.
-///
-/// A provider answers what it likes and a fingerprint reaches logs and metric labels, so
-/// [`NetworkFingerprint::new`] is the only way to build one and it caps the length.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 pub struct NetworkFingerprint(String);
 
 impl NetworkFingerprint {
-    /// Text longer than the longest real fingerprint, Bitcoin's 66 character genesis hash, is cut
-    /// short and marked with an ellipsis.
+    /// The longest fingerprint in use is Bitcoin's genesis hash at 66 characters. This leaves
+    /// room for a chain that reports a longer one.
+    pub const MAX_CHARS: usize = 96;
+    const CUT_SHORT_MARKER: &str = "_TRUNCATED";
+
+    /// Text longer than [`Self::MAX_CHARS`] is cut short, a very long string answered by
+    /// faulty providers does not reach logs and metric labels in full length.
     pub fn new(fingerprint: impl Into<String>) -> Self {
-        const MAX_CHARS: usize = 96;
+        const KEPT_CHARS: usize =
+            NetworkFingerprint::MAX_CHARS - NetworkFingerprint::CUT_SHORT_MARKER.len();
 
         let fingerprint = fingerprint.into();
-        match fingerprint.char_indices().nth(MAX_CHARS) {
-            None => Self(fingerprint),
-            Some((cutoff, _)) => Self(format!("{}…", &fingerprint[..cutoff])),
+        let mut characters = fingerprint.chars();
+        let within_cap: String = characters.by_ref().take(Self::MAX_CHARS).collect();
+        match characters.next() {
+            None => Self(within_cap),
+            Some(_) => {
+                let kept: String = within_cap.chars().take(KEPT_CHARS).collect();
+                Self(kept + Self::CUT_SHORT_MARKER)
+            }
         }
     }
 }
@@ -717,14 +728,31 @@ mod tests {
     }
 
     #[test]
-    fn network_fingerprint_new__should_cut_short_what_a_provider_answers_at_length() {
+    fn network_fingerprint_new__should_keep_an_answer_exactly_at_length() {
         // Given
-        let answered = "🙂".repeat(200);
+        let answered = "a".repeat(NetworkFingerprint::MAX_CHARS);
+
+        // When
+        let fingerprint = NetworkFingerprint::new(&answered);
+
+        // Then
+        assert_eq!(fingerprint.to_string(), answered);
+    }
+
+    #[test]
+    fn network_fingerprint_new__should_truncate_long_provider_results_based_on_chars() {
+        // Given
+        // Four bytes wide character
+        let wide_char = "\u{1F642}";
+        let answered = wide_char.repeat(200);
 
         // When
         let fingerprint = NetworkFingerprint::new(answered);
 
         // Then
-        assert_eq!(fingerprint.to_string(), format!("{}…", "🙂".repeat(96)));
+        let reported = fingerprint.to_string();
+        assert!(reported.starts_with(wide_char));
+        assert!(reported.ends_with(NetworkFingerprint::CUT_SHORT_MARKER));
+        assert_eq!(reported.chars().count(), NetworkFingerprint::MAX_CHARS);
     }
 }

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -68,7 +68,7 @@ impl NetworkFingerprint {
             None => Self(within_cap),
             Some(_) => {
                 let kept: String = within_cap.chars().take(KEPT_CHARS).collect();
-                Self(kept + Self::CUT_SHORT_MARKER)
+                Self(format!("{kept}{}", Self::CUT_SHORT_MARKER))
             }
         }
     }

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -43,8 +43,25 @@ pub trait ForeignChainInspector {
 
 /// The network a provider serves, as the chain itself reports it: a chain id or a genesis hash, in
 /// one canonical text form per chain.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display, From)]
+///
+/// A provider answers what it likes and a fingerprint reaches logs and metric labels, so
+/// [`NetworkFingerprint::new`] is the only way to build one and it caps the length.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Display)]
 pub struct NetworkFingerprint(String);
+
+impl NetworkFingerprint {
+    /// Text longer than the longest real fingerprint, Bitcoin's 66 character genesis hash, is cut
+    /// short and marked with an ellipsis.
+    pub fn new(fingerprint: impl Into<String>) -> Self {
+        const MAX_CHARS: usize = 96;
+
+        let fingerprint = fingerprint.into();
+        match fingerprint.char_indices().nth(MAX_CHARS) {
+            None => Self(fingerprint),
+            Some((cutoff, _)) => Self(format!("{}…", &fingerprint[..cutoff])),
+        }
+    }
+}
 
 /// Reports the [`NetworkFingerprint`] of the provider an inspector talks to, in the form
 /// [`Self::canonical_fingerprint`] produces.
@@ -684,5 +701,30 @@ mod tests {
 
         // Then
         assert_eq!(failure, expected);
+    }
+
+    #[test]
+    fn network_fingerprint_new__should_keep_the_longest_real_fingerprint_whole() {
+        // Given
+        let bitcoin_genesis_hash =
+            "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+
+        // When
+        let fingerprint = NetworkFingerprint::new(bitcoin_genesis_hash);
+
+        // Then
+        assert_eq!(fingerprint.to_string(), bitcoin_genesis_hash);
+    }
+
+    #[test]
+    fn network_fingerprint_new__should_cut_short_what_a_provider_answers_at_length() {
+        // Given
+        let answered = "🙂".repeat(200);
+
+        // When
+        let fingerprint = NetworkFingerprint::new(answered);
+
+        // Then
+        assert_eq!(fingerprint.to_string(), format!("{}…", "🙂".repeat(96)));
     }
 }

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -50,9 +50,8 @@ pub(crate) const NO_PARAMS: [(); 0] = [];
 pub struct NetworkFingerprint(String);
 
 impl NetworkFingerprint {
-    /// The longest fingerprint in use is Bitcoin's genesis hash, at 64 characters. Must stay
-    /// clear of what any chain reports, since fingerprints are compared after the cut and two
-    /// that agree up to it would read as one network.
+    /// Values are compared after the cut, so this must exceed every fingerprint in use. The
+    /// longest is Bitcoin's genesis hash at 64 characters.
     pub const MAX_CHARS: usize = 96;
     const CUT_SHORT_MARKER: &str = "_TRUNCATED";
 

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -50,8 +50,9 @@ pub(crate) const NO_PARAMS: [(); 0] = [];
 pub struct NetworkFingerprint(String);
 
 impl NetworkFingerprint {
-    /// The longest fingerprint in use is Bitcoin's genesis hash at 66 characters. This leaves
-    /// room for a chain that reports a longer one.
+    /// The longest fingerprint in use is Bitcoin's genesis hash, at 64 characters. Must stay
+    /// clear of what any chain reports, since fingerprints are compared after the cut and two
+    /// that agree up to it would read as one network.
     pub const MAX_CHARS: usize = 96;
     const CUT_SHORT_MARKER: &str = "_TRUNCATED";
 

--- a/crates/foreign-chain-inspector/src/starknet/inspector.rs
+++ b/crates/foreign-chain-inspector/src/starknet/inspector.rs
@@ -1,6 +1,6 @@
 use crate::starknet::{StarknetExtractedValue, StarknetTransactionHash};
 use crate::{
-    ForeignChainInspectionError, ForeignChainInspector, NetworkFingerprint,
+    ForeignChainInspectionError, ForeignChainInspector, NO_PARAMS, NetworkFingerprint,
     NetworkFingerprintInspector,
 };
 use foreign_chain_rpc_interfaces::starknet::{
@@ -14,8 +14,6 @@ use near_mpc_contract_interface::types::{StarknetFelt, StarknetLog};
 const GET_TRANSACTION_RECEIPT_METHOD: &str = "starknet_getTransactionReceipt";
 const GET_BLOCK_WITH_TX_HASHES_METHOD: &str = "starknet_getBlockWithTxHashes";
 const CHAIN_ID_METHOD: &str = "starknet_chainId";
-/// `starknet_chainId` takes no arguments. Sent as an explicit empty array.
-const NO_PARAMS: [(); 0] = [];
 
 #[derive(Clone)]
 pub struct StarknetInspector<Client> {

--- a/crates/foreign-chain-inspector/src/starknet/inspector.rs
+++ b/crates/foreign-chain-inspector/src/starknet/inspector.rs
@@ -38,13 +38,11 @@ where
             .request(CHAIN_ID_METHOD, NO_PARAMS)
             .await
             .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
-        Ok(chain_id.canonical_text().into())
+        Ok(NetworkFingerprint::new(chain_id.canonical_text()))
     }
 
     fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {
-        ChainIdResponse(fingerprint.to_owned())
-            .canonical_text()
-            .into()
+        NetworkFingerprint::new(ChainIdResponse(fingerprint.to_owned()).canonical_text())
     }
 }
 

--- a/crates/foreign-chain-inspector/src/starknet/inspector.rs
+++ b/crates/foreign-chain-inspector/src/starknet/inspector.rs
@@ -36,7 +36,7 @@ where
             .request(CHAIN_ID_METHOD, NO_PARAMS)
             .await
             .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
-        Ok(NetworkFingerprint::new(chain_id.canonical_text()))
+        Ok(Self::canonical_fingerprint(&chain_id.0))
     }
 
     fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {

--- a/crates/foreign-chain-inspector/tests/abstract_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/abstract_rpc_manual.rs
@@ -7,14 +7,14 @@ use foreign_chain_inspector::{
     },
 };
 
+// Note: Replace with your actual Abstract RPC endpoint URL
+// Example: QuickNode Abstract endpoint
+const ABSTRACT_RPC_URL: &str = "https://api.testnet.abs.xyz";
+
 #[tokio::test]
 #[ignore = "manual test to sanity check against live Abstract RPC provider"]
 async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     // given
-    // Note: Replace with your actual Abstract RPC endpoint URL
-    // Example: QuickNode Abstract endpoint
-    const ABSTRACT_RPC_URL: &str = "https://api.testnet.abs.xyz";
-
     let threshold = EthereumFinality::Finalized;
 
     // Example transaction from Abstract testnet
@@ -55,4 +55,28 @@ async fn inspector_extracts_block_hash_against_live_rpc_provider() {
         AbstractExtractedValue::BlockHash(expected_block_hash)
     );
     assert_matches!(extracted_values[1], AbstractExtractedValue::Log(_));
+}
+
+/// Abstract testnet's chain id, as shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: &str = "11124";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live Abstract RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        ABSTRACT_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = AbstractInspector::new(http_client);
+
+    // when
+    let fingerprint =
+        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
+            .await
+            .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);
 }

--- a/crates/foreign-chain-inspector/tests/abstract_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/abstract_rpc_manual.rs
@@ -1,14 +1,12 @@
 use assert_matches::assert_matches;
 use foreign_chain_inspector::{
-    EthereumFinality, ForeignChainInspector, RpcAuthentication,
+    EthereumFinality, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
     abstract_chain::{
         AbstractBlockHash, AbstractTransactionHash,
         inspector::{AbstractExtractedValue, AbstractExtractor, AbstractInspector},
     },
 };
 
-// Note: Replace with your actual Abstract RPC endpoint URL
-// Example: QuickNode Abstract endpoint
 const ABSTRACT_RPC_URL: &str = "https://api.testnet.abs.xyz";
 
 #[tokio::test]
@@ -72,10 +70,10 @@ async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_p
     let inspector = AbstractInspector::new(http_client);
 
     // when
-    let fingerprint =
-        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
-            .await
-            .expect("network_fingerprint should succeed");
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
 
     // then
     assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);

--- a/crates/foreign-chain-inspector/tests/arbitrum_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/arbitrum_rpc_manual.rs
@@ -7,12 +7,12 @@ use foreign_chain_inspector::{
     },
 };
 
+const ARBITRUM_RPC_URL: &str = "https://arb1.arbitrum.io/rpc";
+
 #[tokio::test]
 #[ignore = "manual test to sanity check against live Arbitrum RPC provider"]
 async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     // given
-    const ARBITRUM_RPC_URL: &str = "https://arb1.arbitrum.io/rpc";
-
     let threshold = EthereumFinality::Finalized;
 
     // Example transaction on Arbitrum One with 3 logs;
@@ -57,4 +57,28 @@ async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     assert_matches!(extracted_values[1], ArbitrumExtractedValue::Log(_));
     assert_matches!(extracted_values[2], ArbitrumExtractedValue::Log(_));
     assert_matches!(extracted_values[3], ArbitrumExtractedValue::Log(_));
+}
+
+/// Arbitrum One's chain id, as shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: &str = "42161";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live Arbitrum RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        ARBITRUM_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = ArbitrumInspector::new(http_client);
+
+    // when
+    let fingerprint =
+        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
+            .await
+            .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);
 }

--- a/crates/foreign-chain-inspector/tests/arbitrum_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/arbitrum_rpc_manual.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use foreign_chain_inspector::{
-    EthereumFinality, ForeignChainInspector, RpcAuthentication,
+    EthereumFinality, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
     arbitrum::{
         ArbitrumBlockHash, ArbitrumTransactionHash,
         inspector::{ArbitrumExtractedValue, ArbitrumExtractor, ArbitrumInspector},
@@ -74,10 +74,10 @@ async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_p
     let inspector = ArbitrumInspector::new(http_client);
 
     // when
-    let fingerprint =
-        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
-            .await
-            .expect("network_fingerprint should succeed");
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
 
     // then
     assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);

--- a/crates/foreign-chain-inspector/tests/base_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/base_rpc_manual.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use foreign_chain_inspector::{
-    EthereumFinality, ForeignChainInspector, RpcAuthentication,
+    EthereumFinality, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
     base::{
         BaseBlockHash, BaseTransactionHash,
         inspector::{BaseExtractedValue, BaseExtractor, BaseInspector},
@@ -74,10 +74,10 @@ async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_p
     let inspector = BaseInspector::new(http_client);
 
     // when
-    let fingerprint =
-        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
-            .await
-            .expect("network_fingerprint should succeed");
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
 
     // then
     assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);

--- a/crates/foreign-chain-inspector/tests/base_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/base_rpc_manual.rs
@@ -7,12 +7,12 @@ use foreign_chain_inspector::{
     },
 };
 
+const BASE_RPC_URL: &str = "https://mainnet.base.org";
+
 #[tokio::test]
 #[ignore = "manual test to sanity check against live Base RPC provider"]
 async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     // given
-    const BASE_RPC_URL: &str = "https://mainnet.base.org";
-
     let threshold = EthereumFinality::Finalized;
 
     // Example transaction on Base mainnet (block 33554432) with 16 logs;
@@ -57,4 +57,28 @@ async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     assert_matches!(extracted_values[1], BaseExtractedValue::Log(_));
     assert_matches!(extracted_values[2], BaseExtractedValue::Log(_));
     assert_matches!(extracted_values[3], BaseExtractedValue::Log(_));
+}
+
+/// Base mainnet's chain id, as shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: &str = "8453";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live Base RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        BASE_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = BaseInspector::new(http_client);
+
+    // when
+    let fingerprint =
+        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
+            .await
+            .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);
 }

--- a/crates/foreign-chain-inspector/tests/bnb_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/bnb_rpc_manual.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use foreign_chain_inspector::{
-    EthereumFinality, ForeignChainInspector, RpcAuthentication,
+    EthereumFinality, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
     bnb::{
         BnbBlockHash, BnbTransactionHash,
         inspector::{BnbExtractedValue, BnbExtractor, BnbInspector},
@@ -74,10 +74,10 @@ async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_p
     let inspector = BnbInspector::new(http_client);
 
     // when
-    let fingerprint =
-        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
-            .await
-            .expect("network_fingerprint should succeed");
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
 
     // then
     assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);

--- a/crates/foreign-chain-inspector/tests/bnb_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/bnb_rpc_manual.rs
@@ -7,12 +7,12 @@ use foreign_chain_inspector::{
     },
 };
 
+const BNB_RPC_URL: &str = "https://bsc-rpc.publicnode.com";
+
 #[tokio::test]
 #[ignore = "manual test to sanity check against live BNB RPC provider"]
 async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     // given
-    const BNB_RPC_URL: &str = "https://bsc-rpc.publicnode.com";
-
     let threshold = EthereumFinality::Finalized;
 
     // Example DEX swap transaction on BNB with 3 logs
@@ -57,4 +57,28 @@ async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     assert_matches!(extracted_values[1], BnbExtractedValue::Log(_));
     assert_matches!(extracted_values[2], BnbExtractedValue::Log(_));
     assert_matches!(extracted_values[3], BnbExtractedValue::Log(_));
+}
+
+/// BNB mainnet's chain id, as shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: &str = "56";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live BNB RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        BNB_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = BnbInspector::new(http_client);
+
+    // when
+    let fingerprint =
+        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
+            .await
+            .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);
 }

--- a/crates/foreign-chain-inspector/tests/evm_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/evm_inspector.rs
@@ -2,10 +2,14 @@
 
 pub mod common;
 
-use crate::common::{FixedResponseRpcClient, SequentialResponseMockClientBuilder};
+use crate::common::{
+    FixedResponseRpcClient, SequentialResponseMockClientBuilder, mock_client_from_fixed_response,
+};
 
 use foreign_chain_inspector::{
-    EthereumFinality, ForeignChainInspectionError, ForeignChainInspector, RpcAuthentication,
+    EthereumFinality, ForeignChainInspectionError, ForeignChainInspector,
+    NetworkFingerprintInspector, RpcAuthentication,
+    base::inspector::Base,
     build_http_client,
     evm::inspector::{EvmChain, EvmExtractedValue, EvmExtractor, EvmInspector},
 };
@@ -716,3 +720,52 @@ evm_inspector_tests!(
     foreign_chain_inspector::polygon::inspector::Polygon,
     polygon
 );
+
+/// Base mainnet. One chain stands in for all of them: the fingerprint call has no chain-specific
+/// parts.
+const CHAIN_ID_8453: &str = "0x2105";
+const PADDED_CHAIN_ID_8453: &str = "0x002105";
+
+#[tokio::test]
+async fn network_fingerprint__should_return_the_chain_id_in_decimal() {
+    // Given
+    let inspector =
+        EvmInspector::<_, Base>::new(mock_client_from_fixed_response(PADDED_CHAIN_ID_8453));
+
+    // When
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
+
+    // Then
+    assert_eq!(fingerprint.to_string(), "8453");
+}
+
+#[tokio::test]
+async fn network_fingerprint__should_ask_the_provider_for_its_chain_id() {
+    // Given
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST).body_includes(r#""method":"eth_chainId""#);
+            then.status(200).json_body(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": CHAIN_ID_8453,
+            }));
+        })
+        .await;
+    let client = build_http_client(server.url("/"), RpcAuthentication::KeyInUrl).unwrap();
+    let inspector = EvmInspector::<_, Base>::new(client);
+
+    // When
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
+
+    // Then
+    mock.assert_async().await;
+    assert_eq!(fingerprint.to_string(), "8453");
+}

--- a/crates/foreign-chain-inspector/tests/evm_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/evm_inspector.rs
@@ -721,8 +721,7 @@ evm_inspector_tests!(
     polygon
 );
 
-/// Base mainnet. One chain stands in for all of them: the fingerprint call has no chain-specific
-/// parts.
+// Base mainnet, standing in for every EVM chain: the fingerprint call has no chain-specific parts.
 const CHAIN_ID_8453: &str = "0x2105";
 const PADDED_CHAIN_ID_8453: &str = "0x002105";
 

--- a/crates/foreign-chain-inspector/tests/hyperevm_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/hyperevm_rpc_manual.rs
@@ -7,12 +7,12 @@ use foreign_chain_inspector::{
     },
 };
 
+const HYPEREVM_RPC_URL: &str = "https://rpc.hyperliquid.xyz/evm";
+
 #[tokio::test]
 #[ignore = "manual test to sanity check against live HyperEVM RPC provider"]
 async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     // given
-    const HYPEREVM_RPC_URL: &str = "https://rpc.hyperliquid.xyz/evm";
-
     let threshold = EthereumFinality::Finalized;
 
     // Example transaction on HyperEVM (block 0x20c6dc5) with 3 logs;
@@ -57,4 +57,28 @@ async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     assert_matches!(extracted_values[1], HyperEvmExtractedValue::Log(_));
     assert_matches!(extracted_values[2], HyperEvmExtractedValue::Log(_));
     assert_matches!(extracted_values[3], HyperEvmExtractedValue::Log(_));
+}
+
+/// HyperEVM mainnet's chain id, as shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: &str = "999";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live HyperEVM RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        HYPEREVM_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = HyperEvmInspector::new(http_client);
+
+    // when
+    let fingerprint =
+        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
+            .await
+            .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);
 }

--- a/crates/foreign-chain-inspector/tests/hyperevm_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/hyperevm_rpc_manual.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use foreign_chain_inspector::{
-    EthereumFinality, ForeignChainInspector, RpcAuthentication,
+    EthereumFinality, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
     hyperevm::{
         HyperEvmBlockHash, HyperEvmTransactionHash,
         inspector::{HyperEvmExtractedValue, HyperEvmExtractor, HyperEvmInspector},
@@ -74,10 +74,10 @@ async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_p
     let inspector = HyperEvmInspector::new(http_client);
 
     // when
-    let fingerprint =
-        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
-            .await
-            .expect("network_fingerprint should succeed");
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
 
     // then
     assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);

--- a/crates/foreign-chain-inspector/tests/polygon_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/polygon_rpc_manual.rs
@@ -1,6 +1,6 @@
 use assert_matches::assert_matches;
 use foreign_chain_inspector::{
-    EthereumFinality, ForeignChainInspector, RpcAuthentication,
+    EthereumFinality, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
     polygon::{
         PolygonBlockHash, PolygonTransactionHash,
         inspector::{PolygonExtractedValue, PolygonExtractor, PolygonInspector},
@@ -74,10 +74,10 @@ async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_p
     let inspector = PolygonInspector::new(http_client);
 
     // when
-    let fingerprint =
-        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
-            .await
-            .expect("network_fingerprint should succeed");
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
 
     // then
     assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);

--- a/crates/foreign-chain-inspector/tests/polygon_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/polygon_rpc_manual.rs
@@ -7,12 +7,12 @@ use foreign_chain_inspector::{
     },
 };
 
+const POLYGON_RPC_URL: &str = "https://polygon.drpc.org";
+
 #[tokio::test]
 #[ignore = "manual test to sanity check against live Polygon RPC provider"]
 async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     // given
-    const POLYGON_RPC_URL: &str = "https://polygon.drpc.org";
-
     let threshold = EthereumFinality::Finalized;
 
     // Example transaction on Polygon (block 0x5276e5d) with 8 logs;
@@ -57,4 +57,28 @@ async fn inspector_extracts_block_hash_against_live_rpc_provider() {
     assert_matches!(extracted_values[1], PolygonExtractedValue::Log(_));
     assert_matches!(extracted_values[2], PolygonExtractedValue::Log(_));
     assert_matches!(extracted_values[3], PolygonExtractedValue::Log(_));
+}
+
+/// Polygon mainnet's chain id, as shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: &str = "137";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live Polygon RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        POLYGON_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = PolygonInspector::new(http_client);
+
+    // when
+    let fingerprint =
+        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
+            .await
+            .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);
 }

--- a/crates/foreign-chain-rpc-interfaces/src/evm.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/evm.rs
@@ -100,8 +100,7 @@ pub struct Log {
     pub topics: Vec<H256>,
 }
 
-/// RPC response for `eth_chainId`: the EIP-155 chain id as a hex quantity (Base mainnet is
-/// `0x2105`).
+/// RPC response for `eth_chainId`: the EIP-155 chain id as a hex quantity.
 /// <https://ethereum.org/developers/docs/apis/json-rpc/#eth_chainid>
 ///
 /// Kept as text rather than parsed into a [`U64`], so that whatever a provider answers can be
@@ -111,9 +110,8 @@ pub struct Log {
 pub struct ChainIdResponse(pub String);
 
 impl ChainIdResponse {
-    /// Decimal, which is how EIP-155 chain ids are published. A `0x` prefix reads as hex, since
-    /// that is what the RPC answers; anything else as the decimal an operator writes. Text that is
-    /// neither is returned unchanged, to be reported as the network the provider claims.
+    /// Decimal, the form EIP-155 chain ids are published in. A `0x` prefix reads as hex, anything
+    /// else as decimal; text that is neither is returned unchanged.
     pub fn canonical_text(&self) -> String {
         let hex = self
             .0

--- a/crates/foreign-chain-rpc-interfaces/src/evm.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/evm.rs
@@ -113,7 +113,7 @@ pub struct ChainIdResponse(pub String);
 impl ChainIdResponse {
     /// Decimal, the form EIP-155 chain ids are published in. A `0x` prefix reads as hex, anything
     /// else as decimal; text that is neither is returned unchanged.
-    pub fn canonical_text(&self) -> String {
+    pub fn canonical_text(self) -> String {
         let hex = self
             .0
             .strip_prefix("0x")
@@ -124,11 +124,11 @@ impl ChainIdResponse {
         };
         // Empty digits parse as zero, which would report a bare `0x` as chain 0.
         if digits.is_empty() {
-            return self.0.clone();
+            return self.0;
         }
         match U256::from_str_radix(digits, radix) {
             Ok(chain_id) => chain_id.to_string(),
-            Err(_) => self.0.clone(),
+            Err(_) => self.0,
         }
     }
 }

--- a/crates/foreign-chain-rpc-interfaces/src/evm.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/evm.rs
@@ -103,8 +103,7 @@ pub struct Log {
 /// RPC response for `eth_chainId`: the EIP-155 chain id as a hex quantity.
 /// <https://ethereum.org/developers/docs/apis/json-rpc/#eth_chainid>
 ///
-/// Kept as text rather than parsed into a [`U64`], so that whatever a provider answers can be
-/// reported back to an operator.
+/// Kept as text rather than parsed into a [`U64`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
 #[serde(transparent)]
 pub struct ChainIdResponse(pub String);

--- a/crates/foreign-chain-rpc-interfaces/src/evm.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/evm.rs
@@ -4,7 +4,7 @@ use derive_more::{Constructor, From};
 use jsonrpsee::core::traits::ToRpcParams;
 use serde::{Deserialize, Serialize};
 
-pub use ethereum_types::{H160, H256, U64};
+pub use ethereum_types::{H160, H256, U64, U256};
 
 /// Partial RPC response for `eth_getTransactionReceipt`.
 /// <https://ethereum.org/developers/docs/apis/json-rpc/#eth_gettransactionreceipt>
@@ -100,10 +100,81 @@ pub struct Log {
     pub topics: Vec<H256>,
 }
 
+/// RPC response for `eth_chainId`: the EIP-155 chain id as a hex quantity (Base mainnet is
+/// `0x2105`).
+/// <https://ethereum.org/developers/docs/apis/json-rpc/#eth_chainid>
+///
+/// Kept as text rather than parsed into a [`U64`], so that whatever a provider answers can be
+/// reported back to an operator.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[serde(transparent)]
+pub struct ChainIdResponse(pub String);
+
+impl ChainIdResponse {
+    /// Decimal, which is how EIP-155 chain ids are published. A `0x` prefix reads as hex, since
+    /// that is what the RPC answers; anything else as the decimal an operator writes. Text that is
+    /// neither is returned unchanged, to be reported as the network the provider claims.
+    pub fn canonical_text(&self) -> String {
+        let hex = self
+            .0
+            .strip_prefix("0x")
+            .or_else(|| self.0.strip_prefix("0X"));
+        let (digits, radix) = match hex {
+            Some(digits) => (digits, 16),
+            None => (self.0.as_str(), 10),
+        };
+        // Empty digits parse as zero, which would report a bare `0x` as chain 0.
+        if digits.is_empty() {
+            return self.0.clone();
+        }
+        match U256::from_str_radix(digits, radix) {
+            Ok(chain_id) => chain_id.to_string(),
+            Err(_) => self.0.clone(),
+        }
+    }
+}
+
 impl ToRpcParams for &GetTransactionReceiptARgs {
     to_rpc_params_impl!();
 }
 
 impl ToRpcParams for &GetBlockByNumberArgs {
     to_rpc_params_impl!();
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::ChainIdResponse;
+    use rstest::rstest;
+
+    /// Base mainnet.
+    const CHAIN_ID_8453: &str = "0x2105";
+
+    #[rstest]
+    #[case::hex(CHAIN_ID_8453, "8453")]
+    // Padded and upper-cased, as a provider may send it.
+    #[case::padded_and_upper_cased("0x002105", "8453")]
+    // Spellings only an operator writes: the published decimal, and an upper-cased prefix.
+    #[case::decimal("8453", "8453")]
+    #[case::upper_cased_prefix("0X2105", "8453")]
+    #[case::zero("0x0", "0")]
+    // Wider than a u64, which EIP-155 permits.
+    #[case::wider_than_a_u64("0x1ffffffffffffffff", "36893488147419103231")]
+    // Reported as answered by the provider.
+    #[case::not_a_number("mainnet", "mainnet")]
+    #[case::empty_hex("0x", "0x")]
+    fn chain_id_response__should_canonicalize_what_a_provider_answers(
+        #[case] answered: &str,
+        #[case] expected: &str,
+    ) {
+        // Given
+        let json = serde_json::json!(answered);
+
+        // When
+        let response: ChainIdResponse = serde_json::from_value(json).unwrap();
+
+        // Then
+        assert_eq!(response.canonical_text(), expected);
+    }
 }

--- a/crates/foreign-chain-rpc-interfaces/src/evm.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/evm.rs
@@ -4,7 +4,9 @@ use derive_more::{Constructor, From};
 use jsonrpsee::core::traits::ToRpcParams;
 use serde::{Deserialize, Serialize};
 
-pub use ethereum_types::{H160, H256, U64, U256};
+pub use ethereum_types::{H160, H256, U64};
+
+use ethereum_types::U256;
 
 /// Partial RPC response for `eth_getTransactionReceipt`.
 /// <https://ethereum.org/developers/docs/apis/json-rpc/#eth_gettransactionreceipt>

--- a/crates/foreign-chain-rpc-interfaces/src/evm.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/evm.rs
@@ -152,8 +152,9 @@ mod tests {
 
     #[rstest]
     #[case::hex(CHAIN_ID_8453, "8453")]
-    // Padded and upper-cased, as a provider may send it.
-    #[case::padded_and_upper_cased("0x002105", "8453")]
+    // Padded and upper-cased, as a provider may send it. Arbitrum, whose id has hex letters.
+    #[case::padded("0x002105", "8453")]
+    #[case::upper_cased_digits("0xA4B1", "42161")]
     // Spellings only an operator writes: the published decimal, and an upper-cased prefix.
     #[case::decimal("8453", "8453")]
     #[case::upper_cased_prefix("0X2105", "8453")]

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -538,6 +538,8 @@ Not every chain has a fingerprint probe. The table lists the ones that do, with 
 
 The reported and the configured value are normalized before they are compared, because the same fingerprint has several legal spellings. Starknet's is the chain id felt in lowercase `0x` hex without leading zeros, which providers and operators alike are free to pad and upper-case. The EVM chain id is compared in decimal, the form it is published and configured in, while `eth_chainId` answers a `0x` hex quantity.
 
+An answer that is no fingerprint at all is reported as the wrong network, carrying the text the provider sent, so the report says what was actually claimed. An answer longer than any real fingerprint is cut short and ends in `_TRUNCATED`, because it is repeated into logs and metric labels.
+
 #### Why drop-and-log on local-config mismatch, not hard-crash
 
 If an operator's `foreign_chains.yaml` references a `provider_id` not on the whitelist for that chain (e.g. just removed by a vote), the node logs a warning and excludes that provider from registration; the chain is still served by surviving providers. A chain falls off the registration set only when zero providers survive. Hard-crashing would let a single hostile vote-removal participant take a node offline by removing a provider that node depends on.

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -534,8 +534,9 @@ Not every chain has a fingerprint probe. The table lists the ones that do, with 
 | chain | probe |
 |---|---|
 | starknet | `starknet_chainId` |
+| base, bnb, arbitrum, polygon, hyper_evm, abstract | `eth_chainId` |
 
-Starknet's fingerprint is the chain id felt in lowercase `0x` hex without leading zeros. Both providers and operators are free to pad and upper-case it, so the reported and the configured value are normalized before they are compared.
+The reported and the configured value are normalized before they are compared, because the same fingerprint has several legal spellings. Starknet's is the chain id felt in lowercase `0x` hex without leading zeros, which providers and operators alike are free to pad and upper-case. The EVM chain id is compared in decimal, the form it is published and configured in, while `eth_chainId` answers a `0x` hex quantity.
 
 #### Why drop-and-log on local-config mismatch, not hard-crash
 
@@ -691,10 +692,11 @@ The fingerprint is set per chain rather than once per deployment, so a config ca
 each value must match the network of the `rpc_url` beside it. The value is always a quoted string,
 including the fingerprints that look numeric.
 
-Only the chains with a fingerprint probe read the field at all — starknet today, the rest as their
-probes are written. For those chains, leaving it unset is not a silent skip: every provider of the
-chain is reported as `MissingExpectedFingerprint`, because silence reads as healthy on a dashboard. A
-chain with no probe yet reports `ProbeNotImplemented` whether the field is set or not.
+Only the chains with a fingerprint probe read the field at all — starknet and the EVM chains today,
+the rest as their probes are written. For those chains, leaving it unset is not a silent skip: every
+provider of the chain is reported as `MissingExpectedFingerprint`, because silence reads as healthy
+on a dashboard. A chain with no probe yet reports `ProbeNotImplemented` whether the field is set or
+not.
 
 ## Risks
 


### PR DESCRIPTION
Closes #4096. Second slice of the identity probing series, after #4013

`EvmInspector` already serves all six chains, so `eth_chainId` covers Abstract, Arbitrum, Base, BNB, HyperEVM and Polygon at once.

### Notes for review

- **Chain ids are compared in decimal**, the form they are published and configured in, while `eth_chainId` answers a `0x` hex quantity. Parsed as `U256`, since EIP-155 permits ids wider than a `u64`. Text that is neither reads back unchanged, so the report shows what the provider actually claimed.

- **The `NetworkFingerprint` length cap moved into `NetworkFingerprint::new`**. Replaces the probe's `bounded` helper function. An answer past the cap ends in `_TRUNCATED`.

- **The injection of time and the RPC client (#4043) is deliberately not folded in**: I plan to refactor after all chains are wired up for startup probing.