### PR TITLE
feat: add tcb-status support for attestation-cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1071,9 +1071,12 @@ name = "attestation-cli"
 version = "3.14.0"
 dependencies = [
  "anyhow",
+ "assert_matches",
  "attestation",
  "bs58 0.5.1",
  "clap",
+ "dcap-qvl",
+ "hex",
  "mpc-attestation",
  "mpc-primitives",
  "near-mpc-crypto-types",

--- a/crates/attestation-cli/Cargo.toml
+++ b/crates/attestation-cli/Cargo.toml
@@ -13,6 +13,8 @@ anyhow = { workspace = true }
 attestation = { workspace = true }
 bs58 = { workspace = true }
 clap = { workspace = true }
+dcap-qvl = { workspace = true, features = ["report"] }
+hex = { workspace = true }
 mpc-attestation = { workspace = true, features = ["local-verify"] }
 mpc-primitives = { workspace = true }
 node-types = { workspace = true }
@@ -24,6 +26,7 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 near-mpc-crypto-types = { workspace = true }
 tempfile = { workspace = true }
 test-utils = { workspace = true }

--- a/crates/attestation-cli/README.md
+++ b/crates/attestation-cli/README.md
@@ -190,7 +190,7 @@ The node's quote is evaluated against two sets, and both are reported:
 | Set | What it tells you |
 |-----|-------------------|
 | served by the node | What the node's own boot-time collateral says. `/public_data` serves the attestation built at CVM boot, so this can lag reality by days. |
-| Intel `standard` | What the contract decides today. Collateral is fetched with no `update` parameter, exactly as the node does. |
+| Intel `standard` | What the contract will decide the next time the node re-attests. Fetched with no `update` parameter, like the node, though straight from Intel rather than through the node's PCCS, so the two can differ in cache freshness. |
 
 Both verdicts come from `dcap-qvl`, the same verification the contract runs. Contacting Intel is anonymous: no PCS subscription key and no node credentials.
 
@@ -226,8 +226,6 @@ Advisory IDs:           INTEL-SA-01192, INTEL-SA-01245, INTEL-SA-01312, INTEL-SA
 The node above still serves an `UpToDate` set 19 while Intel has moved to 20, which is the lag that makes the served row alone unreliable.
 
 A quote is judged in two independent halves, and either can demote a platform. The TDX module half is `tee_tcb_svn[0]`, the module's ISV SVN, matched against the identity `tee_tcb_svn[1]` selects; a newer Intel TDX module (SEAM) raises it, usually shipped inside a vendor BIOS. The platform half is the rest of `tee_tcb_svn` plus the PCK certificate's SGX components and PCESVN; BIOS and CPU microcode raise those. The shortfall lines say which half is short, so you know which update you need.
-
-Exit code is 0 when Intel rates the platform `UpToDate` and 1 when it does not.
 
 ## Troubleshooting
 

--- a/crates/attestation-cli/README.md
+++ b/crates/attestation-cli/README.md
@@ -2,6 +2,8 @@
 
 Standalone verification tool for MPC node TEE attestations. It performs the same Intel TDX (DCAP) attestation verification that the NEAR contract and MPC nodes use, allowing external auditors, operators, and developers to independently validate that an MPC node is running trusted code inside genuine hardware.
 
+Two subcommands: `verify` answers "is this node's attestation acceptable?", and `tcb-status` answers "does this node's platform still clear Intel's TCB bar?".
+
 ## Building
 
 From the repository root:
@@ -37,7 +39,7 @@ Before running verification you need:
 ## Usage
 
 ```
-attestation-cli [OPTIONS]
+attestation-cli verify [OPTIONS]
 ```
 
 ### Required flags
@@ -65,7 +67,7 @@ attestation-cli [OPTIONS]
 ### Verify a live node
 
 ```bash
-attestation-cli \
+attestation-cli verify \
   --url http://<node-host>:8080/public_data \
   --allowed-image-hash abc123...def \
   --launcher-compose-file launcher-compose.yaml
@@ -82,7 +84,7 @@ curl -o public_data.json http://<node-host>:8080/public_data
 Then verify offline:
 
 ```bash
-attestation-cli \
+attestation-cli verify \
   --file public_data.json \
   --allowed-image-hash abc123...def \
   --launcher-compose-file launcher-compose.yaml
@@ -91,7 +93,7 @@ attestation-cli \
 ### Multiple allowed image hashes
 
 ```bash
-attestation-cli \
+attestation-cli verify \
   --url http://<node-host>:8080/public_data \
   --allowed-image-hash abc123...def \
   --allowed-image-hash 789012...345 \
@@ -101,7 +103,7 @@ attestation-cli \
 ### Custom expected measurements
 
 ```bash
-attestation-cli \
+attestation-cli verify \
   --file public_data.json \
   --allowed-image-hash abc123...def \
   --launcher-compose-file launcher-compose.yaml \
@@ -173,7 +175,59 @@ On failure the output includes the error details and ends with `Verdict: FAIL`.
 
 Attestation verification requires DCAP collateral (certificates, CRLs, TCB info) to validate the Intel TDX quote. The CLI uses the collateral **embedded in the node's attestation payload** (the same collateral that was fetched when the node generated its attestation). This is the same approach used by the MPC contract and node.
 
-The CLI does not currently support fetching fresh collateral from Intel's Provisioning Certification Service (PCS) or overriding CRLs. If the embedded collateral is stale, the verification may fail with a DCAP-related error. See [#2320](https://github.com/near/mpc/issues/2320) and [#2286](https://github.com/near/mpc/issues/2286) for planned improvements.
+`verify` does not currently support fetching fresh collateral from Intel's Provisioning Certification Service (PCS) or overriding CRLs. If the embedded collateral is stale, the verification may fail with a DCAP-related error. See [#2320](https://github.com/near/mpc/issues/2320) and [#2286](https://github.com/near/mpc/issues/2286) for planned improvements. `tcb-status` does fetch fresh collateral, so it is the way to tell a stale snapshot apart from a genuinely rejected platform.
+
+## `tcb-status`
+
+```
+attestation-cli tcb-status [OPTIONS]
+```
+
+Reports where a node's platform stands against Intel's TCB requirements. The contract accepts an attestation only when DCAP returns `UpToDate`, and that verdict depends on Intel's TCB info, which Intel revises on its own schedule: a node accepted yesterday can be rejected today with nothing changed on the operator's side.
+
+The node's quote is evaluated against two sets, and both are reported:
+
+| Set | What it tells you |
+|-----|-------------------|
+| served by the node | What the node's own boot-time collateral says. `/public_data` serves the attestation built at CVM boot, so this can lag reality by days. |
+| Intel `standard` | What the contract decides today. Collateral is fetched with no `update` parameter, exactly as the node does. |
+
+Both verdicts come from `dcap-qvl`, the same verification the contract runs. Contacting Intel is anonymous: no PCS subscription key and no node credentials.
+
+It takes the same `--url` / `--file` data source as `verify`, and nothing else.
+
+```bash
+attestation-cli tcb-status --url http://<node-host>:8080/public_data
+```
+
+```
+=== MPC Node Platform TCB Status ===
+
+--- Platform, as the quote reports it ---
+FMSPC:                  90C06F000000
+tee_tcb_svn:            06010300000000000000000000000000
+TDX module:             TDX_01 at ISV SVN 6
+TDX TCB components:     [6, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+SGX TCB components:     [3, 3, 2, 2, 4, 1, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0]
+PCESVN:                 13
+
+--- served by the node: TCB recovery set 19, issued 2026-08-10T23:45:04Z ---
+Status:                 UpToDate
+
+--- Intel `standard`: TCB recovery set 20, issued 2026-08-24T11:12:32Z ---
+Status:                 OutOfDate
+Advisory IDs:           INTEL-SA-01192, INTEL-SA-01245, INTEL-SA-01312, INTEL-SA-01313
+  TDX module TDX_01 ISV SVN is 6, needs 11 -> update the TDX module (SEAM loader)
+  TDX TCB component 2 is 3, needs 4 -> update BIOS/microcode
+  SGX TCB component 0 is 3, needs 4 -> update BIOS/microcode
+  SGX TCB component 1 is 3, needs 4 -> update BIOS/microcode
+```
+
+The node above still serves an `UpToDate` set 19 while Intel has moved to 20, which is the lag that makes the served row alone unreliable.
+
+A quote is judged in two independent halves, and either can demote a platform. The TDX module half is `tee_tcb_svn[0]`, the module's ISV SVN, matched against the identity `tee_tcb_svn[1]` selects; a newer Intel TDX module (SEAM) raises it, usually shipped inside a vendor BIOS. The platform half is the rest of `tee_tcb_svn` plus the PCK certificate's SGX components and PCESVN; BIOS and CPU microcode raise those. The shortfall lines say which half is short, so you know which update you need.
+
+Exit code is 0 when Intel rates the platform `UpToDate` and 1 when it does not.
 
 ## Troubleshooting
 
@@ -191,6 +245,9 @@ The SHA256 of the `--launcher-compose-file` you provided does not match the comp
 
 **"failed to load expected measurements"**
 The `--expected-measurements` file could not be read or parsed. Ensure it is valid JSON in the `tcb_info.json` format.
+
+**`tcb-status` reports `Rejected` for "served by the node"**
+The collateral in the node's boot-time snapshot has expired. The Intel row is evaluated against freshly fetched collateral, so its verdict still stands; restart the CVM to make the served row meaningful again.
 
 **DCAP verification errors (quote validation, certificate chain, etc.)**
 These indicate the TDX attestation quote failed cryptographic verification. This could mean the attestation is invalid, expired, or the measurements do not match.

--- a/crates/attestation-cli/README.md
+++ b/crates/attestation-cli/README.md
@@ -187,14 +187,16 @@ Reports where a node's platform stands against Intel's TCB requirements. The con
 
 The node's quote is evaluated against two sets, and both are reported:
 
-| Set | What it tells you |
-|-----|-------------------|
+| Collateral source | What it tells you |
+|-------------------|-------------------|
 | served by the node | What the node's own boot-time collateral says. `/public_data` serves the attestation built at CVM boot, so this can lag reality by days. |
-| Intel `standard` | What the contract will decide the next time the node re-attests. Fetched with no `update` parameter, like the node, though straight from Intel rather than through the node's PCCS, so the two can differ in cache freshness. |
+| Intel `standard` | What the contract will decide the next time the node re-attests. Omitting the `update` parameter is what selects the `standard` tier, and it is what the node does too. The fetch goes straight to Intel rather than through the node's PCCS, so the two can differ in cache freshness. |
 
 Both verdicts come from `dcap-qvl`, the same verification the contract runs. Contacting Intel is anonymous: no PCS subscription key and no node credentials.
 
-It takes the same `--url` / `--file` data source as `verify`, and nothing else.
+It takes the same `--url` / `--file` data source as `verify`. Unlike `verify`, network access is always required: `--file` chooses where the quote comes from, not whether Intel is contacted.
+
+`--as-of <unix-timestamp>` evaluates collateral validity at a past instant instead of now. Intel serves only current collateral, so this is for reading a saved quote whose boot-time snapshot has since expired. The Intel row and the exit code stay present-day verdicts, so neither is meaningful with it set.
 
 ```bash
 attestation-cli tcb-status --url http://<node-host>:8080/public_data
@@ -223,9 +225,14 @@ Advisory IDs:           INTEL-SA-01192, INTEL-SA-01245, INTEL-SA-01312, INTEL-SA
   SGX TCB component 1 is 3, needs 4 -> update BIOS/microcode
 ```
 
-The node above still serves an `UpToDate` set 19 while Intel has moved to 20, which is the lag that makes the served row alone unreliable.
+The node above still serves an `UpToDate` set 19 while Intel has moved to 20. The node itself is not stuck: it re-attests to the contract every hour, each time with freshly fetched collateral. What is frozen is `/public_data`, which keeps returning the snapshot built at CVM boot. So a stale served row does not mean the node is submitting stale attestations, and the Intel row is the one that predicts what the next submission will be judged against.
 
-A quote is judged in two independent halves, and either can demote a platform. The TDX module half is `tee_tcb_svn[0]`, the module's ISV SVN, matched against the identity `tee_tcb_svn[1]` selects; a newer Intel TDX module (SEAM) raises it, usually shipped inside a vendor BIOS. The platform half is the rest of `tee_tcb_svn` plus the PCK certificate's SGX components and PCESVN; BIOS and CPU microcode raise those. The shortfall lines say which half is short, so you know which update you need.
+A quote is judged in two independent halves, and either one can demote the platform.
+
+- **TDX module half.** `tee_tcb_svn[0]`, the module's ISV SVN, matched against the identity that `tee_tcb_svn[1]` selects. A newer Intel TDX module (SEAM) raises it, usually shipped inside a vendor BIOS.
+- **Platform half.** The rest of `tee_tcb_svn`, plus the PCK certificate's SGX components and PCESVN. BIOS and CPU microcode raise those.
+
+The shortfall lines say which half is short, so you know which update you need.
 
 ## Troubleshooting
 

--- a/crates/attestation-cli/src/cli.rs
+++ b/crates/attestation-cli/src/cli.rs
@@ -1,13 +1,29 @@
 use std::path::PathBuf;
 
-use clap::{ArgGroup, Parser};
+use clap::{ArgGroup, Args, Parser, Subcommand};
 use mpc_primitives::hash::NodeImageHash;
 
 #[derive(Parser)]
 #[command(name = "attestation-cli")]
 #[command(about = "Standalone verification tool for MPC node TEE attestations")]
-#[command(group(ArgGroup::new("source").required(true)))]
 pub struct Cli {
+    #[command(subcommand)]
+    pub command: Command,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// Verify a node's attestation the way the MPC contract does.
+    Verify(VerifyArgs),
+
+    /// Report where a node's platform stands against Intel's TCB requirements.
+    TcbStatus(Source),
+}
+
+/// Where to read the node's `/public_data` payload from.
+#[derive(Args)]
+#[command(group(ArgGroup::new("source").required(true)))]
+pub struct Source {
     /// Fetch attestation data from a node's /public_data HTTP endpoint
     #[arg(long, group = "source")]
     pub url: Option<url::Url>,
@@ -15,6 +31,12 @@ pub struct Cli {
     /// Read attestation data from a saved JSON file (same format as /public_data response)
     #[arg(long, group = "source")]
     pub file: Option<PathBuf>,
+}
+
+#[derive(Args)]
+pub struct VerifyArgs {
+    #[command(flatten)]
+    pub source: Source,
 
     /// Allowed MPC Docker image hash (hex-encoded SHA256, repeatable)
     #[arg(long = "allowed-image-hash", required = true)]

--- a/crates/attestation-cli/src/cli.rs
+++ b/crates/attestation-cli/src/cli.rs
@@ -17,7 +17,20 @@ pub enum Command {
     Verify(VerifyArgs),
 
     /// Report where a node's platform stands against Intel's TCB requirements.
-    TcbStatus(Source),
+    TcbStatus(TcbStatusArgs),
+}
+
+#[derive(Args)]
+pub struct TcbStatusArgs {
+    #[command(flatten)]
+    pub source: Source,
+
+    /// Evaluate collateral validity as of this UNIX timestamp instead of now.
+    /// Intel serves only current collateral, so this makes the served row
+    /// readable for a saved quote whose snapshot has expired; the Intel row and
+    /// the exit code stay present-day verdicts and are not meaningful with it set.
+    #[arg(long = "as-of")]
+    pub as_of: Option<u64>,
 }
 
 /// Where to read the node's `/public_data` payload from.

--- a/crates/attestation-cli/src/data.rs
+++ b/crates/attestation-cli/src/data.rs
@@ -4,12 +4,12 @@ use std::time::Duration;
 use anyhow::{Context, bail};
 use node_types::http_server::StaticWebData;
 
-use crate::cli::Cli;
+use crate::cli::Source;
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
-pub async fn load(cli: &Cli) -> anyhow::Result<StaticWebData> {
-    match (&cli.url, &cli.file) {
+pub async fn load(source: &Source) -> anyhow::Result<StaticWebData> {
+    match (&source.url, &source.file) {
         (Some(url), None) => fetch(url).await,
         (None, Some(path)) => read(path),
         (None, None) => bail!("either --url or --file must be provided"),

--- a/crates/attestation-cli/src/lib.rs
+++ b/crates/attestation-cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod cli;
 pub mod data;
 pub mod output;
+pub mod tcb_status;
 pub mod verify;

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -8,7 +8,7 @@ async fn main() -> anyhow::Result<()> {
     let command = Cli::parse().command;
     let source = match &command {
         Command::Verify(args) => &args.source,
-        Command::TcbStatus(source) => source,
+        Command::TcbStatus(args) => &args.source,
     };
     let static_data = data::load(source)
         .await
@@ -25,8 +25,8 @@ async fn main() -> anyhow::Result<()> {
                 bail!("attestation verification failed");
             }
         },
-        Command::TcbStatus(_) => {
-            let report = tcb_status::run(&static_data).await?;
+        Command::TcbStatus(args) => {
+            let report = tcb_status::run(&static_data, args.as_of).await?;
             output::print_tcb_status(&report);
             // The verdict and what to do about it are already printed; this
             // sets the exit code, at the cost of a second line on stderr.

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -29,7 +29,7 @@ async fn main() -> anyhow::Result<()> {
             let report = tcb_status::run(&static_data).await?;
             output::print_tcb_status(&report);
             // The verdict and what to do about it are already printed; this
-            // only carries the failure into the exit code.
+            // sets the exit code, at the cost of a second line on stderr.
             if report.is_up_to_date() {
                 Ok(())
             } else {

--- a/crates/attestation-cli/src/main.rs
+++ b/crates/attestation-cli/src/main.rs
@@ -1,24 +1,40 @@
 use anyhow::{Context, bail};
-use attestation_cli::cli::Cli;
-use attestation_cli::{data, output, verify};
+use attestation_cli::cli::{Cli, Command};
+use attestation_cli::{data, output, tcb_status, verify};
 use clap::Parser;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
-    let cli = Cli::parse();
-
-    let static_data = data::load(&cli)
+    let command = Cli::parse().command;
+    let source = match &command {
+        Command::Verify(args) => &args.source,
+        Command::TcbStatus(source) => source,
+    };
+    let static_data = data::load(source)
         .await
         .context("failed to load attestation data")?;
 
-    match verify::run_verification(&static_data, &cli) {
-        Ok(result) => {
-            output::print_success(&static_data, &result);
-            Ok(())
-        }
-        Err(err) => {
-            output::print_failure(&static_data, &err);
-            bail!("attestation verification failed");
+    match &command {
+        Command::Verify(args) => match verify::run_verification(&static_data, args) {
+            Ok(result) => {
+                output::print_success(&static_data, &result);
+                Ok(())
+            }
+            Err(err) => {
+                output::print_failure(&static_data, &err);
+                bail!("attestation verification failed");
+            }
+        },
+        Command::TcbStatus(_) => {
+            let report = tcb_status::run(&static_data).await?;
+            output::print_tcb_status(&report);
+            // The verdict and what to do about it are already printed; this
+            // only carries the failure into the exit code.
+            if report.is_up_to_date() {
+                Ok(())
+            } else {
+                bail!("platform TCB check failed")
+            }
         }
     }
 }

--- a/crates/attestation-cli/src/output.rs
+++ b/crates/attestation-cli/src/output.rs
@@ -2,7 +2,7 @@ use attestation::attestation::VerificationError;
 use node_types::http_server::StaticWebData;
 use time::OffsetDateTime;
 
-use dcap_qvl::{policy::PckIdentity, quote::TDReport10};
+use dcap_qvl::{TcbStatus, policy::PckIdentity, quote::TDReport10};
 
 use crate::tcb_status::{self, Report, TcbVerdict};
 use crate::verify::VerificationResult;
@@ -145,6 +145,24 @@ fn print_verdict(label: &str, verdict: &TcbVerdict) {
                     "  {} is {}, needs {} -> {}",
                     shortfall.component, shortfall.have, shortfall.needs, shortfall.remedy
                 );
+            }
+            // Demoted with nothing to raise: either Intel accepts no level for
+            // this platform, or every SVN clears one and the module identity's
+            // own advisories carry the status down.
+            if shortfalls.is_empty() && claims.tcb.status != TcbStatus::UpToDate {
+                if tcb_info
+                    .tcb_levels
+                    .iter()
+                    .all(|level| level.tcb_status != TcbStatus::UpToDate)
+                {
+                    println!(
+                        "  Intel publishes no UpToDate level for this platform, so no SVN upgrade reaches one."
+                    );
+                } else {
+                    println!(
+                        "  Every SVN clears an accepted level; the status comes from the advisories above."
+                    );
+                }
             }
         }
         TcbVerdict::Rejected(reason) => {

--- a/crates/attestation-cli/src/output.rs
+++ b/crates/attestation-cli/src/output.rs
@@ -2,6 +2,9 @@ use attestation::attestation::VerificationError;
 use node_types::http_server::StaticWebData;
 use time::OffsetDateTime;
 
+use dcap_qvl::policy::QuoteClaims;
+
+use crate::tcb_status::{self, Outcome, Report};
 use crate::verify::VerificationResult;
 
 pub fn print_success(static_data: &StaticWebData, result: &VerificationResult) {
@@ -97,4 +100,79 @@ fn format_timestamp(unix_secs: u64) -> String {
         }
         Err(_) => format!("{unix_secs} (invalid timestamp)"),
     }
+}
+
+pub fn print_tcb_status(report: &Report) {
+    println!("=== MPC Node Platform TCB Status ===");
+
+    // Both rows judge the same quote, so its platform numbers are the same in
+    // each; whichever verified first will do. When neither did, the rejection
+    // reasons below say why.
+    match (&report.served, &report.standard) {
+        (Outcome::Verified { claims, .. }, _) | (_, Outcome::Verified { claims, .. }) => {
+            print_platform(claims);
+        }
+        _ => println!("\nThe platform's own numbers are unavailable: neither evaluation verified."),
+    }
+
+    print_outcome("served by the node", &report.served);
+    print_outcome("Intel `standard`", &report.standard);
+}
+
+fn print_outcome(label: &str, outcome: &Outcome) {
+    println!();
+    match outcome {
+        Outcome::Verified {
+            tcb_info,
+            claims,
+            shortfalls,
+        } => {
+            println!(
+                "--- {label}: TCB recovery set {}, issued {} ---",
+                tcb_info.tcb_evaluation_data_number, tcb_info.issue_date
+            );
+            println!("Status:                 {}", claims.tcb.status);
+            if !claims.tcb.advisory_ids.is_empty() {
+                println!(
+                    "Advisory IDs:           {}",
+                    claims.tcb.advisory_ids.join(", ")
+                );
+            }
+            for shortfall in shortfalls {
+                println!(
+                    "  {} is {}, needs {} -> {}",
+                    shortfall.component, shortfall.have, shortfall.needs, shortfall.remedy
+                );
+            }
+        }
+        Outcome::Rejected(reason) => {
+            println!("--- {label} ---");
+            println!("Rejected:               {reason}");
+        }
+    }
+}
+
+fn print_platform(claims: &QuoteClaims) {
+    // `evaluate` already established the report is TD10, so this never misses.
+    let Some(report) = claims.report.as_td10() else {
+        return;
+    };
+    let pck = &claims.platform.pck;
+    let (module, module_svn) = tcb_status::tdx_module(&report.tee_tcb_svn);
+
+    println!();
+    println!("--- Platform, as the quote reports it ---");
+    println!("FMSPC:                  {}", hex::encode_upper(pck.fmspc));
+    println!(
+        "tee_tcb_svn:            {}",
+        hex::encode(report.tee_tcb_svn)
+    );
+    println!(
+        "TDX module:             {} at ISV SVN {}",
+        module.as_deref().unwrap_or("unnamed"),
+        module_svn
+    );
+    println!("TDX TCB components:     {:?}", report.tee_tcb_svn);
+    println!("SGX TCB components:     {:?}", pck.cpu_svn);
+    println!("PCESVN:                 {}", pck.pce_svn);
 }

--- a/crates/attestation-cli/src/output.rs
+++ b/crates/attestation-cli/src/output.rs
@@ -2,9 +2,9 @@ use attestation::attestation::VerificationError;
 use node_types::http_server::StaticWebData;
 use time::OffsetDateTime;
 
-use dcap_qvl::policy::QuoteClaims;
+use dcap_qvl::{policy::PckIdentity, quote::TDReport10};
 
-use crate::tcb_status::{self, Outcome, Report};
+use crate::tcb_status::{self, Report, TcbVerdict};
 use crate::verify::VerificationResult;
 
 pub fn print_success(static_data: &StaticWebData, result: &VerificationResult) {
@@ -105,24 +105,26 @@ fn format_timestamp(unix_secs: u64) -> String {
 pub fn print_tcb_status(report: &Report) {
     println!("=== MPC Node Platform TCB Status ===");
 
-    // Both rows judge the same quote, so its platform numbers are the same in
-    // each; whichever verified first will do. When neither did, the rejection
-    // reasons below say why.
-    match (&report.served, &report.standard) {
-        (Outcome::Verified { claims, .. }, _) | (_, Outcome::Verified { claims, .. }) => {
-            print_platform(claims);
+    // The PCK numbers come from the certificate a successful verification read,
+    // not from the collateral, so both rows carry identical values and whichever
+    // verified will do. The verdicts themselves do differ, which is the point of
+    // showing two rows.
+    let pck = match (&report.served, &report.standard) {
+        (TcbVerdict::Verified { claims, .. }, _) | (_, TcbVerdict::Verified { claims, .. }) => {
+            Some(&claims.platform.pck)
         }
-        _ => println!("\nThe platform's own numbers are unavailable: neither evaluation verified."),
-    }
+        _ => None,
+    };
+    print_platform(&report.td_report, pck);
 
-    print_outcome("served by the node", &report.served);
-    print_outcome("Intel `standard`", &report.standard);
+    print_verdict("served by the node", &report.served);
+    print_verdict("Intel `standard`", &report.standard);
 }
 
-fn print_outcome(label: &str, outcome: &Outcome) {
+fn print_verdict(label: &str, verdict: &TcbVerdict) {
     println!();
-    match outcome {
-        Outcome::Verified {
+    match verdict {
+        TcbVerdict::Verified {
             tcb_info,
             claims,
             shortfalls,
@@ -145,24 +147,23 @@ fn print_outcome(label: &str, outcome: &Outcome) {
                 );
             }
         }
-        Outcome::Rejected(reason) => {
+        TcbVerdict::Rejected(reason) => {
             println!("--- {label} ---");
             println!("Rejected:               {reason}");
         }
     }
 }
 
-fn print_platform(claims: &QuoteClaims) {
-    // `evaluate` already established the report is TD10, so this never misses.
-    let Some(report) = claims.report.as_td10() else {
-        return;
-    };
-    let pck = &claims.platform.pck;
+/// `pck` is absent when neither collateral verified, which leaves only the half
+/// of the platform the quote describes on its own.
+fn print_platform(report: &TDReport10, pck: Option<&PckIdentity>) {
     let (module, module_svn) = tcb_status::tdx_module(&report.tee_tcb_svn);
 
     println!();
     println!("--- Platform, as the quote reports it ---");
-    println!("FMSPC:                  {}", hex::encode_upper(pck.fmspc));
+    if let Some(pck) = pck {
+        println!("FMSPC:                  {}", hex::encode_upper(pck.fmspc));
+    }
     println!(
         "tee_tcb_svn:            {}",
         hex::encode(report.tee_tcb_svn)
@@ -173,6 +174,14 @@ fn print_platform(claims: &QuoteClaims) {
         module_svn
     );
     println!("TDX TCB components:     {:?}", report.tee_tcb_svn);
-    println!("SGX TCB components:     {:?}", pck.cpu_svn);
-    println!("PCESVN:                 {}", pck.pce_svn);
+    match pck {
+        Some(pck) => {
+            println!("SGX TCB components:     {:?}", pck.cpu_svn);
+            println!("PCESVN:                 {}", pck.pce_svn);
+        }
+        None => {
+            println!("FMSPC, SGX components and PCESVN come from the PCK certificate,");
+            println!("which neither evaluation could read.");
+        }
+    }
 }

--- a/crates/attestation-cli/src/tcb_status.rs
+++ b/crates/attestation-cli/src/tcb_status.rs
@@ -44,7 +44,10 @@ pub enum TcbVerdict {
     Verified {
         tcb_info: TcbInfo,
         claims: QuoteClaims,
-        /// Empty when `UpToDate`, and when no level is accepted at all.
+        /// Empty in three cases: the platform clears an accepted level, Intel
+        /// accepts no level at all, or every SVN clears one and the module
+        /// identity's advisories carry the status down. Only the first is
+        /// `UpToDate`; the other two print a line saying nothing can be raised.
         shortfalls: Vec<Shortfall>,
     },
     /// No status at all. Usually expired collateral in a long-running node's

--- a/crates/attestation-cli/src/tcb_status.rs
+++ b/crates/attestation-cli/src/tcb_status.rs
@@ -3,19 +3,27 @@
 //! Every verdict comes from [`dcap_qvl`], the same verification the contract
 //! runs; this module only chooses which collateral it runs against.
 
+use std::time::Duration;
+
 use anyhow::{Context as _, bail};
 use attestation::attestation::DstackAttestation;
 use dcap_qvl::{
-    QuoteCollateralV3, Tcb, TcbComponents, TcbLevel, TcbStatus,
+    QuoteCollateralV3, TcbLevel, TcbStatus,
     collateral::{CollateralClient, INTEL_PCS_URL},
     policy::{PckIdentity, QuoteClaims, QuotePolicy},
-    quote::TDReport10,
+    quote::{Quote, TDReport10},
     tcb_info::TcbInfo,
     verify::QuoteVerifier,
 };
 use mpc_attestation::attestation::Attestation;
 use mpc_attestation::dcap_conversions::collateral_into_dcap;
 use node_types::http_server::StaticWebData;
+
+/// Whole-fetch bound on the Intel PCS call. `with_default_http` builds a reqwest
+/// client with a 180s timeout of its own, far too long to leave an interactive
+/// command hanging on, and `dcap-qvl` keeps that client out of its public API.
+/// `tee-authority` bounds the same call the same way.
+const PCS_TIMEOUT: Duration = Duration::from_secs(30);
 
 const UPDATE_TDX_MODULE: &str = "update the TDX module (SEAM loader)";
 const UPDATE_BIOS: &str = "update BIOS/microcode";
@@ -61,27 +69,44 @@ impl Report {
 pub async fn run(static_data: &StaticWebData) -> anyhow::Result<Report> {
     let dstack = dstack_attestation(static_data)?;
     let quote = &dstack.quote.0;
+    // A property of the quote, so it decides both rows at once rather than
+    // failing one of them.
+    let report = *Quote::parse(quote)
+        .context("parsing the node's quote")?
+        .report
+        .as_td10()
+        .context("the node's quote does not carry a TDX report")?;
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .context("system clock is before the UNIX epoch")?
         .as_secs();
 
-    // Fetched with no `update` parameter, exactly as the node does, so this is
-    // Intel's `standard` set: what the contract verifies against.
-    let standard = CollateralClient::with_default_http(INTEL_PCS_URL)
-        .context("building the Intel PCS client")?
-        .fetch(quote)
+    // Fetched with no `update` parameter, like the node, so this is Intel's
+    // `standard` set: what the contract will decide at the next re-attestation.
+    // The node reaches it through its PCCS, so the two can differ in cache
+    // freshness.
+    let client = CollateralClient::with_default_http(INTEL_PCS_URL)
+        .context("building the Intel PCS client")?;
+    let standard = tokio::time::timeout(PCS_TIMEOUT, client.fetch(quote))
         .await
+        .with_context(|| format!("Intel's PCS did not respond within {PCS_TIMEOUT:?}"))?
         .context("fetching collateral from Intel's PCS")?;
 
     let served = collateral_into_dcap(dstack.collateral.clone());
     Ok(Report {
-        served: evaluate(quote, &served, now)?,
-        standard: evaluate(quote, &standard, now)?,
+        served: evaluate(quote, &report, &served, now),
+        standard: evaluate(quote, &report, &standard, now),
     })
 }
 
-fn evaluate(quote: &[u8], collateral: &QuoteCollateralV3, now: u64) -> anyhow::Result<Outcome> {
+/// Both failure modes are per-collateral, so each becomes a [`Outcome::Rejected`]
+/// row rather than aborting the other one.
+fn evaluate(
+    quote: &[u8],
+    report: &TDReport10,
+    collateral: &QuoteCollateralV3,
+    now: u64,
+) -> Outcome {
     let claims = match QuoteVerifier::new_prod().verify_with_policy(
         quote,
         collateral,
@@ -89,90 +114,123 @@ fn evaluate(quote: &[u8], collateral: &QuoteCollateralV3, now: u64) -> anyhow::R
         &QuotePolicy::claims_only(now),
     ) {
         Ok(claims) => claims,
-        Err(err) => return Ok(Outcome::Rejected(err.to_string())),
+        Err(err) => return Outcome::Rejected(err.to_string()),
+    };
+    let tcb_info = match parse_tcb_info(collateral) {
+        Ok(tcb_info) => tcb_info,
+        Err(err) => return Outcome::Rejected(err.to_string()),
     };
 
-    let report = *claims
-        .report
-        .as_td10()
-        .context("quote does not carry a TDX report")?;
-    let tcb_info = parse_tcb_info(collateral)?;
-    let shortfalls = shortfalls(&tcb_info, &claims.platform.pck, &report);
-
-    Ok(Outcome::Verified {
+    let shortfalls = shortfalls(&tcb_info, &claims.platform.pck, report);
+    Outcome::Verified {
         tcb_info,
         claims,
         shortfalls,
-    })
+    }
 }
 
-/// Every SVN that Intel's accepted levels put out of the platform's reach.
+/// Every SVN that keeps the platform off Intel's nearest accepted TCB level.
+///
+/// Explanatory only: the status already says whether the platform clears the
+/// bar, this says by how much it misses.
 fn shortfalls(tcb_info: &TcbInfo, pck: &PckIdentity, report: &TDReport10) -> Vec<Shortfall> {
-    let accepted: Vec<_> = tcb_info
-        .tcb_levels
-        .iter()
-        .filter(|level| level.tcb_status == TcbStatus::UpToDate)
-        .collect();
-    let short = |component: String, have: u16, needs: u16, remedy| {
-        (have < needs).then_some(Shortfall {
-            component,
-            have,
-            needs,
-            remedy,
-        })
-    };
-
     let (identity, module_svn) = tdx_module(&report.tee_tcb_svn);
     let module = identity.and_then(|identity| {
         let needs = accepted_module_svn(tcb_info, &identity)?;
-        short(
-            format!("TDX module {identity} ISV SVN"),
-            module_svn.into(),
-            needs.into(),
-            UPDATE_TDX_MODULE,
-        )
+        (module_svn < needs).then(|| Shortfall {
+            component: format!("TDX module {identity} ISV SVN"),
+            have: module_svn.into(),
+            needs: needs.into(),
+            remedy: UPDATE_TDX_MODULE,
+        })
     });
 
-    // `tee_tcb_svn` opens with the two module bytes, already handled above
-    let tdx = report
-        .tee_tcb_svn
+    // Matching is conjunctive per level: a platform is `UpToDate` only once some
+    // single level is cleared on every axis. Reporting the deficit against the
+    // nearest level gives a set that is actionable, where a per-axis minimum
+    // across levels could describe a level that does not exist.
+    let platform = tcb_info
+        .tcb_levels
         .iter()
+        .filter(|level| level.tcb_status == TcbStatus::UpToDate)
+        .map(|level| level_shortfalls(level, pck, report))
+        .min_by_key(|short| {
+            (
+                short.len(),
+                short
+                    .iter()
+                    .map(|s| u32::from(s.needs - s.have))
+                    .sum::<u32>(),
+            )
+        })
+        .unwrap_or_default();
+
+    module.into_iter().chain(platform).collect()
+}
+
+/// The platform-half SVNs one accepted level puts out of reach. Clearing all of
+/// them puts the platform on that level.
+///
+/// Mirrors the per-level predicate of the private `match_platform_tcb` in
+/// `dcap-qvl`'s `src/verify.rs`: a level is cleared only when PCESVN and every
+/// SGX and TDX component sit at or above it. The first two TDX components are
+/// the module's, so they carry the module remedy.
+fn level_shortfalls(level: &TcbLevel, pck: &PckIdentity, report: &TDReport10) -> Vec<Shortfall> {
+    let short = |component: String, have: u8, needs: u8, remedy| {
+        (have < needs).then_some(Shortfall {
+            component,
+            have: have.into(),
+            needs: needs.into(),
+            remedy,
+        })
+    };
+    let tdx = level
+        .tcb
+        .tdx_components
+        .iter()
+        .zip(report.tee_tcb_svn)
         .enumerate()
-        .skip(2)
-        .filter_map(|(index, have)| {
-            let needs = component_minimum(&accepted, index, |tcb| &tcb.tdx_components)?;
+        .filter_map(|(index, (needs, have))| {
+            let remedy = if index < 2 {
+                UPDATE_TDX_MODULE
+            } else {
+                UPDATE_BIOS
+            };
             short(
                 format!("TDX TCB component {index}"),
-                (*have).into(),
-                needs.into(),
+                have,
+                needs.svn,
+                remedy,
+            )
+        });
+    let sgx = level
+        .tcb
+        .sgx_components
+        .iter()
+        .zip(pck.cpu_svn)
+        .enumerate()
+        .filter_map(|(index, (needs, have))| {
+            short(
+                format!("SGX TCB component {index}"),
+                have,
+                needs.svn,
                 UPDATE_BIOS,
             )
         });
-    let sgx = pck.cpu_svn.iter().enumerate().filter_map(|(index, have)| {
-        let needs = component_minimum(&accepted, index, |tcb| &tcb.sgx_components)?;
-        short(
-            format!("SGX TCB component {index}"),
-            (*have).into(),
-            needs.into(),
-            UPDATE_BIOS,
-        )
+    let pce = (pck.pce_svn < level.tcb.pce_svn).then(|| Shortfall {
+        component: "PCESVN".to_owned(),
+        have: pck.pce_svn,
+        needs: level.tcb.pce_svn,
+        remedy: UPDATE_BIOS,
     });
-    let pce = accepted
-        .iter()
-        .map(|level| level.tcb.pce_svn)
-        .min()
-        .and_then(|needs| short("PCESVN".to_owned(), pck.pce_svn, needs, UPDATE_BIOS));
-
-    module
-        .into_iter()
-        .chain(tdx)
-        .chain(sgx)
-        .chain(pce)
-        .collect()
+    tdx.chain(sgx).chain(pce).collect()
 }
 
-/// The `TDX_xx` identity a quote is judged under, and its ISV SVN. A zero
-/// selector means it names none, and the base `tdxModule` entry applies.
+/// The TDX module a quote reports, read out of the first two `tee_tcb_svn`
+/// bytes: byte 1 selects which of Intel's `tdxModuleIdentities` entries the
+/// module is judged under, spelled `TDX_<byte in hex>`, and byte 0 is that
+/// module's ISV SVN. A zero selector means the quote names no identity, and
+/// Intel's base `tdxModule` entry applies instead.
 ///
 /// Mirrors the private `match_tdx_module_identity` in `dcap-qvl`'s
 /// `src/verify.rs`, which surfaces only the converged status, not these.
@@ -193,19 +251,6 @@ fn accepted_module_svn(tcb_info: &TcbInfo, identity: &str) -> Option<u8> {
         .iter()
         .filter(|level| level.tcb_status == TcbStatus::UpToDate)
         .map(|level| level.tcb.isvsvn)
-        .min()
-}
-
-fn component_minimum(
-    accepted: &[&TcbLevel],
-    index: usize,
-    components: impl Fn(&Tcb) -> &Vec<TcbComponents>,
-) -> Option<u8> {
-    accepted
-        .iter()
-        .map(|level| Some(components(&level.tcb).get(index)?.svn))
-        .collect::<Option<Vec<_>>>()?
-        .into_iter()
         .min()
 }
 
@@ -230,6 +275,14 @@ mod tests {
     use assert_matches::assert_matches;
     use test_utils::attestation::{TEST_PUBLIC_DATA_STRING, VALID_ATTESTATION_TIMESTAMP};
 
+    fn td_report(quote: &[u8]) -> TDReport10 {
+        *Quote::parse(quote)
+            .expect("fixture quote parses")
+            .report
+            .as_td10()
+            .expect("fixture is a TDX quote")
+    }
+
     fn served() -> (Vec<u8>, QuoteCollateralV3) {
         let static_data: StaticWebData =
             serde_json::from_str(TEST_PUBLIC_DATA_STRING).expect("fixture is valid StaticWebData");
@@ -243,9 +296,12 @@ mod tests {
 
     fn fixture_claims() -> QuoteClaims {
         let (quote, collateral) = served();
-        match evaluate(&quote, &collateral, VALID_ATTESTATION_TIMESTAMP)
-            .expect("evaluation should not error")
-        {
+        match evaluate(
+            &quote,
+            &td_report(&quote),
+            &collateral,
+            VALID_ATTESTATION_TIMESTAMP,
+        ) {
             Outcome::Verified { claims, .. } => claims,
             Outcome::Rejected(reason) => panic!("the fixture collateral should verify: {reason}"),
         }
@@ -281,8 +337,12 @@ mod tests {
         let (quote, collateral) = served();
 
         // When
-        let outcome = evaluate(&quote, &collateral, VALID_ATTESTATION_TIMESTAMP)
-            .expect("evaluation should not error");
+        let outcome = evaluate(
+            &quote,
+            &td_report(&quote),
+            &collateral,
+            VALID_ATTESTATION_TIMESTAMP,
+        );
 
         // Then
         let Outcome::Verified {
@@ -309,8 +369,12 @@ mod tests {
         let long_after_the_collateral_expired = VALID_ATTESTATION_TIMESTAMP + 365 * 24 * 60 * 60;
 
         // When
-        let outcome = evaluate(&quote, &collateral, long_after_the_collateral_expired)
-            .expect("evaluation should not error");
+        let outcome = evaluate(
+            &quote,
+            &td_report(&quote),
+            &collateral,
+            long_after_the_collateral_expired,
+        );
 
         // Then
         assert_matches!(outcome, Outcome::Rejected(_));
@@ -341,6 +405,35 @@ mod tests {
                 .iter()
                 .all(|shortfall| shortfall.have + 1 == shortfall.needs)
         );
+    }
+
+    #[test]
+    fn shortfalls__should_stay_within_one_level_when_several_are_accepted() {
+        // Given: two accepted levels the platform clears on different axes, so a
+        // per-axis minimum across them would clear both and report nothing.
+        let claims = fixture_claims();
+        let pck = &claims.platform.pck;
+        let report = claims.report.as_td10().expect("fixture is a TDX quote");
+        let mut tcb_info = parse_tcb_info(&served().1).expect("fixture TCB info parses");
+        let mut level_a = tcb_info.tcb_levels[0].clone();
+        level_a.tcb_status = TcbStatus::UpToDate;
+        level_a.tcb.sgx_components[0].svn = pck.cpu_svn[0] + 1;
+        level_a.tcb.pce_svn = pck.pce_svn - 1;
+        let mut level_b = level_a.clone();
+        level_b.tcb.sgx_components[0].svn = pck.cpu_svn[0] - 1;
+        level_b.tcb.pce_svn = pck.pce_svn + 1;
+        tcb_info.tcb_levels = vec![level_a, level_b];
+
+        // When
+        let shortfalls = shortfalls(&tcb_info, pck, report);
+
+        // Then: exactly one axis short, and it comes from a single level.
+        let named: Vec<_> = shortfalls
+            .iter()
+            .map(|shortfall| shortfall.component.as_str())
+            .collect();
+        assert_eq!(named.len(), 1, "reported {named:?}");
+        assert!(named == ["SGX TCB component 0"] || named == ["PCESVN"]);
     }
 
     #[test]

--- a/crates/attestation-cli/src/tcb_status.rs
+++ b/crates/attestation-cli/src/tcb_status.rs
@@ -1,0 +1,376 @@
+//! Where a node's platform stands against Intel's TCB requirements.
+//!
+//! Every verdict comes from [`dcap_qvl`], the same verification the contract
+//! runs; this module only chooses which collateral it runs against.
+
+use anyhow::{Context as _, bail};
+use attestation::attestation::DstackAttestation;
+use dcap_qvl::{
+    QuoteCollateralV3, Tcb, TcbComponents, TcbLevel, TcbStatus,
+    collateral::{CollateralClient, INTEL_PCS_URL},
+    policy::{PckIdentity, QuoteClaims, QuotePolicy},
+    quote::TDReport10,
+    tcb_info::TcbInfo,
+    verify::QuoteVerifier,
+};
+use mpc_attestation::attestation::Attestation;
+use mpc_attestation::dcap_conversions::collateral_into_dcap;
+use node_types::http_server::StaticWebData;
+
+const UPDATE_TDX_MODULE: &str = "update the TDX module (SEAM loader)";
+const UPDATE_BIOS: &str = "update BIOS/microcode";
+
+/// One security version number that Intel's accepted TCB level puts out of reach.
+#[derive(Debug)]
+pub struct Shortfall {
+    pub component: String,
+    pub have: u16,
+    pub needs: u16,
+    pub remedy: &'static str,
+}
+
+#[expect(clippy::large_enum_variant)]
+#[derive(Debug)]
+pub enum Outcome {
+    /// DCAP's verdict and the TCB info it was reached against. The platform's
+    /// own SVNs are in [`QuoteClaims`], under `platform.pck` and `report`.
+    Verified {
+        tcb_info: TcbInfo,
+        claims: QuoteClaims,
+        /// Empty when `UpToDate`, and when no level is accepted at all.
+        shortfalls: Vec<Shortfall>,
+    },
+    /// No status at all. Usually expired collateral in a long-running node's
+    /// boot-time snapshot.
+    Rejected(String),
+}
+
+pub struct Report {
+    /// What the node's own boot-time collateral says, which can lag by days.
+    pub served: Outcome,
+    /// What the contract decides today, against collateral fetched just now.
+    pub standard: Outcome,
+}
+
+impl Report {
+    pub fn is_up_to_date(&self) -> bool {
+        matches!(&self.standard, Outcome::Verified { claims, .. } if claims.tcb.status == TcbStatus::UpToDate)
+    }
+}
+
+pub async fn run(static_data: &StaticWebData) -> anyhow::Result<Report> {
+    let dstack = dstack_attestation(static_data)?;
+    let quote = &dstack.quote.0;
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .context("system clock is before the UNIX epoch")?
+        .as_secs();
+
+    // Fetched with no `update` parameter, exactly as the node does, so this is
+    // Intel's `standard` set: what the contract verifies against.
+    let standard = CollateralClient::with_default_http(INTEL_PCS_URL)
+        .context("building the Intel PCS client")?
+        .fetch(quote)
+        .await
+        .context("fetching collateral from Intel's PCS")?;
+
+    let served = collateral_into_dcap(dstack.collateral.clone());
+    Ok(Report {
+        served: evaluate(quote, &served, now)?,
+        standard: evaluate(quote, &standard, now)?,
+    })
+}
+
+fn evaluate(quote: &[u8], collateral: &QuoteCollateralV3, now: u64) -> anyhow::Result<Outcome> {
+    let claims = match QuoteVerifier::new_prod().verify_with_policy(
+        quote,
+        collateral,
+        now,
+        &QuotePolicy::claims_only(now),
+    ) {
+        Ok(claims) => claims,
+        Err(err) => return Ok(Outcome::Rejected(err.to_string())),
+    };
+
+    let report = *claims
+        .report
+        .as_td10()
+        .context("quote does not carry a TDX report")?;
+    let tcb_info = parse_tcb_info(collateral)?;
+    let shortfalls = shortfalls(&tcb_info, &claims.platform.pck, &report);
+
+    Ok(Outcome::Verified {
+        tcb_info,
+        claims,
+        shortfalls,
+    })
+}
+
+/// Every SVN that Intel's accepted levels put out of the platform's reach.
+fn shortfalls(tcb_info: &TcbInfo, pck: &PckIdentity, report: &TDReport10) -> Vec<Shortfall> {
+    let accepted: Vec<_> = tcb_info
+        .tcb_levels
+        .iter()
+        .filter(|level| level.tcb_status == TcbStatus::UpToDate)
+        .collect();
+    let short = |component: String, have: u16, needs: u16, remedy| {
+        (have < needs).then_some(Shortfall {
+            component,
+            have,
+            needs,
+            remedy,
+        })
+    };
+
+    let (identity, module_svn) = tdx_module(&report.tee_tcb_svn);
+    let module = identity.and_then(|identity| {
+        let needs = accepted_module_svn(tcb_info, &identity)?;
+        short(
+            format!("TDX module {identity} ISV SVN"),
+            module_svn.into(),
+            needs.into(),
+            UPDATE_TDX_MODULE,
+        )
+    });
+
+    // `tee_tcb_svn` opens with the two module bytes, already handled above
+    let tdx = report
+        .tee_tcb_svn
+        .iter()
+        .enumerate()
+        .skip(2)
+        .filter_map(|(index, have)| {
+            let needs = component_minimum(&accepted, index, |tcb| &tcb.tdx_components)?;
+            short(
+                format!("TDX TCB component {index}"),
+                (*have).into(),
+                needs.into(),
+                UPDATE_BIOS,
+            )
+        });
+    let sgx = pck.cpu_svn.iter().enumerate().filter_map(|(index, have)| {
+        let needs = component_minimum(&accepted, index, |tcb| &tcb.sgx_components)?;
+        short(
+            format!("SGX TCB component {index}"),
+            (*have).into(),
+            needs.into(),
+            UPDATE_BIOS,
+        )
+    });
+    let pce = accepted
+        .iter()
+        .map(|level| level.tcb.pce_svn)
+        .min()
+        .and_then(|needs| short("PCESVN".to_owned(), pck.pce_svn, needs, UPDATE_BIOS));
+
+    module
+        .into_iter()
+        .chain(tdx)
+        .chain(sgx)
+        .chain(pce)
+        .collect()
+}
+
+/// The `TDX_xx` identity a quote is judged under, and its ISV SVN. A zero
+/// selector means it names none, and the base `tdxModule` entry applies.
+///
+/// Mirrors the private `match_tdx_module_identity` in `dcap-qvl`'s
+/// `src/verify.rs`, which surfaces only the converged status, not these.
+pub fn tdx_module(tee_tcb_svn: &[u8; 16]) -> (Option<String>, u8) {
+    let [isv_svn, selector, ..] = *tee_tcb_svn;
+    (
+        (selector != 0).then(|| format!("TDX_{selector:02X}")),
+        isv_svn,
+    )
+}
+
+fn accepted_module_svn(tcb_info: &TcbInfo, identity: &str) -> Option<u8> {
+    tcb_info
+        .tdx_module_identities
+        .iter()
+        .find(|candidate| candidate.id.eq_ignore_ascii_case(identity))?
+        .tcb_levels
+        .iter()
+        .filter(|level| level.tcb_status == TcbStatus::UpToDate)
+        .map(|level| level.tcb.isvsvn)
+        .min()
+}
+
+fn component_minimum(
+    accepted: &[&TcbLevel],
+    index: usize,
+    components: impl Fn(&Tcb) -> &Vec<TcbComponents>,
+) -> Option<u8> {
+    accepted
+        .iter()
+        .map(|level| Some(components(&level.tcb).get(index)?.svn))
+        .collect::<Option<Vec<_>>>()?
+        .into_iter()
+        .min()
+}
+
+fn dstack_attestation(static_data: &StaticWebData) -> anyhow::Result<&DstackAttestation> {
+    match &static_data.tee_participant_info {
+        Some(Attestation::Dstack(dstack)) => Ok(dstack),
+        Some(Attestation::Mock(_)) => {
+            bail!("the node serves a Mock attestation, which carries no TCB status")
+        }
+        None => bail!("the node serves no attestation, so it is not running in a TEE"),
+    }
+}
+
+fn parse_tcb_info(collateral: &QuoteCollateralV3) -> anyhow::Result<TcbInfo> {
+    serde_json::from_str(&collateral.tcb_info).context("parsing the collateral's TCB info")
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::*;
+    use assert_matches::assert_matches;
+    use test_utils::attestation::{TEST_PUBLIC_DATA_STRING, VALID_ATTESTATION_TIMESTAMP};
+
+    fn served() -> (Vec<u8>, QuoteCollateralV3) {
+        let static_data: StaticWebData =
+            serde_json::from_str(TEST_PUBLIC_DATA_STRING).expect("fixture is valid StaticWebData");
+        let dstack =
+            dstack_attestation(&static_data).expect("fixture carries a Dstack attestation");
+        (
+            dstack.quote.0.clone(),
+            collateral_into_dcap(dstack.collateral.clone()),
+        )
+    }
+
+    fn fixture_claims() -> QuoteClaims {
+        let (quote, collateral) = served();
+        match evaluate(&quote, &collateral, VALID_ATTESTATION_TIMESTAMP)
+            .expect("evaluation should not error")
+        {
+            Outcome::Verified { claims, .. } => claims,
+            Outcome::Rejected(reason) => panic!("the fixture collateral should verify: {reason}"),
+        }
+    }
+
+    /// Demands one more than the fixture platform reports, on every axis.
+    fn demanding_tcb_info(pck: &PckIdentity, report: &TDReport10) -> TcbInfo {
+        let mut tcb_info = parse_tcb_info(&served().1).expect("fixture TCB info parses");
+        let level = tcb_info
+            .tcb_levels
+            .first_mut()
+            .expect("fixture TCB info has a level");
+        level.tcb_status = TcbStatus::UpToDate;
+        level.tcb.pce_svn = pck.pce_svn + 1;
+        for (component, have) in level.tcb.tdx_components.iter_mut().zip(report.tee_tcb_svn) {
+            component.svn = have + 1;
+        }
+        for (component, have) in level.tcb.sgx_components.iter_mut().zip(pck.cpu_svn) {
+            component.svn = have + 1;
+        }
+        for identity in &mut tcb_info.tdx_module_identities {
+            for level in &mut identity.tcb_levels {
+                level.tcb_status = TcbStatus::UpToDate;
+                level.tcb.isvsvn = tdx_module(&report.tee_tcb_svn).1 + 1;
+            }
+        }
+        tcb_info
+    }
+
+    #[test]
+    fn evaluate__should_report_the_platform_the_quote_describes() {
+        // Given
+        let (quote, collateral) = served();
+
+        // When
+        let outcome = evaluate(&quote, &collateral, VALID_ATTESTATION_TIMESTAMP)
+            .expect("evaluation should not error");
+
+        // Then
+        let Outcome::Verified {
+            claims, shortfalls, ..
+        } = outcome
+        else {
+            panic!("the fixture collateral should verify");
+        };
+        let report = claims.report.as_td10().expect("fixture is a TDX quote");
+        assert_eq!(hex::encode_upper(claims.platform.pck.fmspc), "B0C06F000000");
+        assert_eq!(
+            tdx_module(&report.tee_tcb_svn),
+            (Some("TDX_01".to_owned()), 11)
+        );
+        assert_eq!(claims.platform.pck.pce_svn, 11);
+        assert_eq!(claims.tcb.status, TcbStatus::UpToDate);
+        assert!(shortfalls.is_empty());
+    }
+
+    #[test]
+    fn evaluate__should_reject_collateral_that_has_expired() {
+        // Given
+        let (quote, collateral) = served();
+        let long_after_the_collateral_expired = VALID_ATTESTATION_TIMESTAMP + 365 * 24 * 60 * 60;
+
+        // When
+        let outcome = evaluate(&quote, &collateral, long_after_the_collateral_expired)
+            .expect("evaluation should not error");
+
+        // Then
+        assert_matches!(outcome, Outcome::Rejected(_));
+    }
+
+    #[test]
+    fn shortfalls__should_name_every_svn_the_accepted_level_puts_out_of_reach() {
+        // Given
+        let claims = fixture_claims();
+        let pck = &claims.platform.pck;
+        let report = claims.report.as_td10().expect("fixture is a TDX quote");
+        let tcb_info = demanding_tcb_info(pck, report);
+
+        // When
+        let shortfalls = shortfalls(&tcb_info, pck, report);
+
+        // Then
+        let named: Vec<_> = shortfalls
+            .iter()
+            .map(|shortfall| shortfall.component.as_str())
+            .collect();
+        assert!(named.contains(&"TDX module TDX_01 ISV SVN"));
+        assert!(named.contains(&"TDX TCB component 2"));
+        assert!(named.contains(&"SGX TCB component 0"));
+        assert!(named.contains(&"PCESVN"));
+        assert!(
+            shortfalls
+                .iter()
+                .all(|shortfall| shortfall.have + 1 == shortfall.needs)
+        );
+    }
+
+    #[test]
+    fn shortfalls__should_be_empty_when_the_platform_clears_the_bar() {
+        // Given
+        let claims = fixture_claims();
+        let tcb_info = parse_tcb_info(&served().1).unwrap();
+
+        // When
+        let shortfalls = shortfalls(
+            &tcb_info,
+            &claims.platform.pck,
+            claims.report.as_td10().expect("fixture is a TDX quote"),
+        );
+
+        // Then
+        assert!(shortfalls.is_empty());
+    }
+
+    #[test]
+    fn tdx_module__should_name_no_identity_when_the_quote_selects_none() {
+        // Given
+        let mut tee_tcb_svn = [0u8; 16];
+        tee_tcb_svn[0] = 11;
+
+        // When
+        let (identity, isv_svn) = tdx_module(&tee_tcb_svn);
+
+        // Then
+        assert_eq!(identity, None);
+        assert_eq!(isv_svn, 11);
+    }
+}

--- a/crates/attestation-cli/src/tcb_status.rs
+++ b/crates/attestation-cli/src/tcb_status.rs
@@ -15,8 +15,7 @@ use dcap_qvl::{
     tcb_info::TcbInfo,
     verify::QuoteVerifier,
 };
-use mpc_attestation::attestation::Attestation;
-use mpc_attestation::dcap_conversions::collateral_into_dcap;
+use mpc_attestation::{attestation::Attestation, dcap_conversions::collateral_into_dcap};
 use node_types::http_server::StaticWebData;
 
 /// Whole-fetch bound on the Intel PCS call. `with_default_http` builds a reqwest
@@ -39,7 +38,7 @@ pub struct Shortfall {
 
 #[expect(clippy::large_enum_variant)]
 #[derive(Debug)]
-pub enum Outcome {
+pub enum TcbVerdict {
     /// DCAP's verdict and the TCB info it was reached against. The platform's
     /// own SVNs are in [`QuoteClaims`], under `platform.pck` and `report`.
     Verified {
@@ -54,19 +53,26 @@ pub enum Outcome {
 }
 
 pub struct Report {
+    /// Parsed from the quote itself, so the platform's own numbers survive even
+    /// when neither collateral verifies.
+    pub td_report: TDReport10,
     /// What the node's own boot-time collateral says, which can lag by days.
-    pub served: Outcome,
+    pub served: TcbVerdict,
     /// What the contract decides today, against collateral fetched just now.
-    pub standard: Outcome,
+    pub standard: TcbVerdict,
 }
 
 impl Report {
     pub fn is_up_to_date(&self) -> bool {
-        matches!(&self.standard, Outcome::Verified { claims, .. } if claims.tcb.status == TcbStatus::UpToDate)
+        matches!(&self.standard, TcbVerdict::Verified { claims, .. } if claims.tcb.status == TcbStatus::UpToDate)
     }
 }
 
-pub async fn run(static_data: &StaticWebData) -> anyhow::Result<Report> {
+/// `as_of` overrides the evaluation timestamp for collateral validity windows.
+/// Intel serves only current collateral, so it makes the served row readable for
+/// a saved quote whose snapshot has expired, and leaves the Intel row a
+/// present-day verdict evaluated at a past instant.
+pub async fn run(static_data: &StaticWebData, as_of: Option<u64>) -> anyhow::Result<Report> {
     let dstack = dstack_attestation(static_data)?;
     let quote = &dstack.quote.0;
     // A property of the quote, so it decides both rows at once rather than
@@ -76,37 +82,49 @@ pub async fn run(static_data: &StaticWebData) -> anyhow::Result<Report> {
         .report
         .as_td10()
         .context("the node's quote does not carry a TDX report")?;
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .context("system clock is before the UNIX epoch")?
-        .as_secs();
-
-    // Fetched with no `update` parameter, like the node, so this is Intel's
-    // `standard` set: what the contract will decide at the next re-attestation.
-    // The node reaches it through its PCCS, so the two can differ in cache
-    // freshness.
-    let client = CollateralClient::with_default_http(INTEL_PCS_URL)
-        .context("building the Intel PCS client")?;
-    let standard = tokio::time::timeout(PCS_TIMEOUT, client.fetch(quote))
-        .await
-        .with_context(|| format!("Intel's PCS did not respond within {PCS_TIMEOUT:?}"))?
-        .context("fetching collateral from Intel's PCS")?;
+    let now = match as_of {
+        Some(timestamp) => timestamp,
+        None => std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .context("system clock is before the UNIX epoch")?
+            .as_secs(),
+    };
 
     let served = collateral_into_dcap(dstack.collateral.clone());
+    // An unreachable PCS must not cost the operator the served row, which needs
+    // no network at all.
+    let standard = match fetch_standard(quote).await {
+        Ok(collateral) => evaluate(quote, &report, &collateral, now),
+        Err(err) => TcbVerdict::Rejected(format!("{err:#}")),
+    };
     Ok(Report {
+        td_report: report,
         served: evaluate(quote, &report, &served, now),
-        standard: evaluate(quote, &report, &standard, now),
+        standard,
     })
 }
 
-/// Both failure modes are per-collateral, so each becomes a [`Outcome::Rejected`]
+/// Fetched with no `update` parameter, like the node, so this is Intel's
+/// `standard` set: what the contract will decide at the next re-attestation.
+/// The node reaches it through its PCCS, so the two can differ in cache
+/// freshness.
+async fn fetch_standard(quote: &[u8]) -> anyhow::Result<QuoteCollateralV3> {
+    let client = CollateralClient::with_default_http(INTEL_PCS_URL)
+        .context("building the Intel PCS client")?;
+    tokio::time::timeout(PCS_TIMEOUT, client.fetch(quote))
+        .await
+        .with_context(|| format!("Intel's PCS did not respond within {PCS_TIMEOUT:?}"))?
+        .context("fetching collateral from Intel's PCS")
+}
+
+/// Both failure modes are per-collateral, so each becomes a [`TcbVerdict::Rejected`]
 /// row rather than aborting the other one.
 fn evaluate(
     quote: &[u8],
     report: &TDReport10,
     collateral: &QuoteCollateralV3,
     now: u64,
-) -> Outcome {
+) -> TcbVerdict {
     let claims = match QuoteVerifier::new_prod().verify_with_policy(
         quote,
         collateral,
@@ -114,15 +132,15 @@ fn evaluate(
         &QuotePolicy::claims_only(now),
     ) {
         Ok(claims) => claims,
-        Err(err) => return Outcome::Rejected(err.to_string()),
+        Err(err) => return TcbVerdict::Rejected(err.to_string()),
     };
     let tcb_info = match parse_tcb_info(collateral) {
         Ok(tcb_info) => tcb_info,
-        Err(err) => return Outcome::Rejected(err.to_string()),
+        Err(err) => return TcbVerdict::Rejected(err.to_string()),
     };
 
     let shortfalls = shortfalls(&tcb_info, &claims.platform.pck, report);
-    Outcome::Verified {
+    TcbVerdict::Verified {
         tcb_info,
         claims,
         shortfalls,
@@ -302,8 +320,10 @@ mod tests {
             &collateral,
             VALID_ATTESTATION_TIMESTAMP,
         ) {
-            Outcome::Verified { claims, .. } => claims,
-            Outcome::Rejected(reason) => panic!("the fixture collateral should verify: {reason}"),
+            TcbVerdict::Verified { claims, .. } => claims,
+            TcbVerdict::Rejected(reason) => {
+                panic!("the fixture collateral should verify: {reason}")
+            }
         }
     }
 
@@ -337,7 +357,7 @@ mod tests {
         let (quote, collateral) = served();
 
         // When
-        let outcome = evaluate(
+        let verdict = evaluate(
             &quote,
             &td_report(&quote),
             &collateral,
@@ -345,9 +365,9 @@ mod tests {
         );
 
         // Then
-        let Outcome::Verified {
+        let TcbVerdict::Verified {
             claims, shortfalls, ..
-        } = outcome
+        } = verdict
         else {
             panic!("the fixture collateral should verify");
         };
@@ -369,7 +389,7 @@ mod tests {
         let long_after_the_collateral_expired = VALID_ATTESTATION_TIMESTAMP + 365 * 24 * 60 * 60;
 
         // When
-        let outcome = evaluate(
+        let verdict = evaluate(
             &quote,
             &td_report(&quote),
             &collateral,
@@ -377,7 +397,7 @@ mod tests {
         );
 
         // Then
-        assert_matches!(outcome, Outcome::Rejected(_));
+        assert_matches!(verdict, TcbVerdict::Rejected(_));
     }
 
     #[test]

--- a/crates/attestation-cli/src/verify.rs
+++ b/crates/attestation-cli/src/verify.rs
@@ -13,7 +13,7 @@ use mpc_primitives::hash::{LauncherDockerComposeHash, NodeImageHash};
 use node_types::http_server::StaticWebData;
 use sha2::{Digest, Sha256};
 
-use crate::cli::Cli;
+use crate::cli::VerifyArgs;
 
 const KEY_PROVIDER_EVENT: &str = "key-provider";
 
@@ -31,19 +31,19 @@ pub struct VerificationResult {
 
 pub fn run_verification(
     static_data: &StaticWebData,
-    cli: &Cli,
+    args: &VerifyArgs,
 ) -> Result<VerificationResult, VerificationError> {
     let current_timestamp = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .expect("system clock before UNIX epoch")
         .as_secs();
 
-    verify_at_timestamp(static_data, cli, current_timestamp)
+    verify_at_timestamp(static_data, args, current_timestamp)
 }
 
 pub fn verify_at_timestamp(
     static_data: &StaticWebData,
-    cli: &Cli,
+    args: &VerifyArgs,
     timestamp_seconds: u64,
 ) -> Result<VerificationResult, VerificationError> {
     let attestation = static_data.tee_participant_info.as_ref().ok_or_else(|| {
@@ -61,12 +61,12 @@ pub fn verify_at_timestamp(
 
     // Compute allowed compose hash from the launcher compose file
     let allowed_compose_hash =
-        compute_allowed_compose_hash(&cli.launcher_compose_file).map_err(|e| {
+        compute_allowed_compose_hash(&args.launcher_compose_file).map_err(|e| {
             VerificationError::Custom(format!("failed to read launcher compose file: {e}"))
         })?;
 
     // Load measurements (custom file or compiled-in defaults)
-    let measurements = load_measurements(&cli.expected_measurements).map_err(|e| {
+    let measurements = load_measurements(&args.expected_measurements).map_err(|e| {
         VerificationError::Custom(format!("failed to load expected measurements: {e}"))
     })?;
 
@@ -77,7 +77,7 @@ pub fn verify_at_timestamp(
     } = attestation.verify_locally(
         report_data.into(),
         timestamp_seconds,
-        &cli.allowed_image_hashes,
+        &args.allowed_image_hashes,
         &[allowed_compose_hash],
         &measurements,
     )?;

--- a/crates/attestation-cli/tests/test_verification.rs
+++ b/crates/attestation-cli/tests/test_verification.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use attestation_cli::cli::Cli;
+use attestation_cli::cli::{Source, VerifyArgs};
 use attestation_cli::verify;
 use mpc_attestation::attestation::{Attestation, DEFAULT_EXPIRATION_DURATION_SECONDS};
 use near_mpc_crypto_types::Ed25519PublicKey;
@@ -19,14 +19,16 @@ fn make_static_web_data(attestation: Attestation) -> StaticWebData {
     }
 }
 
-fn make_cli(
+fn make_args(
     compose_path: &std::path::Path,
     image_hash: &str,
     measurements: Option<PathBuf>,
-) -> Cli {
-    Cli {
-        url: None,
-        file: None,
+) -> VerifyArgs {
+    VerifyArgs {
+        source: Source {
+            url: None,
+            file: None,
+        },
         allowed_image_hashes: vec![image_hash.parse().expect("valid image hash hex")],
         launcher_compose_file: compose_path.to_path_buf(),
         expected_measurements: measurements,
@@ -43,9 +45,9 @@ fn full_verification_succeeds_with_valid_attestation() {
     let compose_path = dir.path().join("launcher-compose.yaml");
     std::fs::write(&compose_path, TEST_LAUNCHER_IMAGE_COMPOSE_STRING).unwrap();
 
-    let cli = make_cli(&compose_path, TEST_MPC_IMAGE_DIGEST_HEX, None);
+    let args = make_args(&compose_path, TEST_MPC_IMAGE_DIGEST_HEX, None);
 
-    let result = verify::verify_at_timestamp(&static_data, &cli, VALID_ATTESTATION_TIMESTAMP);
+    let result = verify::verify_at_timestamp(&static_data, &args, VALID_ATTESTATION_TIMESTAMP);
 
     assert!(
         result.is_ok(),
@@ -70,9 +72,9 @@ fn verification_fails_with_wrong_image_hash() {
     std::fs::write(&compose_path, TEST_LAUNCHER_IMAGE_COMPOSE_STRING).unwrap();
 
     let wrong_hash = "0000000000000000000000000000000000000000000000000000000000000000";
-    let cli = make_cli(&compose_path, wrong_hash, None);
+    let args = make_args(&compose_path, wrong_hash, None);
 
-    let result = verify::verify_at_timestamp(&static_data, &cli, VALID_ATTESTATION_TIMESTAMP);
+    let result = verify::verify_at_timestamp(&static_data, &args, VALID_ATTESTATION_TIMESTAMP);
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -91,9 +93,9 @@ fn verification_fails_with_wrong_compose_file() {
     let compose_path = dir.path().join("launcher-compose.yaml");
     std::fs::write(&compose_path, "wrong compose content").unwrap();
 
-    let cli = make_cli(&compose_path, TEST_MPC_IMAGE_DIGEST_HEX, None);
+    let args = make_args(&compose_path, TEST_MPC_IMAGE_DIGEST_HEX, None);
 
-    let result = verify::verify_at_timestamp(&static_data, &cli, VALID_ATTESTATION_TIMESTAMP);
+    let result = verify::verify_at_timestamp(&static_data, &args, VALID_ATTESTATION_TIMESTAMP);
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
@@ -116,13 +118,13 @@ fn run_verification_rejects_none_attestation() {
     let compose_path = dir.path().join("launcher-compose.yaml");
     std::fs::write(&compose_path, "content").unwrap();
 
-    let cli = make_cli(
+    let args = make_args(
         &compose_path,
         "0000000000000000000000000000000000000000000000000000000000000000",
         None,
     );
 
-    let result = verify::run_verification(&static_data, &cli);
+    let result = verify::run_verification(&static_data, &args);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(
@@ -146,13 +148,13 @@ fn run_verification_rejects_mock_attestation() {
     let compose_path = dir.path().join("launcher-compose.yaml");
     std::fs::write(&compose_path, "content").unwrap();
 
-    let cli = make_cli(
+    let args = make_args(
         &compose_path,
         "0000000000000000000000000000000000000000000000000000000000000000",
         None,
     );
 
-    let result = verify::run_verification(&static_data, &cli);
+    let result = verify::run_verification(&static_data, &args);
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
     assert!(err.contains("Mock"), "unexpected error: {err}");
@@ -175,13 +177,13 @@ fn verification_with_custom_measurements_file() {
     )
     .unwrap();
 
-    let cli = make_cli(
+    let args = make_args(
         &compose_path,
         TEST_MPC_IMAGE_DIGEST_HEX,
         Some(measurements_path),
     );
 
-    let result = verify::verify_at_timestamp(&static_data, &cli, VALID_ATTESTATION_TIMESTAMP);
+    let result = verify::verify_at_timestamp(&static_data, &args, VALID_ATTESTATION_TIMESTAMP);
 
     assert!(
         result.is_ok(),

--- a/docs/running-an-mpc-node-in-tdx-external-guide.md
+++ b/docs/running-an-mpc-node-in-tdx-external-guide.md
@@ -1349,7 +1349,7 @@ cargo install --path crates/attestation-cli
 **Online mode** — fetch and verify directly from the node:
 
 ```bash
-attestation-cli \
+attestation-cli verify \
   --url http://<IP>:8080/public_data \
   --allowed-image-hash <IMAGE_HASH> \
   --launcher-compose-file launcher_docker_compose.yaml
@@ -1362,7 +1362,7 @@ attestation-cli \
 curl -o public_data.json http://<IP>:8080/public_data
 
 # Verify from the saved file
-attestation-cli \
+attestation-cli verify \
   --file public_data.json \
   --allowed-image-hash <IMAGE_HASH> \
   --launcher-compose-file launcher_docker_compose.yaml


### PR DESCRIPTION
Closes #4226

This is how the output looks:

```
❯ cargo run -p attestation-cli -- tcb-status --url http://91.134.92.20:8080/public_data
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/attestation-cli tcb-status --url 'http://91.134.92.20:8080/public_data'`
=== MPC Node Platform TCB Status ===

--- Platform, as the quote reports it ---
FMSPC:                  B0C06F000000
tee_tcb_svn:            07010300000000000000000000000000
TDX module:             TDX_01 at ISV SVN 7
TDX TCB components:     [7, 1, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
SGX TCB components:     [3, 3, 2, 2, 4, 1, 0, 5, 0, 0, 0, 0, 0, 0, 0, 0]
PCESVN:                 11

--- served by the node: TCB recovery set 19, issued 2026-08-07T00:44:20Z ---
Status:                 UpToDate

--- Intel `standard`: TCB recovery set 20, issued 2026-08-24T14:06:46Z ---
Status:                 OutOfDate
Advisory IDs:           INTEL-SA-01192, INTEL-SA-01245, INTEL-SA-01312, INTEL-SA-01313
  TDX module TDX_01 ISV SVN is 7, needs 11 -> update the TDX module (SEAM loader)
  TDX TCB component 2 is 3, needs 4 -> update BIOS/microcode
  SGX TCB component 0 is 3, needs 4 -> update BIOS/microcode
  SGX TCB component 1 is 3, needs 4 -> update BIOS/microcode
Error: platform TCB check failed


❯ cargo run -p attestation-cli -- tcb-status --url http://multichain-testnet-01.staking4all.org:8080/public_data
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.18s
     Running `target/debug/attestation-cli tcb-status --url 'http://multichain-testnet-01.staking4all.org:8080/public_data'`
=== MPC Node Platform TCB Status ===

--- Platform, as the quote reports it ---
FMSPC:                  00A06D080000
tee_tcb_svn:            07030600000000000000000000000000
TDX module:             TDX_03 at ISV SVN 7
TDX TCB components:     [7, 3, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
SGX TCB components:     [4, 4, 2, 2, 4, 1, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]
PCESVN:                 13

--- served by the node: TCB recovery set 20, issued 2026-08-18T00:44:59Z ---
Status:                 UpToDate

--- Intel `standard`: TCB recovery set 20, issued 2026-08-24T13:49:58Z ---
Status:                 UpToDate
```