### PR TITLE
ci: install catatonit in the image-publishing workflows

### DIFF
--- a/.github/workflows/docker_build_node.yml
+++ b/.github/workflows/docker_build_node.yml
@@ -41,10 +41,10 @@ jobs:
           echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
           sudo install -m755 repro-env -t /usr/bin
 
-      - name: Install skopeo
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y skopeo
+          sudo apt-get install -y skopeo podman catatonit
 
       - name: Build and push node image
         run: |

--- a/.github/workflows/docker_build_node_gcp.yml
+++ b/.github/workflows/docker_build_node_gcp.yml
@@ -41,10 +41,10 @@ jobs:
           echo '2a00b21ac5e990e0c6a0ccbf3b91e34a073660d1f4553b5f3cda2b09cc4d4d8a  repro-env' | sha256sum -c -
           sudo install -m755 repro-env -t /usr/bin
 
-      - name: Install skopeo
+      - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y skopeo
+          sudo apt-get install -y skopeo podman catatonit
 
       - name: Build and push node gcp image
         run: |

--- a/.github/workflows/docker_build_rust_launcher.yml
+++ b/.github/workflows/docker_build_rust_launcher.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y skopeo liblzma-dev podman
+          sudo apt-get install -y skopeo liblzma-dev podman catatonit
 
       - name: Install repro-env
         run: |


### PR DESCRIPTION
Follow-up to #4125. The image-publishing workflows run `repro-env` but never installed `catatonit`, so they broke on `main` the moment #4125 merged (that merge is a push to `main`, which triggers them). Add `catatonit` to all three, plus `podman` to the two node jobs that installed only `skopeo`.

Note: these workflows only run on push to `main` / release (not on PRs), so this can't be verified by PR CI — it's the same one-line fix already proven green by #4125's `docker-tee-build` job.

Fixes #4127
