### PR TITLE
test: Assert onchain timeout in recon test

### DIFF
--- a/crates/e2e-tests/src/blockchain.rs
+++ b/crates/e2e-tests/src/blockchain.rs
@@ -1,6 +1,8 @@
+use std::time::Duration;
+
 use ed25519_dalek::SigningKey;
 use near_contract_transport::{CallContract, FunctionCallArgs};
-use near_kit::FinalExecutionOutcome;
+use near_kit::{AccountId, CryptoHash, FinalExecutionOutcome};
 use near_mpc_contract_interface::client::MpcContractHandle;
 use near_mpc_contract_interface::types::ProtocolContractState;
 use serde::de::DeserializeOwned;
@@ -8,6 +10,7 @@ use serde::de::DeserializeOwned;
 use crate::conversions::ToNearKey;
 
 const MAX_GAS: near_kit::Gas = near_kit::Gas::from_tgas(1000);
+const TX_STATUS_POLL_INTERVAL: Duration = Duration::from_millis(500);
 
 /// RPC client for any NEAR network (sandbox or testnet).
 ///
@@ -222,6 +225,53 @@ impl DeployedContract {
             .map_err(|e| {
                 anyhow::anyhow!("contract call `{method}` (borsh args, with deposit) failed: {e}")
             })
+    }
+
+    /// Submit a call and return its tx hash once included. Pair with [`Self::wait_tx_final`]
+    /// for requests (e.g. a yielding `sign`) that resolve past the RPC timeout.
+    pub async fn call_from_with_deposit_included(
+        &self,
+        client: &NearKitCaller,
+        method: &str,
+        args: serde_json::Value,
+        gas: near_kit::Gas,
+        deposit: near_kit::NearToken,
+    ) -> anyhow::Result<CryptoHash> {
+        let response = client
+            .inner
+            .call(&self.contract_id, method)
+            .args(args)
+            .gas(gas)
+            .deposit(deposit)
+            .wait_until(near_kit::Included)
+            .await
+            .map_err(|e| anyhow::anyhow!("contract call `{method}` (included) failed: {e}"))?;
+        Ok(response.transaction_hash)
+    }
+
+    /// Poll `tx_status` for `tx_hash` (sent by `signer_id`) until `Final` or `timeout`.
+    pub async fn wait_tx_final(
+        &self,
+        tx_hash: CryptoHash,
+        signer_id: &AccountId,
+        timeout: Duration,
+    ) -> anyhow::Result<FinalExecutionOutcome> {
+        let deadline = tokio::time::Instant::now() + timeout;
+        loop {
+            match self
+                .client
+                .tx_status(&tx_hash, signer_id.as_str(), near_kit::Final)
+                .await
+            {
+                Ok(outcome) => return Ok(outcome),
+                Err(e) if tokio::time::Instant::now() >= deadline => {
+                    return Err(anyhow::anyhow!(
+                        "tx {tx_hash} did not reach Final within {timeout:?}: {e}"
+                    ));
+                }
+                Err(_) => tokio::time::sleep(TX_STATUS_POLL_INTERVAL).await,
+            }
+        }
     }
 
     pub async fn view<T: DeserializeOwned + Send + 'static>(

--- a/crates/e2e-tests/src/blockchain.rs
+++ b/crates/e2e-tests/src/blockchain.rs
@@ -243,7 +243,7 @@ impl DeployedContract {
             .args(args)
             .gas(gas)
             .deposit(deposit)
-            .wait_until(near_kit::Included)
+            .wait_until::<near_kit::Included>()
             .await
             .map_err(|e| anyhow::anyhow!("contract call `{method}` (included) failed: {e}"))?;
         Ok(response.transaction_hash)
@@ -260,7 +260,8 @@ impl DeployedContract {
         loop {
             match self
                 .client
-                .tx_status(&tx_hash, signer_id.as_str(), near_kit::Final)
+                .tx_status(&tx_hash, signer_id.as_str())
+                .wait_until::<Final>()
                 .await
             {
                 Ok(outcome) => return Ok(outcome),

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -9,6 +9,7 @@ use near_kit::AccountId;
 use near_mpc_bounded_collections::NonEmptyBTreeMap;
 use near_mpc_contract_interface::types::CKDRequestArgs;
 use near_mpc_contract_interface::{
+    call_args::SignArgs,
     client::MpcContractHandle,
     method_names,
     types::{
@@ -834,6 +835,33 @@ impl MpcCluster {
             })
             .await
             .context("failed to send sign request")
+    }
+
+    /// Like [`Self::send_sign_request`], but returns the tx hash once included instead
+    /// of awaiting it — for requests that resolve past the RPC timeout.
+    pub async fn send_sign_request_included(
+        &self,
+        domain_id: DomainId,
+        payload: Payload,
+        account_id: &AccountId,
+    ) -> anyhow::Result<near_kit::CryptoHash> {
+        let client = self.client_for(account_id)?;
+        let args = SignArgs::new(SignRequestArgs {
+            path: "test".to_string(),
+            payload,
+            domain_id,
+        });
+        self.contract
+            .call_from_with_deposit_included(
+                &client,
+                method_names::SIGN,
+                serde_json::to_value(&args)?,
+                near_mpc_contract_interface::client::SIGN_GAS,
+                near_kit::NearToken::from_yoctonear(
+                    near_mpc_contract_interface::deposits::SIGN_DEPOSIT_YOCTONEAR,
+                ),
+            )
+            .await
     }
 
     /// Send a CKD (Confidential Key Derivation) request from the given user account.

--- a/crates/e2e-tests/tests/distinct_reconstruction_thresholds.rs
+++ b/crates/e2e-tests/tests/distinct_reconstruction_thresholds.rs
@@ -1,10 +1,10 @@
 use crate::common::{
     DISTINCT_RECONSTRUCTION_THRESHOLDS_PORT_SEED, ckd_domain, damgard_etal_domain,
     generate_ckd_app_public_key, generate_ecdsa_payload, generate_eddsa_payload, must_get_domain,
-    must_setup_cluster, wait_metric_on_nodes,
+    must_setup_cluster,
 };
 
-use e2e_tests::{CLUSTER_WAIT_TIMEOUT, metrics};
+use e2e_tests::CLUSTER_WAIT_TIMEOUT;
 use near_mpc_contract_interface::types::{
     DomainConfig, DomainId, DomainPurpose, Protocol, ReconstructionThreshold,
 };
@@ -97,29 +97,25 @@ async fn distinct_reconstruction_thresholds__should_use_per_domain_threshold_whe
         outcome.failure_message()
     );
 
-    // And Cait-Sith (needs all 6) is unanswerable. Its request never resolves on
-    // chain, and the yield auto-timeout outlives the JSON-RPC call, so we race the
-    // doomed request against the surviving nodes' timeout counter rather than
-    // awaiting it (see `timeout_metric.rs`).
-    tokio::select! {
-        res = wait_metric_on_nodes(
-            &cluster,
-            &[0, 1, 2, 3, 4],
-            metrics::TIMEOUTS_INDEXED,
-            |v| v >= 1,
-            CLUSTER_WAIT_TIMEOUT,
-        ) => res.unwrap_or_else(|_| panic!(
-            "{} did not reach 1 on the surviving nodes — Cait-Sith request was answered \
-             despite only 5 of its 6 required signers being alive",
-            metrics::TIMEOUTS_INDEXED
-        )),
-        _ = cluster.send_sign_request(
-            caitsith_domain.id,
-            generate_ecdsa_payload(&mut rng),
-            cluster.default_user_account(),
-        ) => panic!(
-            "Cait-Sith sign request returned before the timeout metric — it should be \
-             unanswerable with only 5 of 6 required signers alive"
-        ),
-    }
+    // Cait-Sith (needs all 6) is unanswerable: its yield outlives the JSON-RPC call, so
+    // we poll the tx to `Final` instead of awaiting it.
+    let user = cluster.default_user_account().clone();
+    let tx_hash = cluster
+        .send_sign_request_included(caitsith_domain.id, generate_ecdsa_payload(&mut rng), &user)
+        .await
+        .expect("failed to submit Cait-Sith sign request");
+    let outcome = cluster
+        .contract
+        .wait_tx_final(tx_hash, &user, CLUSTER_WAIT_TIMEOUT)
+        .await
+        .expect("Cait-Sith sign request did not reach a final on-chain outcome");
+    assert!(
+        outcome.is_failure(),
+        "Cait-Sith sign request succeeded with only 5 of its 6 required signers alive"
+    );
+    let message = outcome.failure_message().unwrap_or_default();
+    assert!(
+        message.contains("timed out"),
+        "Cait-Sith sign request failed for an unexpected reason: {message}"
+    );
 }


### PR DESCRIPTION
This fixes a [comment](https://github.com/near/mpc/pull/3640#discussion_r3580653619)  by Kevin over my 3164 PR.

TLDR Problem: The old test inferred the Cait-Sith timeout indirectly by racing it against a metric counter

Solution: The PR replaces the metric race in the distinct-reconstruction-thresholds test with a direct assertion on the sign request's on-chain timeout failure.