### PR TITLE
feat: probe Bitcoin provider by genesis block hash

### DIFF
--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -348,6 +348,13 @@ mod tests {
         }
     }
 
+    fn bitcoin_only(config: ForeignChainConfig) -> ForeignChainsConfig {
+        ForeignChainsConfig {
+            bitcoin: Some(config),
+            ..Default::default()
+        }
+    }
+
     fn must_put_chain(
         chains: &mut ForeignChainsConfig,
         chain: ForeignChain,
@@ -840,13 +847,10 @@ mod tests {
         // Given
         let server = httpmock::MockServer::start_async().await;
         mock_fingerprint(&server, BITCOIN_MAINNET).await;
-        let config = ForeignChainsConfig {
-            bitcoin: Some(chain_config(
-                Some(BITCOIN_MAINNET),
-                one_provider("publicnode", &server.base_url()),
-            )),
-            ..Default::default()
-        };
+        let config = bitcoin_only(chain_config(
+            Some(BITCOIN_MAINNET),
+            one_provider("publicnode", &server.base_url()),
+        ));
 
         // When
         let report = probe_all_providers(&config).await;
@@ -863,13 +867,10 @@ mod tests {
         // Given
         let server = httpmock::MockServer::start_async().await;
         mock_fingerprint(&server, BITCOIN_TESTNET3).await;
-        let config = ForeignChainsConfig {
-            bitcoin: Some(chain_config(
-                Some(BITCOIN_MAINNET),
-                one_provider("publicnode", &server.base_url()),
-            )),
-            ..Default::default()
-        };
+        let config = bitcoin_only(chain_config(
+            Some(BITCOIN_MAINNET),
+            one_provider("publicnode", &server.base_url()),
+        ));
 
         // When
         let report = probe_all_providers(&config).await;

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -365,11 +365,11 @@ mod tests {
         *slot = Some(config);
     }
 
-    async fn mock_chain_id<'a>(
+    async fn mock_fingerprint<'a>(
         server: &'a httpmock::MockServer,
-        chain_id: &str,
+        fingerprint: &str,
     ) -> httpmock::Mock<'a> {
-        let body = serde_json::json!({"jsonrpc": "2.0", "result": chain_id, "id": 0});
+        let body = serde_json::json!({"jsonrpc": "2.0", "result": fingerprint, "id": 0});
         server
             .mock_async(|when, then| {
                 when.method(httpmock::Method::POST);
@@ -446,7 +446,7 @@ mod tests {
     async fn probe_all_providers__should_report_a_provider_on_the_expected_network_as_healthy() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        let mock = mock_chain_id(&server, MAINNET).await;
+        let mock = mock_fingerprint(&server, MAINNET).await;
         let config = starknet_only(chain_config(
             Some(MAINNET),
             one_provider("publicnode", &server.base_url()),
@@ -467,7 +467,7 @@ mod tests {
     async fn probe_all_providers__should_report_a_provider_on_another_network_as_wrong_network() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, SEPOLIA).await;
+        mock_fingerprint(&server, SEPOLIA).await;
         let config = starknet_only(chain_config(
             Some(MAINNET),
             one_provider("publicnode", &server.base_url()),
@@ -490,7 +490,7 @@ mod tests {
     async fn probe_all_providers__should_normalize_the_reported_fingerprint_before_comparing() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, PADDED_UPPERCASE_MAINNET).await;
+        mock_fingerprint(&server, PADDED_UPPERCASE_MAINNET).await;
         let config = starknet_only(chain_config(
             Some(MAINNET),
             one_provider("publicnode", &server.base_url()),
@@ -511,7 +511,7 @@ mod tests {
      {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        let mock = mock_chain_id(&server, MAINNET).await;
+        let mock = mock_fingerprint(&server, MAINNET).await;
         let config = starknet_only(chain_config(
             None,
             one_provider("publicnode", &server.base_url()),
@@ -631,7 +631,7 @@ mod tests {
     async fn probe_all_providers__should_normalize_the_configured_fingerprint_before_comparing() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, MAINNET).await;
+        mock_fingerprint(&server, MAINNET).await;
         let config = starknet_only(chain_config(
             Some(PADDED_UPPERCASE_MAINNET),
             one_provider("publicnode", &server.base_url()),
@@ -699,7 +699,7 @@ mod tests {
     async fn probe_all_providers__should_report_each_provider_of_a_chain_separately() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, MAINNET).await;
+        mock_fingerprint(&server, MAINNET).await;
         let mut providers = one_provider("healthy", &server.base_url());
         providers.insert("broken".to_string().into(), provider(CLOSED_PORT_URL));
         let config = starknet_only(chain_config(Some(MAINNET), providers));
@@ -748,7 +748,7 @@ mod tests {
     async fn probe_all_providers__should_report_every_configured_chain_under_its_own_chain() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, MAINNET).await;
+        mock_fingerprint(&server, MAINNET).await;
         let config = ForeignChainsConfig {
             starknet: Some(chain_config(
                 Some(MAINNET),
@@ -784,7 +784,7 @@ mod tests {
         let mut config = ForeignChainsConfig::default();
         for mainnet in EVM_MAINNETS {
             let server = httpmock::MockServer::start_async().await;
-            mock_chain_id(&server, &mainnet.answered()).await;
+            mock_fingerprint(&server, &mainnet.answered()).await;
             must_put_chain(
                 &mut config,
                 mainnet.chain,
@@ -814,7 +814,7 @@ mod tests {
      {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, "0x14a34").await;
+        mock_fingerprint(&server, "0x14a34").await;
         let mut config = ForeignChainsConfig::default();
         must_put_chain(
             &mut config,
@@ -839,7 +839,7 @@ mod tests {
     async fn probe_all_providers__should_report_bitcoin_on_its_genesis_block_as_healthy() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, BITCOIN_MAINNET).await;
+        mock_fingerprint(&server, BITCOIN_MAINNET).await;
         let config = ForeignChainsConfig {
             bitcoin: Some(chain_config(
                 Some(BITCOIN_MAINNET),
@@ -862,7 +862,7 @@ mod tests {
     async fn probe_all_providers__should_report_bitcoin_on_another_network_as_wrong_network() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, BITCOIN_TESTNET3).await;
+        mock_fingerprint(&server, BITCOIN_TESTNET3).await;
         let config = ForeignChainsConfig {
             bitcoin: Some(chain_config(
                 Some(BITCOIN_MAINNET),
@@ -910,7 +910,7 @@ mod tests {
         // Given
         let server = httpmock::MockServer::start_async().await;
         let flood = "n".repeat(5_000);
-        mock_chain_id(&server, &flood).await;
+        mock_fingerprint(&server, &flood).await;
         let config = starknet_only(chain_config(
             Some(MAINNET),
             one_provider("publicnode", &server.base_url()),
@@ -966,7 +966,7 @@ mod tests {
     async fn probe_all_providers__should_keep_auth_material_out_of_the_report() {
         // Given
         let server = httpmock::MockServer::start_async().await;
-        mock_chain_id(&server, SEPOLIA).await;
+        mock_fingerprint(&server, SEPOLIA).await;
         let config = starknet_only(chain_config(
             Some(MAINNET),
             NonEmptyBTreeMap::new(

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use foreign_chain_inspector::abstract_chain::inspector::Abstract;
 use foreign_chain_inspector::arbitrum::inspector::Arbitrum;
 use foreign_chain_inspector::base::inspector::Base;
+use foreign_chain_inspector::bitcoin::inspector::BitcoinInspector;
 use foreign_chain_inspector::bnb::inspector::Bnb;
 use foreign_chain_inspector::evm::inspector::{EvmChain, EvmInspector};
 use foreign_chain_inspector::hyperevm::inspector::HyperEvm;
@@ -107,8 +108,14 @@ pub async fn probe_all_providers(config: &ForeignChainsConfig) -> ProbeReport {
                 ForeignChain::Bnb => probe_evm::<Bnb>(chain, chain_config).await,
                 ForeignChain::HyperEvm => probe_evm::<HyperEvm>(chain, chain_config).await,
                 ForeignChain::Polygon => probe_evm::<Polygon>(chain, chain_config).await,
-                // TODO(#4003): probe Bitcoin, Aptos and Sui. Ethereum, Solana and Ton have no
-                // inspector, so there is nothing to probe them with.
+                ForeignChain::Bitcoin => {
+                    probe_chain(chain, chain_config, |provider| {
+                        Ok(BitcoinInspector::new(prepare_jsonrpc(provider)?))
+                    })
+                    .await
+                }
+                // TODO(#4003): probe Aptos and Sui. Ethereum, Solana and Ton have no inspector, so
+                // there is nothing to probe them with.
                 _ => rows_of(chain, chain_config, ProviderStatus::ProbeNotImplemented),
             }
         });
@@ -237,6 +244,11 @@ mod tests {
     const CLOSED_PORT_URL: &str = "http://127.0.0.1:9";
     /// For a chain with no probe: the value is never read, only whether it is set at all.
     const ANY_FINGERPRINT: &str = "any-fingerprint";
+    /// Bitcoin's genesis block hash, which is what tells its networks apart.
+    const BITCOIN_MAINNET: &str =
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+    const BITCOIN_TESTNET3: &str =
+        "000000000933ea01ad0ee984209779baaec3ced90fa3f408719526f8d77f4943";
 
     struct EvmMainnet {
         chain: ForeignChain,
@@ -329,9 +341,9 @@ mod tests {
         }
     }
 
-    fn bitcoin_only(config: ForeignChainConfig) -> ForeignChainsConfig {
+    fn solana_only(config: ForeignChainConfig) -> ForeignChainsConfig {
         ForeignChainsConfig {
-            bitcoin: Some(config),
+            solana: Some(config),
             ..Default::default()
         }
     }
@@ -717,7 +729,7 @@ mod tests {
     async fn probe_all_providers__should_report_a_chain_with_no_fingerprint_probe_as_not_implemented()
      {
         // Given
-        let config = bitcoin_only(chain_config(
+        let config = solana_only(chain_config(
             Some(ANY_FINGERPRINT),
             one_provider("publicnode", CLOSED_PORT_URL),
         ));
@@ -727,7 +739,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
+            must_status_of(&report, ForeignChain::Solana, "publicnode"),
             ProviderStatus::ProbeNotImplemented
         );
     }
@@ -742,7 +754,7 @@ mod tests {
                 Some(MAINNET),
                 one_provider("publicnode", &server.base_url()),
             )),
-            bitcoin: Some(chain_config(
+            solana: Some(chain_config(
                 Some(ANY_FINGERPRINT),
                 one_provider("publicnode", CLOSED_PORT_URL),
             )),
@@ -758,7 +770,7 @@ mod tests {
             ProviderStatus::Healthy
         );
         assert_eq!(
-            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
+            must_status_of(&report, ForeignChain::Solana, "publicnode"),
             ProviderStatus::ProbeNotImplemented
         );
         assert_eq!(report.counts_per_chain().len(), 2);
@@ -819,6 +831,55 @@ mod tests {
             ProviderStatus::WrongNetwork {
                 expected: NetworkFingerprint::new("8453"),
                 observed: NetworkFingerprint::new("84532"),
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_all_providers__should_report_bitcoin_on_its_genesis_block_as_healthy() {
+        // Given
+        let server = httpmock::MockServer::start_async().await;
+        mock_chain_id(&server, BITCOIN_MAINNET).await;
+        let config = ForeignChainsConfig {
+            bitcoin: Some(chain_config(
+                Some(BITCOIN_MAINNET),
+                one_provider("publicnode", &server.base_url()),
+            )),
+            ..Default::default()
+        };
+
+        // When
+        let report = probe_all_providers(&config).await;
+
+        // Then
+        assert_eq!(
+            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
+            ProviderStatus::Healthy
+        );
+    }
+
+    #[tokio::test]
+    async fn probe_all_providers__should_report_bitcoin_on_another_network_as_wrong_network() {
+        // Given
+        let server = httpmock::MockServer::start_async().await;
+        mock_chain_id(&server, BITCOIN_TESTNET3).await;
+        let config = ForeignChainsConfig {
+            bitcoin: Some(chain_config(
+                Some(BITCOIN_MAINNET),
+                one_provider("publicnode", &server.base_url()),
+            )),
+            ..Default::default()
+        };
+
+        // When
+        let report = probe_all_providers(&config).await;
+
+        // Then
+        assert_eq!(
+            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
+            ProviderStatus::WrongNetwork {
+                expected: NetworkFingerprint::new(BITCOIN_MAINNET),
+                observed: NetworkFingerprint::new(BITCOIN_TESTNET3),
             }
         );
     }

--- a/crates/foreign-chain-inspector/src/bitcoin/inspector.rs
+++ b/crates/foreign-chain-inspector/src/bitcoin/inspector.rs
@@ -41,7 +41,7 @@ where
             .request(GET_BLOCK_HASH_METHOD, &args)
             .await
             .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
-        Ok(Self::canonical_fingerprint(&genesis_hash.0))
+        Ok(NetworkFingerprint::new(genesis_hash.canonical_text()))
     }
 
     fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {

--- a/crates/foreign-chain-inspector/src/bitcoin/inspector.rs
+++ b/crates/foreign-chain-inspector/src/bitcoin/inspector.rs
@@ -1,10 +1,14 @@
 use jsonrpsee::core::client::ClientT;
 
 use crate::bitcoin::{BitcoinExtractedValue, BitcoinTransactionHash};
-use crate::{BlockConfirmations, ForeignChainInspectionError, ForeignChainInspector};
+use crate::{
+    BlockConfirmations, ForeignChainInspectionError, ForeignChainInspector, NetworkFingerprint,
+    NetworkFingerprintInspector,
+};
 use foreign_chain_rpc_interfaces::bitcoin::{
-    GetBlockHashArgs, GetBlockHeaderArgs, GetBlockHeaderVerboseResponse, GetRawTransactionArgs,
-    GetRawTransactionVerboseResponse, TransportBitcoinBlockHash, TransportBitcoinTransactionHash,
+    GetBlockHashArgs, GetBlockHashResponse, GetBlockHeaderArgs, GetBlockHeaderVerboseResponse,
+    GetRawTransactionArgs, GetRawTransactionVerboseResponse, TransportBitcoinBlockHash,
+    TransportBitcoinTransactionHash,
 };
 
 /// <https://developer.bitcoin.org/reference/rpc/getrawtransaction.html>
@@ -16,9 +20,33 @@ const GET_BLOCK_HEADER_METHOD: &str = "getblockheader";
 /// <https://developer.bitcoin.org/reference/rpc/getblockhash.html>
 const GET_BLOCK_HASH_METHOD: &str = "getblockhash";
 
+/// Bitcoin has no chain id, so the genesis block is what tells the networks apart.
+const GENESIS_BLOCK_HEIGHT: u64 = 0;
+
 #[derive(Clone)]
 pub struct BitcoinInspector<Client> {
     client: Client,
+}
+
+impl<Client> NetworkFingerprintInspector for BitcoinInspector<Client>
+where
+    Client: ClientT + Send + Sync,
+{
+    async fn network_fingerprint(&self) -> Result<NetworkFingerprint, ForeignChainInspectionError> {
+        let args = GetBlockHashArgs {
+            height: GENESIS_BLOCK_HEIGHT,
+        };
+        let genesis_hash: GetBlockHashResponse = self
+            .client
+            .request(GET_BLOCK_HASH_METHOD, &args)
+            .await
+            .map_err(ForeignChainInspectionError::classify_rpc_client_error)?;
+        Ok(Self::canonical_fingerprint(&genesis_hash.0))
+    }
+
+    fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {
+        NetworkFingerprint::new(GetBlockHashResponse(fingerprint.to_owned()).canonical_text())
+    }
 }
 
 impl<Client> ForeignChainInspector for BitcoinInspector<Client>

--- a/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
@@ -381,7 +381,7 @@ const GENESIS_HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3
 async fn network_fingerprint__should_ask_the_provider_for_the_hash_at_height_zero() {
     // Given
     let server = MockServer::start_async().await;
-    let mock = server
+    let genesis_height_request = server
         .mock_async(|when, then| {
             when.method(POST)
                 .body_includes(r#""method":"getblockhash""#)
@@ -403,6 +403,6 @@ async fn network_fingerprint__should_ask_the_provider_for_the_hash_at_height_zer
         .expect("network_fingerprint should succeed");
 
     // Then
-    mock.assert_async().await;
+    genesis_height_request.assert_async().await;
     assert_eq!(fingerprint.to_string(), GENESIS_HASH);
 }

--- a/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
@@ -7,7 +7,8 @@ use crate::common::{
 };
 
 use foreign_chain_inspector::{
-    BlockConfirmations, ForeignChainInspectionError, ForeignChainInspector, RpcAuthentication,
+    BlockConfirmations, ForeignChainInspectionError, ForeignChainInspector,
+    NetworkFingerprintInspector, RpcAuthentication,
     bitcoin::{
         BitcoinBlockHash, BitcoinExtractedValue, BitcoinTransactionHash,
         inspector::{BitcoinExtractor, BitcoinInspector},
@@ -371,4 +372,54 @@ async fn inspector_extracts_block_hash_via_http_rpc_client() {
     // then
     let expected_extractions = vec![BitcoinExtractedValue::BlockHash(expected_block_hash)];
     assert_eq!(expected_extractions, extracted_values);
+}
+
+/// Bitcoin mainnet's genesis block hash, as block explorers render it.
+const GENESIS_HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+
+#[tokio::test]
+async fn network_fingerprint__should_return_the_genesis_block_hash_in_lowercase() {
+    // Given
+    let inspector = BitcoinInspector::new(mock_client_from_fixed_response(
+        GENESIS_HASH.to_ascii_uppercase(),
+    ));
+
+    // When
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
+
+    // Then
+    assert_eq!(fingerprint.to_string(), GENESIS_HASH);
+}
+
+#[tokio::test]
+async fn network_fingerprint__should_ask_the_provider_for_the_hash_at_height_zero() {
+    // Given
+    let server = MockServer::start_async().await;
+    let mock = server
+        .mock_async(|when, then| {
+            when.method(POST)
+                .body_includes(r#""method":"getblockhash""#)
+                .body_includes(r#""params":[0]"#);
+            then.status(200).json_body(serde_json::json!({
+                "jsonrpc": "2.0",
+                "id": 0,
+                "result": GENESIS_HASH,
+            }));
+        })
+        .await;
+    let client = build_http_client(server.url("/"), RpcAuthentication::KeyInUrl).unwrap();
+    let inspector = BitcoinInspector::new(client);
+
+    // When
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
+
+    // Then
+    mock.assert_async().await;
+    assert_eq!(fingerprint.to_string(), GENESIS_HASH);
 }

--- a/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/bitcoin_inspector.rs
@@ -378,23 +378,6 @@ async fn inspector_extracts_block_hash_via_http_rpc_client() {
 const GENESIS_HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
 
 #[tokio::test]
-async fn network_fingerprint__should_return_the_genesis_block_hash_in_lowercase() {
-    // Given
-    let inspector = BitcoinInspector::new(mock_client_from_fixed_response(
-        GENESIS_HASH.to_ascii_uppercase(),
-    ));
-
-    // When
-    let fingerprint = inspector
-        .network_fingerprint()
-        .await
-        .expect("network_fingerprint should succeed");
-
-    // Then
-    assert_eq!(fingerprint.to_string(), GENESIS_HASH);
-}
-
-#[tokio::test]
 async fn network_fingerprint__should_ask_the_provider_for_the_hash_at_height_zero() {
     // Given
     let server = MockServer::start_async().await;
@@ -406,7 +389,7 @@ async fn network_fingerprint__should_ask_the_provider_for_the_hash_at_height_zer
             then.status(200).json_body(serde_json::json!({
                 "jsonrpc": "2.0",
                 "id": 0,
-                "result": GENESIS_HASH,
+                "result": GENESIS_HASH.to_ascii_uppercase(),
             }));
         })
         .await;

--- a/crates/foreign-chain-inspector/tests/bitcoin_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/bitcoin_rpc_manual.rs
@@ -119,7 +119,8 @@ struct GetBlockVerbosityOneResponse {
     tx: Vec<String>,
 }
 
-/// Bitcoin mainnet's genesis block hash, as shipped in `expected_network_fingerprint`.
+/// Bitcoin mainnet's genesis block hash, as shipped in the node config file
+/// `foreign_chains.bitcoin.expected_network_fingerprint`.
 const EXPECTED_NETWORK_FINGERPRINT: &str =
     "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
 

--- a/crates/foreign-chain-inspector/tests/bitcoin_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/bitcoin_rpc_manual.rs
@@ -1,5 +1,5 @@
 use foreign_chain_inspector::{
-    BlockConfirmations, ForeignChainInspector, RpcAuthentication,
+    BlockConfirmations, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
     bitcoin::{
         BitcoinBlockHash, BitcoinExtractedValue, BitcoinTransactionHash,
         inspector::{BitcoinExtractor, BitcoinInspector},
@@ -135,10 +135,10 @@ async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_p
     let inspector = BitcoinInspector::new(http_client);
 
     // when
-    let fingerprint =
-        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
-            .await
-            .expect("network_fingerprint should succeed");
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
 
     // then
     assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);

--- a/crates/foreign-chain-inspector/tests/bitcoin_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/bitcoin_rpc_manual.rs
@@ -118,3 +118,28 @@ struct GetBlockchainInfoResponse {
 struct GetBlockVerbosityOneResponse {
     tx: Vec<String>,
 }
+
+/// Bitcoin mainnet's genesis block hash, as shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: &str =
+    "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live Bitcoin RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        PUBLIC_NODE_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = BitcoinInspector::new(http_client);
+
+    // when
+    let fingerprint =
+        foreign_chain_inspector::NetworkFingerprintInspector::network_fingerprint(&inspector)
+            .await
+            .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(fingerprint.to_string(), EXPECTED_NETWORK_FINGERPRINT);
+}

--- a/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
@@ -96,3 +96,74 @@ impl Serialize for GetBlockHashArgs {
 impl ToRpcParams for &GetBlockHashArgs {
     to_rpc_params_impl!();
 }
+
+/// RPC response for `getblockhash`: a block hash in the byte order block explorers render.
+/// <https://developer.bitcoin.org/reference/rpc/getblockhash.html>
+///
+/// Kept as text rather than parsed into a [`TransportBitcoinBlockHash`], so that whatever a
+/// provider answers can be reported back to an operator.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
+#[serde(transparent)]
+pub struct GetBlockHashResponse(pub String);
+
+impl GetBlockHashResponse {
+    /// Lowercase, and without the `0x` an operator may prefix it with. Leading zeros are digits of
+    /// the hash, not padding, so nothing is trimmed; a genesis hash has several. Text that is not a
+    /// 32 byte hash is returned unchanged.
+    pub fn canonical_text(&self) -> String {
+        const HASH_CHARS: usize = 64;
+
+        let digits = self.0.strip_prefix("0x").unwrap_or(&self.0);
+        let is_hash =
+            digits.len() == HASH_CHARS && digits.chars().all(|digit| digit.is_ascii_hexdigit());
+        if is_hash {
+            digits.to_ascii_lowercase()
+        } else {
+            self.0.clone()
+        }
+    }
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::GetBlockHashResponse;
+    use rstest::rstest;
+
+    /// Bitcoin mainnet's genesis block hash, as block explorers render it.
+    const GENESIS_HASH: &str = "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f";
+    const UPPER_CASED_GENESIS_HASH: &str =
+        "000000000019D6689C085AE165831E934FF763AE46A2A6C172B3F1B60A8CE26F";
+
+    #[rstest]
+    #[case::canonical(GENESIS_HASH, GENESIS_HASH)]
+    #[case::upper_cased(UPPER_CASED_GENESIS_HASH, GENESIS_HASH)]
+    // A spelling only an operator writes: the RPC never prefixes a hash.
+    #[case::prefixed(
+        "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        GENESIS_HASH
+    )]
+    // Reported as answered by the provider.
+    #[case::not_a_hash("mainnet", "mainnet")]
+    #[case::too_short(
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26",
+        "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26"
+    )]
+    #[case::not_hex(
+        "00000000zz19d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        "00000000zz19d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f"
+    )]
+    fn get_block_hash_response__should_canonicalize_what_a_provider_answers(
+        #[case] answered: &str,
+        #[case] expected: &str,
+    ) {
+        // Given
+        let json = serde_json::json!(answered);
+
+        // When
+        let response: GetBlockHashResponse = serde_json::from_value(json).unwrap();
+
+        // Then
+        assert_eq!(response.canonical_text(), expected);
+    }
+}

--- a/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
@@ -108,7 +108,7 @@ pub struct GetBlockHashResponse(pub String);
 impl GetBlockHashResponse {
     /// Lowercase, with a `0x` at the beginning stripped. Leading zeros are digits of the hash, so
     /// nothing is trimmed. Text that is not a 32 byte hash is returned unchanged.
-    pub fn canonical_text(&self) -> String {
+    pub fn canonical_text(self) -> String {
         const HASH_CHARS: usize = 64;
 
         let digits = self
@@ -121,7 +121,7 @@ impl GetBlockHashResponse {
         if is_hash {
             digits.to_ascii_lowercase()
         } else {
-            self.0.clone()
+            self.0
         }
     }
 }

--- a/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
@@ -100,20 +100,22 @@ impl ToRpcParams for &GetBlockHashArgs {
 /// RPC response for `getblockhash`: a block hash in the byte order block explorers render.
 /// <https://developer.bitcoin.org/reference/rpc/getblockhash.html>
 ///
-/// Kept as text rather than parsed into a [`TransportBitcoinBlockHash`], so that whatever a
-/// provider answers can be reported back to an operator.
+/// Kept as text rather than parsed into a [`TransportBitcoinBlockHash`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
 #[serde(transparent)]
 pub struct GetBlockHashResponse(pub String);
 
 impl GetBlockHashResponse {
-    /// Lowercase, and without the `0x` an operator may prefix it with. Leading zeros are digits of
-    /// the hash, not padding, so nothing is trimmed; a genesis hash has several. Text that is not a
-    /// 32 byte hash is returned unchanged.
+    /// Lowercase, with a `0x` at the beginning stripped. Leading zeros are digits of the hash, so
+    /// nothing is trimmed. Text that is not a 32 byte hash is returned unchanged.
     pub fn canonical_text(&self) -> String {
         const HASH_CHARS: usize = 64;
 
-        let digits = self.0.strip_prefix("0x").unwrap_or(&self.0);
+        let digits = self
+            .0
+            .strip_prefix("0x")
+            .or_else(|| self.0.strip_prefix("0X"))
+            .unwrap_or(&self.0);
         let is_hash =
             digits.len() == HASH_CHARS && digits.chars().all(|digit| digit.is_ascii_hexdigit());
         if is_hash {
@@ -138,9 +140,13 @@ mod tests {
     #[rstest]
     #[case::canonical(GENESIS_HASH, GENESIS_HASH)]
     #[case::upper_cased(UPPER_CASED_GENESIS_HASH, GENESIS_HASH)]
-    // A spelling only an operator writes: the RPC never prefixes a hash.
+    // Spellings only an operator writes: the RPC never prefixes a hash.
     #[case::prefixed(
         "0x000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+        GENESIS_HASH
+    )]
+    #[case::upper_cased_prefix(
+        "0X000000000019D6689C085AE165831E934FF763AE46A2A6C172B3F1B60A8CE26F",
         GENESIS_HASH
     )]
     // Reported as answered by the provider.

--- a/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
+++ b/crates/foreign-chain-rpc-interfaces/src/bitcoin.rs
@@ -100,7 +100,8 @@ impl ToRpcParams for &GetBlockHashArgs {
 /// RPC response for `getblockhash`: a block hash in the byte order block explorers render.
 /// <https://developer.bitcoin.org/reference/rpc/getblockhash.html>
 ///
-/// Kept as text rather than parsed into a [`TransportBitcoinBlockHash`].
+/// Kept as text since we need to preserve the exact provider response, which might not be a
+/// [`TransportBitcoinBlockHash`].
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Deserialize)]
 #[serde(transparent)]
 pub struct GetBlockHashResponse(pub String);

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -554,8 +554,9 @@ Not every chain has a fingerprint probe. The table lists the ones that do, with 
 |---|---|
 | starknet | `starknet_chainId` |
 | base, bnb, arbitrum, polygon, hyper_evm, abstract | `eth_chainId` |
+| bitcoin | `getblockhash` at height 0 |
 
-The reported and the configured value are normalized before they are compared, because the same fingerprint has several legal spellings. Starknet's is the chain id felt in lowercase `0x` hex without leading zeros, which providers and operators alike are free to pad and upper-case. The EVM chain id is compared in decimal, the form it is published and configured in, while `eth_chainId` answers a `0x` hex quantity.
+The reported and the configured value are normalized before they are compared, because the same fingerprint has several legal spellings. Starknet's is the chain id felt in lowercase `0x` hex without leading zeros, which providers and operators alike are free to pad and upper-case. The EVM chain id is compared in decimal, the form it is published and configured in, while `eth_chainId` answers a `0x` hex quantity. Bitcoin's genesis hash is compared in lowercase hex, with the leading zeros kept, since they are digits of the hash.
 
 An answer that is no fingerprint at all is reported as the wrong network, carrying the text the provider sent, so the report says what was actually claimed. An answer longer than any real fingerprint is cut short and ends in `_TRUNCATED`, because it is repeated into logs and metric labels.
 
@@ -714,8 +715,8 @@ The fingerprint is set per chain rather than once per deployment, so a config ca
 each value must match the network of the `rpc_url` beside it. The value is always a quoted string,
 including the fingerprints that look numeric.
 
-Only the chains with a fingerprint probe read the field at all — starknet and the EVM chains today,
-the rest as their probes are written. For those chains, leaving it unset is not a silent skip: every
+Only the chains with a fingerprint probe read the field at all — starknet, bitcoin and the EVM
+chains today, the rest as their probes are written. For those chains, leaving it unset is not a silent skip: every
 provider of the chain is reported as `MissingExpectedFingerprint`, because silence reads as healthy
 on a dashboard. A chain with no probe yet reports `ProbeNotImplemented` whether the field is set or
 not.


### PR DESCRIPTION
Closes #4091.

Bitcoin has no chain id, so the fingerprint is the genesis block hash and the probe is `getblockhash` at height 0, the method the inspector's canonical chain check already uses.

### Notes for review

- **Nothing is trimmed.** Leading zeros are digits of the hash and the genesis hash opens with ten of them, so normalization is lowercase with an optional `0x` prefix stripped. Text that is not 64 hex characters reads back unchanged, so the report shows what the provider actually claimed.