### PR TITLE
chore(contract): correct the grants map in the design doc and measure its row cost

### DIFF
--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8846,8 +8846,8 @@ mod tests {
     /// [`WORST_CASE_ENTRY_BYTES`] for storage-price changes.
     const WORST_CASE_ENTRY_COST_CEILING: NearToken = NearToken::from_millinear(10);
 
-    /// One `available_attestation_grants` row, for the longest possible account id. The fee
-    /// covers this on top of the entry, since the first grant for an account creates the row.
+    /// Worst case is the longest possible account id. The fee covers this row on top of the
+    /// entry; an account's first grant creates it.
     const WORST_CASE_GRANT_ROW_BYTES: u64 = 194;
 
     fn worst_case_dstack_attestation() -> VerifiedAttestation {
@@ -8892,8 +8892,6 @@ mod tests {
         env::storage_usage() - before
     }
 
-    /// Charged bytes for one grants-map row, measured the same way as
-    /// [`measure_stored_entry_bytes`]: insert into the real map, flush, take the delta.
     fn measure_grant_row_bytes() -> u64 {
         testing_env!(VMContextBuilder::new().build());
         let account: AccountId = "a".repeat(64).parse().unwrap();
@@ -8937,8 +8935,7 @@ mod tests {
         );
     }
 
-    /// Pinned for the same reason as [`stored_attestation_entry__should_have_the_pinned_size`]:
-    /// the prepaid-storage fee is sized from this number plus the entry, so a layout change
+    /// The prepaid-storage fee is sized from this number plus the entry, so a layout change
     /// that grows the row must be seen and the fee revisited.
     #[test]
     fn grant_row__should_have_the_pinned_size() {
@@ -8956,10 +8953,8 @@ mod tests {
     /// row. Pinning the byte counts alone would not catch a lowered default fee, which breaks
     /// the same guarantee.
     ///
-    /// Two things it does not guard. The fee is votable, so a network can choose a value below
-    /// the floor. And `storage_byte_cost` is a near-sdk constant, not a protocol read, so a
-    /// real re-pricing moves the floor without failing here — the residual the design doc's
-    /// Security section accepts.
+    /// Does not guard a votable fee set below the floor, nor a real storage re-pricing —
+    /// `storage_byte_cost` is a near-sdk constant, not a protocol read.
     #[test]
     fn attestation_storage_fee__should_cover_the_entry_and_its_grant_row() {
         // Given

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8892,8 +8892,6 @@ mod tests {
         env::storage_usage() - before
     }
 
-    /// Measured through the contract's own map, so that changing its declaration moves this
-    /// number rather than leaving the fee sized on a stale one.
     fn measure_grant_row_bytes() -> u64 {
         let (_, mut contract, _) = basic_setup(Curve::Edwards25519, &mut OsRng);
         testing_env!(VMContextBuilder::new().build());

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8957,7 +8957,8 @@ mod tests {
     #[test]
     fn attestation_storage_fee__should_cover_the_entry_and_its_grant_row() {
         // Given
-        let floor_bytes = WORST_CASE_ENTRY_BYTES + WORST_CASE_GRANT_ROW_BYTES;
+        let floor_bytes =
+            measure_stored_entry_bytes(worst_case_mock_attestation()) + measure_grant_row_bytes();
 
         // When
         let floor = env::storage_byte_cost().saturating_mul(u128::from(floor_bytes));

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8847,7 +8847,7 @@ mod tests {
     const WORST_CASE_ENTRY_COST_CEILING: NearToken = NearToken::from_millinear(10);
 
     /// One `available_attestation_grants` row, for the longest possible account id. The fee
-    /// covers this on top of the entry, since a grant creates the row.
+    /// covers this on top of the entry, since the first grant for an account creates the row.
     const WORST_CASE_GRANT_ROW_BYTES: u64 = 194;
 
     fn worst_case_dstack_attestation() -> VerifiedAttestation {
@@ -8953,11 +8953,13 @@ mod tests {
     }
 
     /// The fee has to cover what one grant actually buys: the worst-case entry plus the grants
-    /// row that holding it creates. Pinning the byte counts alone would not catch a storage
-    /// price rise or a lowered default fee, which break the same guarantee.
+    /// row. Pinning the byte counts alone would not catch a lowered default fee, which breaks
+    /// the same guarantee.
     ///
-    /// Guards the shipped default only — the fee is votable, so a network can still choose a
-    /// value below the floor.
+    /// Two things it does not guard. The fee is votable, so a network can choose a value below
+    /// the floor. And `storage_byte_cost` is a near-sdk constant, not a protocol read, so a
+    /// real re-pricing moves the floor without failing here — the residual the design doc's
+    /// Security section accepts.
     #[test]
     fn attestation_storage_fee__should_cover_the_entry_and_its_grant_row() {
         // Given

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8848,8 +8848,6 @@ mod tests {
 
     /// Worst case is the longest possible account id. The fee covers this row on top of the
     /// entry; an account's first grant creates it.
-    const WORST_CASE_GRANT_ROW_BYTES: u64 = 194;
-
     fn worst_case_dstack_attestation() -> VerifiedAttestation {
         VerifiedAttestation::Dstack(ValidatedDstackAttestation {
             mpc_image_hash: MAX_HASH.into(),
@@ -8934,29 +8932,16 @@ mod tests {
         );
     }
 
-    /// The prepaid-storage fee is sized from this number plus the entry, so a layout change
-    /// that grows the row must be seen and the fee revisited.
-    #[test]
-    fn grant_row__should_have_the_pinned_size() {
-        // Given / When
-        let bytes_stored = measure_grant_row_bytes();
-
-        // Then
-        assert_eq!(
-            bytes_stored, WORST_CASE_GRANT_ROW_BYTES,
-            "grants row size changed; see this test's doc comment before updating the number"
-        );
-    }
-
-    /// The fee has to cover what one grant actually buys: the worst-case entry plus the grants
-    /// row. Pinning the byte counts alone would not catch a lowered default fee, which breaks
-    /// the same guarantee.
+    /// The fee covers the worst-case entry plus the grants row, and is held to twice that, so
+    /// growth is caught while there is still room rather than once the fee is already breached.
+    /// A failure here is a prompt to re-price, not a broken test.
     ///
     /// Does not guard a votable fee set below the floor, nor a real storage re-pricing —
     /// `storage_byte_cost` is a near-sdk constant, not a protocol read.
     #[test]
-    fn attestation_storage_fee__should_cover_the_entry_and_its_grant_row() {
+    fn attestation_storage_fee__should_keep_double_the_floor() {
         // Given
+        const BUFFER: u128 = 2;
         let floor_bytes =
             measure_stored_entry_bytes(worst_case_mock_attestation()) + measure_grant_row_bytes();
 
@@ -8968,8 +8953,8 @@ mod tests {
 
         // Then
         assert!(
-            floor <= fee,
-            "attestation storage fee ({fee}) must cover the floor \
+            floor.saturating_mul(BUFFER) <= fee,
+            "attestation storage fee ({fee}) must be at least {BUFFER}x the floor \
              ({floor_bytes} bytes, {floor}) at today's storage price"
         );
     }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8846,8 +8846,6 @@ mod tests {
     /// [`WORST_CASE_ENTRY_BYTES`] for storage-price changes.
     const WORST_CASE_ENTRY_COST_CEILING: NearToken = NearToken::from_millinear(10);
 
-    /// Worst case is the longest possible account id. The fee covers this row on top of the
-    /// entry; an account's first grant creates it.
     fn worst_case_dstack_attestation() -> VerifiedAttestation {
         VerifiedAttestation::Dstack(ValidatedDstackAttestation {
             mpc_image_hash: MAX_HASH.into(),
@@ -8936,16 +8934,17 @@ mod tests {
     /// growth is caught while there is still room rather than once the fee is already breached.
     /// A failure here is a prompt to re-price, not a broken test.
     ///
-    /// Does not guard a real storage re-pricing: `storage_byte_cost` is a near-sdk constant,
-    /// not a protocol read.
+    /// Does not guard a real storage re-pricing: [`env::storage_byte_cost`] is a near-sdk
+    /// constant, not a protocol read.
     ///
     /// TODO(#4123): a fee voted below the floor is not caught here either.
     #[test]
     fn attestation_storage_fee__should_keep_double_the_floor() {
         // Given
         const BUFFER: u128 = 2;
-        let floor_bytes =
-            measure_stored_entry_bytes(worst_case_mock_attestation()) + measure_grant_row_bytes();
+        let worst_case_entry_bytes = measure_stored_entry_bytes(worst_case_mock_attestation())
+            .max(measure_stored_entry_bytes(worst_case_dstack_attestation()));
+        let floor_bytes = worst_case_entry_bytes + measure_grant_row_bytes();
 
         // When
         let floor = env::storage_byte_cost().saturating_mul(u128::from(floor_bytes));

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8892,15 +8892,16 @@ mod tests {
         env::storage_usage() - before
     }
 
+    /// Measured through the contract's own map, so that changing its declaration moves this
+    /// number rather than leaving the fee sized on a stale one.
     fn measure_grant_row_bytes() -> u64 {
+        let (_, mut contract, _) = basic_setup(Curve::Edwards25519, &mut OsRng);
         testing_env!(VMContextBuilder::new().build());
         let account: AccountId = "a".repeat(64).parse().unwrap();
 
-        let mut grants: IterableMap<AccountId, u32> =
-            IterableMap::new(StorageKey::AttestationGrants);
         let before = env::storage_usage();
-        grants.insert(account, 1);
-        grants.flush();
+        contract.available_attestation_grants.insert(account, 1);
+        contract.available_attestation_grants.flush();
 
         env::storage_usage() - before
     }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8936,8 +8936,10 @@ mod tests {
     /// growth is caught while there is still room rather than once the fee is already breached.
     /// A failure here is a prompt to re-price, not a broken test.
     ///
-    /// Does not guard a votable fee set below the floor, nor a real storage re-pricing —
-    /// `storage_byte_cost` is a near-sdk constant, not a protocol read.
+    /// Does not guard a real storage re-pricing: `storage_byte_cost` is a near-sdk constant,
+    /// not a protocol read.
+    ///
+    /// TODO(#4123): a fee voted below the floor is not caught here either.
     #[test]
     fn attestation_storage_fee__should_keep_double_the_floor() {
         // Given

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8846,6 +8846,10 @@ mod tests {
     /// [`WORST_CASE_ENTRY_BYTES`] for storage-price changes.
     const WORST_CASE_ENTRY_COST_CEILING: NearToken = NearToken::from_millinear(10);
 
+    /// One `available_attestation_grants` row, for the longest possible account id. The fee
+    /// covers this on top of the entry, since a grant creates the row.
+    const WORST_CASE_GRANT_ROW_BYTES: u64 = 194;
+
     fn worst_case_dstack_attestation() -> VerifiedAttestation {
         VerifiedAttestation::Dstack(ValidatedDstackAttestation {
             mpc_image_hash: MAX_HASH.into(),
@@ -8867,6 +8871,21 @@ mod tests {
     /// Storage the contract pays for one stored attestation entry, measured the way the runtime
     /// charges it. NEAR caps an account id at 64 bytes; every other [`NodeId`] field is fixed-size,
     /// so this is the worst case for the given attestation variant.
+    /// Charged bytes for one grants-map row, measured the same way as
+    /// [`measure_stored_entry_bytes`]: insert into the real map, flush, take the delta.
+    fn measure_grant_row_bytes() -> u64 {
+        testing_env!(VMContextBuilder::new().build());
+        let account: AccountId = "a".repeat(64).parse().unwrap();
+
+        let mut grants: IterableMap<AccountId, u32> =
+            IterableMap::new(StorageKey::AttestationGrants);
+        let before = env::storage_usage();
+        grants.insert(account, 1);
+        grants.flush();
+
+        env::storage_usage() - before
+    }
+
     fn measure_stored_entry_bytes(verified_attestation: VerifiedAttestation) -> u64 {
         testing_env!(VMContextBuilder::new().build());
         let node_id = create_node_id(
@@ -8915,6 +8934,21 @@ mod tests {
             bytes_stored <= WORST_CASE_ENTRY_BYTES,
             "entry ({bytes_stored} bytes) exceeds the pinned worst case \
              ({WORST_CASE_ENTRY_BYTES} bytes)"
+        );
+    }
+
+    /// Pinned for the same reason as [`stored_attestation_entry__should_have_the_pinned_size`]:
+    /// the prepaid-storage fee is sized from this number plus the entry, so a layout change
+    /// that grows the row must be seen and the fee revisited.
+    #[test]
+    fn grant_row__should_have_the_pinned_size() {
+        // Given / When
+        let bytes_stored = measure_grant_row_bytes();
+
+        // Then
+        assert_eq!(
+            bytes_stored, WORST_CASE_GRANT_ROW_BYTES,
+            "grants row size changed; see this test's doc comment before updating the number"
         );
     }
 

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8871,21 +8871,6 @@ mod tests {
     /// Storage the contract pays for one stored attestation entry, measured the way the runtime
     /// charges it. NEAR caps an account id at 64 bytes; every other [`NodeId`] field is fixed-size,
     /// so this is the worst case for the given attestation variant.
-    /// Charged bytes for one grants-map row, measured the same way as
-    /// [`measure_stored_entry_bytes`]: insert into the real map, flush, take the delta.
-    fn measure_grant_row_bytes() -> u64 {
-        testing_env!(VMContextBuilder::new().build());
-        let account: AccountId = "a".repeat(64).parse().unwrap();
-
-        let mut grants: IterableMap<AccountId, u32> =
-            IterableMap::new(StorageKey::AttestationGrants);
-        let before = env::storage_usage();
-        grants.insert(account, 1);
-        grants.flush();
-
-        env::storage_usage() - before
-    }
-
     fn measure_stored_entry_bytes(verified_attestation: VerifiedAttestation) -> u64 {
         testing_env!(VMContextBuilder::new().build());
         let node_id = create_node_id(
@@ -8903,6 +8888,21 @@ mod tests {
             },
         );
         tee_state.stored_attestations.flush();
+
+        env::storage_usage() - before
+    }
+
+    /// Charged bytes for one grants-map row, measured the same way as
+    /// [`measure_stored_entry_bytes`]: insert into the real map, flush, take the delta.
+    fn measure_grant_row_bytes() -> u64 {
+        testing_env!(VMContextBuilder::new().build());
+        let account: AccountId = "a".repeat(64).parse().unwrap();
+
+        let mut grants: IterableMap<AccountId, u32> =
+            IterableMap::new(StorageKey::AttestationGrants);
+        let before = env::storage_usage();
+        grants.insert(account, 1);
+        grants.flush();
 
         env::storage_usage() - before
     }
@@ -8949,6 +8949,31 @@ mod tests {
         assert_eq!(
             bytes_stored, WORST_CASE_GRANT_ROW_BYTES,
             "grants row size changed; see this test's doc comment before updating the number"
+        );
+    }
+
+    /// The fee has to cover what one grant actually buys: the worst-case entry plus the grants
+    /// row that holding it creates. Pinning the byte counts alone would not catch a storage
+    /// price rise or a lowered default fee, which break the same guarantee.
+    ///
+    /// Guards the shipped default only — the fee is votable, so a network can still choose a
+    /// value below the floor.
+    #[test]
+    fn attestation_storage_fee__should_cover_the_entry_and_its_grant_row() {
+        // Given
+        let floor_bytes = WORST_CASE_ENTRY_BYTES + WORST_CASE_GRANT_ROW_BYTES;
+
+        // When
+        let floor = env::storage_byte_cost().saturating_mul(u128::from(floor_bytes));
+        let fee = NearToken::from_millinear(u128::from(
+            Config::default().attestation_storage_fee_millinear,
+        ));
+
+        // Then
+        assert!(
+            floor <= fee,
+            "attestation storage fee ({fee}) must cover the floor \
+             ({floor_bytes} bytes, {floor}) at today's storage price"
         );
     }
 

--- a/crates/contract/tests/sandbox/tee.rs
+++ b/crates/contract/tests/sandbox/tee.rs
@@ -21,9 +21,10 @@ use crate::sandbox::{
 use anyhow::Result;
 use mpc_contract::primitives::{participants::Participants, test_utils::bogus_ed25519_public_key};
 use mpc_primitives::hash::{LauncherDockerComposeHash, LauncherImageHash, NodeImageHash};
+use near_mpc_contract_interface::deposits::STORAGE_BYTE_COST_YOCTONEAR;
 use near_mpc_contract_interface::method_names;
 use near_mpc_contract_interface::types::Protocol;
-use near_mpc_contract_interface::types::{self as dtos, Attestation, MockAttestation};
+use near_mpc_contract_interface::types::{self as dtos, Attestation, Config, MockAttestation};
 use near_workspaces::types::{KeyType, NearToken, SecretKey};
 use near_workspaces::{AccessKey, Account, Contract};
 use rand::SeedableRng;
@@ -1058,6 +1059,62 @@ async fn verify_tee__should_keep_participants_and_stop_signing_when_kickout_drop
 /// A new entry is stored by a submission that attaches no deposit, spending a grant prepaid by
 /// an earlier call. "Zero deposit" is about the submitting node, whose function-call key cannot
 /// attach one, not about the storage being free.
+/// Two grants, not one: consuming a single grant deletes the row, so only the entry would be
+/// measured. Charged against the deposit sent rather than the contract's balance growth, which
+/// also includes its share of the gas burnt.
+#[tokio::test]
+async fn prepay_and_submit__should_not_cost_more_storage_than_the_deposit_paid() -> Result<()> {
+    // Given
+    const GRANTS: u32 = 2;
+    const BUFFER: u128 = 2;
+    let SandboxTestSetup {
+        worker, contract, ..
+    } = SandboxTestSetup::builder()
+        .with_protocols(ALL_PROTOCOLS)
+        .build()
+        .await;
+    let node = worker.dev_create_account().await?;
+    let tls_key = bogus_ed25519_public_key();
+    let config: Config = contract
+        .view(method_names::CONFIG)
+        .args_json(serde_json::json!({}))
+        .await?
+        .json()?;
+    let before = contract.as_account().view_account().await?;
+
+    // When
+    let prepayment = prepay_attestation_grants(&node, &contract, node.id(), GRANTS).await?;
+    assert!(prepayment.is_success(), "prepayment failed: {prepayment:?}");
+    let submission = submit_participant_info(
+        &node,
+        &contract,
+        &Attestation::Mock(MockAttestation::Valid),
+        &tls_key,
+    )
+    .await?;
+    assert!(submission.is_success(), "submission failed: {submission:?}");
+
+    // Then
+    let remaining: u32 = contract
+        .view(method_names::AVAILABLE_ATTESTATION_GRANTS)
+        .args_json(serde_json::json!({ "account_id": node.id() }))
+        .await?
+        .json()?;
+    assert_eq!(remaining, GRANTS - 1, "the row must outlive the submission");
+
+    let after = contract.as_account().view_account().await?;
+    let grown = after.storage_usage - before.storage_usage;
+    let charged = STORAGE_BYTE_COST_YOCTONEAR.saturating_mul(u128::from(grown));
+    let fee = NearToken::from_millinear(u128::from(config.attestation_storage_fee_millinear))
+        .as_yoctonear();
+    assert!(
+        charged.saturating_mul(BUFFER) <= fee,
+        "one grant's storage grew to {grown} bytes ({charged} yocto); the fee ({fee} yocto) \
+         must stay at least {BUFFER}x that, so growth is caught before it breaches"
+    );
+    Ok(())
+}
+
 #[tokio::test]
 async fn submit_participant_info__should_store_a_new_entry_against_a_prepaid_grant() -> Result<()> {
     // Given

--- a/crates/contract/tests/sandbox/tee.rs
+++ b/crates/contract/tests/sandbox/tee.rs
@@ -1114,12 +1114,12 @@ async fn prepay_and_submit_a_constrained_mock__should_use_at_most_half_a_grant_f
     let charged = STORAGE_BYTE_COST_YOCTONEAR.saturating_mul(u128::from(grown));
     let fee = NearToken::from_millinear(u128::from(config.attestation_storage_fee_millinear))
         .as_yoctonear();
-    let deposited = NearToken::from_yoctonear(fee.saturating_mul(u128::from(GRANTS)));
+    let expected_deposit = NearToken::from_yoctonear(fee.saturating_mul(u128::from(GRANTS)));
     let balance_growth = after.balance.saturating_sub(before.balance);
     assert!(
-        balance_growth >= deposited,
+        balance_growth >= expected_deposit,
         "the prepayment must reach the contract's balance: grew {balance_growth}, \
-         deposited {deposited}"
+         deposited {expected_deposit}"
     );
     assert!(
         charged.saturating_mul(BUFFER) <= fee,

--- a/crates/contract/tests/sandbox/tee.rs
+++ b/crates/contract/tests/sandbox/tee.rs
@@ -1054,9 +1054,9 @@ async fn verify_tee__should_keep_participants_and_stop_signing_when_kickout_drop
 /// also includes its share of the gas burnt.
 ///
 /// TODO(#4135): the mock carries every constraint but `expected_measurements`, which no sandbox
-/// helper can get voted in — 240 of the 304 bytes between this entry and the worst case.
+/// helper can get voted in.
 #[tokio::test]
-async fn prepay_and_submit_a_constrained_mock__should_not_cost_more_storage_than_the_deposit_paid()
+async fn prepay_and_submit_a_constrained_mock__should_use_at_most_half_a_grant_fee_of_storage()
 -> Result<()> {
     // Given
     const GRANTS: u32 = 2;

--- a/crates/contract/tests/sandbox/tee.rs
+++ b/crates/contract/tests/sandbox/tee.rs
@@ -1049,23 +1049,43 @@ async fn verify_tee__should_keep_participants_and_stop_signing_when_kickout_drop
     Ok(())
 }
 
-/// A new entry is stored by a submission that attaches no deposit, spending a grant prepaid by
-/// an earlier call. "Zero deposit" is about the submitting node, whose function-call key cannot
-/// attach one, not about the storage being free.
 /// Two grants, not one: consuming a single grant deletes the row, so only the entry would be
 /// measured. Charged against the deposit sent rather than the contract's balance growth, which
 /// also includes its share of the gas burnt.
+///
+/// TODO(#4135): the mock carries every constraint but `expected_measurements`, which no sandbox
+/// helper can get voted in — 240 of the 304 bytes between this entry and the worst case.
 #[tokio::test]
-async fn prepay_and_submit__should_not_cost_more_storage_than_the_deposit_paid() -> Result<()> {
+async fn prepay_and_submit_a_constrained_mock__should_not_cost_more_storage_than_the_deposit_paid()
+-> Result<()> {
     // Given
     const GRANTS: u32 = 2;
     const BUFFER: u128 = 2;
+    const EXPIRY_SECONDS: u64 = 1_000;
     let SandboxTestSetup {
-        worker, contract, ..
+        worker,
+        contract,
+        mpc_signer_accounts,
+        ..
     } = SandboxTestSetup::builder()
         .with_protocols(ALL_PROTOCOLS)
         .build()
         .await;
+    let image_hash = image_digest();
+    for account in &mpc_signer_accounts {
+        vote_for_hash(account, &contract, &image_hash).await?;
+        vote_add_launcher_hash(account, &contract, &LauncherImageHash::from([0xAA; 32])).await?;
+    }
+    let [compose_hash] = get_allowed_launcher_compose_hashes(&contract).await?[..] else {
+        panic!("the launcher and image hashes must derive exactly one compose hash");
+    };
+    let now_seconds = worker.view_block().await?.timestamp() / 1_000_000_000;
+    let attestation = Attestation::Mock(MockAttestation::WithConstraints {
+        mpc_docker_image_hash: Some(image_hash),
+        launcher_docker_compose_hash: Some(compose_hash),
+        expiry_timestamp_seconds: Some(now_seconds + EXPIRY_SECONDS),
+        expected_measurements: None,
+    });
     let node = worker.dev_create_account().await?;
     let tls_key = bogus_ed25519_public_key();
     let config: Config = contract
@@ -1078,13 +1098,7 @@ async fn prepay_and_submit__should_not_cost_more_storage_than_the_deposit_paid()
     // When
     let prepayment = prepay_attestation_grants(&node, &contract, node.id(), GRANTS).await?;
     assert!(prepayment.is_success(), "prepayment failed: {prepayment:?}");
-    let submission = submit_participant_info(
-        &node,
-        &contract,
-        &Attestation::Mock(MockAttestation::Valid),
-        &tls_key,
-    )
-    .await?;
+    let submission = submit_participant_info(&node, &contract, &attestation, &tls_key).await?;
     assert!(submission.is_success(), "submission failed: {submission:?}");
 
     // Then
@@ -1115,6 +1129,9 @@ async fn prepay_and_submit__should_not_cost_more_storage_than_the_deposit_paid()
     Ok(())
 }
 
+/// A new entry is stored by a submission that attaches no deposit, spending a grant prepaid by
+/// an earlier call. "Zero deposit" is about the submitting node, whose function-call key cannot
+/// attach one, not about the storage being free.
 #[tokio::test]
 async fn submit_participant_info__should_store_a_new_entry_against_a_prepaid_grant() -> Result<()> {
     // Given

--- a/crates/contract/tests/sandbox/tee.rs
+++ b/crates/contract/tests/sandbox/tee.rs
@@ -1107,6 +1107,13 @@ async fn prepay_and_submit__should_not_cost_more_storage_than_the_deposit_paid()
     let charged = STORAGE_BYTE_COST_YOCTONEAR.saturating_mul(u128::from(grown));
     let fee = NearToken::from_millinear(u128::from(config.attestation_storage_fee_millinear))
         .as_yoctonear();
+    let deposited = NearToken::from_yoctonear(fee.saturating_mul(u128::from(GRANTS)));
+    let balance_growth = after.balance.saturating_sub(before.balance);
+    assert!(
+        balance_growth >= deposited,
+        "the prepayment must reach the contract's balance: grew {balance_growth}, \
+         deposited {deposited}"
+    );
     assert!(
         charged.saturating_mul(BUFFER) <= fee,
         "one grant's storage grew to {grown} bytes ({charged} yocto); the fee ({fee} yocto) \

--- a/docs/design/operator-prepaid-attestation-storage.md
+++ b/docs/design/operator-prepaid-attestation-storage.md
@@ -53,12 +53,12 @@ Migration and multi-node operators need no special rule: prepay again. Hence no 
 
 ### Fee
 
-0.02 NEAR — a governance-votable `Config` field, not a constant — about 2.5× the floor. Both figures are **charged** bytes, not borsh sizes: they insert into the real map, flush, and take the `env::storage_usage()` delta, so record and key overhead are measured rather than estimated. A test pins 604/599 and forbids updating them to make a failure pass.
+0.02 NEAR — a governance-votable `Config` field, not a constant — about 2.5× the floor. Both figures are **charged** bytes, not borsh sizes: `measure_stored_entry_bytes` and `measure_grant_row_bytes` (`crates/contract/src/lib.rs`) insert into the real map, flush, and take the `env::storage_usage()` delta, so record and key overhead are measured rather than estimated. A test pins each and forbids updating the numbers to make a failure pass.
 
 | Component | Charged bytes | Cost |
 |---|---|---|
 | Worst-case entry: a `Mock` one at 604 (`Dstack` is 599) | 604 | 0.00604 NEAR |
-| Grants-map row, worst-case 64-char account | 194 | 0.00194 NEAR |
+| Grants-map row, worst case (64-char account; a 20-char one is 151) | 194 | 0.00194 NEAR |
 | **Floor** | **798** | **~0.008 NEAR** |
 
 The rest is headroom, so a layout change cannot leave sold grants under-funded. Over-sizing costs nothing — the margin is never returned — while under-sizing silently reopens the drain. Being a `Config` field, the fee can be re-priced without a release.

--- a/docs/design/operator-prepaid-attestation-storage.md
+++ b/docs/design/operator-prepaid-attestation-storage.md
@@ -61,7 +61,7 @@ Migration and multi-node operators need no special rule: prepay again. Hence no 
 | Grants-map row, worst case (64-char account) | 194 | 0.00194 NEAR |
 | **Floor** | **798** | **0.00798 NEAR** |
 
-Measured at the time of writing; the tests hold the fee to twice the floor rather than pinning these numbers, so they fail when the fee stops covering the layout.
+Entry sizes are pinned by `stored_attestation_entry__should_have_the_pinned_size`; the grants row is measured at the time of writing. Either way the fee is held to twice the floor, so a test fails when it stops covering the layout.
 
 The rest is headroom, so a layout change cannot leave sold grants under-funded. Over-sizing costs nothing — the margin is never returned — while under-sizing silently reopens the drain. Being a `Config` field, the fee can be re-priced without a release.
 

--- a/docs/design/operator-prepaid-attestation-storage.md
+++ b/docs/design/operator-prepaid-attestation-storage.md
@@ -55,13 +55,13 @@ Migration and multi-node operators need no special rule: prepay again. Hence no 
 
 0.02 NEAR — a governance-votable `Config` field, not a constant — about 2.5× the floor. Both figures are **charged** bytes, not borsh sizes: `measure_stored_entry_bytes` and `measure_grant_row_bytes` (`crates/contract/src/lib.rs`) insert into the real map, flush, and take the `env::storage_usage()` delta, so record and key overhead are measured rather than estimated.
 
-The table below is a measurement, not a pin. A unit test rebuilds the floor from those two helpers and requires the fee to be at least twice it, and a sandbox test bounds the real prepay-and-submit flow the same way — so both fail when the fee stops covering the layout, not when these numbers move.
-
 | Component | Charged bytes | Cost |
 |---|---|---|
 | Worst-case entry: a `Mock` one at 604 (`Dstack` is 599) | 604 | 0.00604 NEAR |
 | Grants-map row, worst case (64-char account) | 194 | 0.00194 NEAR |
 | **Floor** | **798** | **0.00798 NEAR** |
+
+Measured at the time of writing; the tests hold the fee to twice the floor rather than pinning these numbers, so they fail when the fee stops covering the layout.
 
 The rest is headroom, so a layout change cannot leave sold grants under-funded. Over-sizing costs nothing — the margin is never returned — while under-sizing silently reopens the drain. Being a `Config` field, the fee can be re-priced without a release.
 

--- a/docs/design/operator-prepaid-attestation-storage.md
+++ b/docs/design/operator-prepaid-attestation-storage.md
@@ -19,7 +19,7 @@ Payment and submission must be **separate transactions**, because neither party 
 
 ### Grants
 
-`available_attestation_grants: LookupMap<AccountId, u32>` — a count (not an amount). Prepay `+1`, new entry `−1`, reclaimed entry `+1`, row deleted at zero. The invariant, enforced by refusing to go below zero:
+`available_attestation_grants: IterableMap<AccountId, u32>` — a count (not an amount). Prepay `+1`, new entry `−1`, reclaimed entry `+1`, row deleted at zero. The invariant, enforced by refusing to go below zero:
 
 ```text
 entries an account holds  ≤  grants it has bought
@@ -53,13 +53,13 @@ Migration and multi-node operators need no special rule: prepay again. Hence no 
 
 ### Fee
 
-0.02 NEAR — a governance-votable `Config` field, not a constant — about 2.7× the floor. The entry figure is **charged** bytes, not a borsh size: `measure_stored_entry_bytes` (`crates/contract/src/lib.rs`) inserts into the real map, flushes, and takes the `env::storage_usage()` delta, so `IterableMap` record and key overhead are measured rather than estimated, and a test pins 604/599 and forbids updating them to make a failure pass. The grants-map row is an estimate, which the headroom covers.
+0.02 NEAR — a governance-votable `Config` field, not a constant — about 2.5× the floor. Both figures are **charged** bytes, not borsh sizes: they insert into the real map, flush, and take the `env::storage_usage()` delta, so record and key overhead are measured rather than estimated. A test pins 604/599 and forbids updating them to make a failure pass.
 
 | Component | Charged bytes | Cost |
 |---|---|---|
 | Worst-case entry: a `Mock` one at 604 (`Dstack` is 599) | 604 | 0.00604 NEAR |
-| Grants-map row | ~130 | ~0.0013 NEAR |
-| **Floor** | **~734** | **~0.0073 NEAR** |
+| Grants-map row, worst-case 64-char account | 194 | 0.00194 NEAR |
+| **Floor** | **798** | **~0.008 NEAR** |
 
 The rest is headroom, so a layout change cannot leave sold grants under-funded. Over-sizing costs nothing — the margin is never returned — while under-sizing silently reopens the drain. Being a `Config` field, the fee can be re-priced without a release.
 

--- a/docs/design/operator-prepaid-attestation-storage.md
+++ b/docs/design/operator-prepaid-attestation-storage.md
@@ -59,7 +59,7 @@ Migration and multi-node operators need no special rule: prepay again. Hence no 
 |---|---|---|
 | Worst-case entry: a `Mock` one at 604 (`Dstack` is 599) | 604 | 0.00604 NEAR |
 | Grants-map row, worst case (64-char account) | 194 | 0.00194 NEAR |
-| **Floor** | **798** | **~0.008 NEAR** |
+| **Floor** | **798** | **0.00798 NEAR** |
 
 The rest is headroom, so a layout change cannot leave sold grants under-funded. Over-sizing costs nothing — the margin is never returned — while under-sizing silently reopens the drain. Being a `Config` field, the fee can be re-priced without a release.
 

--- a/docs/design/operator-prepaid-attestation-storage.md
+++ b/docs/design/operator-prepaid-attestation-storage.md
@@ -58,7 +58,7 @@ Migration and multi-node operators need no special rule: prepay again. Hence no 
 | Component | Charged bytes | Cost |
 |---|---|---|
 | Worst-case entry: a `Mock` one at 604 (`Dstack` is 599) | 604 | 0.00604 NEAR |
-| Grants-map row, worst case (64-char account; a 20-char one is 151) | 194 | 0.00194 NEAR |
+| Grants-map row, worst case (64-char account) | 194 | 0.00194 NEAR |
 | **Floor** | **798** | **~0.008 NEAR** |
 
 The rest is headroom, so a layout change cannot leave sold grants under-funded. Over-sizing costs nothing — the margin is never returned — while under-sizing silently reopens the drain. Being a `Config` field, the fee can be re-priced without a release.

--- a/docs/design/operator-prepaid-attestation-storage.md
+++ b/docs/design/operator-prepaid-attestation-storage.md
@@ -53,7 +53,9 @@ Migration and multi-node operators need no special rule: prepay again. Hence no 
 
 ### Fee
 
-0.02 NEAR — a governance-votable `Config` field, not a constant — about 2.5× the floor. Both figures are **charged** bytes, not borsh sizes: `measure_stored_entry_bytes` and `measure_grant_row_bytes` (`crates/contract/src/lib.rs`) insert into the real map, flush, and take the `env::storage_usage()` delta, so record and key overhead are measured rather than estimated. A test pins each and forbids updating the numbers to make a failure pass.
+0.02 NEAR — a governance-votable `Config` field, not a constant — about 2.5× the floor. Both figures are **charged** bytes, not borsh sizes: `measure_stored_entry_bytes` and `measure_grant_row_bytes` (`crates/contract/src/lib.rs`) insert into the real map, flush, and take the `env::storage_usage()` delta, so record and key overhead are measured rather than estimated.
+
+The table below is a measurement, not a pin. A unit test rebuilds the floor from those two helpers and requires the fee to be at least twice it, and a sandbox test bounds the real prepay-and-submit flow the same way — so both fail when the fee stops covering the layout, not when these numbers move.
 
 | Component | Charged bytes | Cost |
 |---|---|---|


### PR DESCRIPTION
Closes #4114.

The design doc drifted from what #4016 shipped:

- It calls the grants map a `LookupMap`; the contract uses an `IterableMap`. Corrected.
- It estimates the grants-map row at ~130 bytes; measured, it is 194 (0.00194 NEAR). Fee table and floor updated — ~0.008 NEAR, against the unchanged 0.02 NEAR fee.

Plus two tests, so the numbers stay true. Neither pins a byte count; both measure.

- A unit test measures the floor and requires the fee to be at least twice it, so growth is caught before it breaches.
- A sandbox test runs the real prepay + submit flow, checks the prepayment reaches the contract balance, and holds the storage one grant buys to half a fee. This is the one that catches a write outside the two maps.

The sandbox test submits the largest mock reachable today (image hash, launcher compose hash, expiry). `expected_measurements` needs a vote helper that does not exist yet — #4135.