### PR TITLE
docs(tdx-guide): enable dstack-vmm on boot so it survives a reboot

### DIFF
--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -257,11 +257,19 @@ After the file is created or modified you must run:
 ```bash
 # to reload the service files
 sudo systemctl daemon-reload
+# to enable the service so it starts automatically on boot (and start it now)
+sudo systemctl enable --now dstack-vmm
 # to start/stop/restart the service
 sudo systemctl start/stop/restart dstack-vmm
 # to check the status the service
 systemctl status dstack-vmm
 ```
+
+`systemctl enable` is required for the service to come back after a host reboot:
+without it the unit's `WantedBy=multi-user.target` is inert, so `dstack-vmm` (and
+every CVM it runs) stays down until it is started manually. Make sure your
+key-provider is likewise enabled on boot, so it is serving on `:3443` before the
+CVMs start.
 
 Notice that some of the commands require `sudo`, so they cannot be run using the
 `mpc` user which has no such permissions by default.


### PR DESCRIPTION
The "VMM service persistence" section defines a boot-capable `dstack-vmm.service` (`WantedBy=multi-user.target`) but only documents `start`, never `enable` — so following the guide, the service **doesn't start after a host reboot** (WantedBy is inert until enabled), leaving dstack-vmm and every CVM down until started manually.

Adds `systemctl enable --now dstack-vmm`, explains why it's needed, and notes the key-provider must be enabled on boot too so `:3443` is up before the CVMs start.

Docs-only, 8 lines.

Fixes #4210
