### PR TITLE
chore(deny): ignore the unmaintained advisories for `im` and its dependencies

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -33,7 +33,7 @@ ignore = [
   # has no patched release. Only reachable through near-vm-runner, which never
   # shares a Store across Engines.
   "RUSTSEC-2026-0222", # wasmtime stores can mix up type indices between engines
-  # `im` and its dependencies, reached only through nearcore's `near-network`.
+  # TODO(#4117): remove once nearcore moves `near-network` off `im`, whose maintained fork is `imbl`.
   "RUSTSEC-2026-0247", # bitmaps is unmaintained
   "RUSTSEC-2026-0248", # im is unmaintained
   "RUSTSEC-2026-0251", # sized-chunks is unmaintained

--- a/deny.toml
+++ b/deny.toml
@@ -33,6 +33,10 @@ ignore = [
   # has no patched release. Only reachable through near-vm-runner, which never
   # shares a Store across Engines.
   "RUSTSEC-2026-0222", # wasmtime stores can mix up type indices between engines
+  # `im` and its dependencies, reached only through nearcore's `near-network`.
+  "RUSTSEC-2026-0247", # bitmaps is unmaintained
+  "RUSTSEC-2026-0248", # im is unmaintained
+  "RUSTSEC-2026-0251", # sized-chunks is unmaintained
 ]
 
 [bans]


### PR DESCRIPTION
`cargo deny check advisories` fails on every PR since RUSTSEC-2026-0247 (bitmaps), -0248 (im) and -0251 (sized-chunks) were published. All three come in through `im v15.1.0`, pulled by nearcore's `near-network`, so they cannot be dropped here, and unmaintained advisories carry no patched version.

Ignored by ID rather than downgrading `unmaintained` to a warning, so future advisories of that class still fail the build.