### PR TITLE
feat: Accept foreign chain requests based on available chain

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11904,6 +11904,7 @@ dependencies = [
  "hex",
  "mpc-attestation",
  "mpc-primitives",
+ "near-mpc-bounded-collections",
  "near-mpc-contract-interface",
  "near-sdk",
  "serde_json",

--- a/crates/contract/src/api/foreign_chain.rs
+++ b/crates/contract/src/api/foreign_chain.rs
@@ -649,6 +649,27 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Requested foreign chain, Bitcoin, is not available.")]
+    fn verify_foreign_tx__should_reject_whitelisted_chain_covered_by_fewer_than_threshold() {
+        // Given: 4 participants, ForeignTx reconstruction threshold 3; only 2 cover Bitcoin.
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, _sk) =
+            basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
+        whitelist_chain(&mut contract, dtos::ForeignChain::Bitcoin);
+        for account_id in participant_account_ids(&contract).iter().take(2) {
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
+        }
+        testing_env!(context.clone());
+
+        // When
+        contract.verify_foreign_transaction(bitcoin_request_args());
+    }
+
+    #[test]
     fn verify_foreign_tx__should_accept_chain_covered_by_threshold_of_participants() {
         // Given: 4 participants, ForeignTx reconstruction threshold 3; only 3 cover Bitcoin.
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);

--- a/crates/contract/src/api/foreign_chain.rs
+++ b/crates/contract/src/api/foreign_chain.rs
@@ -625,7 +625,61 @@ mod tests {
         testing_env!(context.clone());
 
         // When - requesting Bitcoin which is not in the policy
-        contract.verify_foreign_transaction(VerifyForeignTransactionRequestArgs {
+        contract.verify_foreign_transaction(bitcoin_request_args());
+    }
+
+    #[test]
+    #[should_panic(expected = "Requested foreign chain, Bitcoin, is not available.")]
+    fn verify_foreign_tx__should_reject_chain_covered_by_all_participants_but_not_whitelisted() {
+        // Given
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, _sk) =
+            basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
+        for account_id in participant_account_ids(&contract) {
+            register_foreign_chains_config_for(
+                &mut contract,
+                &account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
+        }
+        testing_env!(context.clone());
+
+        // When
+        contract.verify_foreign_transaction(bitcoin_request_args());
+    }
+
+    #[test]
+    fn verify_foreign_tx__should_accept_chain_covered_by_threshold_of_participants() {
+        // Given: 4 participants, ForeignTx reconstruction threshold 3; only 3 cover Bitcoin.
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, _sk) =
+            basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
+        whitelist_chain(&mut contract, dtos::ForeignChain::Bitcoin);
+        for account_id in participant_account_ids(&contract).iter().take(3) {
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
+        }
+        testing_env!(context.clone());
+        let request_args = bitcoin_request_args();
+        let request = args_into_verify_foreign_tx_request(request_args.clone());
+
+        // When
+        contract.verify_foreign_transaction(request_args);
+
+        // Then
+        assert!(
+            contract
+                .pending_verify_foreign_tx_requests
+                .get(&request)
+                .is_some()
+        );
+    }
+
+    fn bitcoin_request_args() -> VerifyForeignTransactionRequestArgs {
+        VerifyForeignTransactionRequestArgs {
             domain_id: DomainId::default().0.into(),
             payload_version: ForeignTxPayloadVersion::V1,
             expected_payload_hash: None,
@@ -634,6 +688,6 @@ mod tests {
                 confirmations: 2.into(),
                 extractors: vec![BitcoinExtractor::BlockHash],
             }),
-        });
+        }
     }
 }

--- a/crates/contract/src/api/foreign_chain.rs
+++ b/crates/contract/src/api/foreign_chain.rs
@@ -49,10 +49,10 @@ impl MpcContract {
         );
 
         let requested_chain = request.request.chain();
-        let supported_chains = self.get_supported_foreign_chains();
-        if !supported_chains.contains(&requested_chain) {
+        let available_chains = self.get_available_foreign_chains();
+        if !available_chains.contains(&requested_chain) {
             env::panic_str(
-                &InvalidParameters::ForeignChainNotSupported {
+                &InvalidParameters::ForeignChainNotAvailable {
                     requested: requested_chain,
                 }
                 .to_string(),
@@ -200,17 +200,16 @@ impl MpcContract {
 mod tests {
     use super::*;
     use crate::api::test_utils::{
-        SharedSecretKey, basic_setup_with_protocol, with_active_participant_and_attested_context,
+        SharedSecretKey, basic_setup_with_protocol, participant_account_ids,
+        register_foreign_chains_config_for, whitelist_chain,
+        with_active_participant_and_attested_context,
     };
-
-    use crate::state::key_event::tests::Environment;
 
     use assert_matches::assert_matches;
     use dtos::{DomainId, ForeignTxSignPayload, Protocol};
     use k256::ecdsa::SigningKey;
     use k256::{self, Secp256k1, elliptic_curve};
 
-    use near_mpc_bounded_collections::NonEmptyBTreeSet;
     use near_mpc_contract_interface::types::{
         BitcoinExtractedValue, BitcoinExtractor, BitcoinRpcRequest, ExtractedValue,
         ForeignTxPayloadVersion, ForeignTxSignPayloadV1,
@@ -220,40 +219,20 @@ mod tests {
     use rand::SeedableRng;
 
     use rstest::rstest;
-    use std::collections::BTreeMap;
     use std::panic;
     use std::str::FromStr;
 
-    /// Register the given foreign chains as supported by all active participants.
-    fn register_supported_chains(
+    /// Whitelists the chains and registers them for all participants, making them available.
+    fn make_chains_available(
         contract: &mut MpcContract,
         chains: impl IntoIterator<Item = dtos::ForeignChain>,
     ) {
-        let foreign_chain_configuration: dtos::ForeignChainConfiguration = chains
-            .into_iter()
-            .map(|foreign_chain| {
-                (
-                    foreign_chain,
-                    NonEmptyBTreeSet::new(dtos::RpcProvider {
-                        rpc_url: "dummy_url.com".to_string(),
-                    }),
-                )
-            })
-            .collect::<BTreeMap<dtos::ForeignChain, NonEmptyBTreeSet<dtos::RpcProvider>>>()
-            .into();
-
-        let participants: Vec<_> = contract
-            .protocol_state
-            .active_participants()
-            .participants()
-            .iter()
-            .map(|(account_id, _, _)| account_id.clone())
-            .collect();
-        for account_id in participants {
-            let _env = Environment::new(None, Some(account_id), None);
-            contract
-                .register_foreign_chain_config(foreign_chain_configuration.clone())
-                .expect("register should succeed");
+        let chains: Vec<_> = chains.into_iter().collect();
+        for chain in &chains {
+            whitelist_chain(contract, *chain);
+        }
+        for account_id in participant_account_ids(contract) {
+            register_foreign_chains_config_for(contract, &account_id, chains.iter().copied());
         }
     }
 
@@ -263,7 +242,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
         let (context, mut contract, secret_key) =
             basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
-        register_supported_chains(&mut contract, [dtos::ForeignChain::Bitcoin]);
+        make_chains_available(&mut contract, [dtos::ForeignChain::Bitcoin]);
         let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
             unreachable!();
         };
@@ -356,7 +335,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
         let (context, mut contract, secret_key) =
             basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
-        register_supported_chains(&mut contract, [dtos::ForeignChain::Bitcoin]);
+        make_chains_available(&mut contract, [dtos::ForeignChain::Bitcoin]);
         testing_env!(context.clone());
         let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
             unreachable!();
@@ -414,7 +393,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
         let (context, mut contract, secret_key) =
             basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
-        register_supported_chains(&mut contract, [dtos::ForeignChain::Bitcoin]);
+        make_chains_available(&mut contract, [dtos::ForeignChain::Bitcoin]);
         testing_env!(context.clone());
         let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
             unreachable!();
@@ -462,7 +441,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
         let (context, mut contract, secret_key) =
             basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
-        register_supported_chains(&mut contract, [dtos::ForeignChain::Bitcoin]);
+        make_chains_available(&mut contract, [dtos::ForeignChain::Bitcoin]);
         testing_env!(context.clone());
         let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
             unreachable!();
@@ -505,7 +484,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
         let (context, mut contract, secret_key) =
             basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
-        register_supported_chains(&mut contract, [dtos::ForeignChain::Bitcoin]);
+        make_chains_available(&mut contract, [dtos::ForeignChain::Bitcoin]);
         testing_env!(context.clone());
         let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
             unreachable!();
@@ -577,7 +556,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
         let (context, mut contract, _secret_key) =
             basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
-        register_supported_chains(&mut contract, [dtos::ForeignChain::Bitcoin]);
+        make_chains_available(&mut contract, [dtos::ForeignChain::Bitcoin]);
         testing_env!(context.clone());
         let request_args = VerifyForeignTransactionRequestArgs {
             domain_id: DomainId::default().0.into(),
@@ -636,14 +615,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "Requested foreign chain, Bitcoin, is not supported.")]
+    #[should_panic(expected = "Requested foreign chain, Bitcoin, is not available.")]
     fn verify_foreign_tx__should_reject_chain_not_in_policy() {
         // Given
         let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
         let (context, mut contract, _sk) =
             basic_setup_with_protocol(Protocol::CaitSith, DomainPurpose::ForeignTx, &mut rng);
-        // Supported chains has Solana but not Bitcoin
-        register_supported_chains(&mut contract, [dtos::ForeignChain::Solana]);
+        make_chains_available(&mut contract, [dtos::ForeignChain::Solana]);
         testing_env!(context.clone());
 
         // When - requesting Bitcoin which is not in the policy

--- a/crates/contract/src/api/foreign_chain_support.rs
+++ b/crates/contract/src/api/foreign_chain_support.rs
@@ -21,9 +21,8 @@ impl MpcContract {
     /// set); panics in [`NotInitialized`](ProtocolContractState::NotInitialized) or when the caller is not a participant. Entries for
     /// accounts that are no longer participants are pruned after resharing by
     /// [`Self::clean_foreign_chain_data`].
-    #[deprecated(
-        note = "superseded by register_foreign_chains_config; feeds only the legacy get_supported_foreign_chains view (https://github.com/near/mpc/issues/3434)"
-    )]
+    #[deprecated(note = "TODO(#3630): drop this. This is superseded by
+        register_foreign_chains_config, and feeds only the legacy get_supported_foreign_chains")]
     #[handle_result]
     pub fn register_foreign_chain_support(
         &mut self,
@@ -114,7 +113,7 @@ impl MpcContract {
     }
 
     #[deprecated(
-        note = "https://github.com/near/mpc/issues/3079. Nodes register via register_foreign_chains_config instead"
+        note = "TODO(#3630): drop this. Nodes register via register_foreign_chains_config instead"
     )]
     #[expect(deprecated)]
     #[handle_result]
@@ -243,7 +242,7 @@ impl MpcContract {
     }
 
     #[deprecated(
-        note = "superseded by get_available_foreign_chains, which gates verify_foreign_transaction (https://github.com/near/mpc/issues/3434)"
+        note = "TODO(#3630): drop this. It's superseded by get_available_foreign_chains, which gates verify_foreign_transaction"
     )]
     pub fn get_supported_foreign_chains(&self) -> dtos::SupportedForeignChains {
         let active_participant_account_ids = self
@@ -289,9 +288,7 @@ impl MpcContract {
             .into()
     }
 
-    #[deprecated(
-        note = "superseded by get_foreign_chains_configs (https://github.com/near/mpc/issues/3434)"
-    )]
+    #[deprecated(note = "TODO(#3630): drop this, it's deprecated.")]
     pub fn get_foreign_chain_support_by_node(&self) -> dtos::ForeignChainSupportByNode {
         self.node_foreign_chain_support.to_dto()
     }

--- a/crates/contract/src/api/foreign_chain_support.rs
+++ b/crates/contract/src/api/foreign_chain_support.rs
@@ -21,6 +21,9 @@ impl MpcContract {
     /// set); panics in [`NotInitialized`](ProtocolContractState::NotInitialized) or when the caller is not a participant. Entries for
     /// accounts that are no longer participants are pruned after resharing by
     /// [`Self::clean_foreign_chain_data`].
+    #[deprecated(
+        note = "superseded by register_foreign_chains_config; feeds only the legacy get_supported_foreign_chains view (https://github.com/near/mpc/issues/3434)"
+    )]
     #[handle_result]
     pub fn register_foreign_chain_support(
         &mut self,
@@ -111,8 +114,9 @@ impl MpcContract {
     }
 
     #[deprecated(
-        note = "https://github.com/near/mpc/issues/3079. Node will be upgraded to use register_foreign_chain_support instead"
+        note = "https://github.com/near/mpc/issues/3079. Nodes register via register_foreign_chains_config instead"
     )]
+    #[expect(deprecated)]
     #[handle_result]
     pub fn register_foreign_chain_config(
         &mut self,
@@ -238,6 +242,9 @@ impl MpcContract {
         Ok(())
     }
 
+    #[deprecated(
+        note = "superseded by get_available_foreign_chains, which gates verify_foreign_transaction (https://github.com/near/mpc/issues/3434)"
+    )]
     pub fn get_supported_foreign_chains(&self) -> dtos::SupportedForeignChains {
         let active_participant_account_ids = self
             .protocol_state
@@ -282,6 +289,9 @@ impl MpcContract {
             .into()
     }
 
+    #[deprecated(
+        note = "superseded by get_foreign_chains_configs (https://github.com/near/mpc/issues/3434)"
+    )]
     pub fn get_foreign_chain_support_by_node(&self) -> dtos::ForeignChainSupportByNode {
         self.node_foreign_chain_support.to_dto()
     }
@@ -306,7 +316,8 @@ mod tests {
     use super::*;
     use crate::api::test_utils::{
         basic_setup, basic_setup_with_protocol, forwarded_participant_call_contract,
-        make_public_key_for_curve, participant_account_ids,
+        make_public_key_for_curve, participant_account_ids, register_foreign_chains_config_for,
+        whitelist_chain,
     };
     use crate::dto_mapping::IntoInterfaceType;
     use crate::primitives::domain::AddDomainsVotes;
@@ -691,59 +702,6 @@ mod tests {
         let _ = contract.vote_update_foreign_chain_providers(batch);
     }
 
-    /// Votes `chain` into the on-chain RPC whitelist using the signing threshold of
-    /// participants (so the chain becomes whitelisted).
-    fn whitelist_chain(contract: &mut MpcContract, chain: dtos::ForeignChain) {
-        let entry = dtos::ChainEntry {
-            providers: NonEmptyBTreeMap::new(
-                dtos::ProviderId("alchemy".to_string()),
-                dtos::ProviderConfig {
-                    base_url: "https://provider.example.com".to_string(),
-                    auth_scheme: dtos::AuthScheme::None,
-                    chain_routing: dtos::ChainRouting::Embedded,
-                },
-            ),
-            quorum: 1,
-        };
-        let batch = NonEmptyBTreeMap::new(chain, entry);
-        let threshold = contract.threshold().unwrap().value() as usize;
-        for account_id in participant_account_ids(contract).iter().take(threshold) {
-            testing_env!(
-                VMContextBuilder::new()
-                    .signer_account_id(account_id.clone())
-                    .predecessor_account_id(account_id.clone())
-                    .build()
-            );
-            contract
-                .vote_update_foreign_chain_providers(batch.clone())
-                .expect("vote should succeed");
-        }
-    }
-
-    fn register_foreign_chain_config(
-        contract: &mut MpcContract,
-        account_id: &AccountId,
-        chains: impl IntoIterator<Item = dtos::ForeignChain>,
-    ) {
-        let foreign_chains_config: dtos::ForeignChainsConfig =
-            chains.into_iter().collect::<BTreeSet<_>>().into();
-        // In mock setup, account_public_key == tls_public_key.
-        let tls_key = contract
-            .protocol_state
-            .threshold_parameters()
-            .unwrap()
-            .participants()
-            .info(account_id)
-            .expect("account must be a participant")
-            .tls_public_key
-            .clone();
-        let mut env = Environment::new(None, Some(account_id.clone()), None);
-        env.set_pk(near_sdk::PublicKey::from(tls_key));
-        contract
-            .register_foreign_chains_config(foreign_chains_config)
-            .expect("register should succeed");
-    }
-
     #[test]
     // Setup with 4 participants, first 3 supporting 4 chains, 4th one supports only 2.
     // Node operator of 4th node spins up new node, and registers config that supports all 4 chains.
@@ -793,12 +751,12 @@ mod tests {
 
         // Nodes 1-3 cover all 4 chains.
         for account_id in participant_ids.iter().take(3) {
-            register_foreign_chain_config(&mut contract, account_id, all_chains);
+            register_foreign_chains_config_for(&mut contract, account_id, all_chains);
         }
 
         // Node 4 (active participant) only covers 2 chains.
         let operator4 = &participant_ids[3];
-        register_foreign_chain_config(&mut contract, operator4, partial_chains);
+        register_foreign_chains_config_for(&mut contract, operator4, partial_chains);
 
         // Operator 4's new migration node (not yet a participant) covers all 4 chains and registers.
         let new_tls_key = dtos::Ed25519PublicKey([99u8; 32]);
@@ -891,10 +849,10 @@ mod tests {
         }
         let participant_ids = participant_account_ids(&contract);
         for account_id in participant_ids.iter().take(3) {
-            register_foreign_chain_config(&mut contract, account_id, all_chains);
+            register_foreign_chains_config_for(&mut contract, account_id, all_chains);
         }
         let operator4 = &participant_ids[3];
-        register_foreign_chain_config(&mut contract, operator4, partial_chains);
+        register_foreign_chains_config_for(&mut contract, operator4, partial_chains);
 
         let available = contract.get_available_foreign_chains();
         assert_eq!(
@@ -965,7 +923,11 @@ mod tests {
 
         // When: exactly the threshold (3) of 4 participants cover Bitcoin — one node does not.
         for account_id in participants.iter().take(3) {
-            register_foreign_chain_config(&mut contract, account_id, [dtos::ForeignChain::Bitcoin]);
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
         }
 
         // Then: Bitcoin is available. A single non-covering node cannot take it down — the
@@ -985,7 +947,11 @@ mod tests {
 
         // When: only 2 of 4 (< threshold) cover Bitcoin.
         for account_id in participants.iter().take(2) {
-            register_foreign_chain_config(&mut contract, account_id, [dtos::ForeignChain::Bitcoin]);
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
         }
 
         // Then: Bitcoin is not available.
@@ -1003,7 +969,11 @@ mod tests {
 
         // When: all 4 participants cover Bitcoin.
         for account_id in &participants {
-            register_foreign_chain_config(&mut contract, account_id, [dtos::ForeignChain::Bitcoin]);
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
         }
 
         // Then: Bitcoin is still not available — `available` is a subset of `whitelisted`.
@@ -1026,7 +996,7 @@ mod tests {
         // - Bitcoin: covered by 3 participants (whitelisted + threshold) -> available.
         // - Ethereum: covered by 1 participant (whitelisted but under threshold) -> not available.
         // - Solana: covered by all 4 (threshold met but not whitelisted) -> not available.
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[0],
             [
@@ -1035,17 +1005,17 @@ mod tests {
                 dtos::ForeignChain::Solana,
             ],
         );
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[1],
             [dtos::ForeignChain::Bitcoin, dtos::ForeignChain::Solana],
         );
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[2],
             [dtos::ForeignChain::Bitcoin, dtos::ForeignChain::Solana],
         );
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[3],
             [dtos::ForeignChain::Solana],
@@ -1070,7 +1040,11 @@ mod tests {
         // GovernanceThreshold (3) participants already cover Bitcoin — but the chain is not whitelisted,
         // so the cache must be empty.
         for account_id in participants.iter().take(3) {
-            register_foreign_chain_config(&mut contract, account_id, [dtos::ForeignChain::Bitcoin]);
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
         }
         assert!(contract.get_available_foreign_chains().is_empty());
 
@@ -1092,7 +1066,11 @@ mod tests {
         let participants = participant_account_ids(&contract);
         whitelist_chain(&mut contract, dtos::ForeignChain::Bitcoin);
         for account_id in participants.iter().take(3) {
-            register_foreign_chain_config(&mut contract, account_id, [dtos::ForeignChain::Bitcoin]);
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
         }
         assert!(
             contract
@@ -1151,7 +1129,11 @@ mod tests {
         let participants = participant_account_ids(&contract);
         whitelist_chain(&mut contract, dtos::ForeignChain::Bitcoin);
         for account_id in participants.iter().take(2) {
-            register_foreign_chain_config(&mut contract, account_id, [dtos::ForeignChain::Bitcoin]);
+            register_foreign_chains_config_for(
+                &mut contract,
+                account_id,
+                [dtos::ForeignChain::Bitcoin],
+            );
         }
         assert!(contract.get_available_foreign_chains().is_empty());
 
@@ -1171,7 +1153,7 @@ mod tests {
         contract.protocol_state = ProtocolContractState::Resharing(resharing);
 
         // When: the 3rd participant (from the old running set) registers during Resharing.
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[2],
             [dtos::ForeignChain::Bitcoin],
@@ -1221,12 +1203,12 @@ mod tests {
         whitelist_chain(&mut contract, dtos::ForeignChain::Bitcoin);
 
         // When: exactly 2 participants register Bitcoin (meets domain threshold=2, below governance threshold=3).
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[0],
             [dtos::ForeignChain::Bitcoin],
         );
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[1],
             [dtos::ForeignChain::Bitcoin],
@@ -1288,18 +1270,18 @@ mod tests {
                 .get_available_foreign_chains()
                 .contains(&dtos::ForeignChain::Bitcoin)
         };
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[0],
             [dtos::ForeignChain::Bitcoin],
         );
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[1],
             [dtos::ForeignChain::Bitcoin],
         );
         let available_below_threshold = bitcoin_available(&contract);
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             &participants[2],
             [dtos::ForeignChain::Bitcoin],
@@ -1409,7 +1391,7 @@ mod tests {
         );
 
         // When: node A (the registered participant node) registers its config.
-        register_foreign_chain_config(
+        register_foreign_chains_config_for(
             &mut contract,
             operator_account,
             [dtos::ForeignChain::Bitcoin],

--- a/crates/contract/src/api/test_utils.rs
+++ b/crates/contract/src/api/test_utils.rs
@@ -268,7 +268,13 @@ pub(crate) fn forwarded_participant_call_contract() -> MpcContract {
 pub(crate) fn whitelist_chain(contract: &mut MpcContract, chain: dtos::ForeignChain) {
     let batch = NonEmptyBTreeMap::new(chain, ::test_utils::contract_types::dummy_chain_entry());
     let threshold = contract.threshold().unwrap().value() as usize;
-    for account_id in participant_account_ids(contract).iter().take(threshold) {
+    let participants = participant_account_ids(contract);
+    assert!(
+        participants.len() >= threshold,
+        "need at least {threshold} participants to whitelist a chain, got {}",
+        participants.len()
+    );
+    for account_id in participants.iter().take(threshold) {
         testing_env!(
             VMContextBuilder::new()
                 .signer_account_id(account_id.clone())

--- a/crates/contract/src/api/test_utils.rs
+++ b/crates/contract/src/api/test_utils.rs
@@ -11,6 +11,7 @@ use crate::primitives::thresholds::{GovernanceThreshold, GovernanceThresholdPara
 use crate::state::ProtocolContractState;
 use crate::state::test_utils::gen_running_state;
 use crate::storage_keys::StorageKey;
+use crate::tee::test_utils::Environment;
 use dtos::{
     Attestation, Curve, DomainConfig, DomainId, DomainPurpose, MockAttestation, Protocol,
     ReconstructionThreshold,
@@ -18,11 +19,13 @@ use dtos::{
 use elliptic_curve::{Field as _, Group};
 use k256::elliptic_curve;
 use near_account_id::AccountId;
+use near_mpc_bounded_collections::NonEmptyBTreeMap;
 use near_mpc_contract_interface::types as dtos;
 use near_sdk::store::{IterableMap, Lazy, LookupMap};
 use near_sdk::test_utils::VMContextBuilder;
 use near_sdk::{NearToken, VMContext, testing_env};
 use rand_core::CryptoRngCore;
+use std::collections::BTreeSet;
 use std::str::FromStr;
 use threshold_signatures::confidential_key_derivation as ckd;
 use threshold_signatures::frost_core::Group as _;
@@ -259,6 +262,47 @@ pub(crate) fn forwarded_participant_call_contract() -> MpcContract {
     testing_env!(ctx);
 
     contract
+}
+
+/// Votes `chain` into the on-chain RPC whitelist with the signing threshold of participants.
+pub(crate) fn whitelist_chain(contract: &mut MpcContract, chain: dtos::ForeignChain) {
+    let batch = NonEmptyBTreeMap::new(chain, ::test_utils::contract_types::dummy_chain_entry());
+    let threshold = contract.threshold().unwrap().value() as usize;
+    for account_id in participant_account_ids(contract).iter().take(threshold) {
+        testing_env!(
+            VMContextBuilder::new()
+                .signer_account_id(account_id.clone())
+                .predecessor_account_id(account_id.clone())
+                .build()
+        );
+        contract
+            .vote_update_foreign_chain_providers(batch.clone())
+            .expect("vote should succeed");
+    }
+}
+
+pub(crate) fn register_foreign_chains_config_for(
+    contract: &mut MpcContract,
+    account_id: &AccountId,
+    chains: impl IntoIterator<Item = dtos::ForeignChain>,
+) {
+    let foreign_chains_config: dtos::ForeignChainsConfig =
+        chains.into_iter().collect::<BTreeSet<_>>().into();
+    // In mock setup, account_public_key == tls_public_key.
+    let tls_key = contract
+        .protocol_state
+        .threshold_parameters()
+        .unwrap()
+        .participants()
+        .info(account_id)
+        .expect("account must be a participant")
+        .tls_public_key
+        .clone();
+    let mut env = Environment::new(None, Some(account_id.clone()), None);
+    env.set_pk(near_sdk::PublicKey::from(tls_key));
+    contract
+        .register_foreign_chains_config(foreign_chains_config)
+        .expect("register should succeed");
 }
 
 impl MpcContract {

--- a/crates/contract/src/errors.rs
+++ b/crates/contract/src/errors.rs
@@ -170,8 +170,8 @@ pub enum InvalidParameters {
     InvalidTeeRemoteAttestation { reason: String },
     #[error("Caller is not the signer account.")]
     CallerNotSigner,
-    #[error("Requested foreign chain, {requested:?}, is not supported.")]
-    ForeignChainNotSupported { requested: ForeignChain },
+    #[error("Requested foreign chain, {requested:?}, is not available.")]
+    ForeignChainNotAvailable { requested: ForeignChain },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, thiserror::Error)]

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -669,8 +669,13 @@ pub async fn make_foreign_chain_available(
     accounts: &[Account],
 ) {
     let batch = NonEmptyBTreeMap::new(chain, test_utils::contract_types::dummy_chain_entry());
-    let threshold = assert_running_return_threshold(contract).await;
-    let votes = accounts.iter().take(threshold.0 as usize).map(|account| {
+    let threshold = assert_running_return_threshold(contract).await.0 as usize;
+    assert!(
+        accounts.len() >= threshold,
+        "need at least {threshold} accounts to whitelist a chain, got {}",
+        accounts.len()
+    );
+    let votes = accounts.iter().take(threshold).map(|account| {
         let batch = batch.clone();
         async move {
             let result = account

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -27,12 +27,13 @@ use mpc_contract::{
     tee::tee_state::NodeId,
 };
 use near_account_id::AccountId;
+use near_mpc_bounded_collections::NonEmptyBTreeMap;
 use near_mpc_contract_interface::types::{
     AptosAddress, AptosEvent, AptosExtractedValue, AptosExtractor, AptosFinality, AptosRpcRequest,
     AptosTxId, Curve, DomainConfig, DomainId, DomainPurpose, ProposeUpdateArgs, Protocol,
     ReconstructionThreshold, SuiAddress, SuiEvent, SuiExtractedValue, SuiExtractor, SuiFinality,
-    SuiRpcRequest, SuiTxId, SupportedForeignChains, TonAddress, TonCellBody, TonExtractedValue,
-    TonExtractor, TonFinality, TonLog, TonRpcRequest, TonTxId,
+    SuiRpcRequest, SuiTxId, TonAddress, TonCellBody, TonExtractedValue, TonExtractor, TonFinality,
+    TonLog, TonRpcRequest, TonTxId,
 };
 use near_mpc_contract_interface::{
     method_names,
@@ -661,26 +662,46 @@ fn hash(code: &[u8]) -> [u8; 32] {
     hasher.finalize().into()
 }
 
-/// registers a foreign chain configuration so the foreign chains are supported
-pub async fn register_foreign_chain_configuration(
-    chain: near_mpc_contract_interface::types::ForeignChain,
+/// Whitelists `chain` and registers it as covered by every node, making it available.
+pub async fn make_foreign_chain_available(
+    chain: dtos::ForeignChain,
     contract: &Contract,
     accounts: &[Account],
 ) {
-    let node_foreign_chain_support = SupportedForeignChains::from(BTreeSet::from([chain]));
-    for account in accounts {
-        let result = account
-            .call_mpc(contract.id())
-            .register_foreign_chain_support(node_foreign_chain_support.clone())
-            .await
-            .unwrap()
-            .into_result();
-        assert!(
-            result.is_ok(),
-            "{} should succeed",
-            method_names::REGISTER_FOREIGN_CHAIN_SUPPORT
-        );
-    }
+    let batch = NonEmptyBTreeMap::new(chain, test_utils::contract_types::dummy_chain_entry());
+    let threshold = assert_running_return_threshold(contract).await;
+    let votes = accounts.iter().take(threshold.0 as usize).map(|account| {
+        let batch = batch.clone();
+        async move {
+            let result = account
+                .call_mpc(contract.id())
+                .vote_update_foreign_chain_providers(batch)
+                .await
+                .unwrap()
+                .into_result();
+            assert!(result.is_ok(), "whitelist vote should succeed: {result:?}");
+        }
+    });
+    futures::future::join_all(votes).await;
+
+    let foreign_chains_config: dtos::ForeignChainsConfig = BTreeSet::from([chain]).into();
+    let registrations = accounts.iter().map(|account| {
+        let foreign_chains_config = foreign_chains_config.clone();
+        async move {
+            let result = account
+                .call_mpc(contract.id())
+                .register_foreign_chains_config(foreign_chains_config)
+                .await
+                .unwrap()
+                .into_result();
+            assert!(
+                result.is_ok(),
+                "{} should succeed: {result:?}",
+                method_names::REGISTER_FOREIGN_CHAINS_CONFIG
+            );
+        }
+    });
+    futures::future::join_all(registrations).await;
 }
 
 /// Poll the contract until a pending foreign-tx request appears (or panic after timeout).

--- a/crates/contract/tests/sandbox/common.rs
+++ b/crates/contract/tests/sandbox/common.rs
@@ -8,7 +8,7 @@ use crate::sandbox::utils::{
     },
     shared_key_utils::{DomainKey, make_key_for_domain},
     sign_utils::{PendingSignRequest, make_and_submit_requests},
-    transactions::CallMpcContract,
+    transactions::{CallMpcContract, execute_async_handle_calls},
 };
 use digest::Digest;
 use dtos::ProtocolContractState;
@@ -676,38 +676,24 @@ pub async fn make_foreign_chain_available(
         "need at least {threshold} accounts to whitelist a chain, got {}",
         accounts.len()
     );
-    let votes = accounts.iter().take(threshold).map(|account| {
+    execute_async_handle_calls(&accounts[..threshold], contract, |handle| {
         let batch = batch.clone();
-        async move {
-            let result = account
-                .call_mpc(contract.id())
-                .vote_update_foreign_chain_providers(batch)
-                .await
-                .unwrap()
-                .into_result();
-            assert!(result.is_ok(), "whitelist vote should succeed: {result:?}");
-        }
-    });
-    futures::future::join_all(votes).await;
+        async move { handle.vote_update_foreign_chain_providers(batch).await }
+    })
+    .await
+    .expect("whitelist vote should succeed");
 
-    let foreign_chains_config: dtos::ForeignChainsConfig = BTreeSet::from([chain]).into();
-    let registrations = accounts.iter().map(|account| {
+    execute_async_handle_calls(accounts, contract, |handle| {
+        let foreign_chains_config: dtos::ForeignChainsConfig = BTreeSet::from([chain]).into();
         let foreign_chains_config = foreign_chains_config.clone();
         async move {
-            let result = account
-                .call_mpc(contract.id())
+            handle
                 .register_foreign_chains_config(foreign_chains_config)
                 .await
-                .unwrap()
-                .into_result();
-            assert!(
-                result.is_ok(),
-                "{} should succeed: {result:?}",
-                method_names::REGISTER_FOREIGN_CHAINS_CONFIG
-            );
         }
-    });
-    futures::future::join_all(registrations).await;
+    })
+    .await
+    .expect("foreign chains config registration should succeed");
 }
 
 /// Poll the contract until a pending foreign-tx request appears (or panic after timeout).

--- a/crates/contract/tests/sandbox/foreign_chain_request.rs
+++ b/crates/contract/tests/sandbox/foreign_chain_request.rs
@@ -5,9 +5,9 @@ use crate::sandbox::common::{
     arbitrum_evm_request, avalanche_evm_request,
     await_pending_foreign_tx_request_observed_on_contract, base_evm_request,
     bitcoin_extracted_values, bitcoin_request, bnb_evm_request, bogus_ton_log_extracted_value,
-    ethereum_evm_request, evm_block_hash_extracted_values, hyper_evm_request, polygon_evm_request,
-    register_foreign_chain_configuration, sign_foreign_tx_response, starknet_extracted_values,
-    starknet_request, sui_extracted_values, sui_request, ton_request,
+    ethereum_evm_request, evm_block_hash_extracted_values, hyper_evm_request,
+    make_foreign_chain_available, polygon_evm_request, sign_foreign_tx_response,
+    starknet_extracted_values, starknet_request, sui_extracted_values, sui_request, ton_request,
 };
 use crate::sandbox::utils::transactions::CallMpcContract;
 use near_mpc_contract_interface::method_names;
@@ -46,7 +46,7 @@ async fn verify_foreign_transaction__should_succeed(
         .build()
         .await;
     let foreign_tx_key = setup.foreign_tx_key();
-    register_foreign_chain_configuration(chain, &setup.contract, &setup.mpc_signer_accounts).await;
+    make_foreign_chain_available(chain, &setup.contract, &setup.mpc_signer_accounts).await;
 
     let user = setup.worker.dev_create_account().await.unwrap();
     let domain_id = dtos::DomainId(foreign_tx_key.domain_id().0);
@@ -113,7 +113,7 @@ async fn verify_foreign_transaction__should_fan_out_response_to_duplicates_from_
         .build()
         .await;
     let foreign_tx_key = setup.foreign_tx_key();
-    register_foreign_chain_configuration(chain, &setup.contract, &setup.mpc_signer_accounts).await;
+    make_foreign_chain_available(chain, &setup.contract, &setup.mpc_signer_accounts).await;
 
     let alice = setup.worker.dev_create_account().await.unwrap();
     let bob = setup.worker.dev_create_account().await.unwrap();
@@ -193,7 +193,7 @@ async fn respond_verify_foreign_tx__should_reject_response_not_matching_expected
         .build()
         .await;
     let foreign_tx_key = setup.foreign_tx_key();
-    register_foreign_chain_configuration(chain, &setup.contract, &setup.mpc_signer_accounts).await;
+    make_foreign_chain_available(chain, &setup.contract, &setup.mpc_signer_accounts).await;
 
     let user = setup.worker.dev_create_account().await.unwrap();
     let domain_id = dtos::DomainId(foreign_tx_key.domain_id().0);
@@ -256,7 +256,7 @@ async fn verify_foreign_transaction__should_succeed_when_response_matches_expect
         .build()
         .await;
     let foreign_tx_key = setup.foreign_tx_key();
-    register_foreign_chain_configuration(chain, &setup.contract, &setup.mpc_signer_accounts).await;
+    make_foreign_chain_available(chain, &setup.contract, &setup.mpc_signer_accounts).await;
 
     let user = setup.worker.dev_create_account().await.unwrap();
     let domain_id = dtos::DomainId(foreign_tx_key.domain_id().0);
@@ -382,7 +382,7 @@ async fn verify_foreign_transaction__should_timeout_without_response(
         .build()
         .await;
     let foreign_tx_key = setup.foreign_tx_key();
-    register_foreign_chain_configuration(chain, &setup.contract, &setup.mpc_signer_accounts).await;
+    make_foreign_chain_available(chain, &setup.contract, &setup.mpc_signer_accounts).await;
 
     let user = setup.worker.dev_create_account().await.unwrap();
 

--- a/crates/e2e-tests/src/cluster.rs
+++ b/crates/e2e-tests/src/cluster.rs
@@ -896,7 +896,7 @@ impl MpcCluster {
             .await
             .context("failed to register backup service")
     }
-    /// View the foreign chains the contract accepts requests for.
+    /// View the legacy supported-chains set; requests are gated on the available set instead.
     pub async fn view_foreign_chains_supported_by_contract(
         &self,
     ) -> anyhow::Result<near_mpc_contract_interface::types::SupportedForeignChains> {
@@ -914,8 +914,8 @@ impl MpcCluster {
             .await
     }
 
-    /// Register foreign chain support on the contract for a specific node.
-    pub async fn register_foreign_chain_config(
+    /// Registers on the legacy supported-chains pipeline, which no longer gates requests.
+    pub async fn register_legacy_foreign_chain_support(
         &self,
         node_index: usize,
         foreign_chain_support: &near_mpc_contract_interface::types::SupportedForeignChains,

--- a/crates/e2e-tests/tests/foreign_chain_configuration.rs
+++ b/crates/e2e-tests/tests/foreign_chain_configuration.rs
@@ -96,12 +96,12 @@ async fn supported_foreign_chains__should_require_all_participants_to_register()
 
     // when — node 2 registers Solana directly on the contract.
     let outcome = cluster
-        .register_foreign_chain_config(2, &solana_foreign_chain_support_dto())
+        .register_legacy_foreign_chain_support(2, &solana_foreign_chain_support_dto())
         .await
         .expect("failed to register foreign chain config from node 2");
     assert!(
         outcome.is_success(),
-        "register_foreign_chain_config failed: {:?}",
+        "register_legacy_foreign_chain_support failed: {:?}",
         outcome.failure_message()
     );
 

--- a/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
+++ b/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
@@ -676,7 +676,7 @@ async fn verify_foreign_transaction__should_sign_all_supported_chains() {
     );
     let failure = outcome.failure_message().unwrap_or_default();
     assert!(
-        failure.contains("Requested foreign chain, Ethereum, is not available"),
+        failure.contains("Requested foreign chain, Solana, is not available"),
         "expected 'is not available' error, got: {failure}"
     );
 

--- a/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
+++ b/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
@@ -639,15 +639,15 @@ async fn verify_foreign_transaction__should_sign_all_supported_chains() {
         .await
         .expect("call should succeed at the RPC level");
 
-    // Then — the contract rejects the unsupported chain
+    // Then — the contract rejects the unavailable chain
     assert!(
         !outcome.is_success(),
-        "expected verify_foreign_transaction to fail for unsupported chain"
+        "expected verify_foreign_transaction to fail for unavailable chain"
     );
     let failure = outcome.failure_message().unwrap_or_default();
     assert!(
-        failure.contains("not supported"),
-        "expected 'not supported' error, got: {failure}"
+        failure.contains("Requested foreign chain, Ethereum, is not available"),
+        "expected 'is not available' error, got: {failure}"
     );
 
     // When — requesting a non-existent domain

--- a/crates/near-mpc-contract-interface/src/client.rs
+++ b/crates/near-mpc-contract-interface/src/client.rs
@@ -7,10 +7,11 @@
 use near_contract_transport::{CallContract, FunctionCallArgs, NearGas, NearToken};
 
 use crate::call_args::{
-    InitArgs, RegisterBackupServiceArgs, RegisterForeignChainSupportArgs, RequestAppPrivateKeyArgs,
-    SignArgs, StartNodeMigrationArgs, SubmitParticipantInfoArgs, UpdateParticipantUrlArgs,
-    VerifyForeignTransactionArgs, VoteAddDomainsArgs, VoteCancelKeygenArgs, VoteNewParametersArgs,
-    VoteTeeVerifierChangeArgs, VoteUpdateArgs,
+    InitArgs, RegisterBackupServiceArgs, RegisterForeignChainSupportArgs,
+    RegisterForeignChainsConfigArgs, RequestAppPrivateKeyArgs, SignArgs, StartNodeMigrationArgs,
+    SubmitParticipantInfoArgs, UpdateParticipantUrlArgs, VerifyForeignTransactionArgs,
+    VoteAddDomainsArgs, VoteCancelKeygenArgs, VoteNewParametersArgs, VoteTeeVerifierChangeArgs,
+    VoteUpdateArgs,
 };
 use crate::deposits::{
     DepositOverflowError, MINIMUM_NODE_MANAGEMENT_DEPOSIT_YOCTONEAR, SIGN_DEPOSIT_YOCTONEAR,
@@ -18,17 +19,18 @@ use crate::deposits::{
 };
 use crate::method_names::{
     CANCEL_NODE_MIGRATION, INIT, PROPOSE_UPDATE, REGISTER_BACKUP_SERVICE,
-    REGISTER_FOREIGN_CHAIN_SUPPORT, REQUEST_APP_PRIVATE_KEY, SIGN, START_NODE_MIGRATION,
-    SUBMIT_PARTICIPANT_INFO, UPDATE_PARTICIPANT_URL, VERIFY_FOREIGN_TRANSACTION, VERIFY_TEE,
-    VOTE_ADD_DOMAINS, VOTE_CANCEL_KEYGEN, VOTE_CANCEL_RESHARING, VOTE_NEW_PARAMETERS,
-    VOTE_TEE_VERIFIER_CHANGE, VOTE_UPDATE, VOTE_UPDATE_FOREIGN_CHAIN_PROVIDERS,
+    REGISTER_FOREIGN_CHAIN_SUPPORT, REGISTER_FOREIGN_CHAINS_CONFIG, REQUEST_APP_PRIVATE_KEY, SIGN,
+    START_NODE_MIGRATION, SUBMIT_PARTICIPANT_INFO, UPDATE_PARTICIPANT_URL,
+    VERIFY_FOREIGN_TRANSACTION, VERIFY_TEE, VOTE_ADD_DOMAINS, VOTE_CANCEL_KEYGEN,
+    VOTE_CANCEL_RESHARING, VOTE_NEW_PARAMETERS, VOTE_TEE_VERIFIER_CHANGE, VOTE_UPDATE,
+    VOTE_UPDATE_FOREIGN_CHAIN_PROVIDERS,
 };
 use crate::types::{
     AccountId, Attestation, BackupServiceInfo, CKDAppPublicKey, CKDRequestArgs, ChainEntry,
     DestinationNodeInfo, DomainConfig, Ed25519PublicKey, EpochId, ForeignChain,
-    GovernanceThresholdParameters, InitConfig, PayloadBytesError, ProposeUpdateArgs,
-    ProposedGovernanceThresholdParameters, SignRequestArgs, SupportedForeignChains,
-    TeeVerifierCodeHash, VerifyForeignTransactionRequestArgs,
+    ForeignChainsConfig, GovernanceThresholdParameters, InitConfig, PayloadBytesError,
+    ProposeUpdateArgs, ProposedGovernanceThresholdParameters, SignRequestArgs,
+    SupportedForeignChains, TeeVerifierCodeHash, VerifyForeignTransactionRequestArgs,
 };
 use near_mpc_bounded_collections::NonEmptyBTreeMap;
 
@@ -298,6 +300,20 @@ impl<C: CallContract> MpcContractHandle<C> {
             serde_json::to_vec(&RegisterForeignChainSupportArgs::new(foreign_chain_support))?;
         self.call(FunctionCallArgs::no_deposit(
             REGISTER_FOREIGN_CHAIN_SUPPORT,
+            args,
+            MAX_GAS,
+        ))
+        .await
+    }
+
+    pub async fn register_foreign_chains_config(
+        &self,
+        foreign_chains_config: ForeignChainsConfig,
+    ) -> Result<C::Output, MpcContractHandleError<C::Error>> {
+        let args =
+            serde_json::to_vec(&RegisterForeignChainsConfigArgs::new(foreign_chains_config))?;
+        self.call(FunctionCallArgs::no_deposit(
+            REGISTER_FOREIGN_CHAINS_CONFIG,
             args,
             MAX_GAS,
         ))

--- a/crates/node/src/network/conn.rs
+++ b/crates/node/src/network/conn.rs
@@ -28,7 +28,7 @@ pub struct ConnectionWithVersion<T> {
     version: usize,
 }
 
-impl<T: Send + Sync + 'static> Clone for ConnectionWithVersion<T> {
+impl<T> Clone for ConnectionWithVersion<T> {
     fn clone(&self) -> Self {
         Self {
             connection: self.connection.clone(),
@@ -37,7 +37,7 @@ impl<T: Send + Sync + 'static> Clone for ConnectionWithVersion<T> {
     }
 }
 
-impl<T: Send + Sync + 'static> ConnectionWithVersion<T> {
+impl<T> ConnectionWithVersion<T> {
     pub fn version(&self) -> usize {
         if self.connection.upgrade().is_some() {
             self.version

--- a/crates/node/src/providers/ecdsa_common.rs
+++ b/crates/node/src/providers/ecdsa_common.rs
@@ -74,10 +74,7 @@ pub struct EcdsaKeyshare<P> {
 }
 
 // Manual `Clone` so callers don't need `P: Clone` — every field is `Clone` regardless of `P`.
-impl<P> Clone for EcdsaKeyshare<P>
-where
-    P: Serialize + DeserializeOwned + Send + 'static,
-{
+impl<P> Clone for EcdsaKeyshare<P> {
     fn clone(&self) -> Self {
         Self {
             keygen_output: self.keygen_output.clone(),
@@ -128,10 +125,7 @@ where
 pub fn lookup_keyshare<P>(
     keyshares: &HashMap<DomainId, EcdsaKeyshare<P>>,
     domain_id: DomainId,
-) -> anyhow::Result<EcdsaKeyshare<P>>
-where
-    P: Serialize + DeserializeOwned + Send + 'static,
-{
+) -> anyhow::Result<EcdsaKeyshare<P>> {
     keyshares
         .get(&domain_id)
         .cloned()

--- a/crates/node/src/requests/debug.rs
+++ b/crates/node/src/requests/debug.rs
@@ -32,7 +32,7 @@ pub(super) struct CompletedRequests<RequestType, ChainRespondArgsType> {
     requests: BinaryHeap<CompletedRequest<RequestType, ChainRespondArgsType>>,
 }
 
-impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> Default
+impl<RequestType: Request, ChainRespondArgsType> Default
     for CompletedRequests<RequestType, ChainRespondArgsType>
 {
     fn default() -> Self {
@@ -42,7 +42,7 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> Default
     }
 }
 
-impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> PartialEq
+impl<RequestType: Request, ChainRespondArgsType> PartialEq
     for CompletedRequest<RequestType, ChainRespondArgsType>
 {
     fn eq(&self, other: &Self) -> bool {
@@ -51,12 +51,12 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> PartialEq
     }
 }
 
-impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> Eq
+impl<RequestType: Request, ChainRespondArgsType> Eq
     for CompletedRequest<RequestType, ChainRespondArgsType>
 {
 }
 
-impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> PartialOrd
+impl<RequestType: Request, ChainRespondArgsType> PartialOrd
     for CompletedRequest<RequestType, ChainRespondArgsType>
 {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
@@ -64,7 +64,7 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> PartialOrd
     }
 }
 
-impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> Ord
+impl<RequestType: Request, ChainRespondArgsType> Ord
     for CompletedRequest<RequestType, ChainRespondArgsType>
 {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
@@ -89,7 +89,7 @@ impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs>
     }
 }
 
-impl<RequestType: Request, ChainRespondArgsType: ChainRespondArgs> Debug
+impl<RequestType: Request, ChainRespondArgsType> Debug
     for CompletedRequest<RequestType, ChainRespondArgsType>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -9,6 +9,7 @@ cargo-near-build = { workspace = true }
 hex = { workspace = true }
 mpc-attestation = { workspace = true, features = ["test-utils", "local-verify"] }
 mpc-primitives = { workspace = true }
+near-mpc-bounded-collections = { workspace = true }
 near-mpc-contract-interface = { workspace = true }
 near-sdk = { workspace = true, features = ["non-contract-usage"] }
 serde_json = { workspace = true }

--- a/crates/test-utils/src/contract_types.rs
+++ b/crates/test-utils/src/contract_types.rs
@@ -1,3 +1,7 @@
+use near_mpc_contract_interface::types::{
+    AuthScheme, ChainEntry, ChainRouting, ProviderConfig, ProviderId,
+};
+
 /// Generates a dummy [`near_mpc_contract_interface::types::Config`] with different values for each field.
 pub fn dummy_config(value: u64) -> near_mpc_contract_interface::types::Config {
     near_mpc_contract_interface::types::Config {
@@ -21,5 +25,20 @@ pub fn dummy_config(value: u64) -> near_mpc_contract_interface::types::Config {
         attestation_storage_fee_millinear: value + 17,
         // Must satisfy `Config::validate` (>= DEFAULT_EXPIRATION_DURATION_SECONDS).
         launcher_hash_unused_ttl_seconds: value + (14 * 24 * 60 * 60),
+    }
+}
+
+/// Generates a dummy single-provider [`near_mpc_contract_interface::types::ChainEntry`] with RPC quorum 1.
+pub fn dummy_chain_entry() -> near_mpc_contract_interface::types::ChainEntry {
+    ChainEntry {
+        providers: near_mpc_bounded_collections::NonEmptyBTreeMap::new(
+            ProviderId("alchemy".to_string()),
+            ProviderConfig {
+                base_url: "https://provider.example.com".to_string(),
+                auth_scheme: AuthScheme::None,
+                chain_routing: ChainRouting::Embedded,
+            },
+        ),
+        quorum: 1,
     }
 }

--- a/docs/design/calculating-supported-foreign-chains.md
+++ b/docs/design/calculating-supported-foreign-chains.md
@@ -21,7 +21,7 @@ per chain, the network-trusted providers and the **RPC quorum** (`ChainEntry.quo
 > **Terms** (whitelisted, available, RPC quorum, signing threshold, *covers*) are defined in
 > [Foreign Chain Transaction Verification Design — Terminology](../foreign-chain-transactions.md#terminology).
 
-The network distinguishes the **whitelisted** set (vote-driven policy, `get_whitelisted_foreign_chains()`)
+The network distinguishes the **whitelisted** set (vote-driven policy, `allowed_foreign_chain_providers()`)
 from the **available** set (servable right now, `get_available_foreign_chains()`):
 
 - **Whitelisted** is derived purely from the on-chain RPC whitelist — **no per-node input can add or
@@ -33,7 +33,7 @@ from the **available** set (servable right now, `get_available_foreign_chains()`
 instead of accepting a request that can't reach the signing threshold and letting it time out. The
 rejection is temporary — `C` becomes serviceable again as soon as enough nodes report coverage.
 
-The legacy `get_supported_foreign_chains()` (the intersection rule) is **to be deprecated** in favour
+The legacy `get_supported_foreign_chains()` (the intersection rule) is **deprecated** in favour
 of the two views above.
 
 ## Why two sets
@@ -147,7 +147,10 @@ node for every chain.
 can roll out before the contract upgrade (node and contract migrate independently):
 
 1. Keep `get_supported_foreign_chains()` unchanged.
-2. Add `get_whitelisted_foreign_chains()` and `get_available_foreign_chains()` (additive).
-3. Vote the RPC providers / chains into the whitelist.
-4. Upgrade the contract.
-5. Switch node code to the new methods and deprecate `get_supported_foreign_chains()`.
+2. Add `allowed_foreign_chain_providers()` and `get_available_foreign_chains()` (additive).
+3. Vote the RPC providers / chains into the whitelist. This must precede step 4 on every
+   network: `available ⊆ whitelisted`, so with an empty whitelist the new gate rejects every
+   request.
+4. Upgrade the contract: `verify_foreign_transaction` gates on the available set instead of
+   the supported set, and `get_supported_foreign_chains()` is deprecated.
+5. Switch node code to the new methods and drop the legacy registration.

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -324,8 +324,9 @@ back here rather than redefining them.
   (`ChainEntry.quorum`), voted in alongside the provider list. A runtime knob; distinct from the
   *signing threshold*.
 - **Signing threshold** — the cryptographic reconstruction threshold of the `ForeignTx` signing
-  domain (`self.threshold()`): how many participants must produce signature shares to sign an
-  observation. Distinct from the RPC quorum.
+  domain (`DomainConfig.reconstruction_threshold`; the max across `ForeignTx` domains if there are
+  several): how many participants must produce signature shares to sign an observation. Distinct
+  from the RPC quorum and from the governance threshold (`self.threshold()`) used for votes.
 - **A node covers (supports) a chain `C`** — the node's local RPC config has at least `rpc_quorum(C)`
   of `C`'s whitelisted providers configured (enough to reach the RPC quorum on its own). Reported
   on-chain via `register_available_foreign_chain_config`. *"Covers" and "supports" are interchangeable; this

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -317,7 +317,7 @@ back here rather than redefining them.
 - **Whitelisted chain** — a chain the network has voted into the on-chain RPC whitelist
   (`foreign_chain_rpc_whitelist`): there is a `ChainEntry` for it (trusted provider list + RPC
   quorum). The policy set every node is expected to cover; **no single operator can add or remove a
-  chain — only a threshold vote can**. Returned by `get_whitelisted_foreign_chains()`. See
+  chain — only a threshold vote can**. Keys of `allowed_foreign_chain_providers()`. See
   [On-chain RPC Provider Whitelist](#on-chain-rpc-provider-whitelist).
 - **RPC quorum** (`rpc_quorum(C)`) — per whitelisted chain `C`, how many of a node's configured
   providers must return the same response for that node to accept a verification result
@@ -342,7 +342,7 @@ back here rather than redefining them.
 
 ## Contract State (Foreign Chain Configurations)
 
-The **whitelisted** set is derived from the **on-chain RPC whitelist** (`foreign_chain_rpc_whitelist`): a chain is whitelisted iff the network has voted in a `ChainEntry` for it, exposed by `get_whitelisted_foreign_chains()`. The **available** set — the chains ≥ signing threshold active nodes currently cover — is computed from the per-participant registrations and exposed by `get_available_foreign_chains()`; `verify_foreign_transaction` gates on it. The per-participant registration also drives alerting (detecting an active node that does not cover a whitelisted chain). See [Calculating the whitelisted and available foreign-chain sets](design/calculating-supported-foreign-chains.md).
+The **whitelisted** set is derived from the **on-chain RPC whitelist** (`foreign_chain_rpc_whitelist`): a chain is whitelisted iff the network has voted in a `ChainEntry` for it, exposed as the keys of `allowed_foreign_chain_providers()`. The **available** set — the chains ≥ signing threshold active nodes currently cover — is computed from the per-participant registrations and exposed by `get_available_foreign_chains()`; `verify_foreign_transaction` gates on it. The per-participant registration also drives alerting (detecting an active node that does not cover a whitelisted chain). See [Calculating the whitelisted and available foreign-chain sets](design/calculating-supported-foreign-chains.md).
 
 ```rust
 pub struct ForeignChainSupportByNode {
@@ -367,7 +367,7 @@ pub enum ForeignChain {
 Relevant contract methods:
 
 * `register_available_foreign_chain_config(foreign_chain_configuration: ForeignChainConfiguration)` — call method (formerly `register_foreign_chain_config`; old name kept as a deprecated wrapper). The authenticated participant (re)registers its per-chain provider set. The call is idempotent.
-* `get_whitelisted_foreign_chains() -> WhitelistedForeignChains` — view method. Returns the chains present in the on-chain RPC whitelist (`foreign_chain_rpc_whitelist`). (`get_supported_foreign_chains()` is superseded by these two views and will be removed; see [Migration](design/calculating-supported-foreign-chains.md#migration).)
+* `allowed_foreign_chain_providers() -> BTreeMap<ForeignChain, ChainEntry>` — Borsh-encoded view method. Returns the on-chain RPC whitelist (`foreign_chain_rpc_whitelist`); its keys are the whitelisted chains. (`get_supported_foreign_chains()` is superseded by these two views and will be removed; see [Migration](design/calculating-supported-foreign-chains.md#migration).)
 * `get_available_foreign_chains() -> AvailableForeignChains` — view method. Returns the chains that ≥ signing threshold active nodes currently cover; `verify_foreign_transaction` gates on this set.
 * `get_available_foreign_chain_by_node() -> ForeignChainSupportByNode` — view method (formerly `get_foreign_chain_support_by_node`; old name kept as a deprecated wrapper). Returns each participant's registered set of covered chains. Feeds the available-set computation and the coverage alerting (does every active node cover every whitelisted chain?).
 
@@ -629,7 +629,7 @@ See "Contract State (Foreign Chain Configurations)" above.
 * Node config contains chain RPC providers and timeouts (API keys stay local).
 * On startup, each node submits a single `register_available_foreign_chain_config` transaction derived from its local configuration. The call is idempotent.
 * Nodes do **not** vote, poll, or wait for network-wide consensus — the transaction is sent and startup continues.
-* `get_whitelisted_foreign_chains()` returns the on-chain RPC whitelist's chains, not these registrations: a chain is *whitelisted* once the network votes in a `ChainEntry`, and no single node can change it. It is *available* — actually served — only while ≥ signing threshold active nodes cover it (`get_available_foreign_chains()`); `verify_foreign_transaction` early-rejects a whitelisted-but-unavailable chain. See [Calculating the whitelisted and available foreign-chain sets](design/calculating-supported-foreign-chains.md).
+* `allowed_foreign_chain_providers()` returns the on-chain RPC whitelist, not these registrations: a chain is *whitelisted* once the network votes in a `ChainEntry`, and no single node can change it. It is *available* — actually served — only while ≥ signing threshold active nodes cover it (`get_available_foreign_chains()`); `verify_foreign_transaction` early-rejects a whitelisted-but-unavailable chain. See [Calculating the whitelisted and available foreign-chain sets](design/calculating-supported-foreign-chains.md).
 * `get_available_foreign_chain_by_node()` exposes per-participant registrations, which feed the availability check and the coverage alerting.
 
 ### Configuration (Node)

--- a/docs/hot-tee-signing-design.md
+++ b/docs/hot-tee-signing-design.md
@@ -406,7 +406,7 @@ The initial governor set and vote threshold are configured at contract deploymen
 | `allowed_launcher_image_hashes()` | View | Archive Signer | Query approved launcher image hashes |
 | `allowed_launcher_compose_hashes()` | View | Archive Signer | Query approved launcher compose hashes |
 | `get_tee_accounts()` | View | Anyone | Query nodes with valid attestations |
-| `get_supported_foreign_chains()` | View | Archive Signer |  Query active foreign chains (opt-in)  |
+| `get_available_foreign_chains()` | View | Archive Signer | Query foreign chains accepted by `verify_foreign_transaction` |
 
 ### Launcher Compose Hash Derivation
 

--- a/docs/tee-lifecycle.md
+++ b/docs/tee-lifecycle.md
@@ -232,7 +232,7 @@ The following attestation methods must be uniform across all governance contract
 | `allowed_docker_image_hashes()` | View | Query approved image hashes |
 | `allowed_launcher_compose_hashes()` | View | Query approved launcher hashes |
 | `get_tee_accounts()` | View | Query participants with valid attestations |
-| `get_supported_foreign_chains()` | View | Query active foreign chains (opt-in) |
+| `get_available_foreign_chains()` | View | Query foreign chains accepted by `verify_foreign_transaction` |
 
 > **Backup Service:** The Backup Service does not yet have TEE governance — `register_backup_service` stores only a public key, with no attestation. The [hard-launch design][backup-tee-methods] plans to add attestation via `TeeState` and the standard methods listed above, but these are not yet implemented.
 


### PR DESCRIPTION
Note: this change does not need to be deployed on the contract before node gets updated. All nodes support all the chains so foreign tx requests will be still accepted during normal operations. After this change is deployed on the contract it will just allow more flexibility.

We do need to vote for new whitelist that contains SUI though.

Closes: https://github.com/near/mpc/issues/4221