### PR TITLE
Use exponential backoff for outbound peer reconnection retries

### DIFF
--- a/crates/node/src/p2p.rs
+++ b/crates/node/src/p2p.rs
@@ -20,6 +20,7 @@ use crate::protocol_version::CURRENT_PROTOCOL_VERSION;
 use crate::tracking::{self, AutoAbortTask, AutoAbortTaskCollection};
 use anyhow::{Context, anyhow};
 use async_trait::async_trait;
+use backon::{BackoffBuilder, ExponentialBuilder};
 use borsh::{BorshDeserialize, BorshSerialize};
 use bytes::Bytes;
 use ed25519_dalek::VerifyingKey;
@@ -379,7 +380,8 @@ impl OutgoingConnection {
 }
 
 impl PersistentConnection {
-    const CONNECTION_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+    const MIN_CONNECTION_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(1);
+    const MAX_CONNECTION_RETRY_DELAY: std::time::Duration = std::time::Duration::from_secs(60);
 
     /// Sends a message over the connection. If the connection was reset, fail.
     fn send_mpc_message(
@@ -419,6 +421,15 @@ impl PersistentConnection {
             &format!("Persistent connection to {}", target_participant_id),
             async move {
                 let mut connection_attempt = Self::MIN_CONNECTION_ID;
+                let new_backoff = || {
+                    ExponentialBuilder::default()
+                        .with_min_delay(Self::MIN_CONNECTION_RETRY_DELAY)
+                        .with_max_delay(Self::MAX_CONNECTION_RETRY_DELAY)
+                        .without_max_times()
+                        .with_jitter()
+                        .build()
+                };
+                let mut backoff = new_backoff();
                 loop {
                     // Re-resolve on every (re)connect so a peer URL update is picked up; only the
                     // next dial is affected, established connections are untouched.
@@ -440,19 +451,26 @@ impl PersistentConnection {
                                 "outgoing connection established"
                             );
 
+                            // Reset backoff now that we've reconnected; a future disconnect
+                            // should retry quickly rather than pick up where we left off.
+                            backoff = new_backoff();
+
                             new_conn
                         }
                         Err(e) => {
+                            let delay = backoff.next().unwrap_or(Self::MAX_CONNECTION_RETRY_DELAY);
+
                             tracing::info!(
                                 my_id = %my_id,
                                 target_participant_id = %target_participant_id,
                                 error = %format_args!("{e:#}"),
+                                retry_delay = ?delay,
                                 "could not connect, retrying"
                             );
 
-                            // Don't immediately retry, to avoid spamming the network with
-                            // connection attempts.
-                            tokio::time::sleep(Self::CONNECTION_RETRY_DELAY).await;
+                            // Back off exponentially, to avoid spamming the network (and our
+                            // own logs) with connection attempts while a peer is down.
+                            tokio::time::sleep(delay).await;
                             continue;
                         }
                     };


### PR DESCRIPTION
## Summary
- `PersistentConnection`'s dial loop in `crates/node/src/p2p.rs` retried on a fixed 1s delay, so a peer that's persistently offline gets dialed — and logged at `info` level — once a second forever, spamming logs (and the network) while unrelated to any other issue.
- Replaced the fixed delay with `backon::ExponentialBuilder` (1s min, 60s max, jittered, unbounded retries), matching the pattern already used in `crates/node/src/indexer/tee.rs`.
- Backoff resets back to the fast 1s retry once a connection succeeds, so a peer that flaps doesn't inherit a long delay from its previous outage.
- Added the resolved `retry_delay` to the existing "could not connect, retrying" log line for visibility into the current backoff state.

Closes #4063

## Verification
- `cargo check -p mpc-node --all-features`: clean
- `cargo clippy -p mpc-node --all-targets --all-features -- -D warnings`: clean (type-checks test code too)
- `cargo fmt -- --check`: clean
- Didn't complete a full `cargo test` link+run locally (same disk constraint as #4102 — linking `mpc-node`'s test binary needs more disk than available here). The two existing `PersistentConnection` tests (`persistent_connection__should_keep_retrying_when_dial_attempt_hangs`, `persistent_connection__should_dial_new_address_after_resolver_update`) use `#[tokio::test(start_paused = true)]`, so tokio's virtual clock auto-advances through `sleep`s regardless of duration — they only assert the loop keeps retrying/dialing, not on the fixed 1s timing, so the growing backoff delays shouldn't affect them. Happy to fix up anything CI's test run surfaces.

## Test plan
- [ ] CI clippy job passes
- [ ] CI test suite passes (including the two `PersistentConnection` retry tests)