### PR TITLE
test(contract): sandbox gas test for the attestation expiry migration

### DIFF
--- a/crates/contract/src/config.rs
+++ b/crates/contract/src/config.rs
@@ -42,7 +42,7 @@ const DEFAULT_VERIFIER_TERA_GAS: u64 = 200;
 /// post-DCAP work (allowlist match, RTMR3 replay, app-compose validation, store).
 const DEFAULT_RESOLVE_VERIFICATION_TERA_GAS: u64 = 60;
 /// Default TTL after which a launcher image hash unused by any participant is evicted.
-pub(crate) const DEFAULT_LAUNCHER_HASH_UNUSED_TTL_SECONDS: u64 = 14 * 24 * 60 * 60; // 14 days
+pub(crate) const DEFAULT_LAUNCHER_HASH_UNUSED_TTL_SECONDS: u64 = 21 * 24 * 60 * 60; // 21 days
 
 /// Config for V2 of the contract.
 #[near(serializers=[borsh, json])]

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8523,22 +8523,30 @@ mod tests {
             expiry_timestamp_seconds: Some(EXPIRY_SECONDS),
             expected_measurements: None,
         };
-        let (mut contract, _, _, _) = setup_running_contract_with_domain(3, 2, 2);
+        let (mut contract, participants, _, _) = setup_running_contract_with_domain(3, 2, 2);
         contract.config.launcher_hash_unused_ttl_seconds = 1_209_600; // deployed 3.14.0 value: 14 days
-        let dstack_key = insert_attestation(
+        let entries = participants.participants();
+        let (participant_account, _, participant) = &entries[0];
+        let dstack_key = participant.tls_public_key.clone();
+        let mock_key = entries[1].2.tls_public_key.clone();
+        let outsider_key = bogus_ed25519_public_key();
+        insert_attestation(
             &mut contract,
-            "dstack.near",
-            VerifiedAttestation::Dstack(ValidatedDstackAttestation {
-                mpc_image_hash: MAX_HASH.into(),
-                launcher_compose_hash: MAX_HASH.into(),
-                expiry_timestamp_seconds: EXPIRY_SECONDS,
-                measurements: default_measurements()[0],
-            }),
+            participant_account.as_str(),
+            &dstack_key,
+            dstack_attestation_expiring_at(EXPIRY_SECONDS),
         );
-        let mock_key = insert_attestation(
+        insert_attestation(
             &mut contract,
-            "mock.near",
+            entries[1].0.as_str(),
+            &mock_key,
             VerifiedAttestation::Mock(mock.clone()),
+        );
+        insert_attestation(
+            &mut contract,
+            "outsider.near",
+            &outsider_key,
+            dstack_attestation_expiring_at(EXPIRY_SECONDS),
         );
         env::state_write(&contract);
         drop(contract);
@@ -8562,6 +8570,14 @@ mod tests {
             VerifiedAttestation::Mock(stored) if *stored == mock
         );
 
+        // A dstack attestation belonging to a non-participant is left alone: the migration
+        // walks the participant set, not the whole map.
+        assert_matches!(
+            &stored.get(&outsider_key).unwrap().verified_attestation,
+            VerifiedAttestation::Dstack(dstack)
+                if dstack.expiry_timestamp_seconds == EXPIRY_SECONDS
+        );
+
         // And the launcher TTL was raised, keeping `Config::validate`'s invariant true.
         assert_ne!(1_209_600, config::DEFAULT_LAUNCHER_HASH_UNUSED_TTL_SECONDS);
         assert_eq!(
@@ -8573,17 +8589,28 @@ mod tests {
     fn insert_attestation(
         contract: &mut MpcContract,
         account_id: &str,
+        tls_public_key: &Ed25519PublicKey,
         verified_attestation: VerifiedAttestation,
-    ) -> Ed25519PublicKey {
-        let node_id = create_node_id(&account_id.parse().unwrap(), &bogus_ed25519_public_key());
-        let tls_public_key = node_id.tls_public_key.clone();
+    ) {
         contract.tee_state.stored_attestations.insert(
             tls_public_key.clone(),
             NodeAttestation {
-                node_id,
+                node_id: NodeId {
+                    account_id: account_id.parse().unwrap(),
+                    tls_public_key: tls_public_key.clone(),
+                    account_public_key: bogus_ed25519_public_key(),
+                },
                 verified_attestation,
             },
         );
-        tls_public_key
+    }
+
+    fn dstack_attestation_expiring_at(expiry_timestamp_seconds: u64) -> VerifiedAttestation {
+        VerifiedAttestation::Dstack(ValidatedDstackAttestation {
+            mpc_image_hash: MAX_HASH.into(),
+            launcher_compose_hash: MAX_HASH.into(),
+            expiry_timestamp_seconds,
+            measurements: default_measurements()[0],
+        })
     }
 }

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -8513,4 +8513,77 @@ mod tests {
              {WORST_CASE_ENTRY_COST_CEILING} at today's storage price"
         );
     }
+    #[test]
+    fn migrate__should_extend_dstack_expiries_and_raise_the_launcher_ttl() {
+        // Given persisted 3.14.0 state holding a dstack and a mock attestation.
+        const EXPIRY_SECONDS: u64 = 1_000_000;
+        let mock = MpcMockAttestation::WithConstraints {
+            mpc_docker_image_hash: None,
+            launcher_docker_compose_hash: None,
+            expiry_timestamp_seconds: Some(EXPIRY_SECONDS),
+            expected_measurements: None,
+        };
+        let (mut contract, _, _, _) = setup_running_contract_with_domain(3, 2, 2);
+        contract.config.launcher_hash_unused_ttl_seconds = 1_209_600; // deployed 3.14.0 value: 14 days
+        let dstack_key = insert_attestation(
+            &mut contract,
+            "dstack.near",
+            VerifiedAttestation::Dstack(ValidatedDstackAttestation {
+                mpc_image_hash: MAX_HASH.into(),
+                launcher_compose_hash: MAX_HASH.into(),
+                expiry_timestamp_seconds: EXPIRY_SECONDS,
+                measurements: default_measurements()[0],
+            }),
+        );
+        let mock_key = insert_attestation(
+            &mut contract,
+            "mock.near",
+            VerifiedAttestation::Mock(mock.clone()),
+        );
+        env::state_write(&contract);
+        drop(contract);
+
+        // When migrating, then writing state back as the `#[init]` wrapper does on chain.
+        let migrated = MpcContract::migrate().expect("3.14.0 state must migrate");
+        env::state_write(&migrated);
+        drop(migrated);
+
+        // Then the dstack expiry moved by one attestation window and the mock is untouched.
+        let reloaded = try_state_read::<MpcContract>().unwrap().unwrap();
+        let stored = &reloaded.tee_state.stored_attestations;
+        assert_matches!(
+            &stored.get(&dstack_key).unwrap().verified_attestation,
+            VerifiedAttestation::Dstack(dstack)
+                if dstack.expiry_timestamp_seconds
+                    == EXPIRY_SECONDS + 14 * 24 * 60 * 60
+        );
+        assert_matches!(
+            &stored.get(&mock_key).unwrap().verified_attestation,
+            VerifiedAttestation::Mock(stored) if *stored == mock
+        );
+
+        // And the launcher TTL was raised, keeping `Config::validate`'s invariant true.
+        assert_ne!(1_209_600, config::DEFAULT_LAUNCHER_HASH_UNUSED_TTL_SECONDS);
+        assert_eq!(
+            reloaded.config.launcher_hash_unused_ttl_seconds,
+            config::DEFAULT_LAUNCHER_HASH_UNUSED_TTL_SECONDS
+        );
+    }
+
+    fn insert_attestation(
+        contract: &mut MpcContract,
+        account_id: &str,
+        verified_attestation: VerifiedAttestation,
+    ) -> Ed25519PublicKey {
+        let node_id = create_node_id(&account_id.parse().unwrap(), &bogus_ed25519_public_key());
+        let tls_public_key = node_id.tls_public_key.clone();
+        contract.tee_state.stored_attestations.insert(
+            tls_public_key.clone(),
+            NodeAttestation {
+                node_id,
+                verified_attestation,
+            },
+        );
+        tls_public_key
+    }
 }

--- a/crates/contract/src/sandbox_test_methods.rs
+++ b/crates/contract/src/sandbox_test_methods.rs
@@ -11,6 +11,10 @@
 use crate::MpcContract;
 use crate::primitives::ckd::CKDRequest;
 use crate::primitives::signature::SignatureRequest;
+use crate::tee::tee_state::{NodeAttestation, NodeId};
+use mpc_attestation::attestation::{
+    ValidatedDstackAttestation, VerifiedAttestation, default_measurements,
+};
 use near_sdk::near;
 
 // Import the generated extension trait from near
@@ -47,5 +51,23 @@ impl MpcContract {
             .unwrap_or(0);
         u32::try_from(len)
             .expect("queue length must fit in u32 — bounded by MAX_PENDING_REQUEST_FAN_OUT")
+    }
+
+    /// Stores a pre-verified dstack attestation, bypassing quote verification. The captured
+    /// fixtures hold one valid `(tls_key, account_key)` identity, so a test needing many
+    /// stored dstack entries cannot produce them through `submit_participant_info`.
+    pub fn store_dstack_attestation(&mut self, node_id: NodeId, expiry_timestamp_seconds: u64) {
+        self.tee_state.stored_attestations.insert(
+            node_id.tls_public_key.clone(),
+            NodeAttestation {
+                node_id,
+                verified_attestation: VerifiedAttestation::Dstack(ValidatedDstackAttestation {
+                    mpc_image_hash: [0u8; 32].into(),
+                    launcher_compose_hash: [0u8; 32].into(),
+                    expiry_timestamp_seconds,
+                    measurements: default_measurements()[0],
+                }),
+            },
+        );
     }
 }

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -497,23 +497,18 @@ impl TeeState {
         removed
     }
 
-    pub(crate) fn extend_dstack_attestation_expiries(&mut self, extension: Duration) {
+    pub(crate) fn extend_dstack_attestation_expiries(
+        &mut self,
+        participants: &Participants,
+        extension: Duration,
+    ) {
         let extension_seconds = extension.as_secs();
 
-        let dstack_tls_keys: Vec<Ed25519PublicKey> = self
-            .stored_attestations
-            .iter()
-            .filter(|(_, node_attestation)| {
-                matches!(
-                    node_attestation.verified_attestation,
-                    VerifiedAttestation::Dstack(_)
-                )
-            })
-            .map(|(tls_pk, _)| tls_pk.clone())
-            .collect();
-
-        for tls_pk in dstack_tls_keys {
-            let Some(node_attestation) = self.stored_attestations.get_mut(&tls_pk) else {
+        for (_, _, participant) in participants.participants() {
+            let Some(node_attestation) = self
+                .stored_attestations
+                .get_mut(&participant.tls_public_key)
+            else {
                 continue;
             };
             if let VerifiedAttestation::Dstack(dstack) = &mut node_attestation.verified_attestation

--- a/crates/contract/src/tee/tee_state.rs
+++ b/crates/contract/src/tee/tee_state.rs
@@ -497,6 +497,34 @@ impl TeeState {
         removed
     }
 
+    pub(crate) fn extend_dstack_attestation_expiries(&mut self, extension: Duration) {
+        let extension_seconds = extension.as_secs();
+
+        let dstack_tls_keys: Vec<Ed25519PublicKey> = self
+            .stored_attestations
+            .iter()
+            .filter(|(_, node_attestation)| {
+                matches!(
+                    node_attestation.verified_attestation,
+                    VerifiedAttestation::Dstack(_)
+                )
+            })
+            .map(|(tls_pk, _)| tls_pk.clone())
+            .collect();
+
+        for tls_pk in dstack_tls_keys {
+            let Some(node_attestation) = self.stored_attestations.get_mut(&tls_pk) else {
+                continue;
+            };
+            if let VerifiedAttestation::Dstack(dstack) = &mut node_attestation.verified_attestation
+            {
+                dstack.expiry_timestamp_seconds = dstack
+                    .expiry_timestamp_seconds
+                    .saturating_add(extension_seconds);
+            }
+        }
+    }
+
     /// Returns the list of accounts that currently have TEE attestations stored.
     /// Note: This may include accounts that are no longer active protocol participants.
     pub fn get_tee_accounts(&self) -> Vec<NodeId> {

--- a/crates/contract/src/v3_14_0_state.rs
+++ b/crates/contract/src/v3_14_0_state.rs
@@ -8,11 +8,14 @@
 //! A better approach: only copy the structures that have changed and import the rest from the existing codebase.
 
 use borsh::{BorshDeserialize, BorshSerialize};
+
+const PRE_3_14_1_EXPIRATION_DURATION_SECONDS: u64 = 60 * 60 * 24 * 7; // 7 days
 use near_mpc_contract_interface::types::{Metrics, VerifyForeignTransactionRequest};
 use near_sdk::{
     AccountId, env,
     store::{Lazy, LookupMap},
 };
+use std::time::Duration;
 
 use crate::{
     SupportedForeignChainsByNode,
@@ -55,6 +58,17 @@ impl From<MpcContract> for crate::MpcContract {
             env::panic_str("Contract must be in running state when migrating.");
         }
 
+        let mut tee_state = old.tee_state;
+        tee_state.extend_dstack_attestation_expiries(Duration::from_secs(
+            mpc_attestation::attestation::DEFAULT_EXPIRATION_DURATION_SECONDS
+                - PRE_3_14_1_EXPIRATION_DURATION_SECONDS,
+        ));
+
+        let mut config = old.config;
+        config.launcher_hash_unused_ttl_seconds = config
+            .launcher_hash_unused_ttl_seconds
+            .max(crate::config::DEFAULT_LAUNCHER_HASH_UNUSED_TTL_SECONDS);
+
         crate::MpcContract {
             protocol_state: old.protocol_state,
             pending_signature_requests: old.pending_signature_requests,
@@ -62,8 +76,8 @@ impl From<MpcContract> for crate::MpcContract {
             pending_verify_foreign_tx_requests: old.pending_verify_foreign_tx_requests,
             proposed_updates: old.proposed_updates,
             node_foreign_chain_support: old.node_foreign_chain_support,
-            config: old.config,
-            tee_state: old.tee_state,
+            config,
+            tee_state,
             accept_requests: old.accept_requests,
             node_migrations: old.node_migrations,
             metrics: old.metrics,

--- a/crates/contract/src/v3_14_0_state.rs
+++ b/crates/contract/src/v3_14_0_state.rs
@@ -54,15 +54,19 @@ pub struct MpcContract {
 
 impl From<MpcContract> for crate::MpcContract {
     fn from(old: MpcContract) -> Self {
-        if !matches!(old.protocol_state, ProtocolContractState::Running(_)) {
+        let ProtocolContractState::Running(running) = &old.protocol_state else {
             env::panic_str("Contract must be in running state when migrating.");
-        }
+        };
+        let participants = running.parameters.participants().clone();
 
         let mut tee_state = old.tee_state;
-        tee_state.extend_dstack_attestation_expiries(Duration::from_secs(
-            mpc_attestation::attestation::DEFAULT_EXPIRATION_DURATION_SECONDS
-                - PRE_3_14_1_EXPIRATION_DURATION_SECONDS,
-        ));
+        tee_state.extend_dstack_attestation_expiries(
+            &participants,
+            Duration::from_secs(
+                mpc_attestation::attestation::DEFAULT_EXPIRATION_DURATION_SECONDS
+                    - PRE_3_14_1_EXPIRATION_DURATION_SECONDS,
+            ),
+        );
 
         let mut config = old.config;
         config.launcher_hash_unused_ttl_seconds = config

--- a/crates/contract/tests/sandbox/contract_configuration.rs
+++ b/crates/contract/tests/sandbox/contract_configuration.rs
@@ -107,7 +107,7 @@ async fn contract_configuration_can_be_set_on_initialization() {
         verifier_tera_gas: Some(15),
         resolve_verification_tera_gas: Some(16),
         // Must satisfy `Config::validate` (>= DEFAULT_EXPIRATION_DURATION_SECONDS).
-        launcher_hash_unused_ttl_seconds: Some(14 * 24 * 60 * 60),
+        launcher_hash_unused_ttl_seconds: Some(21 * 24 * 60 * 60),
     };
 
     let SandboxTestSetup { contract, .. } = SandboxTestSetup::builder()

--- a/crates/contract/tests/sandbox/migration_gas.rs
+++ b/crates/contract/tests/sandbox/migration_gas.rs
@@ -1,0 +1,85 @@
+//! Gas headroom for the `3.14.1` migration, which rewrites one stored dstack attestation per
+//! participant inside the deploy + migrate receipt. That receipt's gas is capped by
+//! `contract_upgrade_deposit_tera_gas`, and a migration that overruns it reverts the whole
+//! upgrade, so the cost has to be checked against the largest participant set we expect.
+
+#![allow(non_snake_case)]
+
+use crate::sandbox::{
+    common::{SandboxTestSetup, propose_and_vote_contract_binary},
+    utils::{
+        contract_build::current_contract_with_sandbox_test_methods,
+        mpc_contract::assert_running_return_participants,
+    },
+};
+use near_mpc_contract_interface::{method_names, types::VerifiedAttestation};
+use serde_json::json;
+
+const PARTICIPANTS: usize = 25;
+const SEEDED_EXPIRY_SECONDS: u64 = 1_000_000;
+
+/// `DEFAULT_EXPIRATION_DURATION_SECONDS` minus `PRE_3_14_1_EXPIRATION_DURATION_SECONDS`.
+const EXPECTED_SHIFT_SECONDS: u64 = 14 * 24 * 60 * 60;
+
+#[tokio::test]
+async fn migrate__should_extend_every_participant_expiry_within_the_upgrade_gas_budget() {
+    let SandboxTestSetup {
+        contract,
+        mpc_signer_accounts,
+        ..
+    } = SandboxTestSetup::builder()
+        .with_number_of_participants(PARTICIPANTS)
+        .with_sandbox_test_methods()
+        .build()
+        .await;
+
+    let participants = assert_running_return_participants(&contract).await.unwrap();
+    let entries = participants.participants.clone();
+    assert_eq!(entries.len(), PARTICIPANTS);
+
+    for (account_id, _, info) in &entries {
+        let outcome = contract
+            .as_account()
+            .call(contract.id(), "store_dstack_attestation")
+            .args_json(json!({
+                "node_id": {
+                    "account_id": account_id,
+                    "tls_public_key": info.tls_public_key,
+                    "account_public_key": info.tls_public_key,
+                },
+                "expiry_timestamp_seconds": SEEDED_EXPIRY_SECONDS,
+            }))
+            .max_gas()
+            .transact()
+            .await
+            .expect("seeding a stored dstack attestation should not error");
+        assert!(outcome.is_success(), "seeding failed: {outcome:#?}");
+    }
+
+    propose_and_vote_contract_binary(
+        &mpc_signer_accounts,
+        &contract,
+        current_contract_with_sandbox_test_methods(),
+    )
+    .await;
+
+    // Every participant's expiry advanced, so `migrate` ran to completion. Had it exceeded the
+    // receipt's gas, the deploy would have reverted with it and these would be unchanged.
+    for (_, _, info) in &entries {
+        let stored: Option<VerifiedAttestation> = contract
+            .view(method_names::GET_ATTESTATION)
+            .args_json(json!({ "tls_public_key": info.tls_public_key }))
+            .await
+            .expect("get_attestation view should succeed")
+            .json()
+            .expect("get_attestation should return a verified attestation");
+
+        let Some(VerifiedAttestation::Dstack(dstack)) = stored else {
+            panic!("expected a stored dstack attestation, got {stored:?}");
+        };
+        assert_eq!(
+            dstack.expiry_timestamp_seconds,
+            SEEDED_EXPIRY_SECONDS + EXPECTED_SHIFT_SECONDS
+        );
+    }
+}

--- a/crates/contract/tests/sandbox/mod.rs
+++ b/crates/contract/tests/sandbox/mod.rs
@@ -2,6 +2,7 @@ pub mod contract_configuration;
 pub mod duplicate_requests_fan_out;
 pub mod foreign_chain_configuration;
 pub mod foreign_chain_request;
+pub mod migration_gas;
 pub mod participants_gas;
 pub mod sign;
 pub mod tee;

--- a/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
+++ b/crates/contract/tests/sandbox/upgrade_from_current_contract.rs
@@ -126,7 +126,7 @@ async fn test_propose_update_config() {
         verifier_tera_gas: 15,
         resolve_verification_tera_gas: 16,
         // Must satisfy `Config::validate` (>= DEFAULT_EXPIRATION_DURATION_SECONDS).
-        launcher_hash_unused_ttl_seconds: 14 * 24 * 60 * 60,
+        launcher_hash_unused_ttl_seconds: 21 * 24 * 60 * 60,
     };
 
     let propose_args = ProposeUpdateArgs {

--- a/crates/mpc-attestation/src/attestation.rs
+++ b/crates/mpc-attestation/src/attestation.rs
@@ -25,7 +25,7 @@ use crate::alloc::string::{String, ToString};
 /// re-verified via [`VerifiedAttestation::re_verify`]. Nodes resubmit hourly,
 /// well within this window, so valid attestations refresh in time.
 // TODO(#1639): extract timestamp from certificate itself
-pub const DEFAULT_EXPIRATION_DURATION_SECONDS: u64 = 60 * 60 * 24 * 7; // 7 days
+pub const DEFAULT_EXPIRATION_DURATION_SECONDS: u64 = 60 * 60 * 24 * 21; // 21 days
 
 // `large_enum_variant` fires only where `usize` is 64-bit; under the contract's
 // wasm32 build the variants are close enough in size that it doesn't, so gate the

--- a/crates/test-utils/src/contract_types.rs
+++ b/crates/test-utils/src/contract_types.rs
@@ -19,6 +19,6 @@ pub fn dummy_config(value: u64) -> near_mpc_contract_interface::types::Config {
         resolve_verification_tera_gas: value + 15,
         fail_attestation_submission_tera_gas: value + 16,
         // Must satisfy `Config::validate` (>= DEFAULT_EXPIRATION_DURATION_SECONDS).
-        launcher_hash_unused_ttl_seconds: value + (14 * 24 * 60 * 60),
+        launcher_hash_unused_ttl_seconds: value + (21 * 24 * 60 * 60),
     }
 }


### PR DESCRIPTION
This is not intended for merge. It is to show that the logic in https://github.com/near/mpc/pull/4178 will allow migration with reasonable gas costs.

by claude:

  Measured gas (sandbox, real vote_update → deploy+migrate receipt):

  | participants | deploy+migrate receipt  |
  |---|---|
  | 10 | 81.009 Tgas |
  | 25 | 84.715 Tgas  |

