### PR TITLE
refactor: renaming threshold in verifier_votes.rs and reducing code redundancy

### DIFF
--- a/crates/contract/src/api/governance.rs
+++ b/crates/contract/src/api/governance.rs
@@ -166,14 +166,14 @@ mod tests {
     #[test]
     fn test_vote_new_parameters_succeeds_with_default_tee_status() {
         let (mut contract, participants, first_participant_id) = setup_tee_test_contract(3, 2);
-        let threshold = GovernanceThreshold::new(2);
+        let governance_threshold = GovernanceThreshold::new(2);
 
         // No attestations submitted - all participants have default TEE status None
         let result = setup_voting_context_and_vote(
             &mut contract,
             &first_participant_id,
             participants,
-            threshold,
+            governance_threshold,
         );
         assert!(
             result.is_ok(),
@@ -188,7 +188,7 @@ mod tests {
     #[test]
     fn test_vote_new_parameters_succeeds_when_all_participants_have_valid_tee() {
         let (mut contract, participants, first_participant_id) = setup_tee_test_contract(3, 2);
-        let threshold = GovernanceThreshold::new(2);
+        let governance_threshold = GovernanceThreshold::new(2);
 
         // Submit valid attestations for all participants
         submit_valid_attestations(&mut contract, &participants, &[0, 1, 2]);
@@ -198,7 +198,7 @@ mod tests {
             &mut contract,
             &first_participant_id,
             participants,
-            threshold,
+            governance_threshold,
         );
         assert!(
             result.is_ok(),
@@ -215,7 +215,7 @@ mod tests {
     #[test]
     fn test_vote_new_parameters_succeeds_after_invalid_attestation_rejected() {
         let (mut contract, participants, first_participant_id) = setup_tee_test_contract(4, 3);
-        let threshold = GovernanceThreshold::new(3);
+        let governance_threshold = GovernanceThreshold::new(3);
 
         // Submit valid attestations for first 3 participants
         submit_valid_attestations(&mut contract, &participants, &[0, 1, 2]);
@@ -245,7 +245,7 @@ mod tests {
             &mut contract,
             &first_participant_id,
             participants,
-            threshold,
+            governance_threshold,
         );
         assert!(
             result.is_ok(),
@@ -459,9 +459,9 @@ mod tests {
         // Given: a participant whose vote is forwarded through another contract,
         // so signer_account_id (the participant) != predecessor_account_id (the forwarder).
         let (mut contract, participants, first_participant_id) = setup_tee_test_contract(3, 2);
-        let threshold = GovernanceThreshold::new(2);
+        let governance_threshold = GovernanceThreshold::new(2);
         let proposal = ProposedGovernanceThresholdParameters::new(
-            GovernanceThresholdParameters::new(participants, threshold).unwrap(),
+            GovernanceThresholdParameters::new(participants, governance_threshold).unwrap(),
             BTreeMap::new(),
         );
 

--- a/crates/contract/src/api/governance.rs
+++ b/crates/contract/src/api/governance.rs
@@ -143,7 +143,7 @@ mod tests {
         contract: &mut MpcContract,
         first_participant_id: &AccountId,
         participants: Participants,
-        threshold: GovernanceThreshold,
+        governance_threshold: GovernanceThreshold,
     ) -> Result<(), Error> {
         let voting_context = VMContextBuilder::new()
             .signer_account_id(first_participant_id.clone())
@@ -153,7 +153,7 @@ mod tests {
         testing_env!(voting_context);
 
         let proposal = ProposedGovernanceThresholdParameters::new(
-            GovernanceThresholdParameters::new(participants, threshold).unwrap(),
+            GovernanceThresholdParameters::new(participants, governance_threshold).unwrap(),
             BTreeMap::new(),
         );
         contract.vote_new_parameters(EpochId::new(1), (&proposal).into_dto_type())
@@ -253,13 +253,13 @@ mod tests {
         );
     }
 
-    /// Builds a Running contract with `num_participants` participants, signing
-    /// threshold `threshold`, and a single CaitSith [`Sign`] domain whose
-    /// reconstruction threshold is `reconstruction_threshold`.
+    /// Builds a Running contract with `num_participants` participants, the given
+    /// governance threshold, and a single CaitSith [`Sign`] domain with the given
+    /// reconstruction threshold.
     fn setup_running_contract_with_domain(
         num_participants: usize,
-        threshold: u64,
-        reconstruction_threshold: u64,
+        governance_threshold: GovernanceThreshold,
+        reconstruction_threshold: ReconstructionThreshold,
     ) -> (MpcContract, Participants, AccountId, DomainId) {
         let participants = gen_participants(num_participants);
         let first_participant_id = participants.participants()[0].0.clone();
@@ -271,16 +271,13 @@ mod tests {
                 .build()
         );
 
-        let parameters = GovernanceThresholdParameters::new(
-            participants.clone(),
-            GovernanceThreshold::new(threshold),
-        )
-        .unwrap();
+        let parameters =
+            GovernanceThresholdParameters::new(participants.clone(), governance_threshold).unwrap();
         let domain_id = DomainId::default();
         let domains = vec![DomainConfig {
             id: domain_id,
             protocol: Protocol::CaitSith,
-            reconstruction_threshold: ReconstructionThreshold::new(reconstruction_threshold),
+            reconstruction_threshold,
             purpose: DomainPurpose::Sign,
         }];
         let (pk, _) = make_public_key_for_curve(Curve::Secp256k1, &mut OsRng);
@@ -317,8 +314,11 @@ mod tests {
     #[test]
     fn vote_new_parameters__should_reject_when_per_domain_threshold_exceeds_participants() {
         // Given: a Running contract with 3 participants and one domain.
-        let (mut contract, participants, signer, domain_id) =
-            setup_running_contract_with_domain(3, 2, 2);
+        let (mut contract, participants, signer, domain_id) = setup_running_contract_with_domain(
+            3,
+            GovernanceThreshold::new(2),
+            ReconstructionThreshold::new(2),
+        );
         // ...and a proposal raising that domain's reconstruction threshold to 4.
         let mut per_domain = BTreeMap::new();
         per_domain.insert(domain_id, ReconstructionThreshold::new(4));
@@ -343,8 +343,11 @@ mod tests {
     #[test]
     fn vote_new_parameters__should_reject_when_shrinking_below_governance_threshold() {
         // Given: a Running contract with 4 participants and a GovernanceThreshold of 3.
-        let (mut contract, participants, signer, _domain_id) =
-            setup_running_contract_with_domain(4, 3, 3);
+        let (mut contract, participants, signer, _domain_id) = setup_running_contract_with_domain(
+            4,
+            GovernanceThreshold::new(3),
+            ReconstructionThreshold::new(3),
+        );
         // ...and a proposal that shrinks the participant set to 2 without touching
         // the per-domain thresholds.
         let proposal = ProposedGovernanceThresholdParameters::new(
@@ -372,8 +375,11 @@ mod tests {
     #[test]
     fn vote_new_parameters__should_reject_when_signing_threshold_exceeds_participants() {
         // Given: a Running contract with 3 participants and one domain.
-        let (mut contract, participants, signer, _domain_id) =
-            setup_running_contract_with_domain(3, 2, 2);
+        let (mut contract, participants, signer, _domain_id) = setup_running_contract_with_domain(
+            3,
+            GovernanceThreshold::new(2),
+            ReconstructionThreshold::new(2),
+        );
         // ...and a proposal whose signing threshold (4) exceeds the participant set.
         let proposal = ProposedGovernanceThresholdParameters::new(
             GovernanceThresholdParameters::new_unvalidated(
@@ -396,8 +402,11 @@ mod tests {
     #[test]
     fn vote_new_parameters__should_accept_per_domain_threshold_within_participant_count() {
         // Given: a Running contract with 5 participants (GovernanceThreshold 4) and one domain.
-        let (mut contract, participants, signer, domain_id) =
-            setup_running_contract_with_domain(5, 4, 2);
+        let (mut contract, participants, signer, domain_id) = setup_running_contract_with_domain(
+            5,
+            GovernanceThreshold::new(4),
+            ReconstructionThreshold::new(2),
+        );
         // ...and a proposal raising the domain's reconstruction threshold to 4,
         // which fits the 5 participants and does not exceed the GovernanceThreshold.
         let mut per_domain = BTreeMap::new();
@@ -418,8 +427,11 @@ mod tests {
     fn vote_new_parameters__should_reject_governance_below_max_reconstruction() {
         // Given: a Running contract with 5 participants, GovernanceThreshold 4, and a
         // domain whose reconstruction threshold is 4.
-        let (mut contract, participants, signer, _domain_id) =
-            setup_running_contract_with_domain(5, 4, 4);
+        let (mut contract, participants, signer, _domain_id) = setup_running_contract_with_domain(
+            5,
+            GovernanceThreshold::new(4),
+            ReconstructionThreshold::new(4),
+        );
         // ...and a proposal lowering the GovernanceThreshold to 3 (valid on its own)
         // while the domain keeps its reconstruction threshold of 4.
         let proposal = ProposedGovernanceThresholdParameters::new(

--- a/crates/contract/src/api/tee_verifier.rs
+++ b/crates/contract/src/api/tee_verifier.rs
@@ -17,7 +17,7 @@ use std::collections::{BTreeMap, BTreeSet};
 impl MpcContract {
     /// Vote for a candidate account to become the trusted verifier contract
     /// account, committing to the code hash the voter audited. When the proposal
-    /// crosses the signing threshold, the trusted verifier account is updated
+    /// crosses the governance threshold, the trusted verifier account is updated
     /// and all pending verifier-change votes are cleared.
     #[handle_result]
     pub fn vote_tee_verifier_change(
@@ -131,7 +131,7 @@ mod tests {
 
     #[test]
     fn vote_tee_verifier_change__should_apply_candidate_when_threshold_reached() {
-        // Given a running contract with 3 participants, signing threshold 2,
+        // Given a running contract with 3 participants, governance threshold 2,
         // starting unconfigured.
         let (mut contract, participants, _) = setup_tee_test_contract(3, 2);
         assert_eq!(contract.tee_verifier_account_id, None);
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn remove_non_participant_tee_verifier_votes__should_drop_votes_from_dropped_participants() {
-        // Given a running contract with 3 participants, signing threshold 3, where
+        // Given a running contract with 3 participants, governance threshold 3, where
         // two participants have cast votes for distinct candidates (neither crosses
         // threshold, so both stay pending).
         let (mut contract, participants, _) = setup_tee_test_contract(3, 3);

--- a/crates/contract/src/tee/verifier_votes.rs
+++ b/crates/contract/src/tee/verifier_votes.rs
@@ -113,16 +113,6 @@ mod tests {
     use crate::primitives::test_utils::{gen_authenticated_participants, gen_participants};
     use mpc_primitives::GovernanceThreshold;
 
-    fn threshold_params(
-        participants: &Participants,
-        threshold: u64,
-    ) -> GovernanceThresholdParameters {
-        GovernanceThresholdParameters::new_unvalidated(
-            participants.clone(),
-            GovernanceThreshold::new(threshold),
-        )
-    }
-
     fn proposal(account: &str, hash_byte: u8) -> VerifierChangeProposal {
         VerifierChangeProposal {
             candidate_account_id: account.parse().unwrap(),
@@ -130,24 +120,39 @@ mod tests {
         }
     }
 
-    /// Build 3 authenticated participants with the given signing threshold,
-    /// alongside fresh, empty pending votes.
-    fn setup_votes(
-        threshold: u64,
-    ) -> (
-        Participants,
-        GovernanceThresholdParameters,
-        Vec<AuthenticatedParticipantId>,
-        TeeVerifierVotes,
-    ) {
-        let (participants, voters) = gen_authenticated_participants(3);
-        let params = threshold_params(&participants, threshold);
-        (
-            participants.clone(),
-            params,
-            voters,
-            TeeVerifierVotes::default(),
-        )
+    /// 3 authenticated participants with the given governance threshold and
+    /// fresh, empty pending votes.
+    struct Voting {
+        participants: Participants,
+        params: GovernanceThresholdParameters,
+        voters: Vec<AuthenticatedParticipantId>,
+        votes: TeeVerifierVotes,
+    }
+
+    impl Voting {
+        fn with_threshold(governance_threshold: u64) -> Self {
+            let (participants, voters) = gen_authenticated_participants(3);
+            let params = GovernanceThresholdParameters::new_unvalidated(
+                participants.clone(),
+                GovernanceThreshold::new(governance_threshold),
+            );
+            Self {
+                participants,
+                params,
+                voters,
+                votes: TeeVerifierVotes::default(),
+            }
+        }
+
+        fn cast(&mut self, voter: usize, proposal: &VerifierChangeProposal) -> Option<AccountId> {
+            self.votes
+                .vote(proposal.clone(), self.voters[voter].clone(), &self.params)
+                .unwrap()
+        }
+
+        fn voter(&self, voter: usize) -> AuthenticatedParticipantId {
+            self.voters[voter].clone()
+        }
     }
 
     /// The expected pending-vote map: each `(proposal, voters)` pair becomes a
@@ -175,71 +180,55 @@ mod tests {
     #[test]
     fn vote__should_not_cross_below_threshold() {
         // Given 3 participants, threshold 2
-        let (_participants, params, voters, mut votes) = setup_votes(2);
+        let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
 
         // When one participant votes
-        let result = votes
-            .vote(proposal.clone(), voters[0].clone(), &params)
-            .unwrap();
+        let result = voting.cast(0, &proposal);
 
         // Then no candidate wins yet, and the single vote is recorded
         assert_eq!(result, None);
         assert_eq!(
-            votes.pending(),
-            expected_votes([(proposal, vec![voters[0].clone()])])
+            voting.votes.pending(),
+            expected_votes([(proposal, vec![voting.voter(0)])])
         );
     }
 
     #[test]
     fn vote__should_cross_threshold_and_clear_pending() {
         // Given 3 participants, threshold 2
-        let (_participants, params, voters, mut votes) = setup_votes(2);
+        let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
 
         // When two participants vote for the same (account, hash)
-        assert_eq!(
-            votes
-                .vote(proposal.clone(), voters[0].clone(), &params)
-                .unwrap(),
-            None
-        );
-        let result = votes
-            .vote(proposal.clone(), voters[1].clone(), &params)
-            .unwrap();
+        assert_eq!(voting.cast(0, &proposal), None);
+        let result = voting.cast(1, &proposal);
 
         // Then the candidate wins and all pending votes are cleared
         assert_eq!(result, Some(proposal.candidate_account_id));
-        assert_eq!(votes.pending(), BTreeMap::new());
+        assert_eq!(voting.votes.pending(), BTreeMap::new());
     }
 
     #[test]
     fn vote__should_not_combine_same_account_different_hashes() {
         // Given 3 participants, threshold 2
-        let (_participants, params, voters, mut votes) = setup_votes(2);
+        let mut voting = Voting::with_threshold(2);
         let candidate = "v.near";
         let proposal_hash_1 = proposal(candidate, 1);
         let proposal_hash_2 = proposal(candidate, 2);
 
         // When two participants vote for the same account but different code hashes
-        assert_eq!(
-            votes
-                .vote(proposal_hash_1.clone(), voters[0].clone(), &params)
-                .unwrap(),
-            None
-        );
-        let result = votes
-            .vote(proposal_hash_2.clone(), voters[1].clone(), &params)
-            .unwrap();
+        assert_eq!(voting.cast(0, &proposal_hash_1), None);
+        let result = voting.cast(1, &proposal_hash_2);
 
         // Then neither bucket reaches threshold: the two votes land in separate
         // (account, hash) buckets.
         assert_eq!(result, None);
         assert_eq!(
-            votes.pending(),
+            voting.votes.pending(),
             expected_votes([
-                (proposal_hash_1, vec![voters[0].clone()]),
-                (proposal_hash_2, vec![voters[1].clone()]),
+                (proposal_hash_1, vec![voting.voter(0)]),
+                (proposal_hash_2, vec![voting.voter(1)]),
             ])
         );
     }
@@ -247,85 +236,73 @@ mod tests {
     #[test]
     fn revote__should_replace_previous_vote() {
         // Given 3 participants, threshold 2
-        let (_participants, params, voters, mut votes) = setup_votes(2);
+        let mut voting = Voting::with_threshold(2);
         let first_proposal = proposal("a.near", 1);
         let second_proposal = proposal("b.near", 1);
 
         // When the same voter votes, then switches to a different candidate
-        votes
-            .vote(first_proposal, voters[0].clone(), &params)
-            .unwrap();
-        votes
-            .vote(second_proposal.clone(), voters[0].clone(), &params)
-            .unwrap();
+        voting.cast(0, &first_proposal);
+        voting.cast(0, &second_proposal);
 
         // Then only the b.near vote remains (the a.near bucket is gone); a
         // second voter on b.near then crosses.
         assert_eq!(
-            votes.pending(),
-            expected_votes([(second_proposal.clone(), vec![voters[0].clone()])])
+            voting.votes.pending(),
+            expected_votes([(second_proposal.clone(), vec![voting.voter(0)])])
         );
-        let result = votes
-            .vote(second_proposal.clone(), voters[1].clone(), &params)
-            .unwrap();
+        let result = voting.cast(1, &second_proposal);
         assert_eq!(result, Some(second_proposal.candidate_account_id));
     }
 
     #[test]
     fn withdraw__should_remove_caller_vote() {
         // Given 3 participants, threshold 2, and one recorded vote
-        let (_participants, params, voters, mut votes) = setup_votes(2);
+        let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
-        votes
-            .vote(proposal.clone(), voters[0].clone(), &params)
-            .unwrap();
+        voting.cast(0, &proposal);
         assert_eq!(
-            votes.pending(),
-            expected_votes([(proposal, vec![voters[0].clone()])])
+            voting.votes.pending(),
+            expected_votes([(proposal, vec![voting.voter(0)])])
         );
 
         // When the caller withdraws
-        votes.withdraw(&voters[0]);
+        voting.votes.withdraw(&voting.voters[0]);
 
         // Then their vote is removed
-        assert_eq!(votes.pending(), BTreeMap::new());
+        assert_eq!(voting.votes.pending(), BTreeMap::new());
 
         // When a voter who never voted withdraws, it is a no-op
-        votes.withdraw(&voters[1]);
-        assert_eq!(votes.pending(), BTreeMap::new());
+        voting.votes.withdraw(&voting.voters[1]);
+        assert_eq!(voting.votes.pending(), BTreeMap::new());
     }
 
     #[test]
     fn retain__should_keep_current_participants_and_drop_the_rest() {
         // Given 3 participants, threshold 3, and two voters sharing one bucket
-        let (participants, params, voters, mut votes) = setup_votes(3);
+        let mut voting = Voting::with_threshold(3);
         let proposal = proposal("v.near", 1);
-        votes
-            .vote(proposal.clone(), voters[0].clone(), &params)
-            .unwrap();
-        votes
-            .vote(proposal.clone(), voters[1].clone(), &params)
-            .unwrap();
+        voting.cast(0, &proposal);
+        voting.cast(1, &proposal);
         let both_voters =
-            expected_votes([(proposal.clone(), vec![voters[0].clone(), voters[1].clone()])]);
-        assert_eq!(votes.pending(), both_voters);
+            expected_votes([(proposal.clone(), vec![voting.voter(0), voting.voter(1)])]);
+        assert_eq!(voting.votes.pending(), both_voters);
 
         // When retaining against the same participant set
-        votes.retain(&participants);
+        voting.votes.retain(&voting.participants);
         // Then it is a no-op
-        assert_eq!(votes.pending(), both_voters);
+        assert_eq!(voting.votes.pending(), both_voters);
 
         // When retaining against a strict subset that excludes voter 0
-        votes.retain(&participants.subset(1..3));
+        voting.votes.retain(&voting.participants.subset(1..3));
         // Then voter 1 is kept and voter 0 is dropped
         assert_eq!(
-            votes.pending(),
-            expected_votes([(proposal, vec![voters[1].clone()])])
+            voting.votes.pending(),
+            expected_votes([(proposal, vec![voting.voter(1)])])
         );
 
         // When retaining against an empty set (no current participants)
-        votes.retain(&gen_participants(0));
+        voting.votes.retain(&gen_participants(0));
         // Then all votes are dropped
-        assert_eq!(votes.pending(), BTreeMap::new());
+        assert_eq!(voting.votes.pending(), BTreeMap::new());
     }
 }

--- a/crates/contract/src/tee/verifier_votes.rs
+++ b/crates/contract/src/tee/verifier_votes.rs
@@ -1,7 +1,7 @@
 //! Participant voting for the trusted `tee-verifier` contract account.
 //!
 //! `mpc-contract` verifies quotes against a single trusted verifier contract
-//! account, chosen by a threshold vote of active participants, each committing
+//! account, chosen by a governance-threshold vote of active participants, each committing
 //! to the `(account_id, code_hash)` pair they audited off-chain.
 
 use crate::{
@@ -58,7 +58,7 @@ impl Default for TeeVerifierVotes {
 
 impl TeeVerifierVotes {
     /// Records the participant's vote for the proposal. Returns the winning
-    /// candidate account once it crosses the signing threshold (votes from
+    /// candidate account once it crosses the governance threshold (votes from
     /// dropped participants don't count); on a win, all pending votes are
     /// cleared and the caller must apply the new verifier account.
     pub fn vote(
@@ -67,7 +67,7 @@ impl TeeVerifierVotes {
         participant: AuthenticatedParticipantId,
         threshold_parameters: &GovernanceThresholdParameters,
     ) -> Result<Option<AccountId>, Error> {
-        let protocol_threshold = threshold_parameters.threshold().value();
+        let governance_threshold = threshold_parameters.threshold().value();
         let participants = threshold_parameters.participants();
         let proposal_hash: ProposalHash = proposal.clone().into();
 
@@ -79,7 +79,7 @@ impl TeeVerifierVotes {
             reason: format!("vote count {count_usize} does not fit in u64: {e}"),
         })?;
 
-        if count >= protocol_threshold {
+        if count >= governance_threshold {
             self.pending.clear();
             Ok(Some(proposal.candidate_account_id))
         } else {

--- a/crates/contract/src/tee/verifier_votes.rs
+++ b/crates/contract/src/tee/verifier_votes.rs
@@ -142,7 +142,7 @@ mod tests {
             }
         }
 
-        fn must_cast(
+        fn cast_votes(
             &mut self,
             voter: usize,
             proposal: &VerifierChangeProposal,
@@ -186,7 +186,7 @@ mod tests {
         let proposal = proposal("v.near", 1);
 
         // When one participant votes
-        let result = voting.must_cast(0, &proposal);
+        let result = voting.cast_votes(0, &proposal);
 
         // Then no candidate wins yet, and the single vote is recorded
         assert_eq!(result, None);
@@ -203,8 +203,8 @@ mod tests {
         let proposal = proposal("v.near", 1);
 
         // When two participants vote for the same (account, hash)
-        assert_eq!(voting.must_cast(0, &proposal), None);
-        let result = voting.must_cast(1, &proposal);
+        assert_eq!(voting.cast_votes(0, &proposal), None);
+        let result = voting.cast_votes(1, &proposal);
 
         // Then the candidate wins and all pending votes are cleared
         assert_eq!(result, Some(proposal.candidate_account_id));
@@ -220,8 +220,8 @@ mod tests {
         let proposal_hash_2 = proposal(candidate, 2);
 
         // When two participants vote for the same account but different code hashes
-        assert_eq!(voting.must_cast(0, &proposal_hash_1), None);
-        let result = voting.must_cast(1, &proposal_hash_2);
+        assert_eq!(voting.cast_votes(0, &proposal_hash_1), None);
+        let result = voting.cast_votes(1, &proposal_hash_2);
 
         // Then neither bucket reaches threshold: the two votes land in separate
         // (account, hash) buckets.
@@ -243,8 +243,8 @@ mod tests {
         let second_proposal = proposal("b.near", 1);
 
         // When the same voter votes, then switches to a different candidate
-        voting.must_cast(0, &first_proposal);
-        voting.must_cast(0, &second_proposal);
+        voting.cast_votes(0, &first_proposal);
+        voting.cast_votes(0, &second_proposal);
 
         // Then only the b.near vote remains (the a.near bucket is gone); a
         // second voter on b.near then crosses.
@@ -252,7 +252,7 @@ mod tests {
             voting.votes.pending(),
             expected_votes([(second_proposal.clone(), vec![voting.voter(0)])])
         );
-        let result = voting.must_cast(1, &second_proposal);
+        let result = voting.cast_votes(1, &second_proposal);
         assert_eq!(result, Some(second_proposal.candidate_account_id));
     }
 
@@ -261,7 +261,7 @@ mod tests {
         // Given 3 participants, governance threshold 2, and one recorded vote
         let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
-        voting.must_cast(0, &proposal);
+        voting.cast_votes(0, &proposal);
         assert_eq!(
             voting.votes.pending(),
             expected_votes([(proposal, vec![voting.voter(0)])])
@@ -283,8 +283,8 @@ mod tests {
         // Given 3 participants, governance threshold 3, and two voters sharing one bucket
         let mut voting = Voting::with_threshold(3);
         let proposal = proposal("v.near", 1);
-        voting.must_cast(0, &proposal);
-        voting.must_cast(1, &proposal);
+        voting.cast_votes(0, &proposal);
+        voting.cast_votes(1, &proposal);
         let both_voters =
             expected_votes([(proposal.clone(), vec![voting.voter(0), voting.voter(1)])]);
         assert_eq!(voting.votes.pending(), both_voters);

--- a/crates/contract/src/tee/verifier_votes.rs
+++ b/crates/contract/src/tee/verifier_votes.rs
@@ -1,8 +1,8 @@
 //! Participant voting for the trusted `tee-verifier` contract account.
 //!
 //! `mpc-contract` verifies quotes against a single trusted verifier contract
-//! account, chosen by a governance-threshold vote of active participants, each committing
-//! to the `(account_id, code_hash)` pair they audited off-chain.
+//! account, chosen by a governance-threshold vote of active participants, each
+//! committing to the `(account_id, code_hash)` pair they audited off-chain.
 
 use crate::{
     errors::{ConversionError, Error},

--- a/crates/contract/src/tee/verifier_votes.rs
+++ b/crates/contract/src/tee/verifier_votes.rs
@@ -120,8 +120,6 @@ mod tests {
         }
     }
 
-    /// 3 authenticated participants with the given governance threshold and
-    /// fresh, empty pending votes.
     struct Voting {
         participants: Participants,
         params: GovernanceThresholdParameters,
@@ -183,7 +181,7 @@ mod tests {
 
     #[test]
     fn vote__should_not_cross_below_threshold() {
-        // Given 3 participants, threshold 2
+        // Given 3 participants, governance threshold 2
         let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
 
@@ -200,7 +198,7 @@ mod tests {
 
     #[test]
     fn vote__should_cross_threshold_and_clear_pending() {
-        // Given 3 participants, threshold 2
+        // Given 3 participants, governance threshold 2
         let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
 
@@ -215,7 +213,7 @@ mod tests {
 
     #[test]
     fn vote__should_not_combine_same_account_different_hashes() {
-        // Given 3 participants, threshold 2
+        // Given 3 participants, governance threshold 2
         let mut voting = Voting::with_threshold(2);
         let candidate = "v.near";
         let proposal_hash_1 = proposal(candidate, 1);
@@ -239,7 +237,7 @@ mod tests {
 
     #[test]
     fn revote__should_replace_previous_vote() {
-        // Given 3 participants, threshold 2
+        // Given 3 participants, governance threshold 2
         let mut voting = Voting::with_threshold(2);
         let first_proposal = proposal("a.near", 1);
         let second_proposal = proposal("b.near", 1);
@@ -260,7 +258,7 @@ mod tests {
 
     #[test]
     fn withdraw__should_remove_caller_vote() {
-        // Given 3 participants, threshold 2, and one recorded vote
+        // Given 3 participants, governance threshold 2, and one recorded vote
         let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
         voting.must_cast(0, &proposal);
@@ -270,19 +268,19 @@ mod tests {
         );
 
         // When the caller withdraws
-        voting.votes.withdraw(&voting.voters[0]);
+        voting.votes.withdraw(&voting.voter(0));
 
         // Then their vote is removed
         assert_eq!(voting.votes.pending(), BTreeMap::new());
 
         // When a voter who never voted withdraws, it is a no-op
-        voting.votes.withdraw(&voting.voters[1]);
+        voting.votes.withdraw(&voting.voter(1));
         assert_eq!(voting.votes.pending(), BTreeMap::new());
     }
 
     #[test]
     fn retain__should_keep_current_participants_and_drop_the_rest() {
-        // Given 3 participants, threshold 3, and two voters sharing one bucket
+        // Given 3 participants, governance threshold 3, and two voters sharing one bucket
         let mut voting = Voting::with_threshold(3);
         let proposal = proposal("v.near", 1);
         voting.must_cast(0, &proposal);

--- a/crates/contract/src/tee/verifier_votes.rs
+++ b/crates/contract/src/tee/verifier_votes.rs
@@ -144,7 +144,11 @@ mod tests {
             }
         }
 
-        fn cast(&mut self, voter: usize, proposal: &VerifierChangeProposal) -> Option<AccountId> {
+        fn must_cast(
+            &mut self,
+            voter: usize,
+            proposal: &VerifierChangeProposal,
+        ) -> Option<AccountId> {
             self.votes
                 .vote(proposal.clone(), self.voters[voter].clone(), &self.params)
                 .unwrap()
@@ -184,7 +188,7 @@ mod tests {
         let proposal = proposal("v.near", 1);
 
         // When one participant votes
-        let result = voting.cast(0, &proposal);
+        let result = voting.must_cast(0, &proposal);
 
         // Then no candidate wins yet, and the single vote is recorded
         assert_eq!(result, None);
@@ -201,8 +205,8 @@ mod tests {
         let proposal = proposal("v.near", 1);
 
         // When two participants vote for the same (account, hash)
-        assert_eq!(voting.cast(0, &proposal), None);
-        let result = voting.cast(1, &proposal);
+        assert_eq!(voting.must_cast(0, &proposal), None);
+        let result = voting.must_cast(1, &proposal);
 
         // Then the candidate wins and all pending votes are cleared
         assert_eq!(result, Some(proposal.candidate_account_id));
@@ -218,8 +222,8 @@ mod tests {
         let proposal_hash_2 = proposal(candidate, 2);
 
         // When two participants vote for the same account but different code hashes
-        assert_eq!(voting.cast(0, &proposal_hash_1), None);
-        let result = voting.cast(1, &proposal_hash_2);
+        assert_eq!(voting.must_cast(0, &proposal_hash_1), None);
+        let result = voting.must_cast(1, &proposal_hash_2);
 
         // Then neither bucket reaches threshold: the two votes land in separate
         // (account, hash) buckets.
@@ -241,8 +245,8 @@ mod tests {
         let second_proposal = proposal("b.near", 1);
 
         // When the same voter votes, then switches to a different candidate
-        voting.cast(0, &first_proposal);
-        voting.cast(0, &second_proposal);
+        voting.must_cast(0, &first_proposal);
+        voting.must_cast(0, &second_proposal);
 
         // Then only the b.near vote remains (the a.near bucket is gone); a
         // second voter on b.near then crosses.
@@ -250,7 +254,7 @@ mod tests {
             voting.votes.pending(),
             expected_votes([(second_proposal.clone(), vec![voting.voter(0)])])
         );
-        let result = voting.cast(1, &second_proposal);
+        let result = voting.must_cast(1, &second_proposal);
         assert_eq!(result, Some(second_proposal.candidate_account_id));
     }
 
@@ -259,7 +263,7 @@ mod tests {
         // Given 3 participants, threshold 2, and one recorded vote
         let mut voting = Voting::with_threshold(2);
         let proposal = proposal("v.near", 1);
-        voting.cast(0, &proposal);
+        voting.must_cast(0, &proposal);
         assert_eq!(
             voting.votes.pending(),
             expected_votes([(proposal, vec![voting.voter(0)])])
@@ -281,8 +285,8 @@ mod tests {
         // Given 3 participants, threshold 3, and two voters sharing one bucket
         let mut voting = Voting::with_threshold(3);
         let proposal = proposal("v.near", 1);
-        voting.cast(0, &proposal);
-        voting.cast(1, &proposal);
+        voting.must_cast(0, &proposal);
+        voting.must_cast(1, &proposal);
         let both_voters =
             expected_votes([(proposal.clone(), vec![voting.voter(0), voting.voter(1)])]);
         assert_eq!(voting.votes.pending(), both_voters);

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -2848,7 +2848,7 @@ expression: abi
       },
       {
         "name": "vote_tee_verifier_change",
-        "doc": " Vote for a candidate account to become the trusted verifier contract\n account, committing to the code hash the voter audited. When the proposal\n crosses the signing threshold, the trusted verifier account is updated\n and all pending verifier-change votes are cleared.",
+        "doc": " Vote for a candidate account to become the trusted verifier contract\n account, committing to the code hash the voter audited. When the proposal\n crosses the governance threshold, the trusted verifier account is updated\n and all pending verifier-change votes are cleared.",
         "kind": "call",
         "params": {
           "serialization_type": "json",


### PR DESCRIPTION
While closing partly #3903 (verifier_votes.rs), I stumbled upon high redundancy in the tests that I couldn't help but shrink.