### PR TITLE
feat(node): metrics for attestation freshness

### DIFF
--- a/crates/node/src/indexer/tx_sender.rs
+++ b/crates/node/src/indexer/tx_sender.rs
@@ -311,7 +311,7 @@ async fn observe_tx_result(
             );
 
             Ok(if attestation_landed {
-                record_attestation_landed();
+                record_attestation_landed(&Clock::real());
                 TransactionStatus::Executed
             } else {
                 TransactionStatus::NotExecuted

--- a/crates/node/src/indexer/tx_sender.rs
+++ b/crates/node/src/indexer/tx_sender.rs
@@ -3,6 +3,9 @@ use super::IndexerState;
 use super::tx_signer::{TransactionSigner, TransactionSigners};
 use crate::config::RespondConfig;
 use crate::metrics;
+use crate::tee::attestation_freshness_metrics::{
+    record_attestation_landed, record_stored_attestation_expiry,
+};
 use crate::types::{
     LogTransaction, SignerContext, SubmittedTransaction, SubmittedTransactionStatus,
     SubmittedTxMetadata,
@@ -284,6 +287,8 @@ async fn observe_tx_result(
                 .get_participant_attestation(&indexer_state.mpc_contract_id, &args.tls_public_key)
                 .await?;
 
+            record_stored_attestation_expiry(stored_attestation.as_ref());
+
             let Some(stored_attestation) = stored_attestation else {
                 tracing::debug!(
                     "no attestation stored on chain for our key; submission not yet landed"
@@ -306,6 +311,7 @@ async fn observe_tx_result(
             );
 
             Ok(if attestation_landed {
+                record_attestation_landed();
                 TransactionStatus::Executed
             } else {
                 TransactionStatus::NotExecuted

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -484,8 +484,9 @@ pub static MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS: LazyLock<prometheus::IntGau
     LazyLock::new(|| {
         prometheus::register_int_gauge!(
             "mpc_attestation_expiry_timestamp_seconds",
-            "Unix time at which the attestation stored on chain for this node's TLS key expires \
-             (-1 if the stored attestation carries no expiry, 0 if none is stored)"
+            "Unix time at which the attestation stored on chain for this node's TLS key expires. \
+             -1 if the stored attestation carries no expiry; 0 if none is stored. Compare against \
+             mpc_indexer_latest_block_timestamp_seconds for the remaining time"
         )
         .unwrap()
     });
@@ -498,3 +499,14 @@ pub static MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS: LazyLock<prometheus::I
         )
         .unwrap()
     });
+
+/// Registers the attestation-freshness gauges, which are otherwise only touched once a submission
+/// reaches the chain.
+///
+/// A metric registers on first dereference, so without this a node that never gets that far
+/// exports no series at all — and an alert on an absent series never fires, in exactly the failure
+/// mode these gauges exist to catch.
+pub fn init_attestation_freshness_metrics() {
+    LazyLock::force(&MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS);
+    LazyLock::force(&MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS);
+}

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -484,9 +484,10 @@ pub static MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS: LazyLock<prometheus::IntGau
     LazyLock::new(|| {
         prometheus::register_int_gauge!(
             "mpc_attestation_expiry_timestamp_seconds",
-            "Unix time at which the attestation stored on chain for this node's TLS key expires. \
-             -1 if the stored attestation carries no expiry; 0 if none is stored. Compare against \
-             mpc_indexer_latest_block_timestamp_seconds for the remaining time"
+            "NEAR block time at which the attestation stored on chain for this node's TLS key \
+             expires. -1 if the stored attestation carries no expiry; 0 if none is stored. \
+             Subtract mpc_indexer_latest_block_timestamp_seconds, not wall clock, for the \
+             remaining time"
         )
         .unwrap()
     });
@@ -495,17 +496,13 @@ pub static MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS: LazyLock<prometheus::I
     LazyLock::new(|| {
         prometheus::register_int_gauge!(
             "mpc_attestation_last_landed_timestamp_seconds",
-            "Unix time at which this node last confirmed an attestation submission landed on chain"
+            "Unix time, by this node's own clock, at which it last confirmed an attestation \
+             submission landed on chain"
         )
         .unwrap()
     });
 
-/// Registers the attestation-freshness gauges, which are otherwise only touched once a submission
-/// reaches the chain.
-///
-/// A metric registers on first dereference, so without this a node that never gets that far
-/// exports no series at all — and an alert on an absent series never fires, in exactly the failure
-/// mode these gauges exist to catch.
+/// An alert cannot fire on a series that does not exist yet.
 pub fn init_attestation_freshness_metrics() {
     LazyLock::force(&MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS);
     LazyLock::force(&MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS);

--- a/crates/node/src/metrics.rs
+++ b/crates/node/src/metrics.rs
@@ -479,3 +479,22 @@ pub static MPC_TEE_ATTESTATION_ATTEMPTS_TOTAL: LazyLock<prometheus::IntCounterVe
 
 pub const MPC_TEE_ATTESTATION_OUTCOME_SUCCESS: &str = "success";
 pub const MPC_TEE_ATTESTATION_OUTCOME_FAILURE: &str = "failure";
+
+pub static MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS: LazyLock<prometheus::IntGauge> =
+    LazyLock::new(|| {
+        prometheus::register_int_gauge!(
+            "mpc_attestation_expiry_timestamp_seconds",
+            "Unix time at which the attestation stored on chain for this node's TLS key expires \
+             (-1 if the stored attestation carries no expiry, 0 if none is stored)"
+        )
+        .unwrap()
+    });
+
+pub static MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS: LazyLock<prometheus::IntGauge> =
+    LazyLock::new(|| {
+        prometheus::register_int_gauge!(
+            "mpc_attestation_last_landed_timestamp_seconds",
+            "Unix time at which this node last confirmed an attestation submission landed on chain"
+        )
+        .unwrap()
+    });

--- a/crates/node/src/tee.rs
+++ b/crates/node/src/tee.rs
@@ -1,4 +1,5 @@
 pub mod allowed_image_hashes_watcher;
+pub mod attestation_freshness_metrics;
 pub mod image_expiry_metrics;
 pub mod remote_attestation;
 

--- a/crates/node/src/tee/attestation_freshness_metrics.rs
+++ b/crates/node/src/tee/attestation_freshness_metrics.rs
@@ -1,0 +1,68 @@
+//! Attestation-freshness gauges.
+//!
+//! Both are absolute timestamps rather than remaining durations: a node that stops re-attesting
+//! also stops updating them, and only the absolute form keeps decaying towards now, so a staleness
+//! alert still fires on a frozen gauge. Each landed submission moves them, so at rest they
+//! advance hourly.
+
+use near_mpc_contract_interface::types::VerifiedAttestation;
+use near_time::Clock;
+
+use crate::metrics::{
+    MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS, MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS,
+};
+
+const NO_ATTESTATION_STORED: i64 = 0;
+const NO_EXPIRY: i64 = -1;
+
+pub(crate) fn record_stored_attestation_expiry(stored: Option<&VerifiedAttestation>) {
+    MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS.set(expiry_gauge_value(stored));
+}
+
+pub(crate) fn record_attestation_landed() {
+    MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS.set(Clock::real().now_utc().unix_timestamp());
+}
+
+fn expiry_gauge_value(stored: Option<&VerifiedAttestation>) -> i64 {
+    match stored.map(VerifiedAttestation::expiry_timestamp_seconds) {
+        None => NO_ATTESTATION_STORED,
+        Some(None) => NO_EXPIRY,
+        Some(Some(expiry)) => i64::try_from(expiry).unwrap_or(i64::MAX),
+    }
+}
+
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::*;
+    use near_mpc_contract_interface::types::MockAttestation;
+    use rstest::rstest;
+
+    const EXPIRES_AT: u64 = 1_754_000_000;
+
+    fn mock_with_expiry(expiry_timestamp_seconds: Option<u64>) -> VerifiedAttestation {
+        VerifiedAttestation::Mock(MockAttestation::WithConstraints {
+            mpc_docker_image_hash: None,
+            launcher_docker_compose_hash: None,
+            expiry_timestamp_seconds,
+            expected_measurements: None,
+        })
+    }
+
+    #[rstest]
+    #[case::nothing_stored(None, NO_ATTESTATION_STORED)]
+    #[case::stored_with_expiry(Some(mock_with_expiry(Some(EXPIRES_AT))), EXPIRES_AT as i64)]
+    #[case::stored_without_expiry(Some(mock_with_expiry(None)), NO_EXPIRY)]
+    #[case::unstamped_mock(Some(VerifiedAttestation::Mock(MockAttestation::Valid)), NO_EXPIRY)]
+    #[case::expiry_beyond_i64(Some(mock_with_expiry(Some(u64::MAX))), i64::MAX)]
+    fn expiry_gauge_value__should_report_stored_expiry_or_a_sentinel(
+        #[case] stored: Option<VerifiedAttestation>,
+        #[case] expected: i64,
+    ) {
+        // When
+        let value = expiry_gauge_value(stored.as_ref());
+
+        // Then
+        assert_eq!(value, expected);
+    }
+}

--- a/crates/node/src/tee/attestation_freshness_metrics.rs
+++ b/crates/node/src/tee/attestation_freshness_metrics.rs
@@ -2,8 +2,8 @@
 //!
 //! Both are absolute timestamps rather than remaining durations: a node that stops re-attesting
 //! also stops updating them, and only the absolute form keeps decaying towards now, so a staleness
-//! alert still fires on a frozen gauge. Each landed submission moves them, so at rest they
-//! advance hourly.
+//! alert still fires on a frozen gauge. At rest both advance hourly — the expiry is re-read on
+//! every submission observation, the landing timestamp only when one is confirmed.
 
 use near_mpc_contract_interface::types::VerifiedAttestation;
 use near_time::Clock;
@@ -19,8 +19,8 @@ pub(crate) fn record_stored_attestation_expiry(stored: Option<&VerifiedAttestati
     MPC_ATTESTATION_EXPIRY_TIMESTAMP_SECONDS.set(expiry_gauge_value(stored));
 }
 
-pub(crate) fn record_attestation_landed() {
-    MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS.set(Clock::real().now_utc().unix_timestamp());
+pub(crate) fn record_attestation_landed(clock: &Clock) {
+    MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS.set(clock.now_utc().unix_timestamp());
 }
 
 fn expiry_gauge_value(stored: Option<&VerifiedAttestation>) -> i64 {
@@ -36,6 +36,7 @@ fn expiry_gauge_value(stored: Option<&VerifiedAttestation>) -> i64 {
 mod tests {
     use super::*;
     use near_mpc_contract_interface::types::MockAttestation;
+    use near_time::{FakeClock, Utc};
     use rstest::rstest;
 
     const EXPIRES_AT: u64 = 1_754_000_000;
@@ -47,6 +48,21 @@ mod tests {
             expiry_timestamp_seconds,
             expected_measurements: None,
         })
+    }
+
+    #[test]
+    fn record_attestation_landed__should_set_the_gauge_to_the_landing_time() {
+        // Given
+        let landed_at = Utc::from_unix_timestamp(EXPIRES_AT as i64).unwrap();
+
+        // When
+        record_attestation_landed(&FakeClock::new(landed_at).clock());
+
+        // Then
+        assert_eq!(
+            MPC_ATTESTATION_LAST_LANDED_TIMESTAMP_SECONDS.get(),
+            EXPIRES_AT as i64
+        );
     }
 
     #[rstest]

--- a/crates/node/src/web.rs
+++ b/crates/node/src/web.rs
@@ -49,6 +49,7 @@ impl IntoResponse for AnyhowErrorWrapper {
 pub(crate) async fn metrics() -> String {
     // Ensure build info metric is always set before gathering metrics
     crate::metrics::init_build_info_metric();
+    crate::metrics::init_attestation_freshness_metrics();
 
     let metric_families = default_registry().gather();
     let mut buffer = vec![];

--- a/docs/design/node-operator-metrics.md
+++ b/docs/design/node-operator-metrics.md
@@ -83,6 +83,9 @@ mpc_attestation_expiry_timestamp_seconds > 0
 mpc_attestation_expiry_timestamp_seconds == 0  for 15m
 ```
 
+A `-1` expiry satisfies neither expiry alert, so a node holding an attestation stored
+without one is covered by the staleness alert alone.
+
 One failing node or a fleet-wide cause (Intel's PCCS and its collateral, usually)? Count
 the affected nodes:
 

--- a/docs/design/node-operator-metrics.md
+++ b/docs/design/node-operator-metrics.md
@@ -36,8 +36,8 @@ on-chain confirmation of an attestation submission, in
 
 | Metric | Measures | How to interpret |
 | --- | --- | --- |
-| [`mpc_attestation_last_landed_timestamp_seconds`](../../crates/node/src/metrics.rs) | Unix time of the last attestation submission this node confirmed on chain | should be under an `ATTESTATION_RESUBMISSION_INTERVAL` (1h) old. Only a confirmed landing advances it, so the gap to now is how long re-attestation has been failing, wherever it broke. One failed attempt is absorbed by the next tick; a growing gap ends in eviction from the participant set. |
-| [`mpc_attestation_expiry_timestamp_seconds`](../../crates/node/src/metrics.rs) | Unix time at which the attestation the contract stores for this node's TLS key expires | should sit a full expiry window ahead of chain time and step forward hourly. `0` = nothing stored (evicted, or never landed one), `-1` = stored without an expiry (legacy entries only; the contract stamps every attestation it accepts). Compare against `mpc_indexer_latest_block_timestamp_seconds`, the clock the contract expires entries against. |
+| [`mpc_attestation_last_landed_timestamp_seconds`](../../crates/node/src/metrics.rs) | Unix time of the last attestation submission this node confirmed on chain | should be under an `ATTESTATION_RESUBMISSION_INTERVAL` (1h) old. A sustained gap ends in this node being dropped from the participant set. |
+| [`mpc_attestation_expiry_timestamp_seconds`](../../crates/node/src/metrics.rs) | NEAR block time at which the attestation the contract stores for this node's TLS key expires | subtract `mpc_indexer_latest_block_timestamp_seconds` — the clock the contract expires entries against, not wall clock — for the runway before this node is dropped from the participant set. `0` = nothing stored (evicted, or never landed one), `-1` = stored without an expiry. |
 
 ## Recommended alerts
 
@@ -66,17 +66,19 @@ time() - mpc_last_backup_served_timestamp_seconds > 86400  for 1h
 mpc_last_backup_served_epoch < mpc_current_epoch_id  for 1h
 
 # Re-attestation stuck (warn): nothing landed in three re-attestation intervals.
-# A single failed attempt is absorbed by the next tick and never reaches this.
-time() - mpc_attestation_last_landed_timestamp_seconds > 3 * 3600  for 1h
+# The primary signal — it fires within hours, while the expiry alert below only
+# does so days later.
+time() - mpc_attestation_last_landed_timestamp_seconds > 3 * 3600  for 15m
 
-# Attestation about to expire (page): under 40% of the 7d window left before the
-# contract drops this node. Measured against chain time, the clock the contract
-# compares against. Keep the threshold a fraction of the configured window rather
-# than a fixed duration. `> 0` drops the sentinels so they are not read as
-# timestamps.
+# Attestation runway low (page): under 3 days before the contract drops this node
+# from the participant set. Backstop for the alert above, and reached only about
+# four days after submissions stop landing. The threshold is a plain duration
+# rather than a fraction of the expiry window (7 days today): keep it below the
+# window, and revisit if the window changes. `> 0` drops the sentinels so they are
+# not read as timestamps.
 mpc_attestation_expiry_timestamp_seconds > 0
   and mpc_attestation_expiry_timestamp_seconds - mpc_indexer_latest_block_timestamp_seconds
-      < 0.4 * 604800  for 15m
+      < 3 * 86400  for 15m
 
 # No attestation stored (page): the contract holds nothing for our TLS key, so this
 # node is out of the attested set. Also covers a node that never landed one.
@@ -85,10 +87,3 @@ mpc_attestation_expiry_timestamp_seconds == 0  for 15m
 
 A `-1` expiry satisfies neither expiry alert, so a node holding an attestation stored
 without one is covered by the staleness alert alone.
-
-One failing node or a fleet-wide cause (Intel's PCCS and its collateral, usually)? Count
-the affected nodes:
-
-```promql
-count(time() - mpc_attestation_last_landed_timestamp_seconds > 3 * 3600)
-```

--- a/docs/design/node-operator-metrics.md
+++ b/docs/design/node-operator-metrics.md
@@ -30,6 +30,15 @@ serves keyshares over the migration service to the backup service registered for
 | [`mpc_last_backup_served_timestamp_seconds`](../../crates/node/src/metrics.rs) | Unix time of the last keyshare set served to the backup service | should be recent. A large gap since the last resharing means backups are not being taken. Confirms the node served the keyshares, not that the backup service persisted them. |
 | [`mpc_current_epoch_id`](../../crates/node/src/metrics.rs) | epoch id of the keyset the contract currently holds | the reference point for `mpc_last_backup_served_epoch`. Increments on every resharing; unset until the first keyset exists. During a resharing it stays at the old epoch, which is the one still available to back up. |
 
+Attestation freshness, in [`metrics.rs`](../../crates/node/src/metrics.rs). Set from the
+on-chain confirmation of an attestation submission, in
+[`attestation_freshness_metrics.rs`](../../crates/node/src/tee/attestation_freshness_metrics.rs):
+
+| Metric | Measures | How to interpret |
+| --- | --- | --- |
+| [`mpc_attestation_last_landed_timestamp_seconds`](../../crates/node/src/metrics.rs) | Unix time of the last attestation submission this node confirmed on chain | should be under an `ATTESTATION_RESUBMISSION_INTERVAL` (1h) old. Only a confirmed landing advances it, so the gap to now is how long re-attestation has been failing, wherever it broke. One failed attempt is absorbed by the next tick; a growing gap ends in eviction from the participant set. |
+| [`mpc_attestation_expiry_timestamp_seconds`](../../crates/node/src/metrics.rs) | Unix time at which the attestation the contract stores for this node's TLS key expires | should sit a full expiry window ahead of chain time and step forward hourly. `0` = nothing stored (evicted, or never landed one), `-1` = stored without an expiry (legacy entries only; the contract stamps every attestation it accepts). Compare against `mpc_indexer_latest_block_timestamp_seconds`, the clock the contract expires entries against. |
+
 ## Recommended alerts
 
 ```promql
@@ -55,4 +64,28 @@ time() - mpc_last_backup_served_timestamp_seconds > 86400  for 1h
 # been served to the backup service since. Also fires if the node has never served
 # a backup, since the gauge starts at 0.
 mpc_last_backup_served_epoch < mpc_current_epoch_id  for 1h
+
+# Re-attestation stuck (warn): nothing landed in three re-attestation intervals.
+# A single failed attempt is absorbed by the next tick and never reaches this.
+time() - mpc_attestation_last_landed_timestamp_seconds > 3 * 3600  for 1h
+
+# Attestation about to expire (page): under 40% of the 7d window left before the
+# contract drops this node. Measured against chain time, the clock the contract
+# compares against. Keep the threshold a fraction of the configured window rather
+# than a fixed duration. `> 0` drops the sentinels so they are not read as
+# timestamps.
+mpc_attestation_expiry_timestamp_seconds > 0
+  and mpc_attestation_expiry_timestamp_seconds - mpc_indexer_latest_block_timestamp_seconds
+      < 0.4 * 604800  for 15m
+
+# No attestation stored (page): the contract holds nothing for our TLS key, so this
+# node is out of the attested set. Also covers a node that never landed one.
+mpc_attestation_expiry_timestamp_seconds == 0  for 15m
+```
+
+One failing node or a fleet-wide cause (Intel's PCCS and its collateral, usually)? Count
+the affected nodes:
+
+```promql
+count(time() - mpc_attestation_last_landed_timestamp_seconds > 3 * 3600)
 ```


### PR DESCRIPTION
Closes #3951

Two gauges written where the node already confirms a submission on chain (#3736), so no new RPC:

- `mpc_attestation_last_landed_timestamp_seconds` — advances only on a confirmed landing, so the gap to now is how long re-attestation has been failing. One failed attempt is absorbed by the next hourly tick; only sustained failure grows it.
- `mpc_attestation_expiry_timestamp_seconds` — the expiry the contract stores for our TLS key, so time-to-eviction is directly visible. Sentinels follow #3752: `0` nothing stored, `-1` stored without an expiry (defensive — the contract stamps every attestation it accepts).

Absolute timestamps rather than remaining durations: a node that stops re-attesting also stops updating the gauges, and only the absolute form keeps decaying towards now, so the alert still fires on a frozen gauge. A frozen "seconds remaining" would sit at a healthy value forever, which is the silent failure this fixes.

Metric interpretation, alert expressions, and the query separating one bad node from a fleet-wide cause are in `docs/design/node-operator-metrics.md`.

Alerting on these lives in https://github.com/near/mpc-private/issues/559 and needs deployed nodes first. Not covered: a node that is fully down publishes nothing, and we don't scrape third-party operators.