### PR TITLE
chore(standards): Don't require `must_` prefix on all panicking test helpers

### DIFF
--- a/crates/backup-cli/src/service.rs
+++ b/crates/backup-cli/src/service.rs
@@ -418,7 +418,7 @@ mod tests {
             .expect("the service should read local storage on startup")
     }
 
-    async fn must_back_up_if_needed(
+    async fn back_up_if_needed(
         service: &mut TestService,
         state: &ProtocolContractState,
     ) -> BackupOutcome {
@@ -434,7 +434,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), FakeKeyshareStorage::empty()).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
+        let outcome = back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
 
         // Then
         assert_eq!(
@@ -456,7 +456,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), storage).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &running_state_with_epoch(6)).await;
+        let outcome = back_up_if_needed(&mut service, &running_state_with_epoch(6)).await;
 
         // Then
         assert_eq!(
@@ -477,7 +477,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), storage).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
+        let outcome = back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
 
         // Then
         assert_eq!(
@@ -498,7 +498,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), storage).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
+        let outcome = back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
 
         // Then
         assert_eq!(
@@ -518,7 +518,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), storage).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
+        let outcome = back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
 
         // Then
         assert_eq!(
@@ -537,7 +537,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), FakeKeyshareStorage::empty()).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &resharing_state()).await;
+        let outcome = back_up_if_needed(&mut service, &resharing_state()).await;
 
         // Then
         assert_eq!(
@@ -565,7 +565,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), FakeKeyshareStorage::empty()).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &contract_state).await;
+        let outcome = back_up_if_needed(&mut service, &contract_state).await;
 
         // Then
         assert_eq!(
@@ -602,7 +602,7 @@ mod tests {
         .await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
+        let outcome = back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
 
         // Then
         assert_eq!(
@@ -623,7 +623,7 @@ mod tests {
         let mut service = service(FakeP2PClient::new(), storage).await;
 
         // When
-        let outcome = must_back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
+        let outcome = back_up_if_needed(&mut service, &running_state_with_epoch(5)).await;
 
         // Then
         assert_eq!(

--- a/crates/chain-gateway/tests/event_subscriber_integration.rs
+++ b/crates/chain-gateway/tests/event_subscriber_integration.rs
@@ -24,9 +24,7 @@ use rstest::rstest;
 
 const EVENT_TIMEOUT: Duration = Duration::from_secs(10);
 
-async fn must_recv_block_update(
-    receiver: &mut tokio::sync::mpsc::Receiver<BlockUpdate>,
-) -> BlockUpdate {
+async fn recv_block_update(receiver: &mut tokio::sync::mpsc::Receiver<BlockUpdate>) -> BlockUpdate {
     tokio::time::timeout(EVENT_TIMEOUT, receiver.recv())
         .await
         .expect("expected a block update before timeout")
@@ -92,7 +90,7 @@ async fn test_event_subscriber_executor_function_call_success_success_calls_are_
         .unwrap();
 
     // Then: expect a matching block update
-    let BlockUpdate { events, .. } = must_recv_block_update(&mut receiver).await;
+    let BlockUpdate { events, .. } = recv_block_update(&mut receiver).await;
 
     assert_eq!(events.len(), 1);
 
@@ -243,7 +241,7 @@ async fn test_event_subscriber_receiver(#[case] expect_success: bool) {
         .unwrap();
 
     // Then: expect a matching block update
-    let BlockUpdate { events, .. } = must_recv_block_update(&mut receiver).await;
+    let BlockUpdate { events, .. } = recv_block_update(&mut receiver).await;
 
     assert_eq!(events.len(), 1);
 
@@ -286,7 +284,7 @@ async fn test_event_subscriber_receiver_error_if_non_private_call() {
         .unwrap();
 
     // Then: expect a matching block update
-    let BlockUpdate { events, .. } = must_recv_block_update(&mut receiver).await;
+    let BlockUpdate { events, .. } = recv_block_update(&mut receiver).await;
 
     assert_eq!(events.len(), 1);
 
@@ -355,7 +353,7 @@ async fn test_event_subscriber_channel_buffer_handles_backpressure(
     drop(watch_value);
 
     for _ in 0..expected_received {
-        must_recv_block_update(&mut receiver).await;
+        recv_block_update(&mut receiver).await;
     }
     receiver
         .try_recv()
@@ -388,7 +386,7 @@ async fn test_block_status_handle_becomes_final() {
         .await
         .unwrap();
 
-    let BlockUpdate { status, .. } = must_recv_block_update(&mut receiver).await;
+    let BlockUpdate { status, .. } = recv_block_update(&mut receiver).await;
 
     // Sync on the state viewer observing the finalised state change.
     let mut watch_value = observer_gw

--- a/crates/contract/src/primitives/ckd.rs
+++ b/crates/contract/src/primitives/ckd.rs
@@ -112,7 +112,7 @@ mod tests {
     /// Finds a point on the G1 curve that is not in the prime-order subgroup
     /// by scanning x-coordinates: the subgroup has index ~2^125 in the curve
     /// group, so essentially every curve point qualifies.
-    fn must_g1_point_outside_subgroup() -> G1Affine {
+    fn g1_point_outside_subgroup() -> G1Affine {
         let mut candidate = [0u8; 48];
         candidate[0] = 0x80; // compressed-encoding flag
         for x in 0u8..=255 {
@@ -127,8 +127,8 @@ mod tests {
         panic!("no G1 point outside the prime-order subgroup found");
     }
 
-    /// G2 counterpart of [`must_g1_point_outside_subgroup`].
-    fn must_g2_point_outside_subgroup() -> G2Affine {
+    /// G2 counterpart of [`g1_point_outside_subgroup`].
+    fn g2_point_outside_subgroup() -> G2Affine {
         let mut candidate = [0u8; 96];
         candidate[0] = 0x80; // compressed-encoding flag
         for x in 0u8..=255 {
@@ -145,7 +145,7 @@ mod tests {
 
     /// Finds a compressed G1 encoding whose x-coordinate is a valid field
     /// element but lies on no curve point (x^3 + 4 is a non-square).
-    fn must_g1_x_not_on_curve() -> [u8; 48] {
+    fn g1_x_not_on_curve() -> [u8; 48] {
         let mut candidate = [0u8; 48];
         candidate[0] = 0x80; // compressed-encoding flag
         for x in 0u8..=255 {
@@ -160,8 +160,8 @@ mod tests {
         panic!("no x-coordinate off the G1 curve found");
     }
 
-    /// G2 counterpart of [`must_g1_x_not_on_curve`].
-    fn must_g2_x_not_on_curve() -> [u8; 96] {
+    /// G2 counterpart of [`g1_x_not_on_curve`].
+    fn g2_x_not_on_curve() -> [u8; 96] {
         let mut candidate = [0u8; 96];
         candidate[0] = 0x80; // compressed-encoding flag
         for x in 0u8..=255 {
@@ -293,7 +293,7 @@ mod tests {
         // subgroup, paired with the G2 identity. A host that skipped the
         // subgroup check would evaluate the pairing to the identity and
         // return true; the subgroup check is the only reason this fails.
-        let rogue = must_g1_point_outside_subgroup();
+        let rogue = g1_point_outside_subgroup();
         let g2_identity = G2Projective::identity().to_uncompressed();
         let pairing_input = [rogue.to_uncompressed().as_slice(), &g2_identity].concat();
 
@@ -311,7 +311,7 @@ mod tests {
     #[expect(non_snake_case)]
     fn bls12381_pairing_check__should_reject_g2_point_outside_prime_order_subgroup() {
         // Given: a non-subgroup G2 point paired with the G1 identity
-        let rogue = must_g2_point_outside_subgroup();
+        let rogue = g2_point_outside_subgroup();
         let g1_identity = G1Projective::identity().to_uncompressed();
         let pairing_input = [g1_identity.as_slice(), &rogue.to_uncompressed()].concat();
 
@@ -355,7 +355,7 @@ mod tests {
     #[expect(non_snake_case)]
     fn bls12381_p1_decompress__should_abort_on_x_coordinate_not_on_curve() {
         // Given: a compressed encoding whose x-coordinate lies on no curve point
-        let candidate = must_g1_x_not_on_curve();
+        let candidate = g1_x_not_on_curve();
 
         // When / Then: the host rejects it and the SDK wrapper aborts
         env::bls12381_p1_decompress(candidate);
@@ -378,7 +378,7 @@ mod tests {
     #[expect(non_snake_case)]
     fn bls12381_p2_decompress__should_abort_on_x_coordinate_not_on_curve() {
         // Given: a compressed encoding whose x-coordinate lies on no curve point
-        let candidate = must_g2_x_not_on_curve();
+        let candidate = g2_x_not_on_curve();
 
         // When / Then: the host rejects it and the SDK wrapper aborts
         env::bls12381_p2_decompress(candidate);
@@ -440,7 +440,7 @@ mod tests {
         // alone accepts it and only the pairing-check subgroup validation can
         // reject it
         let app_pk = dtos::CKDAppPublicKeyPV {
-            pk1: dtos::Bls12381G1PublicKey(must_g1_point_outside_subgroup().to_compressed()),
+            pk1: dtos::Bls12381G1PublicKey(g1_point_outside_subgroup().to_compressed()),
             pk2: dtos::Bls12381G2PublicKey(G2Projective::generator().to_compressed()),
         };
 

--- a/crates/foreign-chain-health-check/src/probe.rs
+++ b/crates/foreign-chain-health-check/src/probe.rs
@@ -408,7 +408,7 @@ mod tests {
         }
     }
 
-    fn must_put_chain(
+    fn put_chain(
         chains: &mut ForeignChainsConfig,
         chain: ForeignChain,
         config: ForeignChainConfig,
@@ -495,7 +495,7 @@ mod tests {
     }
 
     /// Keyed by chain too: provider names repeat across chains in real configs.
-    fn must_status_of(report: &ProbeReport, chain: ForeignChain, provider: &str) -> ProviderStatus {
+    fn status_of(report: &ProbeReport, chain: ForeignChain, provider: &str) -> ProviderStatus {
         report
             .rows()
             .iter()
@@ -521,7 +521,7 @@ mod tests {
         // Then
         mock.assert_async().await;
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::Healthy
         );
     }
@@ -541,7 +541,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::WrongNetwork {
                 expected: NetworkFingerprint::new(MAINNET),
                 observed: NetworkFingerprint::new(SEPOLIA),
@@ -564,7 +564,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::Healthy
         );
     }
@@ -585,7 +585,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::MissingExpectedFingerprint
         );
         mock.assert_calls_async(0).await;
@@ -604,7 +604,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::Unreachable
         );
     }
@@ -624,7 +624,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "keyed"),
+            status_of(&report, ForeignChain::Starknet, "keyed"),
             ProviderStatus::RequestRejected
         );
         mock.assert_calls_async(1).await;
@@ -645,7 +645,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::RequestRejected
         );
     }
@@ -665,7 +665,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::MalformedResponse
         );
     }
@@ -685,7 +685,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "slow"),
+            status_of(&report, ForeignChain::Starknet, "slow"),
             ProviderStatus::TimedOut
         );
     }
@@ -705,7 +705,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::Healthy
         );
     }
@@ -735,7 +735,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "keyed"),
+            status_of(&report, ForeignChain::Starknet, "keyed"),
             ProviderStatus::AuthTokenUnresolved
         );
     }
@@ -753,7 +753,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "wrong-scheme"),
+            status_of(&report, ForeignChain::Starknet, "wrong-scheme"),
             ProviderStatus::ClientSetupFailed
         );
     }
@@ -772,11 +772,11 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "healthy"),
+            status_of(&report, ForeignChain::Starknet, "healthy"),
             ProviderStatus::Healthy
         );
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "broken"),
+            status_of(&report, ForeignChain::Starknet, "broken"),
             ProviderStatus::Unreachable
         );
         assert_eq!(
@@ -802,7 +802,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Solana, "publicnode"),
+            status_of(&report, ForeignChain::Solana, "publicnode"),
             ProviderStatus::ProbeNotImplemented
         );
     }
@@ -829,11 +829,11 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "publicnode"),
+            status_of(&report, ForeignChain::Starknet, "publicnode"),
             ProviderStatus::Healthy
         );
         assert_eq!(
-            must_status_of(&report, ForeignChain::Solana, "publicnode"),
+            status_of(&report, ForeignChain::Solana, "publicnode"),
             ProviderStatus::ProbeNotImplemented
         );
         assert_eq!(report.counts_per_chain().len(), 2);
@@ -848,7 +848,7 @@ mod tests {
         for mainnet in EVM_MAINNETS {
             let server = httpmock::MockServer::start_async().await;
             mock_fingerprint(&server, &mainnet.answered()).await;
-            must_put_chain(
+            put_chain(
                 &mut config,
                 mainnet.chain,
                 chain_config(
@@ -865,7 +865,7 @@ mod tests {
         // Then
         for EvmMainnet { chain, .. } in EVM_MAINNETS {
             assert_eq!(
-                must_status_of(&report, chain, "publicnode"),
+                status_of(&report, chain, "publicnode"),
                 ProviderStatus::Healthy,
                 "{chain:?}"
             );
@@ -879,7 +879,7 @@ mod tests {
         let server = httpmock::MockServer::start_async().await;
         mock_fingerprint(&server, "0x14a34").await;
         let mut config = ForeignChainsConfig::default();
-        must_put_chain(
+        put_chain(
             &mut config,
             ForeignChain::Base,
             chain_config(Some("8453"), one_provider("publicnode", &server.base_url())),
@@ -890,7 +890,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Base, "publicnode"),
+            status_of(&report, ForeignChain::Base, "publicnode"),
             ProviderStatus::WrongNetwork {
                 expected: NetworkFingerprint::new("8453"),
                 observed: NetworkFingerprint::new("84532"),
@@ -913,7 +913,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
+            status_of(&report, ForeignChain::Bitcoin, "publicnode"),
             ProviderStatus::Healthy
         );
     }
@@ -933,7 +933,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Bitcoin, "publicnode"),
+            status_of(&report, ForeignChain::Bitcoin, "publicnode"),
             ProviderStatus::WrongNetwork {
                 expected: NetworkFingerprint::new(BITCOIN_MAINNET),
                 observed: NetworkFingerprint::new(BITCOIN_TESTNET3),
@@ -972,7 +972,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Aptos, PROVIDER_NAME),
+            status_of(&report, ForeignChain::Aptos, PROVIDER_NAME),
             ProviderStatus::Healthy
         );
     }
@@ -995,7 +995,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Aptos, PROVIDER_NAME),
+            status_of(&report, ForeignChain::Aptos, PROVIDER_NAME),
             ProviderStatus::WrongNetwork {
                 expected: NetworkFingerprint::new(APTOS_MAINNET.to_string()),
                 observed: NetworkFingerprint::new(APTOS_TESTNET.to_string()),
@@ -1086,7 +1086,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Sui, PROVIDER_NAME),
+            status_of(&report, ForeignChain::Sui, PROVIDER_NAME),
             expected
         );
     }
@@ -1104,7 +1104,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Sui, PROVIDER_NAME),
+            status_of(&report, ForeignChain::Sui, PROVIDER_NAME),
             ProviderStatus::Unreachable
         );
     }
@@ -1124,7 +1124,7 @@ mod tests {
 
         // Then
         assert_eq!(
-            must_status_of(&report, ForeignChain::Starknet, "keyed"),
+            status_of(&report, ForeignChain::Starknet, "keyed"),
             ProviderStatus::Unreachable
         );
         mock.assert_calls_async(2).await;
@@ -1146,7 +1146,7 @@ mod tests {
 
         // Then
         let ProviderStatus::WrongNetwork { observed, .. } =
-            must_status_of(&report, ForeignChain::Starknet, "publicnode")
+            status_of(&report, ForeignChain::Starknet, "publicnode")
         else {
             panic!("expected the flood to read as the wrong network");
         };
@@ -1213,7 +1213,7 @@ mod tests {
 
         // Then
         assert_matches!(
-            must_status_of(&report, ForeignChain::Starknet, "keyed"),
+            status_of(&report, ForeignChain::Starknet, "keyed"),
             ProviderStatus::WrongNetwork { .. }
         );
         let rendered = format!("{report:?}");

--- a/crates/node/src/indexer/near_data_wipe.rs
+++ b/crates/node/src/indexer/near_data_wipe.rs
@@ -167,7 +167,7 @@ mod tests {
     use crate::home_paths::near_data_dir;
     use rstest::rstest;
 
-    fn must_read_recorded(home: &Path) -> Option<u64> {
+    fn read_recorded(home: &Path) -> Option<u64> {
         std::fs::read_to_string(wipe_token_file(home))
             .ok()
             .map(|s| s.trim().parse().unwrap())
@@ -207,7 +207,7 @@ mod tests {
 
         // Then
         assert_eq!(data_dir.exists(), expect_data_dir_exists);
-        assert_eq!(must_read_recorded(home), expect_recorded);
+        assert_eq!(read_recorded(home), expect_recorded);
     }
 
     #[test]
@@ -226,7 +226,7 @@ mod tests {
         // cleanup is non-fatal (retried on the next startup), so the wipe succeeds.
         result.unwrap();
         assert!(!not_a_dir.exists());
-        assert_eq!(must_read_recorded(home), Some(1));
+        assert_eq!(read_recorded(home), Some(1));
     }
 
     #[test]

--- a/crates/node/src/p2p.rs
+++ b/crates/node/src/p2p.rs
@@ -1473,17 +1473,17 @@ mod tests {
         (server, client)
     }
 
-    fn must_make_signing_key() -> SigningKey {
+    fn make_signing_key() -> SigningKey {
         SigningKey::generate(&mut StdRng::seed_from_u64(42))
     }
 
-    fn must_make_client_config() -> Arc<ClientConfig> {
-        let (_server_config, client_config) = configure_tls(&must_make_signing_key()).unwrap();
+    fn make_client_config() -> Arc<ClientConfig> {
+        let (_server_config, client_config) = configure_tls(&make_signing_key()).unwrap();
         Arc::new(client_config)
     }
 
-    fn must_make_tls_acceptor() -> TlsAcceptor {
-        let (server_config, _client_config) = configure_tls(&must_make_signing_key()).unwrap();
+    fn make_tls_acceptor() -> TlsAcceptor {
+        let (server_config, _client_config) = configure_tls(&make_signing_key()).unwrap();
         TlsAcceptor::from(Arc::new(server_config))
     }
 
@@ -1500,7 +1500,7 @@ mod tests {
         let result = timeout(
             Duration::from_secs(60),
             OutgoingConnection::new(
-                must_make_client_config(),
+                make_client_config(),
                 &target_address,
                 ParticipantId::from_raw(1),
                 &ParticipantIdentities::default(),
@@ -1526,7 +1526,7 @@ mod tests {
     async fn persistent_connection__should_keep_retrying_when_dial_attempt_hangs() {
         // Given a listener that accepts TCP connections but never responds.
         let (target_address, mut accept_rx, listener_task) = must_spawn_silent_listener().await;
-        let client_config = must_make_client_config();
+        let client_config = make_client_config();
         let my_id = ParticipantId::from_raw(0);
         let target_id = ParticipantId::from_raw(1);
 
@@ -1570,7 +1570,7 @@ mod tests {
         // Given
         let (addr_a, mut accept_a, task_a) = must_spawn_silent_listener().await;
         let (addr_b, mut accept_b, task_b) = must_spawn_silent_listener().await;
-        let client_config = must_make_client_config();
+        let client_config = make_client_config();
         let my_id = ParticipantId::from_raw(0);
         let target_id = ParticipantId::from_raw(1);
         let resolved_address = Arc::new(Mutex::new(addr_a.clone()));
@@ -1622,7 +1622,7 @@ mod tests {
     {
         // Given
         let (tcp_stream, _silent_client) = must_accept_silent_connection().await;
-        let tls_acceptor = must_make_tls_acceptor();
+        let tls_acceptor = make_tls_acceptor();
         let (message_sender, _message_receiver) = mpsc::unbounded_channel();
         let my_id = ParticipantId::from_raw(0);
         let connectivities = Arc::new(AllNodeConnectivities::<

--- a/docs/engineering-standards.md
+++ b/docs/engineering-standards.md
@@ -52,19 +52,6 @@ This function contains an `.unwrap()`, but we can still guarantee that
 this function will never ever panic. Therefore it's not violating
 the "Don't panic" principle.
 
-### `must_` prefix for panicking test helpers
-
-In test code, plumbing helpers (loading WASM artifacts, resolving binary
-paths, extracting setup data from a known-good state) should panic on
-failure instead of returning `Result`: the failure means the test wasn't
-built or wired correctly, not that the system under test misbehaved, so
-there's no useful error path. Such helpers must be prefixed with `must_`
-(e.g. `must_load_contract_wasm`, `must_get_bls_public_key`) so callers
-can see at the call site that the function will panic on failure.
-
-Helpers whose failure could be a meaningful test outcome (network calls,
-state observations) should still return `Result`.
-
 ## Maintain Local Reasonability
 It's often tempting to write code that has implicit sequential dependencies.
 In these scenarios, the correctness of one expression depends on
@@ -218,6 +205,17 @@ fn <system_under_test>__should_<test_assertion>(){
 the system under test (SUT) can be many things, but typically this would be a function,
 method or a struct.
 
+### Use the `must_` prefix for plumbing test helpers
+
+In test code, plumbing helpers (loading WASM artifacts, resolving binary
+paths, extracting setup data from a known-good state) can depend on setup
+external to the system under test.
+Such helpers may panic even if the system under test is implemented correctly.
+
+Prefix these functions with `must_` (e.g. `must_load_contract_wasm`,
+`must_get_bls_public_key`) to signal at the call site that they require the
+test to be built and wired correctly.
+
 ## Measure performance
 It's easy to get stuck in arguments about what's faster or more expensive
 when comparing different approaches. In these scenarios, we should strive
@@ -370,4 +368,3 @@ but reviewers are the only safeguard. When a backticked word merely looks
 like an item but is not one (an algorithm name, a type in a crate we
 deliberately do not depend on, a `cfg(test)` item rustdoc cannot see),
 leave it as a plain code span.
-


### PR DESCRIPTION
Closes #4277 

This PR does two things:
1. Updates the formulation in our engineering standards to not imply that any panicking test helper should have a `must_` prefix.
2. Rename some instances where this prefix causes more confusion than help.