### PR TITLE
feat(foreign-tx): ethereum support

### DIFF
--- a/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
+++ b/crates/e2e-tests/tests/foreign_chain_tx_validation.rs
@@ -19,8 +19,9 @@ use near_mpc_contract_interface::types::{
     BitcoinExtractor, BitcoinRpcRequest, BitcoinTxId, BlockConfirmations, DomainConfig, DomainId,
     DomainPurpose, EvmExtractor, EvmFinality, EvmRpcRequest, EvmTxId, ForeignChain,
     ForeignChainRpcRequest, ForeignTxPayloadVersion, Protocol, ReconstructionThreshold,
-    StarknetExtractor, StarknetFelt, StarknetFinality, StarknetRpcRequest, StarknetTxId,
-    VerifyForeignTransactionRequestArgs, VerifyForeignTransactionResponse,
+    SolanaFinality, SolanaRpcRequest, SolanaTxId, StarknetExtractor, StarknetFelt,
+    StarknetFinality, StarknetRpcRequest, StarknetTxId, VerifyForeignTransactionRequestArgs,
+    VerifyForeignTransactionResponse,
 };
 use near_mpc_sdk::foreign_chain::ForeignChainRequestBuilder;
 
@@ -56,6 +57,7 @@ struct MockServerUrls {
     hyper_evm: String,
     avalanche: String,
     adi: String,
+    ethereum: String,
     polygon: Vec<String>,
 }
 
@@ -118,6 +120,7 @@ fn build_foreign_chains_config(urls: &MockServerUrls) -> ForeignChainsConfig {
         hyper_evm: Some(mock_chain(&urls.hyper_evm, Default::default())),
         avalanche: Some(mock_chain(&urls.avalanche, Default::default())),
         adi: Some(mock_chain(&urls.adi, Default::default())),
+        ethereum: Some(mock_chain(&urls.ethereum, Default::default())),
         polygon: Some(mock_chain_with_providers(
             common::build_providers_from_urls(&urls.polygon, "polygon"),
         )),
@@ -135,6 +138,7 @@ async fn setup_foreign_tx_cluster() -> anyhow::Result<ForeignTxTestEnv> {
     let hyper_evm_server = MockServer::start();
     let avalanche_server = MockServer::start();
     let adi_server = MockServer::start();
+    let ethereum_server = MockServer::start();
 
     let bitcoin_mock_id = setup_bitcoin_mock(
         &bitcoin_server,
@@ -162,6 +166,7 @@ async fn setup_foreign_tx_cluster() -> anyhow::Result<ForeignTxTestEnv> {
     setup_evm_mock(&hyper_evm_server, MockAuthExpectation::None);
     setup_evm_mock(&avalanche_server, MockAuthExpectation::None);
     setup_evm_mock(&adi_server, MockAuthExpectation::None);
+    setup_evm_mock(&ethereum_server, MockAuthExpectation::None);
 
     // Polygon is configured with three RPC providers so the test can assert
     // that `FanOut` queries every one of them.
@@ -185,6 +190,7 @@ async fn setup_foreign_tx_cluster() -> anyhow::Result<ForeignTxTestEnv> {
         hyper_evm: hyper_evm_server.url("/"),
         avalanche: avalanche_server.url("/"),
         adi: adi_server.url("/"),
+        ethereum: ethereum_server.url("/"),
         polygon: polygon_mocks.iter().map(|m| m.server.url("/")).collect(),
     };
 
@@ -198,6 +204,7 @@ async fn setup_foreign_tx_cluster() -> anyhow::Result<ForeignTxTestEnv> {
         hyper_evm_server,
         avalanche_server,
         adi_server,
+        ethereum_server,
     ];
 
     let fc_config = build_foreign_chains_config(&urls);
@@ -212,6 +219,7 @@ async fn setup_foreign_tx_cluster() -> anyhow::Result<ForeignTxTestEnv> {
         ForeignChain::HyperEvm,
         ForeignChain::Avalanche,
         ForeignChain::Adi,
+        ForeignChain::Ethereum,
         ForeignChain::Polygon,
     ]
     .into_iter()
@@ -539,6 +547,25 @@ async fn verify_adi(env: &ForeignTxTestEnv) -> anyhow::Result<()> {
     verify_foreign_tx_response(&outcome)
 }
 
+async fn verify_ethereum(env: &ForeignTxTestEnv) -> anyhow::Result<()> {
+    let request = VerifyForeignTransactionRequestArgs {
+        request: ForeignChainRpcRequest::Ethereum(EvmRpcRequest {
+            tx_id: EvmTxId([0xbb; 32]),
+            extractors: vec![EvmExtractor::BlockHash, EvmExtractor::Log { log_index: 0 }],
+            finality: EvmFinality::Finalized,
+        }),
+        domain_id: env.foreign_tx_domain_id,
+        payload_version: ForeignTxPayloadVersion::V1,
+        expected_payload_hash: None,
+    };
+    let outcome = env
+        .cluster
+        .send_verify_foreign_transaction(&request)
+        .await
+        .context("verify_foreign_transaction (Ethereum) failed")?;
+    verify_foreign_tx_response(&outcome)
+}
+
 /// A successful verification implies the credentialed mock answered,
 /// so this is a backstop against the mock setup being loosened to answer unauthenticated requests.
 fn assert_authenticated_provider_was_queried(mock: &MockServerExt, provider: &str) {
@@ -593,7 +620,7 @@ async fn verify_polygon(env: &ForeignTxTestEnv) -> anyhow::Result<()> {
 #[expect(non_snake_case)]
 async fn verify_foreign_transaction__should_sign_all_supported_chains() {
     // Given — 2-node cluster with Bitcoin, Abstract, BNB, Base, Starknet,
-    // Arbitrum, HyperEVM, Avalanche, ADI, and Polygon configured
+    // Arbitrum, HyperEVM, Avalanche, ADI, Ethereum, and Polygon configured
     let env = setup_foreign_tx_cluster()
         .await
         .expect("setup_foreign_tx_cluster failed");
@@ -626,17 +653,20 @@ async fn verify_foreign_transaction__should_sign_all_supported_chains() {
         .await
         .expect("avalanche verification failed");
     verify_adi(&env).await.expect("adi verification failed");
+    verify_ethereum(&env)
+        .await
+        .expect("ethereum verification failed");
     verify_polygon(&env)
         .await
         .expect("polygon verification failed");
     assert_fan_out_queried_every_polygon_provider(&env);
 
-    // When — requesting Ethereum, which is not in the foreign chain config
+    // When — requesting Solana, which is not in the foreign chain config
     let request = VerifyForeignTransactionRequestArgs {
-        request: ForeignChainRpcRequest::Ethereum(EvmRpcRequest {
-            tx_id: EvmTxId([0xbb; 32]),
-            extractors: vec![EvmExtractor::BlockHash],
-            finality: EvmFinality::Finalized,
+        request: ForeignChainRpcRequest::Solana(SolanaRpcRequest {
+            tx_id: SolanaTxId([0xbb; 64]),
+            finality: SolanaFinality::Finalized,
+            extractors: vec![],
         }),
         domain_id: env.foreign_tx_domain_id,
         payload_version: ForeignTxPayloadVersion::V1,

--- a/crates/foreign-chain-health-check/src/golden.rs
+++ b/crates/foreign-chain-health-check/src/golden.rs
@@ -31,6 +31,7 @@ pub struct SuiVector {
 }
 
 pub struct GoldenSet {
+    pub ethereum: Option<BlockHashVector>,
     pub base: Option<BlockHashVector>,
     pub bnb: Option<BlockHashVector>,
     pub arbitrum: Option<BlockHashVector>,
@@ -53,6 +54,10 @@ pub fn golden_set(network: Network) -> GoldenSet {
 }
 
 const MAINNET: GoldenSet = GoldenSet {
+    ethereum: Some(BlockHashVector {
+        tx: "7f1c6a58dc880438236d0b0a4ae166e9e9a038dbea8ec074149bd8b176332cac",
+        block_hash: "34e5a6cfbdbb84f7625df1de69d218ade4da72f4a2558064a156674e72e976c9",
+    }),
     base: Some(BlockHashVector {
         tx: "a11eaa1236e80f26ddc7aca164f2ba4c6c2726405cb12b1aa8f52c520bad99e1",
         block_hash: "b8488c9272c547c45e63ea76cc2d1c927c8f888e2721f790b14db996b6cc6aca",
@@ -104,6 +109,7 @@ const MAINNET: GoldenSet = GoldenSet {
 };
 
 const TESTNET: GoldenSet = GoldenSet {
+    ethereum: None,
     base: None,
     bnb: None,
     arbitrum: None,
@@ -202,6 +208,7 @@ mod tests {
         for network in [Network::Mainnet, Network::Testnet] {
             let set = golden_set(network);
             for v in [
+                set.ethereum,
                 set.base,
                 set.bnb,
                 set.arbitrum,

--- a/crates/foreign-chain-health-check/src/lib.rs
+++ b/crates/foreign-chain-health-check/src/lib.rs
@@ -20,6 +20,7 @@ use foreign_chain_inspector::arbitrum::inspector::Arbitrum;
 use foreign_chain_inspector::avalanche::inspector::Avalanche;
 use foreign_chain_inspector::base::inspector::Base;
 use foreign_chain_inspector::bnb::inspector::Bnb;
+use foreign_chain_inspector::ethereum::inspector::Ethereum;
 use foreign_chain_inspector::evm::inspector::EvmChain;
 use foreign_chain_inspector::http_client::HttpClient;
 use foreign_chain_inspector::hyperevm::inspector::HyperEvm;
@@ -50,6 +51,11 @@ pub async fn check_all_providers(
     let golden = golden::golden_set(network);
     let mut out = Vec::new();
 
+    if let Some(cfg) = &fc.ethereum {
+        run_evm::<Ethereum>("ethereum", cfg, golden.ethereum, network, &mut out).await;
+    } else {
+        mark_not_configured("ethereum", &mut out);
+    }
     if let Some(cfg) = &fc.base {
         run_evm::<Base>("base", cfg, golden.base, network, &mut out).await;
     } else {
@@ -112,11 +118,6 @@ pub async fn check_all_providers(
     }
 
     // Configured but not yet supported by the node (see verify_foreign_tx/sign.rs).
-    if let Some(cfg) = &fc.ethereum {
-        mark_skipped("ethereum", cfg, "not yet supported by the node", &mut out);
-    } else {
-        mark_not_configured("ethereum", &mut out);
-    }
     if let Some(cfg) = &fc.solana {
         mark_skipped("solana", cfg, "not yet supported by the node", &mut out);
     } else {
@@ -392,7 +393,7 @@ mod tests {
     async fn check_all_providers__should_skip_configured_but_unsupported_chains() {
         // Given a configured but not-yet-supported chain
         let fc = ForeignChainsConfig {
-            ethereum: Some(config_with_provider(AuthConfig::None)),
+            solana: Some(config_with_provider(AuthConfig::None)),
             ..Default::default()
         };
 
@@ -400,12 +401,12 @@ mod tests {
         let results = check_all_providers(&fc, Network::Mainnet).await;
 
         // Then it is reported skipped as unsupported, not probed
-        let ethereum = results
+        let solana = results
             .iter()
-            .find(|r| r.chain == "ethereum")
-            .expect("ethereum row");
+            .find(|r| r.chain == "solana")
+            .expect("solana row");
         assert_matches!(
-            &ethereum.status,
+            &solana.status,
             Status::Skipped(reason) if reason.contains("not yet supported")
         );
     }
@@ -420,6 +421,7 @@ mod tests {
 
         // Then every known chain still appears, each with a "not configured" placeholder
         let expected = [
+            "ethereum",
             "base",
             "bnb",
             "arbitrum",
@@ -432,7 +434,6 @@ mod tests {
             "starknet",
             "aptos",
             "sui",
-            "ethereum",
             "solana",
         ];
         for chain in expected {
@@ -467,8 +468,11 @@ mod tests {
         let results = check_all_providers(&fc, Network::Mainnet).await;
 
         // Then
-        assert_eq!(results[0].chain, "base");
-        let Status::Failed(reason) = &results[0].status else {
+        let base = results
+            .iter()
+            .find(|r| r.chain == "base")
+            .expect("base row");
+        let Status::Failed(reason) = &base.status else {
             panic!("expected Failed, got a pass/skip");
         };
         assert!(reason.contains("DEFINITELY_UNSET_TOKEN_ENV"));
@@ -541,7 +545,7 @@ mod tests {
                 expected_network_fingerprint: None,
                 providers,
             }),
-            ethereum: Some(config_with_provider(AuthConfig::None)),
+            solana: Some(config_with_provider(AuthConfig::None)),
             ..Default::default()
         };
 
@@ -559,6 +563,6 @@ mod tests {
         };
         assert_matches!(status("aptos", "healthy"), Status::Passed);
         assert_matches!(status("aptos", "broken"), Status::Failed(_));
-        assert_matches!(status("ethereum", "only"), Status::Skipped(_));
+        assert_matches!(status("solana", "only"), Status::Skipped(_));
     }
 }

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -11,6 +11,7 @@ use foreign_chain_inspector::avalanche::inspector::Avalanche;
 use foreign_chain_inspector::base::inspector::Base;
 use foreign_chain_inspector::bitcoin::inspector::BitcoinInspector;
 use foreign_chain_inspector::bnb::inspector::Bnb;
+use foreign_chain_inspector::ethereum::inspector::Ethereum;
 use foreign_chain_inspector::evm::inspector::{EvmChain, EvmInspector};
 use foreign_chain_inspector::hyperevm::inspector::HyperEvm;
 use foreign_chain_inspector::polygon::inspector::Polygon;
@@ -114,6 +115,7 @@ pub async fn probe_all_providers(config: &ForeignChainsConfig) -> ProbeReport {
                 ForeignChain::Avalanche => probe_evm::<Avalanche>(chain, chain_config).await,
                 ForeignChain::Base => probe_evm::<Base>(chain, chain_config).await,
                 ForeignChain::Bnb => probe_evm::<Bnb>(chain, chain_config).await,
+                ForeignChain::Ethereum => probe_evm::<Ethereum>(chain, chain_config).await,
                 ForeignChain::HyperEvm => probe_evm::<HyperEvm>(chain, chain_config).await,
                 ForeignChain::Polygon => probe_evm::<Polygon>(chain, chain_config).await,
                 ForeignChain::Bitcoin => {
@@ -141,7 +143,7 @@ pub async fn probe_all_providers(config: &ForeignChainsConfig) -> ProbeReport {
                     })
                     .await
                 }
-                // Ethereum, Solana and Ton have no inspector to probe them with.
+                // Solana and Ton have no inspector to probe them with.
                 _ => rows_of(chain, chain_config, ProviderStatus::ProbeNotImplemented),
             }
         });
@@ -258,8 +260,8 @@ mod tests {
     use super::*;
     use assert_matches::assert_matches;
     use foreign_chain_inspector::{
-        abstract_chain, adi, aptos, arbitrum, avalanche, base, bitcoin, bnb, hyperevm, polygon,
-        starknet, sui,
+        abstract_chain, adi, aptos, arbitrum, avalanche, base, bitcoin, bnb, ethereum, hyperevm,
+        polygon, starknet, sui,
     };
     use foreign_chain_rpc_interfaces::sui::Status;
     use foreign_chain_rpc_interfaces::sui::proto::ledger_service_server::{
@@ -307,7 +309,7 @@ mod tests {
     }
 
     /// Every EVM chain the probe covers, with its mainnet chain id.
-    const EVM_MAINNETS: [EvmMainnet; 8] = [
+    const EVM_MAINNETS: [EvmMainnet; 9] = [
         EvmMainnet {
             chain: ForeignChain::Abstract,
             chain_id: abstract_chain::MAINNET_CHAIN_ID,
@@ -331,6 +333,10 @@ mod tests {
         EvmMainnet {
             chain: ForeignChain::Bnb,
             chain_id: bnb::MAINNET_CHAIN_ID,
+        },
+        EvmMainnet {
+            chain: ForeignChain::Ethereum,
+            chain_id: ethereum::MAINNET_CHAIN_ID,
         },
         EvmMainnet {
             chain: ForeignChain::HyperEvm,
@@ -414,6 +420,7 @@ mod tests {
             ForeignChain::Avalanche => &mut chains.avalanche,
             ForeignChain::Base => &mut chains.base,
             ForeignChain::Bnb => &mut chains.bnb,
+            ForeignChain::Ethereum => &mut chains.ethereum,
             ForeignChain::HyperEvm => &mut chains.hyper_evm,
             ForeignChain::Polygon => &mut chains.polygon,
             other => panic!("no config slot wired for `{other:?}`"),

--- a/crates/foreign-chain-inspector/src/ethereum.rs
+++ b/crates/foreign-chain-inspector/src/ethereum.rs
@@ -1,0 +1,8 @@
+pub use ethereum_types;
+
+pub mod inspector;
+
+pub const MAINNET_CHAIN_ID: u64 = 1;
+
+mpc_primitives::define_hash!(EthereumBlockHash, 32);
+mpc_primitives::define_hash!(EthereumTransactionHash, 32);

--- a/crates/foreign-chain-inspector/src/ethereum/inspector.rs
+++ b/crates/foreign-chain-inspector/src/ethereum/inspector.rs
@@ -1,0 +1,16 @@
+use crate::{
+    ethereum::{EthereumBlockHash, EthereumTransactionHash},
+    evm::inspector::EvmChain,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct Ethereum;
+
+impl EvmChain for Ethereum {
+    type BlockHash = EthereumBlockHash;
+    type TransactionHash = EthereumTransactionHash;
+}
+
+pub type EthereumInspector<Client> = crate::evm::inspector::EvmInspector<Client, Ethereum>;
+pub type EthereumExtractedValue = crate::evm::inspector::EvmExtractedValue<Ethereum>;
+pub type EthereumExtractor = crate::evm::inspector::EvmExtractor;

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -24,6 +24,7 @@ pub mod base;
 pub mod bitcoin;
 pub mod bnb;
 pub mod contract_interface_conversions;
+pub mod ethereum;
 pub mod evm;
 pub mod hyperevm;
 pub mod polygon;

--- a/crates/foreign-chain-inspector/tests/ethereum_rpc_manual.rs
+++ b/crates/foreign-chain-inspector/tests/ethereum_rpc_manual.rs
@@ -1,0 +1,83 @@
+use assert_matches::assert_matches;
+use foreign_chain_inspector::{
+    EthereumFinality, ForeignChainInspector, NetworkFingerprintInspector, RpcAuthentication,
+    ethereum::{
+        EthereumBlockHash, EthereumTransactionHash, MAINNET_CHAIN_ID,
+        inspector::{EthereumExtractedValue, EthereumExtractor, EthereumInspector},
+    },
+};
+
+const ETHEREUM_RPC_URL: &str = "https://ethereum-rpc.publicnode.com";
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live Ethereum RPC provider"]
+async fn inspector_extracts_block_hash_against_live_rpc_provider() {
+    // given
+    let threshold = EthereumFinality::Finalized;
+
+    // Example transaction on Ethereum (block 0x444f76) with 1 log at block-wide index 0x10;
+    // https://etherscan.io/tx/0x7f1c6a58dc880438236d0b0a4ae166e9e9a038dbea8ec074149bd8b176332cac
+    let transaction_id: EthereumTransactionHash =
+        "7f1c6a58dc880438236d0b0a4ae166e9e9a038dbea8ec074149bd8b176332cac"
+            .parse()
+            .unwrap();
+    let expected_block_hash: EthereumBlockHash =
+        "34e5a6cfbdbb84f7625df1de69d218ade4da72f4a2558064a156674e72e976c9"
+            .parse()
+            .unwrap();
+
+    let http_client = foreign_chain_inspector::build_http_client(
+        ETHEREUM_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = EthereumInspector::new(http_client);
+
+    // when
+    let extracted_values = inspector
+        .extract(
+            transaction_id,
+            threshold,
+            vec![
+                EthereumExtractor::BlockHash,
+                EthereumExtractor::Log { log_index: 0x10 },
+            ],
+        )
+        .await
+        .expect("extract should succeed");
+
+    // then
+    assert_eq!(extracted_values.len(), 2);
+    assert_eq!(
+        extracted_values[0],
+        EthereumExtractedValue::BlockHash(expected_block_hash)
+    );
+    assert_matches!(extracted_values[1], EthereumExtractedValue::Log(_));
+}
+
+/// As shipped in `expected_network_fingerprint`.
+const EXPECTED_NETWORK_FINGERPRINT: u64 = MAINNET_CHAIN_ID;
+
+#[tokio::test]
+#[ignore = "manual test to sanity check against live Ethereum RPC provider"]
+async fn network_fingerprint_matches_the_shipped_config_value_against_live_rpc_provider() {
+    // given
+    let http_client = foreign_chain_inspector::build_http_client(
+        ETHEREUM_RPC_URL.to_string(),
+        RpcAuthentication::KeyInUrl,
+    )
+    .unwrap();
+    let inspector = EthereumInspector::new(http_client);
+
+    // when
+    let fingerprint = inspector
+        .network_fingerprint()
+        .await
+        .expect("network_fingerprint should succeed");
+
+    // then
+    assert_eq!(
+        fingerprint.to_string(),
+        EXPECTED_NETWORK_FINGERPRINT.to_string()
+    );
+}

--- a/crates/foreign-chain-inspector/tests/evm_inspector.rs
+++ b/crates/foreign-chain-inspector/tests/evm_inspector.rs
@@ -725,6 +725,10 @@ evm_inspector_tests!(
     avalanche
 );
 evm_inspector_tests!(foreign_chain_inspector::adi::inspector::Adi, adi);
+evm_inspector_tests!(
+    foreign_chain_inspector::ethereum::inspector::Ethereum,
+    ethereum
+);
 
 // Base mainnet, standing in for every EVM chain: the fingerprint call has no chain-specific parts.
 const CHAIN_ID_8453: &str = "0x2105";

--- a/crates/near-mpc-sdk/src/foreign_chain.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain.rs
@@ -9,6 +9,7 @@ pub mod avalanche;
 pub mod base;
 pub mod bitcoin;
 pub mod bnb;
+pub mod ethereum;
 pub mod evm;
 pub mod hyper_evm;
 pub mod polygon;

--- a/crates/near-mpc-sdk/src/foreign_chain/ethereum.rs
+++ b/crates/near-mpc-sdk/src/foreign_chain/ethereum.rs
@@ -1,0 +1,63 @@
+use crate::{
+    foreign_chain::{
+        ForeignChainRequestBuilder,
+        evm::{EvmChainVariant, EvmRequest},
+    },
+    sign::NotSet,
+};
+
+pub use crate::foreign_chain::evm::EvmBlockHash as EthereumBlockHash;
+pub use crate::foreign_chain::evm::{
+    EvmExtractedValue, EvmExtractor, EvmFinality, EvmLog, EvmRpcRequest, EvmTxId,
+    ForeignChainRpcRequest,
+};
+
+#[derive(Debug, Clone)]
+pub struct Ethereum;
+
+impl EvmChainVariant for Ethereum {
+    fn wrap(request: EvmRpcRequest) -> ForeignChainRpcRequest {
+        ForeignChainRpcRequest::Ethereum(request)
+    }
+}
+
+pub type EthereumRequest<TxId, Finality> = EvmRequest<Ethereum, TxId, Finality>;
+
+impl ForeignChainRequestBuilder<EthereumRequest<NotSet, NotSet>, NotSet> {
+    pub fn new_ethereum() -> Self {
+        Self {
+            request: EvmRequest {
+                tx_id: NotSet,
+                finality: NotSet,
+                expected_block_hash: None,
+                expected_logs: vec![],
+                _chain: std::marker::PhantomData,
+            },
+            domain_id: NotSet,
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use assert_matches::assert_matches;
+    use near_mpc_contract_interface::types::DomainId;
+
+    use crate::foreign_chain::ForeignChainRequestBuilder;
+
+    use super::*;
+
+    #[test]
+    fn build_wraps_into_ethereum_variant() {
+        // given / when
+        let (_verifier, request_args) = ForeignChainRequestBuilder::new_ethereum()
+            .with_tx_id(EvmTxId::from([1; 32]))
+            .with_finality(EvmFinality::Finalized)
+            .with_domain_id(DomainId::from(1))
+            .build()
+            .unwrap();
+
+        // then
+        assert_matches!(request_args.request, ForeignChainRpcRequest::Ethereum(_));
+    }
+}

--- a/crates/near-mpc-sdk/tests/ethereum.rs
+++ b/crates/near-mpc-sdk/tests/ethereum.rs
@@ -1,0 +1,27 @@
+use assert_matches::assert_matches;
+use near_mpc_sdk::foreign_chain::{
+    DomainId, ForeignChainRequestBuilder,
+    ethereum::{EvmFinality, EvmTxId, ForeignChainRpcRequest},
+};
+
+#[test]
+fn no_extractor_added() {
+    // given
+    let domain_id = DomainId::from(2);
+    let tx_id = EvmTxId::from([123; 32]);
+
+    // when
+    let (_verifier, built_sign_request_args) = ForeignChainRequestBuilder::new_ethereum()
+        .with_tx_id(tx_id)
+        .with_finality(EvmFinality::Finalized)
+        .with_domain_id(domain_id)
+        .build()
+        .unwrap();
+
+    // then
+    let no_extractors = vec![];
+
+    assert_matches!(built_sign_request_args.request, ForeignChainRpcRequest::Ethereum(ethereum_rpc_request) => {
+        assert_eq!(ethereum_rpc_request.extractors, no_extractors);
+    });
+}

--- a/crates/node/src/providers/verify_foreign_tx.rs
+++ b/crates/node/src/providers/verify_foreign_tx.rs
@@ -15,6 +15,7 @@ use foreign_chain_inspector::avalanche::inspector::AvalancheInspector;
 use foreign_chain_inspector::base::inspector::BaseInspector;
 use foreign_chain_inspector::bitcoin::inspector::BitcoinInspector;
 use foreign_chain_inspector::bnb::inspector::BnbInspector;
+use foreign_chain_inspector::ethereum::inspector::EthereumInspector;
 use foreign_chain_inspector::http_client::HttpClient;
 use foreign_chain_inspector::hyperevm::inspector::HyperEvmInspector;
 use foreign_chain_inspector::polygon::inspector::PolygonInspector;
@@ -37,6 +38,7 @@ use tokio::sync::watch;
 /// config and constructing them on every call.
 pub(crate) struct ForeignChainInspectors<Client> {
     pub bitcoin: Option<FanOut<BitcoinInspector<Client>>>,
+    pub ethereum: Option<FanOut<EthereumInspector<Client>>>,
     pub abstract_chain: Option<FanOut<AbstractInspector<Client>>>,
     pub bnb: Option<FanOut<BnbInspector<Client>>>,
     pub starknet: Option<FanOut<StarknetInspector<Client>>>,
@@ -123,6 +125,10 @@ impl ForeignChainInspectors<HttpClient> {
             bitcoin: build_fanout(
                 config.bitcoin.as_ref(),
                 with_http_client(BitcoinInspector::new),
+            )?,
+            ethereum: build_fanout(
+                config.ethereum.as_ref(),
+                with_http_client(EthereumInspector::new),
             )?,
             abstract_chain: build_fanout(
                 config.abstract_chain.as_ref(),

--- a/crates/node/src/providers/verify_foreign_tx/sign.rs
+++ b/crates/node/src/providers/verify_foreign_tx/sign.rs
@@ -9,6 +9,7 @@ use foreign_chain_inspector::avalanche::inspector::AvalancheExtractor;
 use foreign_chain_inspector::base::inspector::BaseExtractor;
 use foreign_chain_inspector::bitcoin::inspector::BitcoinExtractor;
 use foreign_chain_inspector::bnb::inspector::BnbExtractor;
+use foreign_chain_inspector::ethereum::inspector::EthereumExtractor;
 use foreign_chain_inspector::hyperevm::inspector::HyperEvmExtractor;
 use foreign_chain_inspector::polygon::inspector::PolygonExtractor;
 use foreign_chain_inspector::starknet::inspector::{StarknetExtractor, StarknetFinality};
@@ -187,8 +188,27 @@ impl VerifyForeignTxProvider {
             })?;
 
         let values: Vec<dtos::ExtractedValue> = match request {
-            dtos::ForeignChainRpcRequest::Ethereum(_request) => {
-                bail!("ForeignChainRpcRequest::Ethereum is unsupported")
+            dtos::ForeignChainRpcRequest::Ethereum(request) => {
+                let inspector = self
+                    .inspectors
+                    .ethereum
+                    .as_ref()
+                    .context("no inspector configured for Ethereum")?;
+
+                let transaction_id = request.tx_id.0.into();
+                let finality: EthereumFinality = request.finality.clone().try_into()?;
+                let extractors: Vec<EthereumExtractor> = request
+                    .extractors
+                    .iter()
+                    .cloned()
+                    .map(TryInto::try_into)
+                    .collect::<Result<_, _>>()?;
+                let values = inspector
+                    .extract(transaction_id, finality, extractors)
+                    .timeout(FOREIGN_CHAIN_INSPECTION_TIMEOUT)
+                    .await
+                    .context("timed out during execution of foreign chain request")??;
+                values.into_iter().map(Into::into).collect()
             }
             dtos::ForeignChainRpcRequest::Solana(_request) => {
                 bail!("ForeignChainRpcRequest::Solana is unsupported")

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -548,12 +548,12 @@ Once wired into node startup, each resolved provider gets its self-identifying R
 
 Taking the expected value from operator config rather than a constant in the attested binary is a deliberate trade. It makes mixed-network and local deployments checkable at all, since a config may pair one chain's mainnet with another's testnet and no binary can ship a value for a devnet. The cost is that the check no longer binds an operator: they can set the wrong value, or omit the field and get no check at all, and either way they fool only their own node's diagnostics. The network-level defenses against a wrong URL are unchanged: threshold voter review of the whitelist, and the provider fan-out, which fails the individual request when a provider disagrees with its siblings.
 
-Every chain with an inspector is probed, each by the RPC below. `solana` and `ethereum` have none, so they ignore `expected_network_fingerprint`. The fingerprint values themselves are tabulated once, under [Configuration (Node)](#configuration-node).
+Every chain with an inspector is probed, each by the RPC below. `solana` has none, so it ignores `expected_network_fingerprint`. The fingerprint values themselves are tabulated once, under [Configuration (Node)](#configuration-node).
 
 | chain | probe |
 |---|---|
 | starknet | `starknet_chainId` |
-| base, bnb, arbitrum, polygon, hyper_evm, avalanche, adi, abstract | `eth_chainId` |
+| ethereum, base, bnb, arbitrum, polygon, hyper_evm, avalanche, adi, abstract | `eth_chainId` |
 | bitcoin | `getblockhash` at height 0 |
 | aptos | the ledger info at the REST root |
 | sui | `GetServiceInfo` |
@@ -690,6 +690,7 @@ checkpoint digest — hence the neutral name.
 
 | chain | fingerprint | mainnet | testnet |
 |---|---|---|---|
+| ethereum | EIP-155 chain id, decimal | `"1"` | `"11155111"` (Sepolia) |
 | base | EIP-155 chain id, decimal | `"8453"` | `"84532"` (Sepolia) |
 | bnb | EIP-155 chain id, decimal | `"56"` | `"97"` |
 | arbitrum | EIP-155 chain id, decimal | `"42161"` | `"421614"` (Sepolia) |
@@ -712,8 +713,8 @@ separates the test networks from each other where a network *name* would not: te
 `"0f9188f13cb7b2c71f2a335e3a4fc328bf5beb436012afca590b1a11466e2206"`. Aptos's one-byte id space
 separates mainnet from testnet, but two devnets can collide.
 
-`solana` and `ethereum` are configurable but absent from the table: neither has an inspector, so
-there is nothing about them to verify in the first place.
+`solana` is configurable but absent from the table: it has no inspector, so
+there is nothing about it to verify in the first place.
 
 The fingerprint is set per chain rather than once per deployment, so a config can mix networks, and
 each value must match the network of the `rpc_url` beside it. The value is always a quoted string,
@@ -721,7 +722,7 @@ including the fingerprints that look numeric.
 
 Every chain with an inspector is probed, and for those, leaving the field unset is not a silent
 skip: every provider of the chain is reported as `MissingExpectedFingerprint`, because silence reads
-as healthy on a dashboard. `solana` and `ethereum` report `ProbeNotImplemented` whether the field is
+as healthy on a dashboard. `solana` reports `ProbeNotImplemented` whether the field is
 set or not.
 
 ## Risks


### PR DESCRIPTION
Adds Ethereum mainnet to foreign transaction verification. With this, every
EVM chain supported by omni-bridge (Eth, Arb, Base, Bnb, Pol, HlEvm, Abs) is
covered. Like Avalanche and ADI (#4145), this is mechanical wiring — Ethereum
reuses the generic `EvmInspector` the same way the other EVM chains do.

## The chain

* **Ethereum** — chain id 1 (Sepolia 11155111). The one EVM chain with real
  `safe`/`finalized` semantics: `finalized` lags `latest` by ~13 minutes
  (two epochs), `safe` by one. The inspector's existing finality handling
  covers all three tags.

## Changes

Ethereum has been a `ForeignChain`/`ForeignChainRpcRequest` variant since the
beginning (discriminant 2), and already had a node config slot, web-UI
provider counts, and contract sandbox test rows — so unlike #4145 there are
**no contract-interface changes and no ABI/borsh snapshot churn**. What was
missing was everything behind the enum:

* inspector marker module (`foreign_chain_inspector::ethereum`) + the
  `eth_chainId` fingerprint constant;
* node dispatch: an `EthereumInspector` fan-out slot and a real
  `ForeignChainRpcRequest::Ethereum` arm in `sign.rs`, replacing the
  `bail!("… is unsupported")`;
* health check: golden vector + `run_evm::<Ethereum>` (was `mark_skipped`),
  fingerprint probe arm, and the matching test rows;
* SDK builder (`new_ethereum()`) and tests;
* e2e coverage: Ethereum joins the mock cluster in
  `verify_foreign_transaction__should_sign_all_supported_chains`; the
  negative "chain not in config" branch now uses Solana, the remaining
  requestable-but-unsupported chain;
* docs tables (`foreign-chain-transactions.md`): ethereum moves from the
  "no inspector" carve-outs into the `eth_chainId` probe row and the
  fingerprint table.

The pinned golden transaction is
`0x7f1c6a58dc880438236d0b0a4ae166e9e9a038dbea8ec074149bd8b176332cac`
(block 4,476,790, hash `0x34e5a6cf…76c9`): post-Byzantium (so the receipt
carries `status: 1`, which the inspector requires) with one log at
block-wide index 0x10. Values cross-checked against two independent
generations of ethers.js provider test fixtures (v5.7 and v6), which are
CI-validated against live mainnet.

## Testing

* clippy / fmt / touched crates' tests pass.
* The new `#[ignore]`d manual tests mirror the Avalanche/ADI ones
  (block-hash + log extraction on the pinned tx, `eth_chainId` fingerprint 1)
  — run them against a live RPC before merging; the sandbox this change was
  authored in has no egress to RPC providers.
