### PR TITLE
ci: install catatonit for repro-env podman builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,15 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y skopeo liblzma-dev podman catatonit
+          # repro-env bind-mounts /usr/bin/catatonit as the container entrypoint, but the
+          # Ubuntu 24.04 package installs the binary elsewhere (e.g. /usr/libexec), so link
+          # it into place if the runner does not already provide it there.
+          if [ ! -e /usr/bin/catatonit ]; then
+            src="$(dpkg -L catatonit 2>/dev/null | grep -m1 '/catatonit$')"
+            : "${src:=/usr/libexec/podman/catatonit}"
+            sudo ln -s "$src" /usr/bin/catatonit
+          fi
+          test -e /usr/bin/catatonit
 
       - name: Install repro-env
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,21 @@ jobs:
           echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
           sudo install -m755 repro-env -t /usr/bin
 
+      - name: Provide catatonit for repro-env
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y catatonit
+          # repro-env bind-mounts /usr/bin/catatonit as the container entrypoint, but the
+          # Ubuntu 24.04 package installs the binary elsewhere (e.g. /usr/libexec), so link
+          # it into place (this job relies on the runner's podman; only catatonit is missing).
+          if [ ! -e /usr/bin/catatonit ]; then
+            src="$(dpkg -L catatonit 2>/dev/null | grep -m1 '/catatonit$')"
+            : "${src:=/usr/libexec/podman/catatonit}"
+            sudo ln -s "$src" /usr/bin/catatonit
+          fi
+          echo "catatonit -> $(readlink -f /usr/bin/catatonit || echo MISSING)"
+          test -e /usr/bin/catatonit
+
       - name: Build MPC Node binary and image
         run: |
           export NODE_IMAGE_NAME=test_image_tag_ci

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y skopeo liblzma-dev podman
+          sudo apt-get install -y skopeo liblzma-dev podman catatonit
 
       - name: Install repro-env
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,20 +57,10 @@ jobs:
           echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
           sudo install -m755 repro-env -t /usr/bin
 
-      - name: Provide catatonit for repro-env
+      - name: Install catatonit for repro-env
         run: |
           sudo apt-get update
           sudo apt-get install -y catatonit
-          # repro-env bind-mounts /usr/bin/catatonit as the container entrypoint, but the
-          # Ubuntu 24.04 package installs the binary elsewhere (e.g. /usr/libexec), so link
-          # it into place (this job relies on the runner's podman; only catatonit is missing).
-          if [ ! -e /usr/bin/catatonit ]; then
-            src="$(dpkg -L catatonit 2>/dev/null | grep -m1 '/catatonit$')"
-            : "${src:=/usr/libexec/podman/catatonit}"
-            sudo ln -s "$src" /usr/bin/catatonit
-          fi
-          echo "catatonit -> $(readlink -f /usr/bin/catatonit || echo MISSING)"
-          test -e /usr/bin/catatonit
 
       - name: Build MPC Node binary and image
         run: |
@@ -104,15 +94,6 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y skopeo liblzma-dev podman catatonit
-          # repro-env bind-mounts /usr/bin/catatonit as the container entrypoint, but the
-          # Ubuntu 24.04 package installs the binary elsewhere (e.g. /usr/libexec), so link
-          # it into place if the runner does not already provide it there.
-          if [ ! -e /usr/bin/catatonit ]; then
-            src="$(dpkg -L catatonit 2>/dev/null | grep -m1 '/catatonit$')"
-            : "${src:=/usr/libexec/podman/catatonit}"
-            sudo ln -s "$src" /usr/bin/catatonit
-          fi
-          test -e /usr/bin/catatonit
 
       - name: Install repro-env
         run: |


### PR DESCRIPTION
`repro-env` needs `/usr/bin/catatonit` (its container entrypoint), which the `warp-ubuntu-2404` runners stopped providing — breaking the TEE-image and launcher build jobs. Install the `catatonit` package in both repro-env jobs.

Fixes #4126
