### PR TITLE
Remove account_id parameter from IndexerViewClient methods

### DIFF
--- a/crates/node/src/indexer.rs
+++ b/crates/node/src/indexer.rs
@@ -76,7 +76,10 @@ impl IndexerState {
         mpc_contract_id: AccountId,
     ) -> Self {
         Self {
-            view_client: IndexerViewClient { view_client },
+            view_client: IndexerViewClient {
+                view_client,
+                mpc_contract_id: mpc_contract_id.clone(),
+            },
             client: IndexerClient { client },
             rpc_handler: IndexerRpcHandler { rpc_handler },
             mpc_contract_id,
@@ -88,21 +91,15 @@ impl IndexerState {
 #[derive(Clone)]
 pub(crate) struct IndexerViewClient {
     view_client: MultithreadRuntimeHandle<ViewClientActor>,
+    /// AccountId for the mpc contract. Duplicated from [`IndexerState`] so that
+    /// callers reaching `view_client` don't need to also thread the contract id through.
+    mpc_contract_id: AccountId,
 }
 
-// TODO(#1514): during refactor I noticed the account id is always taken from the indexer state as well.
-// We should remove this account_id parameter...
-//
-// example:
-// indexer_state.view_client.get_mpc_tee_accounts(indexer_state.mpc_contract_id.clone()).await
-// =>
-// indexer_state.view_client.get_mpc_tee_accounts().await
-// This pattern repeats for all the methods.
 // TODO(#1956): There is a lot of duplicate code here that could be simplified
 impl IndexerViewClient {
     pub(crate) async fn get_pending_request(
         &self,
-        mpc_contract_id: &AccountId,
         chain_signature_request: &dtos::SignatureRequest,
     ) -> anyhow::Result<Option<YieldIndex>> {
         let get_pending_request_args: Vec<u8> = serde_json::to_string(
@@ -112,7 +109,7 @@ impl IndexerViewClient {
         .into_bytes();
 
         let request = QueryRequest::CallFunction {
-            account_id: mpc_contract_id.clone(),
+            account_id: self.mpc_contract_id.clone(),
             method_name: GET_PENDING_REQUEST.to_string(),
             args: get_pending_request_args.into(),
         };
@@ -142,7 +139,6 @@ impl IndexerViewClient {
 
     pub(crate) async fn get_pending_ckd_request(
         &self,
-        mpc_contract_id: &AccountId,
         chain_ckd_request: &dtos::CKDRequest,
     ) -> anyhow::Result<Option<YieldIndex>> {
         let get_pending_request_args: Vec<u8> = serde_json::to_string(
@@ -152,7 +148,7 @@ impl IndexerViewClient {
         .into_bytes();
 
         let request = QueryRequest::CallFunction {
-            account_id: mpc_contract_id.clone(),
+            account_id: self.mpc_contract_id.clone(),
             method_name: GET_PENDING_CKD_REQUEST.to_string(),
             args: get_pending_request_args.into(),
         };
@@ -182,7 +178,6 @@ impl IndexerViewClient {
 
     pub(crate) async fn get_pending_verify_foreign_tx_request(
         &self,
-        mpc_contract_id: &AccountId,
         chain_verify_foreign_tx_request: &dtos::VerifyForeignTransactionRequest,
     ) -> anyhow::Result<Option<YieldIndex>> {
         let get_pending_request_args: Vec<u8> =
@@ -193,7 +188,7 @@ impl IndexerViewClient {
             .into_bytes();
 
         let request = QueryRequest::CallFunction {
-            account_id: mpc_contract_id.clone(),
+            account_id: self.mpc_contract_id.clone(),
             method_name: GET_PENDING_VERIFY_FOREIGN_TX_REQUEST.to_string(),
             args: get_pending_request_args.into(),
         };
@@ -223,7 +218,6 @@ impl IndexerViewClient {
 
     pub(crate) async fn get_participant_attestation(
         &self,
-        mpc_contract_id: &AccountId,
         participant_tls_public_key: &near_mpc_contract_interface::types::Ed25519PublicKey,
     ) -> anyhow::Result<Option<near_mpc_contract_interface::types::VerifiedAttestation>> {
         let get_attestation_args: Vec<u8> = serde_json::to_string(
@@ -233,7 +227,7 @@ impl IndexerViewClient {
         .into_bytes();
 
         let request = QueryRequest::CallFunction {
-            account_id: mpc_contract_id.clone(),
+            account_id: self.mpc_contract_id.clone(),
             method_name: GET_ATTESTATION.to_string(),
             args: get_attestation_args.into(),
         };
@@ -263,37 +257,29 @@ impl IndexerViewClient {
 
     pub(crate) async fn get_supported_chains(
         &self,
-        mpc_contract_id: &AccountId,
     ) -> anyhow::Result<dtos::SupportedForeignChains> {
-        let (_height, policy) = self
-            .get_mpc_state(mpc_contract_id.clone(), GET_SUPPORTED_FOREIGN_CHAINS)
-            .await?;
+        let (_height, policy) = self.get_mpc_state(GET_SUPPORTED_FOREIGN_CHAINS).await?;
         Ok(policy)
     }
 
     pub(crate) async fn get_foreign_chains_configs(
         &self,
-        mpc_contract_id: &AccountId,
     ) -> anyhow::Result<(u64, dtos::ForeignChainsConfigs)> {
-        self.get_mpc_state(mpc_contract_id.clone(), GET_FOREIGN_CHAINS_CONFIGS)
-            .await
+        self.get_mpc_state(GET_FOREIGN_CHAINS_CONFIGS).await
     }
 
     pub(crate) async fn get_available_chains(
         &self,
-        mpc_contract_id: &AccountId,
     ) -> anyhow::Result<(u64, dtos::AvailableForeignChains)> {
-        self.get_mpc_state(mpc_contract_id.clone(), GET_AVAILABLE_FOREIGN_CHAINS)
-            .await
+        self.get_mpc_state(GET_AVAILABLE_FOREIGN_CHAINS).await
     }
 
     /// Borsh-decoding view-fn query (`get_mpc_state` is JSON-only).
     pub(crate) async fn get_allowed_foreign_chain_providers(
         &self,
-        mpc_contract_id: AccountId,
     ) -> anyhow::Result<std::collections::BTreeMap<dtos::ForeignChain, dtos::ChainEntry>> {
         let request = QueryRequest::CallFunction {
-            account_id: mpc_contract_id,
+            account_id: self.mpc_contract_id.clone(),
             method_name: ALLOWED_FOREIGN_CHAIN_PROVIDERS.to_string(),
             args: vec![].into(),
         };
@@ -335,18 +321,15 @@ impl IndexerViewClient {
 
     pub(crate) async fn get_mpc_contract_state_dto(
         &self,
-        mpc_contract_id: AccountId,
     ) -> anyhow::Result<(u64, dtos::ProtocolContractState)> {
-        self.get_mpc_state(mpc_contract_id, STATE).await
+        self.get_mpc_state(STATE).await
     }
 
     pub(crate) async fn get_mpc_allowed_image_hashes(
         &self,
-        mpc_contract_id: AccountId,
     ) -> anyhow::Result<(u64, Vec<dtos::AllowedMpcDockerImageHash>)> {
-        let (block_height, response): (u64, AllowedDockerImageHashesResponse) = self
-            .get_mpc_state(mpc_contract_id, ALLOWED_DOCKER_IMAGE_HASHES)
-            .await?;
+        let (block_height, response): (u64, AllowedDockerImageHashesResponse) =
+            self.get_mpc_state(ALLOWED_DOCKER_IMAGE_HASHES).await?;
 
         // TODO(#3751): drop this logic after upgrading the contract.
         let entries = match response {
@@ -363,36 +346,26 @@ impl IndexerViewClient {
     }
     pub(crate) async fn get_mpc_allowed_launcher_compose_hashes(
         &self,
-        mpc_contract_id: AccountId,
     ) -> anyhow::Result<(u64, Vec<LauncherDockerComposeHash>)> {
-        self.get_mpc_state(mpc_contract_id, ALLOWED_LAUNCHER_COMPOSE_HASHES)
-            .await
+        self.get_mpc_state(ALLOWED_LAUNCHER_COMPOSE_HASHES).await
     }
 
-    pub(crate) async fn get_mpc_tee_accounts(
-        &self,
-        mpc_contract_id: AccountId,
-    ) -> anyhow::Result<(u64, Vec<dtos::NodeId>)> {
-        self.get_mpc_state(mpc_contract_id, GET_TEE_ACCOUNTS).await
+    pub(crate) async fn get_mpc_tee_accounts(&self) -> anyhow::Result<(u64, Vec<dtos::NodeId>)> {
+        self.get_mpc_state(GET_TEE_ACCOUNTS).await
     }
 
     pub(crate) async fn get_mpc_migration_info(
         &self,
-        mpc_contract_id: AccountId,
     ) -> anyhow::Result<(u64, ContractMigrationInfo)> {
-        self.get_mpc_state(mpc_contract_id, MIGRATION_INFO).await
+        self.get_mpc_state(MIGRATION_INFO).await
     }
 
-    async fn get_mpc_state<State>(
-        &self,
-        mpc_contract_id: AccountId,
-        endpoint: &str,
-    ) -> anyhow::Result<(u64, State)>
+    async fn get_mpc_state<State>(&self, endpoint: &str) -> anyhow::Result<(u64, State)>
     where
         State: for<'de> Deserialize<'de>,
     {
         let request = QueryRequest::CallFunction {
-            account_id: mpc_contract_id,
+            account_id: self.mpc_contract_id.clone(),
             method_name: endpoint.to_string(),
             args: vec![].into(),
         };
@@ -436,10 +409,7 @@ impl RealForeignChainPolicyReader {
 
 impl ReadSupportedForeignChain for RealForeignChainPolicyReader {
     async fn get_supported_chains(&self) -> anyhow::Result<dtos::SupportedForeignChains> {
-        self.indexer_state
-            .view_client
-            .get_supported_chains(&self.indexer_state.mpc_contract_id)
-            .await
+        self.indexer_state.view_client.get_supported_chains().await
     }
 }
 
@@ -473,7 +443,7 @@ impl ReadAttestationExpiry for RealAttestationExpiryReader {
             let stored = self
                 .indexer_state
                 .view_client
-                .get_participant_attestation(&self.indexer_state.mpc_contract_id, tls_public_key)
+                .get_participant_attestation(tls_public_key)
                 .await?;
             Ok(stored.and_then(|attestation| attestation.expiry_timestamp_seconds()))
         })

--- a/crates/node/src/indexer/foreign_chain.rs
+++ b/crates/node/src/indexer/foreign_chain.rs
@@ -46,12 +46,8 @@ pub async fn monitor_foreign_chain_supporters(
 /// a transiently inconsistent snapshot, corrected on the next poll.
 async fn read_supporters(indexer_state: &IndexerState) -> anyhow::Result<ForeignChainSupporters> {
     let ((_, available_chains), (_, configs)) = tokio::try_join!(
-        indexer_state
-            .view_client
-            .get_available_chains(&indexer_state.mpc_contract_id),
-        indexer_state
-            .view_client
-            .get_foreign_chains_configs(&indexer_state.mpc_contract_id)
+        indexer_state.view_client.get_available_chains(),
+        indexer_state.view_client.get_foreign_chains_configs()
     )?;
     Ok(supporters_by_available_chain(&available_chains, &configs))
 }

--- a/crates/node/src/indexer/migrations.rs
+++ b/crates/node/src/indexer/migrations.rs
@@ -81,11 +81,7 @@ async fn fetch_migrations_once(indexer_state: Arc<IndexerState>) -> (u64, Contra
 
         tracing::debug!(target: "indexer", "querying migration state");
 
-        match indexer_state
-            .view_client
-            .get_mpc_migration_info(indexer_state.mpc_contract_id.clone())
-            .await
-        {
+        match indexer_state.view_client.get_mpc_migration_info().await {
             Ok(res) => {
                 return res;
             }

--- a/crates/node/src/indexer/participants.rs
+++ b/crates/node/src/indexer/participants.rs
@@ -327,7 +327,7 @@ pub async fn monitor_contract_state(
 
             let (height, protocol_state) = match indexer_state
                 .view_client
-                .get_mpc_contract_state_dto(indexer_state.mpc_contract_id.clone())
+                .get_mpc_contract_state_dto()
                 .await
             {
                 Ok(contract_state) => contract_state,

--- a/crates/node/src/indexer/tee.rs
+++ b/crates/node/src/indexer/tee.rs
@@ -4,7 +4,6 @@ use std::{sync::Arc, time::Duration};
 
 use backon::{BackoffBuilder, ExponentialBuilder};
 use mpc_primitives::hash::LauncherDockerComposeHash;
-use near_account_id::AccountId;
 use near_mpc_contract_interface::types::{
     AllowedMpcDockerImageHash, ChainEntry, ForeignChain, NodeId,
 };
@@ -24,11 +23,10 @@ async fn monitor_allowed_hashes<Fetcher, T, FetcherResponseFuture>(
     get_mpc_allowed_hashes: &Fetcher,
 ) where
     T: PartialEq,
-    Fetcher: Fn(AccountId) -> FetcherResponseFuture + Send + Sync,
+    Fetcher: Fn() -> FetcherResponseFuture + Send + Sync,
     FetcherResponseFuture: Future<Output = anyhow::Result<(u64, T)>> + Send,
 {
     let fetch_allowed_hashes = {
-        let indexer_state = indexer_state.clone();
         async move || {
             let mut backoff = ExponentialBuilder::default()
                 .with_min_delay(MIN_BACKOFF_DURATION)
@@ -38,7 +36,7 @@ async fn monitor_allowed_hashes<Fetcher, T, FetcherResponseFuture>(
                 .build();
 
             loop {
-                match get_mpc_allowed_hashes(indexer_state.mpc_contract_id.clone()).await {
+                match get_mpc_allowed_hashes().await {
                     Ok((_block_height, allowed_hashes)) => {
                         break allowed_hashes;
                     }
@@ -81,7 +79,7 @@ pub async fn monitor_allowed_docker_images(
     indexer_state: Arc<IndexerState>,
 ) {
     let view_client = indexer_state.view_client.clone();
-    let fetcher = { |id| view_client.get_mpc_allowed_image_hashes(id) };
+    let fetcher = { || view_client.get_mpc_allowed_image_hashes() };
 
     monitor_allowed_hashes(sender, indexer_state, &fetcher).await
 }
@@ -95,7 +93,7 @@ pub async fn monitor_allowed_launcher_compose_hashes(
     indexer_state: Arc<IndexerState>,
 ) {
     let view_client = indexer_state.view_client.clone();
-    let fetcher = { |id| view_client.get_mpc_allowed_launcher_compose_hashes(id) };
+    let fetcher = { || view_client.get_mpc_allowed_launcher_compose_hashes() };
 
     monitor_allowed_hashes(sender, indexer_state, &fetcher).await
 }
@@ -110,11 +108,7 @@ async fn fetch_tee_accounts_with_retry(indexer_state: &IndexerState) -> Vec<Node
         .build();
 
     loop {
-        match indexer_state
-            .view_client
-            .get_mpc_tee_accounts(indexer_state.mpc_contract_id.clone())
-            .await
-        {
+        match indexer_state.view_client.get_mpc_tee_accounts().await {
             Ok((_block_height, tee_accounts)) => return tee_accounts,
             Err(e) => {
                 tracing::error!(target: "mpc", "error reading TEE accounts from chain: {:?}", e);
@@ -160,7 +154,7 @@ async fn fetch_allowed_foreign_chain_providers_with_retry(
     loop {
         match indexer_state
             .view_client
-            .get_allowed_foreign_chain_providers(indexer_state.mpc_contract_id.clone())
+            .get_allowed_foreign_chain_providers()
             .await
         {
             Ok(whitelist) => return whitelist,

--- a/crates/node/src/indexer/tx_sender.rs
+++ b/crates/node/src/indexer/tx_sender.rs
@@ -230,7 +230,7 @@ async fn observe_tx_result(
             // A successful respond removes the request from contract state.
             let pending_request_response = indexer_state
                 .view_client
-                .get_pending_request(&indexer_state.mpc_contract_id, &respond_args.request)
+                .get_pending_request(&respond_args.request)
                 .await?;
 
             let transaction_status = match pending_request_response {
@@ -246,7 +246,7 @@ async fn observe_tx_result(
             // A successful respond removes the request from contract state.
             let pending_request_response = indexer_state
                 .view_client
-                .get_pending_ckd_request(&indexer_state.mpc_contract_id, &respond_args.request)
+                .get_pending_ckd_request(&respond_args.request)
                 .await?;
 
             let transaction_status = match pending_request_response {
@@ -262,10 +262,7 @@ async fn observe_tx_result(
             // A successful respond removes the request from contract state.
             let pending_request_response = indexer_state
                 .view_client
-                .get_pending_verify_foreign_tx_request(
-                    &indexer_state.mpc_contract_id,
-                    &respond_args.request,
-                )
+                .get_pending_verify_foreign_tx_request(&respond_args.request)
                 .await?;
 
             let transaction_status = match pending_request_response {
@@ -281,7 +278,7 @@ async fn observe_tx_result(
         } => {
             let stored_attestation = indexer_state
                 .view_client
-                .get_participant_attestation(&indexer_state.mpc_contract_id, &args.tls_public_key)
+                .get_participant_attestation(&args.tls_public_key)
                 .await?;
 
             let Some(stored_attestation) = stored_attestation else {


### PR DESCRIPTION
## Summary
- `IndexerViewClient` is always accessed through `IndexerState`, which already holds `mpc_contract_id` — every method taking it as a parameter was passing the same redundant value at every call site (there was already a `TODO(#1514)` in the code noting this)
- `IndexerViewClient` now stores its own copy of `mpc_contract_id`, set once in `IndexerState::new`
- Removed the parameter from all 12 methods on `IndexerViewClient` (`get_pending_request`, `get_pending_ckd_request`, `get_pending_verify_foreign_tx_request`, `get_participant_attestation`, `get_supported_chains`, `get_foreign_chains_configs`, `get_available_chains`, `get_allowed_foreign_chain_providers`, `get_mpc_contract_state_dto`, `get_mpc_allowed_image_hashes`, `get_mpc_allowed_launcher_compose_hashes`, `get_mpc_tee_accounts`, `get_mpc_migration_info`) and the private `get_mpc_state` helper
- Updated all call sites in `tx_sender.rs`, `tee.rs` (including the generic `monitor_allowed_hashes` fetcher, whose `Fetcher` bound dropped its `AccountId` argument), `participants.rs`, `foreign_chain.rs`, and `migrations.rs`
- `IndexerState::mpc_contract_id` itself is unchanged — it's still needed for building outgoing transactions, unrelated to `IndexerViewClient`

Closes #1514

## Verification
- `cargo check -p mpc-node --all-features`: clean
- `cargo clippy -p mpc-node --all-targets --all-features -- -D warnings`: clean (type-checks test code too)
- `cargo fmt -- --check`: clean
- Wasn't able to complete a full `cargo test` link+run locally (linking `mpc-node`'s test binary, which statically pulls in `nearcore`/`near-client`/etc., needs more disk than my local environment has available) — `cargo check`/`clippy --all-targets` already confirm the test code (including `#[cfg(test)]` modules) type-checks correctly under the new signatures. Happy to fix up anything CI's actual test run surfaces.

## Test plan
- [ ] CI clippy job passes
- [ ] CI test suite passes