### PR TITLE
feat: inject the foreign chain probe's dependencies and report setup failure causes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3863,6 +3863,7 @@ dependencies = [
  "near-mpc-bounded-collections",
  "near-mpc-contract-interface",
  "serde_json",
+ "thiserror 2.0.20",
  "tokio",
 ]
 
@@ -3896,11 +3897,11 @@ dependencies = [
 name = "foreign-chain-rpc-auth"
 version = "3.14.0"
 dependencies = [
- "anyhow",
  "assert_matches",
  "foreign-chain-inspector",
  "http",
  "mpc-node-config",
+ "thiserror 2.0.20",
  "url",
 ]
 
@@ -6262,6 +6263,7 @@ dependencies = [
  "serde",
  "serde_with",
  "serde_yaml",
+ "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
  "url",
 ]

--- a/crates/foreign-chain-health-check/Cargo.toml
+++ b/crates/foreign-chain-health-check/Cargo.toml
@@ -20,10 +20,12 @@ http = { workspace = true }
 mpc-node-config = { workspace = true }
 near-mpc-bounded-collections = { workspace = true }
 near-mpc-contract-interface = { workspace = true }
+thiserror = { workspace = true }
 tokio = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+foreign-chain-inspector = { workspace = true, features = ["test-utils"] }
 httpmock = { workspace = true }
 serde_json = { workspace = true }
 

--- a/crates/foreign-chain-health-check/src/lib.rs
+++ b/crates/foreign-chain-health-check/src/lib.rs
@@ -141,15 +141,33 @@ fn provider_name(name: &RpcProviderName) -> String {
     name.as_str().to_owned()
 }
 
-fn prepare_jsonrpc(provider: &ForeignChainProviderConfig) -> anyhow::Result<HttpClient> {
+/// Why a provider's RPC client could not be assembled from its config. No variant carries
+/// the token or the URL: [`AuthConfig::Path`] and [`AuthConfig::Query`] splice the token
+/// into the URL, so echoing either could leak it. The report row already names the chain
+/// and provider, which is enough to locate the offending entry in the operator's config.
+///
+/// [`AuthConfig::Path`]: mpc_node_config::AuthConfig::Path
+/// [`AuthConfig::Query`]: mpc_node_config::AuthConfig::Query
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ProviderSetupError {
+    #[error(transparent)]
+    Auth(#[from] foreign_chain_rpc_auth::RpcAuthError),
+    /// The client builder's own message is withheld: it can echo the token-spliced URL.
+    #[error("the RPC client could not be built from the configured URL")]
+    ClientBuild,
+}
+
+fn prepare_jsonrpc(
+    provider: &ForeignChainProviderConfig,
+) -> Result<HttpClient, ProviderSetupError> {
     let mut url = provider.rpc_url.clone();
     let auth = auth_config_to_rpc_auth(provider.auth.clone(), &mut url)?;
-    build_http_client(url, auth).map_err(|e| anyhow::anyhow!("failed to build HTTP client: {e}"))
+    build_http_client(url, auth).map_err(|_| ProviderSetupError::ClientBuild)
 }
 
 fn prepare_aptos(
     provider: &ForeignChainProviderConfig,
-) -> anyhow::Result<(String, Option<(HeaderName, HeaderValue)>)> {
+) -> Result<(String, Option<(HeaderName, HeaderValue)>), ProviderSetupError> {
     let mut url = provider.rpc_url.clone();
     let auth = auth_config_to_rpc_auth(provider.auth.clone(), &mut url)?;
     let header = match auth {
@@ -328,7 +346,7 @@ async fn run_sui(
 fn prepare_sui(
     provider: &ForeignChainProviderConfig,
     timeout: Duration,
-) -> anyhow::Result<GrpcSuiClient> {
+) -> Result<GrpcSuiClient, ProviderSetupError> {
     let mut url = provider.rpc_url.clone();
     let auth = auth_config_to_rpc_auth(provider.auth.clone(), &mut url)?;
     let header = match auth {
@@ -338,8 +356,7 @@ fn prepare_sui(
             header_value,
         } => Some((header_name, header_value)),
     };
-    GrpcSuiClient::new(url, header, timeout)
-        .map_err(|e| anyhow::anyhow!("failed to build the Sui gRPC client: {e}"))
+    GrpcSuiClient::new(url, header, timeout).map_err(|_| ProviderSetupError::ClientBuild)
 }
 
 fn mark_skipped(

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -24,7 +24,7 @@ use mpc_node_config::{ForeignChainConfig, ForeignChainProviderConfig, ForeignCha
 use near_mpc_bounded_collections::NonEmptyVec;
 use near_mpc_contract_interface::types::{ForeignChain, ProviderId};
 
-use crate::{prepare_aptos, prepare_jsonrpc};
+use crate::{ProviderSetupError, prepare_aptos, prepare_jsonrpc};
 
 /// One provider's verdict. Anything other than [`ProviderStatus::Healthy`] is unhealthy.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -40,8 +40,10 @@ pub enum ProviderStatus {
     RequestRejected,
     MalformedResponse,
     TimedOut,
-    AuthTokenUnresolved,
-    ClientSetupFailed,
+    /// The provider's RPC client could not be built; the cause is safe to log.
+    SetupFailed {
+        cause: ProviderSetupError,
+    },
     /// The chain is configured without an `expected_network_fingerprint`, so its providers cannot
     /// be checked.
     MissingExpectedFingerprint,
@@ -95,8 +97,6 @@ impl ProbeReport {
 /// Each provider is tried up to `max_retries` times, `timeout_sec` per try, and only for as long as
 /// the failures stay transient. This returns within the largest configured `timeout_sec *
 /// max_retries`, plus the [`foreign_chain_inspector::RETRY_BACKOFF`] between tries.
-///
-/// TODO(#4043): take the inspectors as a dependency instead
 pub async fn probe_all_providers(config: &ForeignChainsConfig) -> ProbeReport {
     let probe_attempts = config
         .iter_chains()
@@ -157,7 +157,7 @@ where
 async fn probe_chain<I>(
     chain: ForeignChain,
     config: &ForeignChainConfig,
-    new_inspector: impl Fn(&ForeignChainProviderConfig) -> anyhow::Result<I>,
+    new_inspector: impl Fn(&ForeignChainProviderConfig) -> Result<I, ProviderSetupError>,
 ) -> Vec<ProviderHealth>
 where
     I: foreign_chain_inspector::NetworkFingerprintInspector + Clone + Send + Sync + 'static,
@@ -173,10 +173,10 @@ where
         let provider_id = ProviderId(name.as_str().to_owned());
         match new_inspector(provider) {
             Ok(inspector) => inspectors.push((provider_id, inspector)),
-            Err(error) => rows.push(ProviderHealth {
+            Err(cause) => rows.push(ProviderHealth {
                 chain,
                 provider: provider_id,
-                status: setup_failure(&error),
+                status: ProviderStatus::SetupFailed { cause },
             }),
         }
     }
@@ -197,16 +197,6 @@ where
         });
     }
     rows
-}
-
-/// [`ProviderStatus`] carries no error text, so the one actionable cause gets its own variant. Only
-/// a token read from the environment can fail to resolve; a [`std::env::VarError`] identifies it.
-fn setup_failure(error: &anyhow::Error) -> ProviderStatus {
-    if error.chain().any(|cause| cause.is::<std::env::VarError>()) {
-        ProviderStatus::AuthTokenUnresolved
-    } else {
-        ProviderStatus::ClientSetupFailed
-    }
 }
 
 fn rows_of(
@@ -252,7 +242,9 @@ fn classify(
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
-    use mpc_node_config::{AuthConfig, TokenConfig};
+    use foreign_chain_inspector::testing::{ScriptedInspector, ScriptedReply};
+    use foreign_chain_rpc_auth::RpcAuthError;
+    use mpc_node_config::{AuthConfig, TokenConfig, TokenResolveError};
     use near_mpc_bounded_collections::NonEmptyBTreeMap;
     use std::num::NonZeroU64;
 
@@ -447,28 +439,11 @@ mod tests {
         mock_error_object(server, 200, -32601, "Method not found").await
     }
 
-    /// Throttling over HTTP 200, so only the JSON-RPC code tells the caller to back off.
-    async fn mock_throttled_over_http_200(server: &httpmock::MockServer) -> httpmock::Mock<'_> {
-        mock_error_object(server, 200, -32005, "limit exceeded").await
-    }
-
     async fn mock_non_jsonrpc_body(server: &httpmock::MockServer) -> httpmock::Mock<'_> {
         server
             .mock_async(|when, then| {
                 when.method(httpmock::Method::POST);
                 then.status(200).body("<html>gateway</html>");
-            })
-            .await
-    }
-
-    async fn mock_never_answers_in_time(server: &httpmock::MockServer) -> httpmock::Mock<'_> {
-        let body = serde_json::json!({"jsonrpc": "2.0", "result": MAINNET, "id": 0});
-        server
-            .mock_async(|when, then| {
-                when.method(httpmock::Method::POST);
-                then.status(200)
-                    .json_body(body)
-                    .delay(Duration::from_secs(30));
             })
             .await
     }
@@ -482,6 +457,136 @@ mod tests {
             .unwrap_or_else(|| panic!("missing row for `{chain:?}` provider `{provider}`"))
             .status
             .clone()
+    }
+
+    /// Rows arrive in completion order, so tests match them by provider, never by index.
+    fn must_row_status_of(rows: &[ProviderHealth], provider: &str) -> ProviderStatus {
+        rows.iter()
+            .find(|row| row.provider.0 == provider)
+            .unwrap_or_else(|| panic!("missing row for provider `{provider}`"))
+            .status
+            .clone()
+    }
+
+    // The `probe_chain` tests run under a paused tokio clock; see
+    // `foreign_chain_inspector::testing` for the rules. Never combine paused time with the
+    // httpmock-backed `probe_all_providers` tests in this module: a real socket stays silent
+    // while the clock auto-advances, so timeouts fire before any response.
+
+    #[tokio::test(start_paused = true)]
+    async fn probe_chain__should_report_a_provider_that_never_answers_as_timed_out_without_waiting()
+    {
+        // Given — only the 1s per-try timeout can end the attempt.
+        let hung = ScriptedInspector::new([ScriptedReply::Hang]);
+        let config = chain_config(Some(MAINNET), one_provider("hung", "scripted://hung"));
+        let started = tokio::time::Instant::now();
+
+        // When
+        let rows = probe_chain(ForeignChain::Starknet, &config, |_| Ok(hung.clone())).await;
+
+        // Then
+        assert_eq!(must_row_status_of(&rows, "hung"), ProviderStatus::TimedOut);
+        assert_eq!(started.elapsed(), Duration::from_secs(1));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn probe_chain__should_retry_a_transient_failure_and_report_the_later_answer() {
+        // Given
+        let flaky = ScriptedInspector::new([
+            ScriptedReply::TransientFailure {
+                delay: Duration::ZERO,
+            },
+            ScriptedReply::Answer {
+                delay: Duration::ZERO,
+                fingerprint: MAINNET.to_string(),
+            },
+        ]);
+        let config = with_retries(
+            chain_config(Some(MAINNET), one_provider("flaky", "scripted://flaky")),
+            2,
+        );
+
+        // When
+        let rows = probe_chain(ForeignChain::Starknet, &config, |_| Ok(flaky.clone())).await;
+
+        // Then
+        assert_eq!(must_row_status_of(&rows, "flaky"), ProviderStatus::Healthy);
+        assert_eq!(flaky.calls(), 2);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn probe_chain__should_report_each_scripted_provider_on_its_own_answer() {
+        // Given — one fake per provider: clones share their script, so sharing one fake
+        // across providers would drain a single queue in arbitrary order.
+        let on_mainnet = ScriptedInspector::new([ScriptedReply::Answer {
+            delay: Duration::ZERO,
+            fingerprint: MAINNET.to_string(),
+        }]);
+        let elsewhere = ScriptedInspector::new([ScriptedReply::Answer {
+            delay: Duration::ZERO,
+            fingerprint: SEPOLIA.to_string(),
+        }]);
+        let mut providers = one_provider("on-mainnet", "scripted://on-mainnet");
+        providers.insert(
+            "elsewhere".to_string().into(),
+            provider("scripted://elsewhere"),
+        );
+        let config = chain_config(Some(MAINNET), providers);
+
+        // When
+        let rows = probe_chain(ForeignChain::Starknet, &config, |provider| {
+            Ok(match provider.rpc_url.as_str() {
+                "scripted://on-mainnet" => on_mainnet.clone(),
+                _ => elsewhere.clone(),
+            })
+        })
+        .await;
+
+        // Then
+        assert_eq!(
+            must_row_status_of(&rows, "on-mainnet"),
+            ProviderStatus::Healthy
+        );
+        assert_eq!(
+            must_row_status_of(&rows, "elsewhere"),
+            ProviderStatus::WrongNetwork {
+                expected: NetworkFingerprint::new(MAINNET),
+                observed: NetworkFingerprint::new(SEPOLIA),
+            }
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn probe_chain__should_report_setup_failures_next_to_probed_providers() {
+        // Given
+        let probed = ScriptedInspector::new([ScriptedReply::Answer {
+            delay: Duration::ZERO,
+            fingerprint: MAINNET.to_string(),
+        }]);
+        let mut providers = one_provider("probed", "scripted://probed");
+        providers.insert(
+            "unbuildable".to_string().into(),
+            provider("scripted://unbuildable"),
+        );
+        let config = chain_config(Some(MAINNET), providers);
+
+        // When
+        let rows = probe_chain(ForeignChain::Starknet, &config, |provider| {
+            match provider.rpc_url.as_str() {
+                "scripted://probed" => Ok(probed.clone()),
+                _ => Err(ProviderSetupError::ClientBuild),
+            }
+        })
+        .await;
+
+        // Then
+        assert_eq!(must_row_status_of(&rows, "probed"), ProviderStatus::Healthy);
+        assert_eq!(
+            must_row_status_of(&rows, "unbuildable"),
+            ProviderStatus::SetupFailed {
+                cause: ProviderSetupError::ClientBuild
+            }
+        );
     }
 
     #[tokio::test]
@@ -650,26 +755,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probe_all_providers__should_report_a_provider_that_does_not_answer_in_time() {
-        // Given
-        let server = httpmock::MockServer::start_async().await;
-        mock_never_answers_in_time(&server).await;
-        let config = starknet_only(chain_config(
-            Some(MAINNET),
-            one_provider("slow", &server.base_url()),
-        ));
-
-        // When
-        let report = probe_all_providers(&config).await;
-
-        // Then
-        assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "slow"),
-            ProviderStatus::TimedOut
-        );
-    }
-
-    #[tokio::test]
     async fn probe_all_providers__should_normalize_the_configured_fingerprint_before_comparing() {
         // Given
         let server = httpmock::MockServer::start_async().await;
@@ -715,7 +800,13 @@ mod tests {
         // Then
         assert_eq!(
             must_status_of(&report, ForeignChain::Starknet, "keyed"),
-            ProviderStatus::AuthTokenUnresolved
+            ProviderStatus::SetupFailed {
+                cause: ProviderSetupError::Auth(RpcAuthError::Token(
+                    TokenResolveError::EnvVarUnset {
+                        env: "PROBE_TEST_TOKEN_THAT_IS_NOT_SET".to_string()
+                    }
+                ))
+            }
         );
     }
 
@@ -733,7 +824,9 @@ mod tests {
         // Then
         assert_eq!(
             must_status_of(&report, ForeignChain::Starknet, "wrong-scheme"),
-            ProviderStatus::ClientSetupFailed
+            ProviderStatus::SetupFailed {
+                cause: ProviderSetupError::ClientBuild
+            }
         );
     }
 
@@ -983,27 +1076,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn probe_all_providers__should_retry_a_provider_that_refused_with_a_rate_limit_code() {
-        // Given
-        let server = httpmock::MockServer::start_async().await;
-        let mock = mock_throttled_over_http_200(&server).await;
-        let config = starknet_only(with_retries(
-            chain_config(Some(MAINNET), one_provider("keyed", &server.base_url())),
-            2,
-        ));
-
-        // When
-        let report = probe_all_providers(&config).await;
-
-        // Then
-        assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "keyed"),
-            ProviderStatus::Unreachable
-        );
-        mock.assert_calls_async(2).await;
-    }
-
-    #[tokio::test]
     async fn probe_all_providers__should_bound_the_fingerprint_a_provider_reports() {
         // Given
         let server = httpmock::MockServer::start_async().await;
@@ -1062,24 +1134,28 @@ mod tests {
 
     #[tokio::test]
     async fn probe_all_providers__should_keep_auth_material_out_of_the_report() {
-        // Given
+        // Given — one provider answers the wrong network, one cannot even be built; both
+        // splice the token into their URL through `Path` auth.
         let server = httpmock::MockServer::start_async().await;
         mock_fingerprint(&server, SEPOLIA).await;
-        let config = starknet_only(chain_config(
-            Some(MAINNET),
-            NonEmptyBTreeMap::new(
-                "keyed".to_string().into(),
-                ForeignChainProviderConfig {
-                    rpc_url: format!("{}/v2/API_KEY", server.base_url()),
-                    auth: AuthConfig::Path {
-                        placeholder: "API_KEY".to_string(),
-                        token: TokenConfig::Val {
-                            val: "super-secret".to_string(),
-                        },
-                    },
+        let path_authed = |rpc_url: String| ForeignChainProviderConfig {
+            rpc_url,
+            auth: AuthConfig::Path {
+                placeholder: "API_KEY".to_string(),
+                token: TokenConfig::Val {
+                    val: "super-secret".to_string(),
                 },
-            ),
-        ));
+            },
+        };
+        let mut providers = NonEmptyBTreeMap::new(
+            "keyed".to_string().into(),
+            path_authed(format!("{}/v2/API_KEY", server.base_url())),
+        );
+        providers.insert(
+            "unbuildable".to_string().into(),
+            path_authed("ws://127.0.0.1:9/v2/API_KEY".to_string()),
+        );
+        let config = starknet_only(chain_config(Some(MAINNET), providers));
 
         // When
         let report = probe_all_providers(&config).await;
@@ -1089,8 +1165,15 @@ mod tests {
             must_status_of(&report, ForeignChain::Starknet, "keyed"),
             ProviderStatus::WrongNetwork { .. }
         );
+        assert_eq!(
+            must_status_of(&report, ForeignChain::Starknet, "unbuildable"),
+            ProviderStatus::SetupFailed {
+                cause: ProviderSetupError::ClientBuild
+            }
+        );
         let rendered = format!("{report:?}");
         assert!(!rendered.contains("super-secret"), "{rendered}");
         assert!(!rendered.contains("127.0.0.1"), "{rendered}");
+        assert!(!rendered.contains("ws://"), "{rendered}");
     }
 }

--- a/crates/foreign-chain-inspector/Cargo.toml
+++ b/crates/foreign-chain-inspector/Cargo.toml
@@ -4,6 +4,9 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[features]
+test-utils = []
+
 [dependencies]
 bs58 = { workspace = true }
 derive_more = { workspace = true }

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -29,6 +29,8 @@ pub mod hyperevm;
 pub mod polygon;
 pub mod starknet;
 pub mod sui;
+#[cfg(any(test, feature = "test-utils"))]
+pub mod testing;
 
 pub trait ForeignChainInspector {
     type TransactionId;
@@ -238,6 +240,8 @@ where
     /// Unlike [`FanOut::extract`], disagreement is not an error: a diagnostic caller needs the
     /// individual answers. Each provider gets up to `attempts` tries, `timeout` per try plus
     /// [`RETRY_BACKOFF`] between them, and only a transient failure is retried.
+    ///
+    /// All waiting goes through [`tokio::time`], so paused-time tests are supported.
     pub async fn network_fingerprints(
         &self,
         timeout: Duration,
@@ -533,6 +537,7 @@ pub fn build_http_client(
 #[expect(non_snake_case)]
 mod tests {
     use super::*;
+    use crate::testing::{ScriptedInspector, ScriptedReply};
     use assert_matches::assert_matches;
     use rstest::rstest;
 
@@ -774,5 +779,157 @@ mod tests {
         assert!(reported.starts_with(wide_char));
         assert!(reported.ends_with(NetworkFingerprint::CUT_SHORT_MARKER));
         assert_eq!(reported.chars().count(), NetworkFingerprint::MAX_CHARS);
+    }
+    // The tests below run under a paused tokio clock; see `crate::testing` for the rules.
+
+    fn fingerprint_of(chain: &str) -> String {
+        format!("fingerprint-of-{chain}")
+    }
+
+    fn one_scripted_provider(
+        replies: impl IntoIterator<Item = ScriptedReply>,
+    ) -> (FanOut<ScriptedInspector>, ScriptedInspector) {
+        let inspector = ScriptedInspector::new(replies);
+        let inspectors: NonEmptyVec<_> = vec![(ProviderId("only".to_string()), inspector.clone())]
+            .try_into()
+            .expect("one inspector");
+        (FanOut::new(inspectors), inspector)
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn network_fingerprints__should_retry_a_transient_failure_and_report_the_later_success() {
+        // Given
+        let (fan_out, inspector) = one_scripted_provider([
+            ScriptedReply::TransientFailure {
+                delay: Duration::ZERO,
+            },
+            ScriptedReply::Answer {
+                delay: Duration::ZERO,
+                fingerprint: fingerprint_of("mainnet"),
+            },
+        ]);
+        let started = tokio::time::Instant::now();
+
+        // When
+        let results = fan_out
+            .network_fingerprints(Duration::from_secs(1), NonZeroU64::new(3).unwrap())
+            .await;
+
+        // Then
+        let fingerprint = results[0]
+            .1
+            .as_ref()
+            .expect("second attempt should succeed");
+        assert_eq!(fingerprint.to_string(), fingerprint_of("mainnet"));
+        assert_eq!(inspector.calls(), 2);
+        assert_eq!(started.elapsed(), RETRY_BACKOFF);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn network_fingerprints__should_stop_after_the_configured_number_of_attempts() {
+        // Given
+        let (fan_out, inspector) = one_scripted_provider([
+            ScriptedReply::TransientFailure {
+                delay: Duration::ZERO,
+            },
+            ScriptedReply::TransientFailure {
+                delay: Duration::ZERO,
+            },
+            ScriptedReply::TransientFailure {
+                delay: Duration::ZERO,
+            },
+        ]);
+        let started = tokio::time::Instant::now();
+
+        // When
+        let results = fan_out
+            .network_fingerprints(Duration::from_secs(1), NonZeroU64::new(3).unwrap())
+            .await;
+
+        // Then
+        assert_matches!(
+            results[0].1,
+            Err(ForeignChainInspectionError::RpcRequestFailed(_))
+        );
+        assert_eq!(inspector.calls(), 3);
+        assert_eq!(started.elapsed(), 2 * RETRY_BACKOFF);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn network_fingerprints__should_not_retry_a_provider_that_refused_the_request() {
+        // Given
+        let (fan_out, inspector) = one_scripted_provider([ScriptedReply::Refusal {
+            delay: Duration::ZERO,
+        }]);
+        let started = tokio::time::Instant::now();
+
+        // When
+        let results = fan_out
+            .network_fingerprints(Duration::from_secs(1), NonZeroU64::new(3).unwrap())
+            .await;
+
+        // Then
+        assert_matches!(
+            results[0].1,
+            Err(ForeignChainInspectionError::RpcRequestRejected(_))
+        );
+        assert_eq!(inspector.calls(), 1);
+        assert_eq!(started.elapsed(), Duration::ZERO);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn network_fingerprints__should_retry_an_attempt_that_timed_out() {
+        // Given
+        let (fan_out, inspector) = one_scripted_provider([
+            ScriptedReply::Hang,
+            ScriptedReply::Answer {
+                delay: Duration::ZERO,
+                fingerprint: fingerprint_of("mainnet"),
+            },
+        ]);
+        let started = tokio::time::Instant::now();
+
+        // When
+        let results = fan_out
+            .network_fingerprints(Duration::from_secs(1), NonZeroU64::new(2).unwrap())
+            .await;
+
+        // Then
+        let fingerprint = results[0]
+            .1
+            .as_ref()
+            .expect("second attempt should succeed");
+        assert_eq!(fingerprint.to_string(), fingerprint_of("mainnet"));
+        assert_eq!(inspector.calls(), 2);
+        assert_eq!(started.elapsed(), Duration::from_secs(1) + RETRY_BACKOFF);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn network_fingerprints__should_probe_the_providers_concurrently() {
+        // Given — two providers, one instance each: clones share their script.
+        let slow = ScriptedInspector::new([ScriptedReply::Answer {
+            delay: Duration::from_secs(3),
+            fingerprint: fingerprint_of("slow"),
+        }]);
+        let fast = ScriptedInspector::new([ScriptedReply::Answer {
+            delay: Duration::from_secs(1),
+            fingerprint: fingerprint_of("fast"),
+        }]);
+        let inspectors: NonEmptyVec<_> = vec![
+            (ProviderId("slow".to_string()), slow),
+            (ProviderId("fast".to_string()), fast),
+        ]
+        .try_into()
+        .expect("two inspectors");
+        let started = tokio::time::Instant::now();
+
+        // When
+        let results = FanOut::new(inspectors)
+            .network_fingerprints(Duration::from_secs(5), NonZeroU64::new(1).unwrap())
+            .await;
+
+        // Then — the total is the slowest provider, not the sum.
+        assert!(results.iter().all(|(_, outcome)| outcome.is_ok()));
+        assert_eq!(started.elapsed(), Duration::from_secs(3));
     }
 }

--- a/crates/foreign-chain-inspector/src/testing.rs
+++ b/crates/foreign-chain-inspector/src/testing.rs
@@ -1,0 +1,107 @@
+//! Scripted test doubles for the network fingerprint probe.
+//!
+//! Under `#[tokio::test(start_paused = true)]` every scripted delay is a virtual timer, so
+//! retry, backoff and timeout behavior runs deterministically and in microseconds of wall
+//! time. Never combine paused time with a real socket (httpmock, tonic): the runtime
+//! auto-advances the clock while the socket is silent, firing timeouts before any real
+//! response can land.
+
+use std::collections::VecDeque;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use crate::{ForeignChainInspectionError, NetworkFingerprint, NetworkFingerprintInspector};
+
+/// One scripted attempt: a virtual delay, then an outcome. Outcomes are constructed fresh
+/// per attempt because [`ForeignChainInspectionError`] is not `Clone`.
+#[derive(Debug)]
+pub enum ScriptedReply {
+    /// Answer `fingerprint` after `delay`. Keep the string under
+    /// [`NetworkFingerprint`]'s length cap, or it is truncated on the way out.
+    Answer {
+        delay: Duration,
+        fingerprint: String,
+    },
+    /// A transient failure ([`ForeignChainInspectionError::RpcRequestFailed`]) after
+    /// `delay`; the fan-out retries it.
+    TransientFailure { delay: Duration },
+    /// A refusal ([`ForeignChainInspectionError::RpcRequestRejected`]) after `delay`;
+    /// the fan-out does not retry it.
+    Refusal { delay: Duration },
+    /// Never resolves; only the caller's timeout ends the attempt.
+    Hang,
+}
+
+/// A [`NetworkFingerprintInspector`] that answers each call from a queue of
+/// [`ScriptedReply`]s and panics on a call beyond the script, so an unexpected extra
+/// attempt fails loudly. Clones share the queue and the call counter — the fan-out clones
+/// its inspector into the per-provider task — so use one instance per provider and keep a
+/// clone in the test for [`ScriptedInspector::calls`].
+#[derive(Clone)]
+pub struct ScriptedInspector {
+    script: Arc<Mutex<VecDeque<ScriptedReply>>>,
+    calls: Arc<AtomicUsize>,
+}
+
+impl std::fmt::Debug for ScriptedInspector {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ScriptedInspector")
+            .field(
+                "replies_left",
+                &self.script.lock().expect("script mutex poisoned").len(),
+            )
+            .field("calls", &self.calls())
+            .finish()
+    }
+}
+
+impl ScriptedInspector {
+    pub fn new(replies: impl IntoIterator<Item = ScriptedReply>) -> Self {
+        Self {
+            script: Arc::new(Mutex::new(replies.into_iter().collect())),
+            calls: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+
+    /// How many attempts reached this inspector so far.
+    pub fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+impl NetworkFingerprintInspector for ScriptedInspector {
+    async fn network_fingerprint(&self) -> Result<NetworkFingerprint, ForeignChainInspectionError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        let reply = self
+            .script
+            .lock()
+            .expect("script mutex poisoned")
+            .pop_front()
+            .expect("call beyond the script");
+        match reply {
+            ScriptedReply::Answer { delay, fingerprint } => {
+                tokio::time::sleep(delay).await;
+                Ok(NetworkFingerprint::new(fingerprint))
+            }
+            ScriptedReply::TransientFailure { delay } => {
+                tokio::time::sleep(delay).await;
+                Err(ForeignChainInspectionError::RpcRequestFailed(
+                    "scripted transient failure".to_string(),
+                ))
+            }
+            ScriptedReply::Refusal { delay } => {
+                tokio::time::sleep(delay).await;
+                Err(ForeignChainInspectionError::RpcRequestRejected(
+                    "scripted refusal".to_string(),
+                ))
+            }
+            ScriptedReply::Hang => std::future::pending().await,
+        }
+    }
+
+    /// Identity: tests script the exact canonical string they assert.
+    fn canonical_fingerprint(fingerprint: &str) -> NetworkFingerprint {
+        NetworkFingerprint::new(fingerprint)
+    }
+}

--- a/crates/foreign-chain-inspector/tests/starknet_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/starknet_inspector.rs
@@ -7,7 +7,7 @@ use crate::common::{
 };
 
 use foreign_chain_inspector::{
-    FanOut, ForeignChainInspectionError, ForeignChainInspector, NetworkFingerprintInspector,
+    ForeignChainInspectionError, ForeignChainInspector, NetworkFingerprintInspector,
     RpcAuthentication, build_http_client,
     starknet::{
         StarknetBlockHash, StarknetExtractedValue, StarknetTransactionHash,
@@ -23,14 +23,8 @@ use foreign_chain_rpc_interfaces::starknet::{
 use httpmock::prelude::*;
 use httpmock::{HttpMockRequest, HttpMockResponse};
 use jsonrpsee::core::client::error::Error as RpcClientError;
-use near_mpc_bounded_collections::NonEmptyVec;
-use near_mpc_contract_interface::types::ProviderId;
 use near_mpc_contract_interface::types::{StarknetFelt, StarknetLog};
 use rstest::rstest;
-use std::num::NonZeroU64;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::time::Duration;
 
 fn mock_receipt(
     finality_status: StarknetFinalityStatus,
@@ -534,111 +528,6 @@ async fn network_fingerprint__should_return_the_canonical_chain_id() {
 
     // Then
     assert_eq!(fingerprint.to_string(), MAINNET_CHAIN_ID);
-}
-
-/// Builds a fan-out of one Starknet provider whose client runs `respond` on each call, and reports
-/// the number of calls it received.
-#[expect(
-    clippy::type_complexity,
-    reason = "the client holds an unnameable closure type, so the tuple has to spell it out"
-)]
-fn single_provider_fan_out(
-    respond: impl Fn(usize) -> Result<serde_json::Value, RpcClientError> + Send + Sync + 'static,
-) -> (
-    FanOut<
-        StarknetInspector<
-            FixedResponseRpcClient<
-                impl Fn() -> Result<serde_json::Value, RpcClientError> + Clone + Sync,
-            >,
-        >,
-    >,
-    Arc<AtomicUsize>,
-) {
-    let calls = Arc::new(AtomicUsize::new(0));
-    let seen = Arc::clone(&calls);
-    let respond: Arc<dyn Fn(usize) -> Result<serde_json::Value, RpcClientError> + Send + Sync> =
-        Arc::new(respond);
-    let client = FixedResponseRpcClient::new(move || respond(seen.fetch_add(1, Ordering::SeqCst)));
-    let inspectors: NonEmptyVec<_> = vec![(
-        ProviderId("only".to_string()),
-        StarknetInspector::new(client),
-    )]
-    .try_into()
-    .expect("one inspector");
-    (FanOut::new(inspectors), calls)
-}
-
-fn transport_error() -> RpcClientError {
-    RpcClientError::Transport(Box::new(std::io::Error::new(
-        std::io::ErrorKind::ConnectionRefused,
-        "connection refused",
-    )))
-}
-
-fn bad_api_key_error() -> RpcClientError {
-    RpcClientError::Call(jsonrpsee::types::ErrorObject::owned(
-        -32600,
-        "Must be authenticated!",
-        None::<()>,
-    ))
-}
-
-#[tokio::test]
-async fn network_fingerprints__should_retry_a_transient_failure_and_report_the_later_success() {
-    // Given
-    let (fan_out, calls) = single_provider_fan_out(|call| match call {
-        0 => Err(transport_error()),
-        _ => Ok(serde_json::json!(MAINNET_CHAIN_ID)),
-    });
-
-    // When
-    let results = fan_out
-        .network_fingerprints(Duration::from_secs(1), NonZeroU64::new(2).unwrap())
-        .await;
-
-    // Then
-    assert_eq!(calls.load(Ordering::SeqCst), 2);
-    let fingerprint = results[0]
-        .1
-        .as_ref()
-        .expect("second attempt should succeed");
-    assert_eq!(fingerprint.to_string(), MAINNET_CHAIN_ID);
-}
-
-#[tokio::test]
-async fn network_fingerprints__should_stop_after_the_configured_number_of_attempts() {
-    // Given
-    let (fan_out, calls) = single_provider_fan_out(|_| Err(transport_error()));
-
-    // When
-    let results = fan_out
-        .network_fingerprints(Duration::from_secs(1), NonZeroU64::new(3).unwrap())
-        .await;
-
-    // Then
-    assert_eq!(calls.load(Ordering::SeqCst), 3);
-    assert_matches!(
-        results[0].1,
-        Err(ForeignChainInspectionError::RpcRequestFailed(_))
-    );
-}
-
-#[tokio::test]
-async fn network_fingerprints__should_not_retry_a_provider_that_refused_the_request() {
-    // Given
-    let (fan_out, calls) = single_provider_fan_out(|_| Err(bad_api_key_error()));
-
-    // When
-    let results = fan_out
-        .network_fingerprints(Duration::from_secs(1), NonZeroU64::new(3).unwrap())
-        .await;
-
-    // Then
-    assert_eq!(calls.load(Ordering::SeqCst), 1);
-    assert_matches!(
-        results[0].1,
-        Err(ForeignChainInspectionError::RpcRequestRejected(_))
-    );
 }
 
 #[tokio::test]

--- a/crates/foreign-chain-rpc-auth/Cargo.toml
+++ b/crates/foreign-chain-rpc-auth/Cargo.toml
@@ -5,10 +5,10 @@ edition.workspace = true
 license.workspace = true
 
 [dependencies]
-anyhow = { workspace = true }
 foreign-chain-inspector = { workspace = true }
 http = { workspace = true }
 mpc-node-config = { workspace = true }
+thiserror = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]

--- a/crates/foreign-chain-rpc-auth/src/lib.rs
+++ b/crates/foreign-chain-rpc-auth/src/lib.rs
@@ -1,7 +1,21 @@
-use anyhow::Context;
 use foreign_chain_inspector::RpcAuthentication;
 use http::HeaderValue;
-use mpc_node_config::AuthConfig;
+use mpc_node_config::{AuthConfig, TokenResolveError};
+
+/// Why an [`AuthConfig`] could not be turned into an [`RpcAuthentication`]. No variant
+/// carries the token or the URL: [`AuthConfig::Path`] and [`AuthConfig::Query`] splice the
+/// token into the URL, so echoing either could leak it.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RpcAuthError {
+    #[error("could not resolve the auth token: {0}")]
+    Token(#[from] TokenResolveError),
+    #[error("the resolved token is not a legal value for header `{header}`")]
+    TokenNotAHeaderValue { header: http::HeaderName },
+    #[error(
+        "the RPC URL could not be parsed, so the auth query parameter cannot be appended: {reason}"
+    )]
+    UrlNotParseable { reason: url::ParseError },
+}
 
 /// Convert an [`AuthConfig`] into a [`foreign_chain_inspector::RpcAuthentication`].
 ///
@@ -12,7 +26,7 @@ use mpc_node_config::AuthConfig;
 pub fn auth_config_to_rpc_auth(
     auth: AuthConfig,
     rpc_url: &mut String,
-) -> anyhow::Result<RpcAuthentication> {
+) -> Result<RpcAuthentication, RpcAuthError> {
     match auth {
         AuthConfig::None => Ok(RpcAuthentication::KeyInUrl),
         AuthConfig::Header {
@@ -25,7 +39,11 @@ pub fn auth_config_to_rpc_auth(
                 Some(scheme) => format!("{scheme} {token_value}"),
                 None => token_value,
             };
-            let mut header_value = HeaderValue::from_str(&header_value_str)?;
+            let mut header_value = HeaderValue::from_str(&header_value_str).map_err(|_| {
+                RpcAuthError::TokenNotAHeaderValue {
+                    header: header_name.clone(),
+                }
+            })?;
             // Redacts the token from `Debug` output and excludes it from HPACK
             // dynamic-table indexing on h2 connections.
             header_value.set_sensitive(true);
@@ -42,7 +60,7 @@ pub fn auth_config_to_rpc_auth(
         AuthConfig::Query { name, token } => {
             let token_value = token.resolve()?;
             let mut parsed_rpc_url = url::Url::parse(rpc_url)
-                .with_context(|| format!("invalid RPC URL: `{rpc_url}`"))?;
+                .map_err(|reason| RpcAuthError::UrlNotParseable { reason })?;
             parsed_rpc_url
                 .query_pairs_mut()
                 .append_pair(&name, &token_value);
@@ -256,6 +274,36 @@ mod tests {
         let result = auth_config_to_rpc_auth(auth, &mut url);
 
         // Then
-        result.unwrap_err();
+        assert_matches!(result, Err(RpcAuthError::UrlNotParseable { .. }));
+    }
+
+    #[test]
+    fn auth_config_to_rpc_auth__should_keep_the_token_and_url_out_of_every_error() {
+        // Given — each failure mode, with a recognizable token in play.
+        let unparseable_url = AuthConfig::Query {
+            name: "api-key".to_string(),
+            token: TokenConfig::Val {
+                val: "super-secret-token".to_string(),
+            },
+        };
+        let illegal_header_value = AuthConfig::Header {
+            name: http::HeaderName::from_static("x-api-key"),
+            scheme: None,
+            token: TokenConfig::Val {
+                val: "super-secret\ntoken".to_string(),
+            },
+        };
+
+        // When
+        let url_error =
+            auth_config_to_rpc_auth(unparseable_url, &mut "::not a url::".to_string()).unwrap_err();
+        let header_error =
+            auth_config_to_rpc_auth(illegal_header_value, &mut "https://x.example".to_string())
+                .unwrap_err();
+
+        // Then
+        let rendered = format!("{url_error} {url_error:?} {header_error} {header_error:?}");
+        assert!(!rendered.contains("super-secret"));
+        assert!(!rendered.contains("not a url"));
     }
 }

--- a/crates/node-config/Cargo.toml
+++ b/crates/node-config/Cargo.toml
@@ -18,6 +18,7 @@ near-mpc-contract-interface = { workspace = true }
 serde = { workspace = true }
 serde_with = { workspace = true }
 serde_yaml = { workspace = true }
+thiserror = { workspace = true }
 toml = { workspace = true }
 url = { workspace = true, features = ["serde"] }
 

--- a/crates/node-config/src/foreign_chains.rs
+++ b/crates/node-config/src/foreign_chains.rs
@@ -9,7 +9,7 @@ use near_mpc_bounded_collections::NonEmptyBTreeSet;
 use near_mpc_contract_interface::types as dtos;
 use serde::{Deserialize, Serialize};
 
-pub use auth::{AuthConfig, TokenConfig};
+pub use auth::{AuthConfig, TokenConfig, TokenResolveError};
 
 mod auth;
 

--- a/crates/node-config/src/foreign_chains/auth.rs
+++ b/crates/node-config/src/foreign_chains/auth.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use anyhow::Context;
 use serde::{Deserialize, Serialize};
 use serde_with::{DisplayFromStr, serde_as};
 
@@ -47,16 +46,32 @@ pub enum TokenConfig {
     Val { val: String },
 }
 
+/// Why a [`TokenConfig`] could not be resolved. Payloads name the variable, never its
+/// value: [`std::env::VarError::NotUnicode`] carries the token's bytes and displays them,
+/// so the source error is deliberately not retained.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum TokenResolveError {
+    #[error("environment variable `{env}` is not set")]
+    EnvVarUnset { env: String },
+    #[error("environment variable `{env}` is set but is not valid unicode")]
+    EnvVarNotUnicode { env: String },
+}
+
 impl TokenConfig {
-    pub fn resolve(&self) -> anyhow::Result<String> {
+    pub fn resolve(&self) -> Result<String, TokenResolveError> {
         match self {
             // TODO(#2335): do not resolve env variables this deep in the binary.
             // Should be resolved at start, preferably in the config so we can kill env configs
             //
             // One option is to have a separate secrets config file.
-            TokenConfig::Env { env } => {
-                std::env::var(env).with_context(|| format!("environment variable {env} is not set"))
-            }
+            TokenConfig::Env { env } => std::env::var(env).map_err(|error| match error {
+                std::env::VarError::NotPresent => {
+                    TokenResolveError::EnvVarUnset { env: env.clone() }
+                }
+                std::env::VarError::NotUnicode(_) => {
+                    TokenResolveError::EnvVarNotUnicode { env: env.clone() }
+                }
+            }),
             TokenConfig::Val { val } => Ok(val.clone()),
         }
     }
@@ -100,6 +115,8 @@ pub(crate) fn validate_auth_config(auth: &AuthConfig, rpc_url: &str) -> anyhow::
 mod tests {
     use super::*;
     use assert_matches::assert_matches;
+    #[cfg(unix)]
+    use std::os::unix::ffi::OsStringExt;
 
     #[test]
     fn strip_placeholder__borrows_for_none_auth() {
@@ -151,5 +168,54 @@ mod tests {
         let result = auth.strip_placeholder(url);
         assert_matches!(result, Cow::Owned(_));
         assert_eq!(result, "https://rpc.ankr.com/near/");
+    }
+
+    #[test]
+    fn resolve__should_report_an_unset_env_var_by_name() {
+        // Given
+        let token = TokenConfig::Env {
+            env: "AUTH_TEST_TOKEN_THAT_IS_NEVER_SET".to_string(),
+        };
+
+        // When
+        let error = token.resolve().unwrap_err();
+
+        // Then
+        assert_eq!(
+            error,
+            TokenResolveError::EnvVarUnset {
+                env: "AUTH_TEST_TOKEN_THAT_IS_NEVER_SET".to_string()
+            }
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn resolve__should_report_a_non_unicode_env_var_by_name_without_its_value() {
+        // Given
+        let var = "AUTH_TEST_TOKEN_WITH_INVALID_UNICODE";
+        // SAFETY: mutating the process environment is unsound with concurrent readers of
+        // any variable; nextest, the repo's mandated runner, gives this test its own
+        // process, so no other thread touches the environment while it runs.
+        unsafe {
+            std::env::set_var(var, std::ffi::OsString::from_vec(vec![0x66, 0xff, 0x67]));
+        }
+        let token = TokenConfig::Env {
+            env: var.to_string(),
+        };
+
+        // When
+        let error = token.resolve().unwrap_err();
+
+        // Then
+        assert_eq!(
+            error,
+            TokenResolveError::EnvVarNotUnicode {
+                env: var.to_string()
+            }
+        );
+        let rendered = format!("{error} {error:?}");
+        assert!(rendered.contains(var));
+        assert!(!rendered.contains('\u{fffd}'));
     }
 }

--- a/crates/node-config/src/lib.rs
+++ b/crates/node-config/src/lib.rs
@@ -3,6 +3,7 @@ pub mod start;
 
 pub use foreign_chains::{
     AuthConfig, ForeignChainConfig, ForeignChainProviderConfig, ForeignChainsConfig, TokenConfig,
+    TokenResolveError,
 };
 pub use start::{
     ChainId, DownloadConfigType, GcpStartConfig, LogConfig, LogFormat, NearInitConfig,


### PR DESCRIPTION
Closes #4043

Reviewer note: the injection seam is `probe_chain`, one level below `probe_all_providers`, which still wires the real inspectors; that is the seam the issue's analysis prescribes.