### PR TITLE
fix: Surfacing failure by replacing join_all with try_join

### DIFF
--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -156,12 +156,13 @@ where
         debug_receiver: tokio::sync::broadcast::Receiver<DebugRequest>,
     ) -> anyhow::Result<()> {
         let client = self.client.clone();
-        let metrics_emitter = tracking::spawn("periodically emits metrics", async move {
-            loop {
-                client.emit_metrics();
-                tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-            }
-        });
+        let metrics_emitter: AutoAbortTask<anyhow::Result<()>> =
+            tracking::spawn("periodically emits metrics", async move {
+                loop {
+                    client.emit_metrics();
+                    tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+                }
+            });
 
         let monitor_passive_channels = {
             tracking::spawn(
@@ -234,7 +235,7 @@ where
         // `try_join!` surfaces the failure and aborts the rest on drop.
         futures::try_join!(
             async move { monitor_passive_channels.await? },
-            async move { metrics_emitter.await.map_err(anyhow::Error::from) },
+            async move { metrics_emitter.await? },
             async move { monitor_chain.await? },
             async move { robust_ecdsa_background_tasks.await? },
             async move { ecdsa_background_tasks.await? },

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -235,8 +235,7 @@ where
             self.ckd_provider.clone().spawn_background_tasks(),
         );
 
-        // Awaiting in sequence would park a failure behind the tasks that never
-        // return; `try_join!` surfaces it and aborts the rest on drop.
+        // `try_join!` surfaces the failure and aborts the rest on drop.
         futures::try_join!(
             async move { monitor_passive_channels.await? },
             async move { metrics_emitter.await.map_err(anyhow::Error::from) },

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -19,7 +19,7 @@ use crate::requests::queue::{
 use crate::storage::{
     CKDRequestStorage, SignRequestStorage, VerifyForeignTransactionRequestStorage,
 };
-use crate::tracking::{self, AutoAbortTaskCollection};
+use crate::tracking::{self, AutoAbortTask, AutoAbortTaskCollection};
 use crate::trait_extensions::convert_to_contract_dto::IntoContractInterfaceType;
 use crate::types::SignatureRequest;
 use crate::types::{CKDRequest, RequestsUpdate, VerifyForeignTxRequest};
@@ -182,7 +182,7 @@ where
             )
         };
 
-        let tee_verification_handle = {
+        let tee_verification_handle: AutoAbortTask<anyhow::Result<()>> = {
             let chain_txn_sender = chain_txn_sender.clone();
             tracking::spawn("tee_verification", async move {
                 loop {
@@ -190,11 +190,7 @@ where
                         .send(ChainSendTransactionRequest::VerifyTee())
                         .await
                     {
-                        tracing::error!(
-                            "Receiver dropped, error sending VerifyTee request: {:?}",
-                            e
-                        );
-                        return;
+                        anyhow::bail!("receiver dropped, cannot send VerifyTee request: {e:?}");
                     }
                     metrics::VERIFY_TEE_REQUESTS_SENT.inc();
                     sleep(TEE_CONTRACT_VERIFICATION_INVOCATION_INTERVAL_DURATION).await;
@@ -239,12 +235,12 @@ where
         futures::try_join!(
             async move { monitor_passive_channels.await? },
             async move { metrics_emitter.await.map_err(anyhow::Error::from) },
-            async move { monitor_chain.await.map_err(anyhow::Error::from) },
+            async move { monitor_chain.await? },
             async move { robust_ecdsa_background_tasks.await? },
             async move { ecdsa_background_tasks.await? },
             async move { eddsa_background_tasks.await? },
             async move { ckd_background_tasks.await? },
-            async move { tee_verification_handle.await.map_err(anyhow::Error::from) },
+            async move { tee_verification_handle.await? },
         )?;
 
         Ok(())
@@ -257,7 +253,7 @@ where
         >,
         chain_txn_sender: impl TransactionSender + 'static,
         mut debug_receiver: tokio::sync::broadcast::Receiver<DebugRequest>,
-    ) {
+    ) -> anyhow::Result<()> {
         let mut tasks = AutoAbortTaskCollection::new();
         let mut pending_signatures =
             PendingRequests::<SignatureRequest, contract_args::SignatureRespondArgs>::new(
@@ -290,9 +286,7 @@ where
                 }
                 block_update = block_update_receiver.recv() => {
                     let Some(block_update) = block_update else {
-                        // If this branch hits, it means the channel is closed, meaning the
-                        // indexer is being shutdown. So just quit this task.
-                        break;
+                        anyhow::bail!("block update channel closed, the indexer is shutting down");
                     };
 
                     self.client.update_indexer_height(block_update.block.height.into());

--- a/crates/node/src/mpc_client.rs
+++ b/crates/node/src/mpc_client.rs
@@ -235,14 +235,18 @@ where
             self.ckd_provider.clone().spawn_background_tasks(),
         );
 
-        let _ = monitor_passive_channels.await?;
-        metrics_emitter.await?;
-        monitor_chain.await?;
-        let _ = robust_ecdsa_background_tasks.await?;
-        let _ = ecdsa_background_tasks.await?;
-        let _ = eddsa_background_tasks.await?;
-        let _ = ckd_background_tasks.await?;
-        tee_verification_handle.await?;
+        // Awaiting in sequence would park a failure behind the tasks that never
+        // return; `try_join!` surfaces it and aborts the rest on drop.
+        futures::try_join!(
+            async move { monitor_passive_channels.await? },
+            async move { metrics_emitter.await.map_err(anyhow::Error::from) },
+            async move { monitor_chain.await.map_err(anyhow::Error::from) },
+            async move { robust_ecdsa_background_tasks.await? },
+            async move { ecdsa_background_tasks.await? },
+            async move { eddsa_background_tasks.await? },
+            async move { ckd_background_tasks.await? },
+            async move { tee_verification_handle.await.map_err(anyhow::Error::from) },
+        )?;
 
         Ok(())
     }

--- a/crates/node/src/providers.rs
+++ b/crates/node/src/providers.rs
@@ -95,8 +95,8 @@ pub trait SignatureProvider {
     async fn process_channel(&self, channel: NetworkTaskChannel) -> anyhow::Result<()>;
 
     /// Spawns any auxiliary logic that performs pre-computation (typically meant to optimize signature delay).
-    /// Returning ends the provider's participation in the current MPC job, so return `Ok` only
-    /// once nothing is left running, and report an unexpected stop as `Err`.
+    /// Any task owned by the returned future is aborted when this returns, so return `Ok` only
+    /// once nothing is left running, and `Err` if a spawned task stops unexpectedly.
     async fn spawn_background_tasks(self: Arc<Self>) -> anyhow::Result<()>;
 }
 

--- a/crates/node/src/providers.rs
+++ b/crates/node/src/providers.rs
@@ -95,6 +95,8 @@ pub trait SignatureProvider {
     async fn process_channel(&self, channel: NetworkTaskChannel) -> anyhow::Result<()>;
 
     /// Spawns any auxiliary logic that performs pre-computation (typically meant to optimize signature delay).
+    /// Returning ends the provider's participation in the current MPC job, so return `Ok` only
+    /// once nothing is left running, and report an unexpected stop as `Err`.
     async fn spawn_background_tasks(self: Arc<Self>) -> anyhow::Result<()>;
 }
 

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -257,9 +257,8 @@ impl SignatureProvider for EcdsaSignatureProvider {
             let reconstruction_threshold_usize: usize = t.inner().try_into()?;
             let reconstruction_threshold_bound =
                 TSReconstructionThreshold::from(reconstruction_threshold_usize);
-            let description = format!("generate triples for t={}", t.inner());
-            let task = tracking::spawn(
-                &description,
+            background_tasks.push(tracking::spawn_described(
+                format!("generate triples for t={}", t.inner()),
                 Self::run_background_triple_generation(
                     self.client.clone(),
                     self.mpc_config.clone(),
@@ -267,22 +266,18 @@ impl SignatureProvider for EcdsaSignatureProvider {
                     triple_store.clone(),
                     reconstruction_threshold_bound,
                 ),
-            );
-            background_tasks.push((description, task));
+            ));
         }
 
-        let description = "report triple metrics".to_string();
-        let task = tracking::spawn(
-            &description,
+        background_tasks.push(tracking::spawn_described(
+            "report triple metrics".to_string(),
             Self::run_triple_metrics_reporting(self.triple_stores.values().cloned().collect()),
-        );
-        background_tasks.push((description, task));
+        ));
 
         for (domain_id, data) in &self.keyshares {
             let triple_store = self.triple_store_for_t(data.reconstruction_threshold)?;
-            let description = format!("generate presignatures for domain {}", domain_id.0);
-            let task = tracking::spawn(
-                &description,
+            background_tasks.push(tracking::spawn_described(
+                format!("generate presignatures for domain {}", domain_id.0),
                 Self::run_background_presignature_generation(
                     self.client.clone(),
                     self.config.presignature.clone().into(),
@@ -290,8 +285,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
                     *domain_id,
                     data.clone(),
                 ),
-            );
-            background_tasks.push((description, task));
+            ));
         }
 
         let Some((description, outcome)) = tracking::first_task_exit(background_tasks).await else {

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -249,9 +249,8 @@ impl SignatureProvider for EcdsaSignatureProvider {
     }
 
     async fn spawn_background_tasks(self: Arc<Self>) -> anyhow::Result<()> {
-        // One triple generator per distinct `t` this node serves; cait-sith
-        // triples are generated with exactly `t` parties, so each store is fed
-        // by a generator running at its own threshold.
+        // One triple generator per distinct `t`: cait-sith generates triples with
+        // exactly `t` parties, so each store is fed at its own threshold.
         let mut background_tasks = Vec::new();
         for (&t, triple_store) in &self.triple_stores {
             let reconstruction_threshold_usize: usize = t.inner().try_into()?;
@@ -288,9 +287,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
             ));
         }
 
-        let Some((description, outcome)) = tracking::first_task_exit(background_tasks).await else {
-            return Ok(());
-        };
+        let (description, outcome) = tracking::first_task_exit(background_tasks).await;
         // These tasks never return, so any exit is a failure.
         let Err(join_error) = outcome;
         anyhow::bail!("ecdsa background task \"{description}\" ended unexpectedly: {join_error}")

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -252,15 +252,14 @@ impl SignatureProvider for EcdsaSignatureProvider {
         // One triple generator per distinct `t` this node serves; cait-sith
         // triples are generated with exactly `t` parties, so each store is fed
         // by a generator running at its own threshold.
-        let mut generate_triples = Vec::new();
-        let mut task_labels: Vec<String> = Vec::new();
+        let mut background_tasks = Vec::new();
         for (&t, triple_store) in &self.triple_stores {
             let reconstruction_threshold_usize: usize = t.inner().try_into()?;
             let reconstruction_threshold_bound =
                 TSReconstructionThreshold::from(reconstruction_threshold_usize);
-            task_labels.push(format!("triple generation (t={})", t.inner()));
-            generate_triples.push(tracking::spawn(
-                &format!("generate triples for t={}", t.inner()),
+            let description = format!("generate triples for t={}", t.inner());
+            let task = tracking::spawn(
+                &description,
                 Self::run_background_triple_generation(
                     self.client.clone(),
                     self.mpc_config.clone(),
@@ -268,21 +267,21 @@ impl SignatureProvider for EcdsaSignatureProvider {
                     triple_store.clone(),
                     reconstruction_threshold_bound,
                 ),
-            ));
+            );
+            background_tasks.push((description, task));
         }
 
-        // Held outside the select group below: it never completes. Aborted on drop.
+        // Kept out of the group below: it never completes. Aborted on drop.
         let _metrics_task = tracking::spawn(
             "report triple metrics",
             Self::run_triple_metrics_reporting(self.triple_stores.values().cloned().collect()),
         );
 
-        let mut generate_presignatures = Vec::new();
         for (domain_id, data) in &self.keyshares {
             let triple_store = self.triple_store_for_t(data.reconstruction_threshold)?;
-            task_labels.push(format!("presignature generation (domain {})", domain_id.0));
-            generate_presignatures.push(tracking::spawn(
-                &format!("generate presignatures for domain {}", domain_id.0),
+            let description = format!("generate presignatures for domain {}", domain_id.0);
+            let task = tracking::spawn(
+                &description,
                 Self::run_background_presignature_generation(
                     self.client.clone(),
                     self.config.presignature.clone().into(),
@@ -290,21 +289,15 @@ impl SignatureProvider for EcdsaSignatureProvider {
                     *domain_id,
                     data.clone(),
                 ),
-            ));
+            );
+            background_tasks.push((description, task));
         }
 
-        let mut background_tasks = generate_triples;
-        background_tasks.extend(generate_presignatures);
-
-        // Generators never return, so any exit is a failure.
-        if background_tasks.is_empty() {
+        let Some((description, outcome)) = tracking::first_task_exit(background_tasks).await else {
             return Ok(());
-        }
-        let (Err(join_error), index, _remaining) =
-            futures::future::select_all(background_tasks).await;
-        anyhow::bail!(
-            "ecdsa background {} task ended unexpectedly: {join_error}",
-            task_labels[index]
-        )
+        };
+        // Generators never return, so any exit is a failure.
+        let Err(join_error) = outcome;
+        anyhow::bail!("ecdsa background task \"{description}\" ended unexpectedly: {join_error}")
     }
 }

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -253,10 +253,12 @@ impl SignatureProvider for EcdsaSignatureProvider {
         // triples are generated with exactly `t` parties, so each store is fed
         // by a generator running at its own threshold.
         let mut generate_triples = Vec::new();
+        let mut task_labels: Vec<String> = Vec::new();
         for (&t, triple_store) in &self.triple_stores {
             let reconstruction_threshold_usize: usize = t.inner().try_into()?;
             let reconstruction_threshold_bound =
                 TSReconstructionThreshold::from(reconstruction_threshold_usize);
+            task_labels.push(format!("triple generation (t={})", t.inner()));
             generate_triples.push(tracking::spawn(
                 &format!("generate triples for t={}", t.inner()),
                 Self::run_background_triple_generation(
@@ -269,8 +271,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
             ));
         }
 
-        // Held outside the join group below: this reporter never completes, so
-        // joining it would mask generator failures. Aborted on drop when this returns.
+        // Held outside the select group below: it never completes. Aborted on drop.
         let _metrics_task = tracking::spawn(
             "report triple metrics",
             Self::run_triple_metrics_reporting(self.triple_stores.values().cloned().collect()),
@@ -279,6 +280,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
         let mut generate_presignatures = Vec::new();
         for (domain_id, data) in &self.keyshares {
             let triple_store = self.triple_store_for_t(data.reconstruction_threshold)?;
+            task_labels.push(format!("presignature generation (domain {})", domain_id.0));
             generate_presignatures.push(tracking::spawn(
                 &format!("generate presignatures for domain {}", domain_id.0),
                 Self::run_background_presignature_generation(
@@ -291,15 +293,18 @@ impl SignatureProvider for EcdsaSignatureProvider {
             ));
         }
 
-        for Err(join_error) in futures::future::join_all(generate_triples).await {
-            tracing::error!(
-                "ecdsa background triple generation task ended unexpectedly: {join_error}"
-            );
-        }
-        for Err(join_error) in futures::future::join_all(generate_presignatures).await {
-            tracing::error!("ecdsa background presignature task ended unexpectedly: {join_error}");
-        }
+        let mut background_tasks = generate_triples;
+        background_tasks.extend(generate_presignatures);
 
-        Ok(())
+        // Generators never return, so any exit is a failure.
+        if background_tasks.is_empty() {
+            return Ok(());
+        }
+        let (Err(join_error), index, _remaining) =
+            futures::future::select_all(background_tasks).await;
+        anyhow::bail!(
+            "ecdsa background {} task ended unexpectedly: {join_error}",
+            task_labels[index]
+        )
     }
 }

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -271,11 +271,12 @@ impl SignatureProvider for EcdsaSignatureProvider {
             background_tasks.push((description, task));
         }
 
-        // Kept out of the group below: it never completes. Aborted on drop.
-        let _metrics_task = tracking::spawn(
-            "report triple metrics",
+        let description = "report triple metrics".to_string();
+        let task = tracking::spawn(
+            &description,
             Self::run_triple_metrics_reporting(self.triple_stores.values().cloned().collect()),
         );
+        background_tasks.push((description, task));
 
         for (domain_id, data) in &self.keyshares {
             let triple_store = self.triple_store_for_t(data.reconstruction_threshold)?;
@@ -296,7 +297,7 @@ impl SignatureProvider for EcdsaSignatureProvider {
         let Some((description, outcome)) = tracking::first_task_exit(background_tasks).await else {
             return Ok(());
         };
-        // Generators never return, so any exit is a failure.
+        // These tasks never return, so any exit is a failure.
         let Err(join_error) = outcome;
         anyhow::bail!("ecdsa background task \"{description}\" ended unexpectedly: {join_error}")
     }

--- a/crates/node/src/providers/robust_ecdsa.rs
+++ b/crates/node/src/providers/robust_ecdsa.rs
@@ -184,10 +184,12 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
     }
 
     async fn spawn_background_tasks(self: Arc<Self>) -> anyhow::Result<()> {
+        let mut task_labels: Vec<String> = Vec::new();
         let generate_presignatures = self
             .keyshares
             .iter()
             .map(|(domain_id, data)| {
+                task_labels.push(format!("presignature generation (domain {})", domain_id.0));
                 tracking::spawn(
                     &format!("generate presignatures for domain {}", domain_id.0),
                     presign::run_background_presignature_generation(
@@ -201,13 +203,16 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
             })
             .collect::<Vec<_>>();
 
-        for Err(join_error) in futures::future::join_all(generate_presignatures).await {
-            tracing::error!(
-                "Damgard et al background presignature task ended unexpectedly: {join_error}"
-            );
+        // Generators never return, so any exit is a failure.
+        if generate_presignatures.is_empty() {
+            return Ok(());
         }
-
-        Ok(())
+        let (Err(join_error), index, _remaining) =
+            futures::future::select_all(generate_presignatures).await;
+        anyhow::bail!(
+            "Damgard et al background {} task ended unexpectedly: {join_error}",
+            task_labels[index]
+        )
     }
 }
 

--- a/crates/node/src/providers/robust_ecdsa.rs
+++ b/crates/node/src/providers/robust_ecdsa.rs
@@ -184,14 +184,13 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
     }
 
     async fn spawn_background_tasks(self: Arc<Self>) -> anyhow::Result<()> {
-        let mut task_labels: Vec<String> = Vec::new();
-        let generate_presignatures = self
+        let background_tasks = self
             .keyshares
             .iter()
             .map(|(domain_id, data)| {
-                task_labels.push(format!("presignature generation (domain {})", domain_id.0));
-                tracking::spawn(
-                    &format!("generate presignatures for domain {}", domain_id.0),
+                let description = format!("generate presignatures for domain {}", domain_id.0);
+                let task = tracking::spawn(
+                    &description,
                     presign::run_background_presignature_generation(
                         self.client.clone(),
                         self.mpc_config.clone(),
@@ -199,19 +198,18 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
                         *domain_id,
                         data.clone(),
                     ),
-                )
+                );
+                (description, task)
             })
             .collect::<Vec<_>>();
 
-        // Generators never return, so any exit is a failure.
-        if generate_presignatures.is_empty() {
+        let Some((description, outcome)) = tracking::first_task_exit(background_tasks).await else {
             return Ok(());
-        }
-        let (Err(join_error), index, _remaining) =
-            futures::future::select_all(generate_presignatures).await;
+        };
+        // Generators never return, so any exit is a failure.
+        let Err(join_error) = outcome;
         anyhow::bail!(
-            "Damgard et al background {} task ended unexpectedly: {join_error}",
-            task_labels[index]
+            "Damgard et al background task \"{description}\" ended unexpectedly: {join_error}"
         )
     }
 }

--- a/crates/node/src/providers/robust_ecdsa.rs
+++ b/crates/node/src/providers/robust_ecdsa.rs
@@ -188,9 +188,8 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
             .keyshares
             .iter()
             .map(|(domain_id, data)| {
-                let description = format!("generate presignatures for domain {}", domain_id.0);
-                let task = tracking::spawn(
-                    &description,
+                tracking::spawn_described(
+                    format!("generate presignatures for domain {}", domain_id.0),
                     presign::run_background_presignature_generation(
                         self.client.clone(),
                         self.mpc_config.clone(),
@@ -198,8 +197,7 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
                         *domain_id,
                         data.clone(),
                     ),
-                );
-                (description, task)
+                )
             })
             .collect::<Vec<_>>();
 

--- a/crates/node/src/providers/robust_ecdsa.rs
+++ b/crates/node/src/providers/robust_ecdsa.rs
@@ -201,9 +201,7 @@ impl SignatureProvider for RobustEcdsaSignatureProvider {
             })
             .collect::<Vec<_>>();
 
-        let Some((description, outcome)) = tracking::first_task_exit(background_tasks).await else {
-            return Ok(());
-        };
+        let (description, outcome) = tracking::first_task_exit(background_tasks).await;
         // Generators never return, so any exit is a failure.
         let Err(join_error) = outcome;
         anyhow::bail!(

--- a/crates/node/src/tracking.rs
+++ b/crates/node/src/tracking.rs
@@ -91,9 +91,18 @@ where
         .into()
 }
 
-/// Resolves when the first of `tasks` exits, yielding its description and outcome
-/// and aborting the rest. `None` if `tasks` is empty. Unlike joining, an exit is
-/// observed without waiting on siblings that may never return.
+/// Like [`spawn`], but pairs the task with its description for [`first_task_exit`].
+pub fn spawn_described<F, R>(description: String, f: F) -> (String, AutoAbortTask<R>)
+where
+    F: Future<Output = R> + Send + 'static,
+    R: Send + 'static,
+{
+    let task = spawn(&description, f);
+    (description, task)
+}
+
+/// Resolves when the first of `tasks` exits, yielding its description and outcome and
+/// aborting the rest. `None` if `tasks` is empty.
 pub async fn first_task_exit<R>(
     tasks: Vec<(String, AutoAbortTask<R>)>,
 ) -> Option<(String, Result<R, JoinError>)> {

--- a/crates/node/src/tracking.rs
+++ b/crates/node/src/tracking.rs
@@ -102,15 +102,18 @@ where
 }
 
 /// Resolves when the first of `tasks` exits, yielding its description and outcome and
-/// aborting the rest. `None` if `tasks` is empty.
+/// aborting the rest. Never resolves if `tasks` is empty.
 pub async fn first_task_exit<R>(
     tasks: Vec<(String, AutoAbortTask<R>)>,
-) -> Option<(String, Result<R, JoinError>)> {
+) -> (String, Result<R, JoinError>) {
     let mut running = tasks
         .into_iter()
         .map(|(description, task)| async move { (description, task.await) })
         .collect::<FuturesUnordered<_>>();
-    running.next().await
+    match running.next().await {
+        Some(exit) => exit,
+        None => std::future::pending().await,
+    }
 }
 
 /// A collection of tasks that should all be aborted when the collection itself
@@ -535,26 +538,27 @@ mod tests {
             // When we wait for the first exit,
             first_task_exit(tasks).await
         });
-        let exited = runtime.block_on(root);
+        let (description, outcome) = runtime.block_on(root);
 
         // Then it resolves to the panicking task rather than waiting on its sibling.
-        let (description, outcome) = exited.expect("a task exited");
         assert_eq!(description, "panics");
         assert!(outcome.expect_err("the task panicked").is_panic());
     }
 
     #[test]
     #[expect(non_snake_case)]
-    fn first_task_exit__should_resolve_to_none_when_there_are_no_tasks() {
+    fn first_task_exit__should_never_resolve_when_there_are_no_tasks() {
         // Given no tasks to wait on,
         let runtime = named_runtime("first-task-exit-empty");
         let tasks: Vec<(String, AutoAbortTask<()>)> = Vec::new();
 
         // When we wait for the first exit,
-        let exited = runtime.block_on(first_task_exit(tasks));
+        let exited = runtime.block_on(async {
+            tokio::time::timeout(std::time::Duration::from_millis(50), first_task_exit(tasks)).await
+        });
 
-        // Then there is nothing to report.
-        assert!(exited.is_none());
+        // Then there is no exit to report.
+        exited.expect_err("first_task_exit resolved without any tasks");
     }
 }
 

--- a/crates/node/src/tracking.rs
+++ b/crates/node/src/tracking.rs
@@ -1,4 +1,5 @@
 use futures::FutureExt;
+use futures::stream::{FuturesUnordered, StreamExt};
 use std::collections::VecDeque;
 use std::fmt::Debug;
 use std::future::Future;
@@ -88,6 +89,19 @@ where
     handle
         .spawn(current_task().scope_checked(description, f))
         .into()
+}
+
+/// Resolves when the first of `tasks` exits, yielding its description and outcome
+/// and aborting the rest. `None` if `tasks` is empty. Unlike joining, an exit is
+/// observed without waiting on siblings that may never return.
+pub async fn first_task_exit<R>(
+    tasks: Vec<(String, AutoAbortTask<R>)>,
+) -> Option<(String, Result<R, JoinError>)> {
+    let mut running = tasks
+        .into_iter()
+        .map(|(description, task)| async move { (description, task.await) })
+        .collect::<FuturesUnordered<_>>();
+    running.next().await
 }
 
 /// A collection of tasks that should all be aborted when the collection itself
@@ -490,6 +504,48 @@ mod tests {
 
         // Then the task ran on the provided runtime's worker thread.
         assert_eq!(thread_name, "spawn-checked-on-target");
+    }
+
+    #[test]
+    #[expect(non_snake_case)]
+    fn first_task_exit__should_resolve_to_the_task_that_exited() {
+        // Given a task that panics next to one that never returns,
+        let runtime = named_runtime("first-task-exit");
+        let (root, _handle) = start_root_task("test-root", async {
+            let tasks = vec![
+                (
+                    "never returns".to_string(),
+                    spawn("never returns", std::future::pending::<()>()),
+                ),
+                (
+                    "panics".to_string(),
+                    spawn("panics", async { panic!("task panicked") }),
+                ),
+            ];
+
+            // When we wait for the first exit,
+            first_task_exit(tasks).await
+        });
+        let exited = runtime.block_on(root);
+
+        // Then it resolves to the panicking task rather than waiting on its sibling.
+        let (description, outcome) = exited.expect("a task exited");
+        assert_eq!(description, "panics");
+        assert!(outcome.expect_err("the task panicked").is_panic());
+    }
+
+    #[test]
+    #[expect(non_snake_case)]
+    fn first_task_exit__should_resolve_to_none_when_there_are_no_tasks() {
+        // Given no tasks to wait on,
+        let runtime = named_runtime("first-task-exit-empty");
+        let tasks: Vec<(String, AutoAbortTask<()>)> = Vec::new();
+
+        // When we wait for the first exit,
+        let exited = runtime.block_on(first_task_exit(tasks));
+
+        // Then there is nothing to report.
+        assert!(exited.is_none());
     }
 }
 


### PR DESCRIPTION
crates/node/src/providers/ecdsa.rs: has `spawn_background_tasks` which uses `join_all` to generate triples.

With multiple threshold-specific triple generators, if one task dies but others keep running (normal infinite loops), `join_all` never returns, so the failure is never surfaced.

This PR addresses this issue by changing to JoinSet/select_all so any unexpected task exit is observed immediately.
It also reworks the `bail!` which output is discarded one level up in mpc_client.rs:239 where the `anyhow::Result<()>` carrying the failing message is discarded using `let _ = [...]`. 