### PR TITLE
docs+build-images: document catatonit as a reproducible-build dependency

### DIFF
--- a/deployment/build-images.sh
+++ b/deployment/build-images.sh
@@ -62,8 +62,8 @@ require_cmds() {
 
 require_cmds docker git find touch skopeo
 
-if $USE_NODE || $USE_RUST_LAUNCHER; then
-    require_cmds repro-env podman
+if $USE_NODE || $USE_NODE_GCP || $USE_RUST_LAUNCHER; then
+    require_cmds repro-env podman catatonit
 fi
 
 if ! docker buildx &>/dev/null; then

--- a/docs/reproducible-builds.md
+++ b/docs/reproducible-builds.md
@@ -12,11 +12,13 @@ security and verification purposes.
 - `docker` with buildx support
 - `jq`
 - `git`
+- `skopeo`
 
-**Additional requirements for building the node image**:
+**Additional requirements for building the node or launcher image**:
 
 - `repro-env` - Tool for reproducible build environments ([install here](https://github.com/kpcyrd/repro-env))
 - `podman`
+- `catatonit` - podman's container entrypoint, which `repro-env` requires
 
 **Requirements for building the MPC contract** (either path works):
 

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1849,8 +1849,8 @@ git checkout 828f816be36aed6f0d2438e0131b3e9d7d0931ad
 ```
 
 * Compile it using the reproduce build script. For this you need to install
-  `repro-env`, `docker-buildx`, and `skopeo`, and have the `docker` daemon
-  running.
+  `repro-env`, `podman`, `catatonit`, `docker-buildx`, and `skopeo`, and have
+  the `docker` daemon running.
 
 ```bash
 $ ./deployment/build-images.sh --node
@@ -1955,7 +1955,7 @@ cd mpc/
 git checkout <commit-hash>
 ```
 
-* Compile it using the reproducible build script. For this you need to install `repro-env`, `docker-buildx`, and `skopeo`, and have the `docker` daemon running.
+* Compile it using the reproducible build script. For this you need to install `repro-env`, `podman`, `catatonit`, `docker-buildx`, and `skopeo`, and have the `docker` daemon running.
 
 ```bash
 $ ./deployment/build-images.sh --rust-launcher


### PR DESCRIPTION
Follow-up to #4128 — the docs/preflight side (no workflow files).

`repro-env` requires `catatonit` (its podman container entrypoint), but the reproducible-build prerequisite lists never mentioned it — nor `skopeo` (required unconditionally). So an operator reproducing the node image to verify a manifest digest before voting hits the opaque `statfs /usr/bin/catatonit` error the CI outage surfaced. Also hardens `build-images.sh`'s preflight to check `catatonit` and cover `--node-gcp` (which reaches `repro-env build` but was skipping the check).

Docs-only + one preflight guard; no behavior change to successful builds (a missing dep now fails fast with `Missing dependency: catatonit` instead of podman's opaque error).

Fixes #4129
