### PR TITLE
refactor: getting rid of threshold terminology in running.rs and threshold.rs

### DIFF
--- a/crates/contract/src/state/running.rs
+++ b/crates/contract/src/state/running.rs
@@ -650,12 +650,12 @@ pub mod running_tests {
         state: &RunningContractState,
         protocol: Protocol,
         purpose: DomainPurpose,
-        threshold: u64,
+        reconstruction_threshold: ReconstructionThreshold,
     ) -> Vec<DomainConfig> {
         vec![DomainConfig {
             id: DomainId(state.domains.next_domain_id()),
             protocol,
-            reconstruction_threshold: ReconstructionThreshold::new(threshold),
+            reconstruction_threshold,
             purpose,
         }]
     }
@@ -668,7 +668,13 @@ pub mod running_tests {
         let mut state = gen_running_state_with_params(1, 5, 5);
         let mut env = Environment::new(None, None, None);
         env.set_signer(&state.parameters.participants().participants()[0].0);
-        let proposal = single_domain_proposal(&state, Protocol::CaitSith, DomainPurpose::Sign, 3);
+        let reconstruction_threshold = ReconstructionThreshold::new(3);
+        let proposal = single_domain_proposal(
+            &state,
+            Protocol::CaitSith,
+            DomainPurpose::Sign,
+            reconstruction_threshold,
+        );
 
         // When
         let res = state.vote_add_domains(proposal);
@@ -684,9 +690,14 @@ pub mod running_tests {
         let mut env = Environment::new(None, None, None);
         env.set_signer(&state.parameters.participants().participants()[0].0);
         // Use the GovernanceThreshold as the ReconstructionThreshold (the maximum allowed).
-        let governance = state.parameters.threshold().value();
-        let proposal =
-            single_domain_proposal(&state, Protocol::CaitSith, DomainPurpose::Sign, governance);
+        let governance_value = state.parameters.threshold().value();
+        let reconstruction_threshold = ReconstructionThreshold::new(governance_value);
+        let proposal = single_domain_proposal(
+            &state,
+            Protocol::CaitSith,
+            DomainPurpose::Sign,
+            reconstruction_threshold,
+        );
 
         // When
         let res = state.vote_add_domains(proposal);
@@ -881,7 +892,13 @@ pub mod running_tests {
         let mut state = gen_running_state(1);
         let mut env = Environment::new(None, None, None);
         env.set_signer(&state.parameters.participants().participants()[0].0);
-        let proposal = single_domain_proposal(&state, Protocol::CaitSith, DomainPurpose::Sign, 2);
+        let reconstruction_threshold = ReconstructionThreshold::new(2);
+        let proposal = single_domain_proposal(
+            &state,
+            Protocol::CaitSith,
+            DomainPurpose::Sign,
+            reconstruction_threshold,
+        );
 
         // When
         let res = state.vote_add_domains(proposal);
@@ -897,7 +914,13 @@ pub mod running_tests {
         let mut state = gen_running_state_with_params(1, 4, 3);
         let mut env = Environment::new(None, None, None);
         env.set_signer(&state.parameters.participants().participants()[0].0);
-        let proposal = single_domain_proposal(&state, Protocol::Frost, DomainPurpose::Sign, 3);
+        let reconstruction_threshold = ReconstructionThreshold::new(3);
+        let proposal = single_domain_proposal(
+            &state,
+            Protocol::Frost,
+            DomainPurpose::Sign,
+            reconstruction_threshold,
+        );
 
         // When
         let res = state.vote_add_domains(proposal);

--- a/crates/node/src/providers/ecdsa/key_resharing.rs
+++ b/crates/node/src/providers/ecdsa/key_resharing.rs
@@ -115,11 +115,12 @@ mod tests {
     #[tokio::test]
     async fn test_key_resharing() {
         let mut rng = rand::rngs::StdRng::from_seed([1u8; 32]);
-        const THRESHOLD: usize = 3;
         const NUM_PARTICIPANTS: usize = 4;
+        const RECONSTRUCTION_THRESHOLD: usize = 3;
+        let reconstruction_threshold = ReconstructionThreshold::from(RECONSTRUCTION_THRESHOLD);
         let participants = generate_participants_with_random_ids(NUM_PARTICIPANTS, &mut rng);
         let keygens: std::collections::HashMap<_, _> =
-            run_keygen::<Secp256K1Sha256, _>(&participants, THRESHOLD, &mut rng)
+            run_keygen::<Secp256K1Sha256, _>(&participants, reconstruction_threshold, &mut rng)
                 .into_iter()
                 .collect();
         let pubkey = keygens.iter().next().unwrap().1.public_key;
@@ -154,9 +155,9 @@ mod tests {
                             .ok_or_else(|| anyhow::anyhow!("No channel"))?
                     };
                     let key = KeyResharingComputation {
-                        reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
+                        reconstruction_threshold,
                         old_participants,
-                        old_reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
+                        old_reconstruction_threshold: reconstruction_threshold,
                         my_share: keyshare,
                         public_key: pubkey,
                     }

--- a/crates/node/src/providers/eddsa/key_resharing.rs
+++ b/crates/node/src/providers/eddsa/key_resharing.rs
@@ -117,12 +117,13 @@ mod tests {
     #[tokio::test]
     async fn test_key_resharing() {
         let mut rng = rand::rngs::StdRng::from_seed([1u8; 32]);
-        const THRESHOLD: usize = 3;
         const NUM_PARTICIPANTS: usize = 4;
+        const RECONSTRUCTION_THRESHOLD: usize = 3;
+        let reconstruction_threshold = ReconstructionThreshold::from(RECONSTRUCTION_THRESHOLD); 
         let participants = generate_participants_with_random_ids(NUM_PARTICIPANTS, &mut rng);
         let old_participants = into_participant_ids(&participants);
         let keygens: std::collections::HashMap<_, _> =
-            run_keygen::<Ed25519Sha512, _>(&participants, THRESHOLD, &mut rng)
+            run_keygen::<Ed25519Sha512, _>(&participants, reconstruction_threshold, &mut rng)
                 .into_iter()
                 .collect();
         let mut new_participants = into_participant_ids(&participants);
@@ -156,9 +157,9 @@ mod tests {
                             .ok_or_else(|| anyhow::anyhow!("No channel"))?
                     };
                     let key = KeyResharingComputation {
-                        reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
+                        reconstruction_threshold,
                         old_participants,
-                        old_reconstruction_threshold: ReconstructionThreshold::from(THRESHOLD),
+                        old_reconstruction_threshold: reconstruction_threshold,
                         my_share: keyshare,
                         public_key: pubkey,
                     }

--- a/crates/node/src/providers/eddsa/key_resharing.rs
+++ b/crates/node/src/providers/eddsa/key_resharing.rs
@@ -119,7 +119,7 @@ mod tests {
         let mut rng = rand::rngs::StdRng::from_seed([1u8; 32]);
         const NUM_PARTICIPANTS: usize = 4;
         const RECONSTRUCTION_THRESHOLD: usize = 3;
-        let reconstruction_threshold = ReconstructionThreshold::from(RECONSTRUCTION_THRESHOLD); 
+        let reconstruction_threshold = ReconstructionThreshold::from(RECONSTRUCTION_THRESHOLD);
         let participants = generate_participants_with_random_ids(NUM_PARTICIPANTS, &mut rng);
         let old_participants = into_participant_ids(&participants);
         let keygens: std::collections::HashMap<_, _> =


### PR DESCRIPTION
As part of #3903 I get rid of threshold terms and add some strong typing