### PR TITLE
refactor: simplifying storage by giving it to the client directly - #3851

### DIFF
--- a/crates/node/src/assets/cleanup.rs
+++ b/crates/node/src/assets/cleanup.rs
@@ -240,7 +240,6 @@ mod tests {
         let (mut start_data, my_participant_id, reconstruction_threshold) =
             test_utils::gen_four_participants();
         let all_participants = get_participant_ids(start_data.clone());
-        let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
         let dir = tempfile::tempdir().unwrap();
         let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
         let client = new_test_client(all_participants.clone(), my_participant_id);

--- a/crates/node/src/assets/cleanup.rs
+++ b/crates/node/src/assets/cleanup.rs
@@ -246,7 +246,7 @@ mod tests {
         let triple_store = TripleStorage::new(
             FakeClock::default().clock(),
             db.clone(),
-            &client,
+            client,
             reconstruction_threshold,
         )
         .unwrap();
@@ -311,7 +311,7 @@ mod tests {
         let triple_store = TripleStorage::new(
             FakeClock::default().clock(),
             db.clone(),
-            &client,
+            client,
             reconstruction_threshold,
         )
         .unwrap();
@@ -366,7 +366,7 @@ mod tests {
         let triple_store = TripleStorage::new(
             FakeClock::default().clock(),
             db.clone(),
-            &client,
+            client,
             reconstruction_threshold,
         )
         .unwrap();

--- a/crates/node/src/assets/cleanup.rs
+++ b/crates/node/src/assets/cleanup.rs
@@ -129,14 +129,11 @@ fn cleanup_behavior(
 
 #[cfg(test)]
 mod tests {
+    use crate::network::testing::new_test_client;
     use crate::assets::cleanup::EpochData;
     use crate::assets::cleanup::{delete_stale_triples_and_presignatures, get_epoch_data};
     use crate::assets::test_utils;
-    use crate::assets::test_utils::TestContext;
-    use crate::assets::test_utils::get_participant_ids;
-    use crate::assets::test_utils::make_triple;
-    use crate::assets::test_utils::random_verifying_key;
-    use crate::assets::test_utils::triple_v2_key;
+    use crate::assets::test_utils::{TestContext, get_participant_ids, make_triple, random_verifying_key, triple_v2_key};
     use crate::db::EPOCH_ID_KEY;
     use crate::db::{DBCol, SecretDB};
     use crate::primitives::UniqueId;
@@ -244,14 +241,11 @@ mod tests {
         let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
         let dir = tempfile::tempdir().unwrap();
         let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let client = new_test_client(all_participants.clone(), my_participant_id);
         let triple_store = TripleStorage::new(
             FakeClock::default().clock(),
             db.clone(),
-            my_participant_id,
-            {
-                let alive = alive_participants.clone();
-                Arc::new(move || alive.lock().unwrap().clone())
-            },
+            &client,
             reconstruction_threshold,
         )
         .unwrap();
@@ -310,17 +304,13 @@ mod tests {
             .take(all_participants.len() - 1)
             .copied()
             .collect();
-        let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
         let dir = tempfile::tempdir().unwrap();
         let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let client = new_test_client(all_participants.clone(), my_participant_id);
         let triple_store = TripleStorage::new(
             FakeClock::default().clock(),
             db.clone(),
-            my_participant_id,
-            {
-                let alive = alive_participants.clone();
-                Arc::new(move || alive.lock().unwrap().clone())
-            },
+            &client,
             reconstruction_threshold,
         )
         .unwrap();
@@ -369,17 +359,13 @@ mod tests {
             .iter()
             .find(|p| **p != my_participant_id)
             .unwrap();
-        let alive_participants = Arc::new(Mutex::new(all_participants.clone()));
         let dir = tempfile::tempdir().unwrap();
         let db = SecretDB::new(dir.path(), [1; 16]).unwrap();
+        let client = new_test_client(all_participants.clone(), my_participant_id);
         let triple_store = TripleStorage::new(
             FakeClock::default().clock(),
             db.clone(),
-            my_participant_id,
-            {
-                let alive = alive_participants.clone();
-                Arc::new(move || alive.lock().unwrap().clone())
-            },
+            &client,
             reconstruction_threshold,
         )
         .unwrap();

--- a/crates/node/src/assets/cleanup.rs
+++ b/crates/node/src/assets/cleanup.rs
@@ -129,13 +129,15 @@ fn cleanup_behavior(
 
 #[cfg(test)]
 mod tests {
-    use crate::network::testing::new_test_client;
     use crate::assets::cleanup::EpochData;
     use crate::assets::cleanup::{delete_stale_triples_and_presignatures, get_epoch_data};
     use crate::assets::test_utils;
-    use crate::assets::test_utils::{TestContext, get_participant_ids, make_triple, random_verifying_key, triple_v2_key};
+    use crate::assets::test_utils::{
+        TestContext, get_participant_ids, make_triple, random_verifying_key, triple_v2_key,
+    };
     use crate::db::EPOCH_ID_KEY;
     use crate::db::{DBCol, SecretDB};
+    use crate::network::testing::new_test_client;
     use crate::primitives::UniqueId;
     use crate::providers::ecdsa::triple::TripleStorage;
     use mpc_primitives::domain::DomainId;

--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -866,6 +866,7 @@ impl NetworkTaskChannel {
 #[cfg(test)]
 pub mod testing {
     use super::conn::{ConnectionVersion, NodeConnectivityInterface};
+    use super::indexer_heights::IndexerHeightTracker;
     use super::{
         ChannelId, MeshNetworkTransportSender, NetworkTaskChannel, NetworkTaskChannelSender,
     };
@@ -874,7 +875,6 @@ pub mod testing {
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use tokio::sync::mpsc;
-    use super::indexer_heights::IndexerHeightTracker;
 
     pub struct TestMeshTransport {
         participant_ids: Vec<ParticipantId>,

--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -14,7 +14,6 @@ use crate::requests::queue::NetworkAPIForRequests;
 use crate::tracking::{self, AutoAbortTask};
 use anyhow::Context as _;
 use conn::{ConnectionVersion, NodeConnectivityInterface};
-use indexer_heights::IndexerHeightTracker;
 use lru::LruCache;
 use rand::prelude::IteratorRandom;
 use std::collections::hash_map::Entry;
@@ -875,6 +874,7 @@ pub mod testing {
     use std::collections::{HashMap, HashSet};
     use std::sync::Arc;
     use tokio::sync::mpsc;
+    use super::indexer_heights::IndexerHeightTracker;
 
     pub struct TestMeshTransport {
         participant_ids: Vec<ParticipantId>,

--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -5,6 +5,7 @@ pub mod handshake;
 pub mod indexer_heights;
 
 use crate::metrics::networking_metrics;
+use crate::network::indexer_heights::IndexerHeightTracker;
 use crate::primitives::{
     ChannelId, IndexerHeightMessage, MpcMessage, MpcMessageKind, MpcPeerMessage, MpcStartMessage,
     MpcTaskId, ParticipantId, PeerMessage, UniqueId,
@@ -1000,6 +1001,29 @@ pub mod testing {
         }
 
         transports
+    }
+
+    /// Synchronous [`MeshNetworkClient`] for unit tests. All participants are reported alive.
+    pub fn new_test_client(
+        participants: Vec<ParticipantId>,
+        my_participant_id: ParticipantId,
+    ) -> Arc<super::MeshNetworkClient> {
+        let transport = Arc::new(TestMeshTransportSender {
+            transport: Arc::new(TestMeshTransport {
+                participant_ids: participants.clone(),
+                senders: HashMap::new(),
+            }),
+            my_participant_id,
+        });
+        let channels = Arc::new(std::sync::Mutex::new(
+            super::NetworkTaskChannelManager::new(),
+        ));
+        let indexer_heights = Arc::new(IndexerHeightTracker::new(&participants));
+        Arc::new(super::MeshNetworkClient::new(
+            transport,
+            channels,
+            indexer_heights,
+        ))
     }
 
     /// Builds a channel over the given participant set, returning the raw inbound sender so

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -66,7 +66,12 @@ impl EcdsaSignatureProvider {
         {
             triple_stores.insert(
                 t,
-                Arc::new(TripleStorage::new(clock.clone(), db.clone(), client.clone(), t)?),
+                Arc::new(TripleStorage::new(
+                    clock.clone(),
+                    db.clone(),
+                    client.clone(),
+                    t,
+                )?),
             );
         }
 

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -16,9 +16,7 @@ use crate::db::SecretDB;
 use crate::metrics::tokio_task_metrics::ECDSA_TASK_MONITORS;
 use crate::network::{MeshNetworkClient, NetworkTaskChannel};
 use crate::primitives::{MpcTaskId, ParticipantId, UniqueId};
-use crate::providers::DomainKeyshare;
-use crate::providers::SignatureProvider;
-use crate::providers::ecdsa_common;
+use crate::providers::{DomainKeyshare, SignatureProvider, ecdsa_common};
 use crate::storage::SignRequestStorage;
 use crate::tracking;
 use mpc_node_config::ConfigFile;
@@ -68,13 +66,7 @@ impl EcdsaSignatureProvider {
         {
             triple_stores.insert(
                 t,
-                Arc::new(TripleStorage::new(
-                    clock.clone(),
-                    db.clone(),
-                    client.my_participant_id(),
-                    ecdsa_common::active_participants_query(&client),
-                    t,
-                )?),
+                Arc::new(TripleStorage::new(clock.clone(), db.clone(), &client, t)?),
             );
         }
 

--- a/crates/node/src/providers/ecdsa.rs
+++ b/crates/node/src/providers/ecdsa.rs
@@ -58,7 +58,7 @@ impl EcdsaSignatureProvider {
         sign_request_store: Arc<SignRequestStorage>,
         keyshares: HashMap<DomainId, DomainKeyshare<Secp256K1Sha256>>,
     ) -> anyhow::Result<Self> {
-        let keyshares = ecdsa_common::build_keyshares(&clock, &db, &client, keyshares)?;
+        let keyshares = ecdsa_common::build_keyshares(&clock, &db, client.clone(), keyshares)?;
 
         // cait-sith triple generation runs with exactly `t` parties, so keep one store per distinct reconstruction threshold.
         let mut triple_stores = HashMap::new();
@@ -66,7 +66,7 @@ impl EcdsaSignatureProvider {
         {
             triple_stores.insert(
                 t,
-                Arc::new(TripleStorage::new(clock.clone(), db.clone(), &client, t)?),
+                Arc::new(TripleStorage::new(clock.clone(), db.clone(), client.clone(), t)?),
             );
         }
 

--- a/crates/node/src/providers/ecdsa/triple.rs
+++ b/crates/node/src/providers/ecdsa/triple.rs
@@ -10,6 +10,7 @@ use crate::primitives::{ParticipantId, UniqueId};
 use crate::protocol::NamedProtocol;
 use crate::providers::HasParticipants;
 use crate::providers::ecdsa::{EcdsaSignatureProvider, EcdsaTaskId};
+use crate::providers::ecdsa_common::active_participants_query;
 use crate::tracking::AutoAbortTaskCollection;
 use mpc_node_config::TripleConfig;
 use mpc_primitives::ReconstructionThreshold;
@@ -55,8 +56,7 @@ impl TripleStorage {
     pub fn new(
         clock: Clock,
         db: Arc<SecretDB>,
-        my_participant_id: ParticipantId,
-        alive_participant_ids_query: Arc<dyn Fn() -> Vec<ParticipantId> + Send + Sync>,
+        client: &Arc<MeshNetworkClient>,
         reconstruction_threshold: ReconstructionThreshold,
     ) -> anyhow::Result<Self> {
         Ok(Self(DistributedAssetStorage::<PairedTriple>::new(
@@ -64,9 +64,9 @@ impl TripleStorage {
             db,
             DBCol::TripleV2,
             reconstruction_threshold.inner().to_be_bytes().to_vec(),
-            my_participant_id,
+            client.my_participant_id(),
             |participants, pair| pair.is_subset_of_active_participants(participants),
-            alive_participant_ids_query,
+            active_participants_query(client),
         )?))
     }
 }
@@ -385,7 +385,7 @@ mod tests {
     use crate::assets::test_utils::{make_triple, triple_v2_key};
     use crate::db::{DBCol, SecretDB};
     use crate::network::computation::MpcLeaderCentricComputation;
-    use crate::network::testing::run_test_clients;
+    use crate::network::testing::{new_test_client, run_test_clients};
     use crate::network::{MeshNetworkClient, NetworkTaskChannel};
     use crate::primitives::{MpcTaskId, ParticipantId, UniqueId};
     use crate::providers::ecdsa::EcdsaTaskId;
@@ -569,13 +569,13 @@ mod tests {
         db: Arc<SecretDB>,
         my_participant_id: ParticipantId,
         reconstruction_threshold: ReconstructionThreshold,
-        alive: Vec<ParticipantId>,
+        participants: Vec<ParticipantId>,
     ) -> TripleStorage {
+        let client = new_test_client(participants, my_participant_id);
         TripleStorage::new(
             near_time::FakeClock::default().clock(),
             db,
-            my_participant_id,
-            Arc::new(move || alive.clone()),
+            &client,
             reconstruction_threshold,
         )
         .unwrap()

--- a/crates/node/src/providers/ecdsa/triple.rs
+++ b/crates/node/src/providers/ecdsa/triple.rs
@@ -56,7 +56,7 @@ impl TripleStorage {
     pub fn new(
         clock: Clock,
         db: Arc<SecretDB>,
-        client: &Arc<MeshNetworkClient>,
+        client: Arc<MeshNetworkClient>,
         reconstruction_threshold: ReconstructionThreshold,
     ) -> anyhow::Result<Self> {
         Ok(Self(DistributedAssetStorage::<PairedTriple>::new(
@@ -575,7 +575,7 @@ mod tests {
         TripleStorage::new(
             near_time::FakeClock::default().clock(),
             db,
-            &client,
+            client,
             reconstruction_threshold,
         )
         .unwrap()

--- a/crates/node/src/providers/ecdsa_common.rs
+++ b/crates/node/src/providers/ecdsa_common.rs
@@ -196,8 +196,7 @@ mod tests {
 
                     // When
                     let keyshares =
-                        build_keyshares::<Vec<u8>>(&Clock::real(), &db, client, keyshares)
-                            .unwrap();
+                        build_keyshares::<Vec<u8>>(&Clock::real(), &db, client, keyshares).unwrap();
 
                     // Then each domain keeps the threshold it was configured with
                     assert_eq!(keyshares[&low].reconstruction_threshold, low_threshold);

--- a/crates/node/src/providers/ecdsa_common.rs
+++ b/crates/node/src/providers/ecdsa_common.rs
@@ -48,7 +48,7 @@ where
     pub fn new(
         clock: Clock,
         db: Arc<SecretDB>,
-        client: &Arc<MeshNetworkClient>,
+        client: Arc<MeshNetworkClient>,
         domain_id: DomainId,
     ) -> anyhow::Result<Self> {
         Ok(Self(DistributedAssetStorage::<
@@ -94,17 +94,16 @@ where
 
 /// The "are all these participants still alive?" query both the presignature and triple stores use.
 pub fn active_participants_query(
-    client: &Arc<MeshNetworkClient>,
+    client: Arc<MeshNetworkClient>,
 ) -> Arc<dyn Fn() -> Vec<ParticipantId> + Send + Sync> {
-    let network_client = client.clone();
-    Arc::new(move || network_client.all_alive_participant_ids())
+    Arc::new(move || client.all_alive_participant_ids())
 }
 
 /// Attaches a freshly-created presignature store to each domain's [`DomainKeyshare`].
 pub fn build_keyshares<P>(
     clock: &Clock,
     db: &Arc<SecretDB>,
-    client: &Arc<MeshNetworkClient>,
+    client: Arc<MeshNetworkClient>,
     keyshares: HashMap<DomainId, DomainKeyshare<Secp256K1Sha256>>,
 ) -> anyhow::Result<HashMap<DomainId, EcdsaKeyshare<P>>>
 where
@@ -115,7 +114,7 @@ where
         let presignature_store = Arc::new(PresignatureStorage::new(
             clock.clone(),
             db.clone(),
-            client,
+            client.clone(),
             domain_id,
         )?);
         result.insert(

--- a/crates/node/src/providers/ecdsa_common.rs
+++ b/crates/node/src/providers/ecdsa_common.rs
@@ -196,7 +196,7 @@ mod tests {
 
                     // When
                     let keyshares =
-                        build_keyshares::<Vec<u8>>(&Clock::real(), &db, &client, keyshares)
+                        build_keyshares::<Vec<u8>>(&Clock::real(), &db, client, keyshares)
                             .unwrap();
 
                     // Then each domain keeps the threshold it was configured with

--- a/crates/node/src/providers/robust_ecdsa.rs
+++ b/crates/node/src/providers/robust_ecdsa.rs
@@ -60,7 +60,7 @@ impl RobustEcdsaSignatureProvider {
         sign_request_store: Arc<SignRequestStorage>,
         keyshares: HashMap<DomainId, DomainKeyshare<Secp256K1Sha256>>,
     ) -> anyhow::Result<Self> {
-        let keyshares = ecdsa_common::build_keyshares(&clock, &db, &client, keyshares)?;
+        let keyshares = ecdsa_common::build_keyshares(&clock, &db, client.clone(), keyshares)?;
 
         Ok(Self {
             config,


### PR DESCRIPTION
Simplifies the triple generation part following https://github.com/near/mpc/issues/3164. Concretely, it refactors TripleStorage::new so the storage takes the network client directly, instead of being handed the two pieces of state it used to derive from that client.

Net effect: TripleStorage depends on one cohesive object (the mesh client) rather than being passed several client-derived values separately.

Reference https://github.com/near/mpc/issues/1680#issuecomment-4852112094