### PR TITLE
docs(migration): clarify backup-cli node address format and migration port

### DIFF
--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -182,7 +182,10 @@ Now backup the keyshares from your currently running node.
 ### Obtain Node Information
 
 You'll need:
-- **MPC node address**: The host where your node is running (e.g., `node.example.com`). Available from the contract — your participant entry's `url` in the `state` view.
+- **MPC node address**: The host where your node is running, as bare `host:port` (e.g. `node.example.com:8079`). The host is available from the contract — your participant entry's `url` in the `state` view.
+
+  > **Strip the URL scheme.** The contract stores participant URLs with a scheme (e.g. `http://node.example.com:80`), but `--mpc-node-address` accepts only `host:port`. Passing `http://node.example.com:8079` makes the CLI resolve `http://node.example.com` as a hostname and fail with `TCP connect: failed to lookup address information: Name or service not known`. The port in the contract URL is the P2P port, not the migration port — see [Run the Backup](#run-the-backup).
+
 - **MPC node P2P public key**: The Ed25519 public key used for P2P communication. Available from the contract (your participant's `tls_public_key` in `state` / `get_tee_accounts`), or from the node's public-data endpoint:
 
   ```bash
@@ -205,7 +208,12 @@ near contract call-function as-read-only \
 This saves the contract state to `contract_state.json`, which the backup-cli uses to determine the current epoch and which keyshares to request from the node (based on the domains in the current keyset).
 
 ### Run the Backup
-Port 8079 is the default port for the migration endpoint.
+
+The migration endpoint listens on the node's `migration_web_ui` port. `8079` is the current default, but nodes configured before that default was introduced commonly use `8081`. Read the actual value from the node instead of assuming:
+
+```bash
+curl -s http://<IP>:8080/debug/node_config | jq -r .migration_web_ui
+```
 
 ```bash
 backup-cli \
@@ -409,7 +417,9 @@ After verifying the migration was successful:
 
 If backup-cli cannot connect to your node:
 
-- **Verify firewall rules**: Ensure the backup service can reach the node's address and that port 8079 is open and accessible.
+- **`failed to lookup address information: Name or service not known`**: `--mpc-node-address` must be a bare `host:port` with no URL scheme and no trailing path. A value like `http://node.example.com:8079` is parsed as hostname `http://node.example.com`, which no resolver can answer.
+- **Verify the port**: The migration endpoint uses the node's `migration_web_ui` port, which is not always the `8079` default — read it from `http://<IP>:8080/debug/node_config`. The same endpoint shows the bind address, which must not be loopback-only.
+- **Verify firewall rules**: Ensure the backup service can reach the node's address and that the migration port is open and accessible. Test with `nc -vz <host> <port>` rather than `curl`; the endpoint is a raw TLS channel authenticated against the registered backup-service key, so it does not answer plain HTTP requests.
 
 ## Known Limitations
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -224,7 +224,7 @@ backup-cli \
   --backup-encryption-key-hex $BACKUP_ENCRYPTION_KEY
 ```
 
-> **No `http://` in `--mpc-node-address`.** The value is a bare `host:port`. Prefixing it with a scheme — `http://node.example.com:8079` — makes the CLI treat `http://node.example.com` as the hostname and fail with `TCP connect: failed to lookup address information: Name or service not known`, which reads like a firewall problem but is not one.
+> **No `http://` in `--mpc-node-address`** — it takes a bare `host:port`. With a scheme, the lookup fails with `Name or service not known`.
 
 The encrypted keyshares are now stored in `$BACKUP_HOME_DIR/permanent_keys/epoch_<EPOCH>_with_<NUM_DOMAINS>_domains` (with a `key` hard-link in that directory).
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -184,7 +184,7 @@ Now backup the keyshares from your currently running node.
 You'll need:
 - **MPC node address**: The host where your node is running, as bare `host:port` (e.g. `node.example.com:8079`). The host is available from the contract — your participant entry's `url` in the `state` view.
 
-  > **Strip the URL scheme.** The contract stores participant URLs with a scheme (e.g. `http://node.example.com:80`), but `--mpc-node-address` accepts only `host:port`. Passing `http://node.example.com:8079` makes the CLI resolve `http://node.example.com` as a hostname and fail with `TCP connect: failed to lookup address information: Name or service not known`. The port in the contract URL is the P2P port, not the migration port — see [Run the Backup](#run-the-backup).
+  > **Strip the URL scheme.** The contract stores participant URLs with a scheme (e.g. `http://node.example.com:80`), but `--mpc-node-address` accepts only `host:port`. Passing `http://node.example.com:8079` makes the CLI resolve `http://node.example.com` as a hostname and fail on the TCP connect, with `failed to lookup address information: Name or service not known` as the underlying cause. The port in the contract URL is the P2P port, not the migration port — see [Run the Backup](#run-the-backup).
 
 - **MPC node P2P public key**: The Ed25519 public key used for P2P communication. Available from the contract (your participant's `tls_public_key` in `state` / `get_tee_accounts`), or from the node's public-data endpoint:
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -183,9 +183,6 @@ Now backup the keyshares from your currently running node.
 
 You'll need:
 - **MPC node address**: The host where your node is running, as bare `host:port` (e.g. `node.example.com:8079`). The host is available from the contract — your participant entry's `url` in the `state` view.
-
-  > **Strip the URL scheme.** The contract stores participant URLs with a scheme (e.g. `http://node.example.com:80`), but `--mpc-node-address` accepts only `host:port`. Passing `http://node.example.com:8079` makes the CLI resolve `http://node.example.com` as a hostname and fail on the TCP connect, with `failed to lookup address information: Name or service not known` as the underlying cause. The port in the contract URL is the P2P port, not the migration port — see [Run the Backup](#run-the-backup).
-
 - **MPC node P2P public key**: The Ed25519 public key used for P2P communication. Available from the contract (your participant's `tls_public_key` in `state` / `get_tee_accounts`), or from the node's public-data endpoint:
 
   ```bash
@@ -212,7 +209,7 @@ This saves the contract state to `contract_state.json`, which the backup-cli use
 The migration endpoint listens on the node's `migration_web_ui` port. `8079` is the current default, but nodes configured before that default was introduced commonly use `8081`. Read the actual value from the node instead of assuming:
 
 ```bash
-curl -s http://<IP>:8080/debug/node_config | jq -r .migration_web_ui
+curl -s http://<IP>:8080/debug/node_config | jq -r '.migration_web_ui | split(":") | last'
 ```
 
 ```bash

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -224,6 +224,8 @@ backup-cli \
   --backup-encryption-key-hex $BACKUP_ENCRYPTION_KEY
 ```
 
+> **No `http://` in `--mpc-node-address`.** The value is a bare `host:port`. Prefixing it with a scheme — `http://node.example.com:8079` — makes the CLI treat `http://node.example.com` as the hostname and fail with `TCP connect: failed to lookup address information: Name or service not known`, which reads like a firewall problem but is not one.
+
 The encrypted keyshares are now stored in `$BACKUP_HOME_DIR/permanent_keys/epoch_<EPOCH>_with_<NUM_DOMAINS>_domains` (with a `key` hard-link in that directory).
 
 


### PR DESCRIPTION
Closes #4064

Docs-only.

- `--mpc-node-address` is documented as bare `host:port`, with a warning that the contract participant `url` carries a scheme that must be stripped, and that its port is the P2P port rather than the migration port
- Migration port is read from the node's `migration_web_ui` via `/debug/node_config` instead of asserting the `8079` default — nodes configured before that default use `8081`
- Troubleshooting gains the `Name or service not known` case, the port/bind-address check, and `nc` instead of `curl` for reachability (the endpoint is raw TLS with backup-service key auth)

CLI-side validation for the same footgun is tracked in #4065.
