### PR TITLE
feat: support {} host-label wildcard in on-chain base_url

### DIFF
--- a/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+++ b/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
@@ -1946,6 +1946,11 @@ pub struct ProviderConfig {
     /// Provider's stable base. When `chain_routing == Embedded`, the chain identifier
     /// is already inside `base_url` (subdomain or path prefix). Otherwise `base_url`
     /// is chain-agnostic and `chain_routing` carries the chain marker.
+    ///
+    /// A single `{}` stands for one operator-chosen host label, for providers that
+    /// put a per-operator slug in the hostname (e.g. QuickNode's
+    /// `https://{}.sui-testnet.quiknode.pro`); nodes match it against exactly one
+    /// label of the local URL, keeping the rest of the host pinned.
     pub base_url: String,
     pub auth_scheme: AuthScheme,
     pub chain_routing: ChainRouting,

--- a/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
+++ b/crates/near-mpc-contract-interface/src/types/foreign_chain.rs
@@ -1947,8 +1947,7 @@ pub struct ProviderConfig {
     /// is already inside `base_url` (subdomain or path prefix). Otherwise `base_url`
     /// is chain-agnostic and `chain_routing` carries the chain marker.
     ///
-    /// A single `{}` stands for one operator-chosen host label, for providers that
-    /// put a per-operator slug in the hostname (e.g. QuickNode's
+    /// A single `{}` allows per-operator slug (e.g. QuickNode's
     /// `https://{}.sui-testnet.quiknode.pro`); nodes match it against exactly one
     /// label of the local URL, keeping the rest of the host pinned.
     pub base_url: String,

--- a/crates/node/src/foreign_chain_whitelist_verifier.rs
+++ b/crates/node/src/foreign_chain_whitelist_verifier.rs
@@ -1094,7 +1094,6 @@ mod tests {
             "https://evil.com?x=.abstract-testnet.quiknode.pro",
             WILDCARD
         ));
-        // An empty label, and a suffix that is not where the host ends.
         assert!(!base_url_matches(
             "https://.abstract-testnet.quiknode.pro/",
             WILDCARD

--- a/crates/node/src/foreign_chain_whitelist_verifier.rs
+++ b/crates/node/src/foreign_chain_whitelist_verifier.rs
@@ -190,6 +190,8 @@ fn compare_provider(
 /// The first `{}` in `base` matches one non-empty run of `[A-Za-z0-9-]` — a single host
 /// label in the bases we use, where a provider puts a per-operator slug in the hostname
 /// (e.g. QuickNode's `https://{}.sui-testnet.quiknode.pro`).
+/// The character after `{}` must not itself be a label character:
+/// a base like `https://api-{}-v2.example.com` never matches.
 fn base_url_matches(local: &str, base: &str) -> bool {
     let l = local.trim_end_matches('/');
     let b = base.trim_end_matches('/');

--- a/crates/node/src/foreign_chain_whitelist_verifier.rs
+++ b/crates/node/src/foreign_chain_whitelist_verifier.rs
@@ -189,10 +189,7 @@ fn compare_provider(
 ///
 /// The first `{}` in `base` matches one non-empty run of `[A-Za-z0-9-]` — a single host
 /// label in the bases we use, where a provider puts a per-operator slug in the hostname
-/// (e.g. QuickNode's `https://{}.sui-testnet.quiknode.pro`). The run is consumed greedily
-/// with no backtracking, so a base whose `{}` is directly followed by another label
-/// character (e.g. `https://api-{}-v2.example.com`) never matches; a second `{}` is
-/// matched literally.
+/// (e.g. QuickNode's `https://{}.sui-testnet.quiknode.pro`).
 fn base_url_matches(local: &str, base: &str) -> bool {
     let l = local.trim_end_matches('/');
     let b = base.trim_end_matches('/');

--- a/crates/node/src/foreign_chain_whitelist_verifier.rs
+++ b/crates/node/src/foreign_chain_whitelist_verifier.rs
@@ -186,16 +186,36 @@ fn compare_provider(
 
 /// Path-boundary-aware prefix check. `https://api.example.com/v2` matches `/v2`,
 /// `/v2/eth`, `/v2?key=x`, `/v2#frag` — but not `/v2-evil`.
+///
+/// The first `{}` in `base` matches one non-empty run of `[A-Za-z0-9-]` — a single host
+/// label in the bases we use, where a provider puts a per-operator slug in the hostname
+/// (e.g. QuickNode's `https://{}.sui-testnet.quiknode.pro`). The run is consumed greedily
+/// with no backtracking, so a base whose `{}` is directly followed by another label
+/// character (e.g. `https://api-{}-v2.example.com`) never matches; a second `{}` is
+/// matched literally.
 fn base_url_matches(local: &str, base: &str) -> bool {
     let l = local.trim_end_matches('/');
     let b = base.trim_end_matches('/');
-    if l == b {
-        return true;
-    }
-    let Some(rest) = l.strip_prefix(b) else {
+
+    let Some((prefix, suffix)) = b.split_once("{}") else {
+        return starts_with_at_boundary(l, b);
+    };
+    let Some(rest) = l.strip_prefix(prefix) else {
         return false;
     };
-    rest.starts_with('/') || rest.starts_with('?') || rest.starts_with('#')
+    let label_len = rest
+        .find(|c: char| !c.is_ascii_alphanumeric() && c != '-')
+        .unwrap_or(rest.len());
+    label_len > 0 && starts_with_at_boundary(&rest[label_len..], suffix)
+}
+
+/// Like [`str::starts_with`], but `prefix` must end where a URL component does.
+fn starts_with_at_boundary(s: &str, prefix: &str) -> bool {
+    if s == prefix {
+        return true;
+    }
+    s.strip_prefix(prefix)
+        .is_some_and(|rest| rest.starts_with('/') || rest.starts_with('?') || rest.starts_with('#'))
 }
 
 enum RoutingCheck {
@@ -1040,6 +1060,60 @@ mod tests {
         assert!(!base_url_matches(
             "https://eth.alchemy.com/v2foo.attacker.example/",
             "https://eth.alchemy.com/v2"
+        ));
+    }
+
+    const WILDCARD: &str = "https://{}.abstract-testnet.quiknode.pro";
+
+    #[test]
+    fn base_url_matches__should_accept_any_single_host_label_for_a_wildcard_base() {
+        assert!(base_url_matches(
+            "https://misty-fabled-sunset.abstract-testnet.quiknode.pro/abc123",
+            WILDCARD
+        ));
+        assert!(base_url_matches(
+            "https://acme7.abstract-testnet.quiknode.pro/{api_key}",
+            WILDCARD
+        ));
+        assert!(base_url_matches(
+            "https://acme7.abstract-testnet.quiknode.pro",
+            WILDCARD
+        ));
+    }
+
+    #[test]
+    fn base_url_matches__should_reject_wildcard_spanning_a_label_boundary() {
+        // The wildcard must not swallow `/`, `.`, or `?` — each would let the pinned domain
+        // suffix land somewhere other than the host.
+        assert!(!base_url_matches(
+            "https://evil.example.com/.abstract-testnet.quiknode.pro/",
+            WILDCARD
+        ));
+        assert!(!base_url_matches(
+            "https://a.b.abstract-testnet.quiknode.pro/",
+            WILDCARD
+        ));
+        assert!(!base_url_matches(
+            "https://evil.com?x=.abstract-testnet.quiknode.pro",
+            WILDCARD
+        ));
+        // An empty label, and a suffix that is not where the host ends.
+        assert!(!base_url_matches(
+            "https://.abstract-testnet.quiknode.pro/",
+            WILDCARD
+        ));
+        assert!(!base_url_matches(
+            "https://acme7.abstract-testnet.quiknode.pro.evil.io/",
+            WILDCARD
+        ));
+        assert!(!base_url_matches(
+            "https://acme7.abstract-testnet.quiknode.proevil/",
+            WILDCARD
+        ));
+        // Userinfo trick: the whole whitelisted host as `user@` of an attacker host.
+        assert!(!base_url_matches(
+            "https://acme7.abstract-testnet.quiknode.pro@evil.com/",
+            WILDCARD
         ));
     }
 }

--- a/docs/design/allowing-per-node-foreign-chain-rpc-configuration.md
+++ b/docs/design/allowing-per-node-foreign-chain-rpc-configuration.md
@@ -90,6 +90,8 @@ struct ProviderEntry {
     // Provider's stable base. When `chain_routing == Embedded`, the chain identifier is
     // already encoded in `base_url` (subdomain or path prefix). Otherwise `base_url` is
     // chain-agnostic and `chain_routing` carries the chain marker.
+    // A single `{}` stands for one operator-chosen host label (QuickNode-style
+    // per-operator slugs, e.g. `https://{}.sui-testnet.quiknode.pro`).
     base_url: String,
     auth_scheme: AuthScheme,   // Header / Path / Query / None — where the operator's token gets injected
     chain_routing: ChainRouting, // Embedded / PathSegment / QueryParam — exactly one
@@ -106,7 +108,7 @@ struct ChainVote {
 This shape differs from earlier sketches of this design in two important ways:
 
 - **Per-chain keying**, not a global `BTreeSet<RpcProvider>` + URL prefix match. A provider voted in for `Ethereum` is structurally invisible when the node loads its `Polygon` section, so cross-chain confusion (e.g. an Ethereum-mainnet URL accidentally accepted under a testnet bucket) is impossible at lookup time.
-- **Connection config on chain.** `base_url`, `auth_scheme`, and `chain_routing` live in the whitelist entry instead of being supplied by the operator. The operator only picks `provider_id` and supplies the API token via env. This removes the operator's syntactic surface to inject extra path/query components that could redirect the call.
+- **Connection config on chain.** `base_url`, `auth_scheme`, and `chain_routing` live in the whitelist entry instead of being supplied by the operator. The operator only picks `provider_id` and supplies the API token via env. This removes the operator's syntactic surface to inject extra path/query components that could redirect the call. For providers that embed a per-operator slug in the hostname, the voted `base_url` carries a `{}` in the slug's place: the operator chooses that one host label, and every other label stays pinned by the vote.
 
 ### Nodes checking if local configuration is valid
 
@@ -114,7 +116,7 @@ On startup, the node validates that every `provider_id` it references in its loc
 
 Drop-and-log rather than hard-crash so that a single hostile vote-removal participant can't take a node offline by removing a provider that node depends on — operators see the dropped providers in logs/alerts and react.
 
-Since the nodes are running in a Trusted Execution Environment (TEE), this functionality lets the node guard against operators that might otherwise point the binary at a malicious RPC URL. The full URL is assembled from on-chain `base_url` + `chain_routing` + operator-supplied token via `auth_scheme`, so the operator never writes a URL directly.
+Since the nodes are running in a Trusted Execution Environment (TEE), this functionality lets the node guard against operators that might otherwise point the binary at a malicious RPC URL. The full URL is assembled from on-chain `base_url` + `chain_routing` + operator-supplied token via `auth_scheme`, so the operator never writes a URL directly — for `{}` bases, the operator's slug fills exactly one host label under the domain suffix the vote pinned.
 
 ### Individual node quorum of RPC providers for verification requests
 

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -531,7 +531,7 @@ Providers use three mutually-exclusive conventions to identify which chain a req
 - **Path segment** (Ankr): `https://rpc.ankr.com/eth/…`
 - **Query param** (dRPC): `https://lb.drpc.org/ogrpc?network=ethereum&…`
 
-If `base_url` were a single string *and* the operator chose the auth scheme, the operator could declare e.g. `auth: { kind: Query, name: "network", token_env: KEY }` against a `base_url` ending in `…?network=ethereum&`. The assembled URL becomes `…?network=ethereum&network=sepolia` — most servers take the last value, redirecting the call to Sepolia. Modelling chain identity as a `ChainRouting` enum (`Embedded` | `PathSegment` | `QueryParam`) and putting `auth_scheme` on chain removes that syntactic surface. The operator only supplies a token *value*; they have no way to inject extra path components or query keys.
+If `base_url` were a single string *and* the operator chose the auth scheme, the operator could declare e.g. `auth: { kind: Query, name: "network", token_env: KEY }` against a `base_url` ending in `…?network=ethereum&`. The assembled URL becomes `…?network=ethereum&network=sepolia` — most servers take the last value, redirecting the call to Sepolia. Modelling chain identity as a `ChainRouting` enum (`Embedded` | `PathSegment` | `QueryParam`) and putting `auth_scheme` on chain removes that syntactic surface. The operator only supplies a token *value* — plus, for providers with per-operator hostnames, the one host label a `{}` in the voted `base_url` stands for; they have no way to inject extra path components or query keys.
 
 #### Why each `(chain, provider_id)` gets its own `ProviderEntry`
 

--- a/docs/foreign-chain-transactions.md
+++ b/docs/foreign-chain-transactions.md
@@ -407,7 +407,7 @@ The per-participant registration model above leaves the network with no shared n
 | Source of truth for "trusted provider" | Implicit consensus across operator yamls (everyone independently set the same URLs)         | Explicit on-chain `foreign_chain_rpc_whitelist`, mutated by `vote_update_foreign_chain_providers(votes: Vec<ChainVote>)` — each `ChainVote` is a full per-chain snapshot (provider list + RPC response quorum). The chain's stored state is replaced when the protocol's signing threshold of participants holds the same canonical proposal.                                                            |
 | Where the RPC URL lives                | Operator's `foreign_chains.yaml`, as a full string with auth placeholders                   | Contract `ProviderEntry`: `base_url` + `auth_scheme` + `chain_routing` enum (`Embedded` / `PathSegment` / `QueryParam` — exactly one). Node assembles the final URL at startup.                  |
 | Where the operator's API key lives     | Operator's yaml, via `TokenConfig::env`                                                     | Operator's yaml, via `TokenConfig::env` *(unchanged)*                                                                                                                                          |
-| What the operator picks                | Full URL, auth scheme, token reference                                                      | `provider_id` (label) + token reference                                                                                                                                                        |
+| What the operator picks                | Full URL, auth scheme, token reference                                                      | `provider_id` (label) + token reference. When the voted `base_url` carries a `{}`, it is meant for operator specific slug                                                              |
 | Adding a new provider                  | Every operator updates their yaml; the network effectively supports a chain once enough do  | Threshold of participants vote in `(chain, ProviderEntry)`; operators reference it by `provider_id` only                                                                                       |
 | Removing a compromised provider        | Every operator manually edits their yaml; coordination problem                              | Threshold of participants vote remove; nodes pick up the change via the indexer and drop the provider on next reconfigure                                                                       |
 | Testnet vs mainnet separation          | Implicit — operator decides what URL goes under which chain                                 | Per-`ForeignChain` map slot, plus a recurring *network fingerprint probe* that calls the chain's self-identifying RPC and compares the response against the chain's `expected_network_fingerprint` from operator config — catches both lookup-level (wrong bucket) and content-level (wrong URL voted into the right bucket) confusion. |
@@ -475,7 +475,7 @@ pub struct ForeignChainRpcWhitelist {
 
 ### Example URL assembly
 
-The node assembles the final URL deterministically: start from `base_url`, apply `chain_routing` (no-op for `Embedded`, append segment for `PathSegment`, merge param for `QueryParam`), then apply `auth_scheme` to inject the token.
+The node assembles the final URL deterministically: start from `base_url`, fill a `{}` (if present) with the operator-specific host label (`SLUG` in the table below), apply `chain_routing` (no-op for `Embedded`, append segment for `PathSegment`, merge param for `QueryParam`), then apply `auth_scheme` to inject the token.
 
 | Vote                  | base_url                                | chain_routing                                  | auth_scheme       | Assembled URL                                              |
 |-----------------------|------------------------------------------|------------------------------------------------|-------------------|------------------------------------------------------------|
@@ -484,6 +484,7 @@ The node assembles the final URL deterministically: start from `base_url`, apply
 | `(Sepolia, ankr)`     | `https://rpc.ankr.com`                   | `PathSegment { segment: "eth_sepolia" }`       | `Path("")`        | `https://rpc.ankr.com/eth_sepolia/TOKEN`                   |
 | `(Ethereum, drpc)`    | `https://lb.drpc.org/ogrpc`              | `QueryParam { name: "network", value: "ethereum" }` | `Query("dkey")` | `https://lb.drpc.org/ogrpc?network=ethereum&dkey=TOKEN`  |
 | `(Ethereum, infura)`  | `https://mainnet.infura.io/v3/`          | `Embedded`                                     | `Path("")`        | `https://mainnet.infura.io/v3/TOKEN`                       |
+| `(Sui, quicknode)`    | `https://{}.sui-mainnet.quiknode.pro`    | `Embedded`                                     | `Path("")`        | `https://SLUG.sui-mainnet.quiknode.pro/TOKEN`              |
 
 ### Vote semantics
 
@@ -593,7 +594,7 @@ If an operator's `foreign_chains.yaml` references a `provider_id` not on the whi
 ### Out of scope / deferred
 
 - **Per-chain quorum policy** (`RpcPolicy.quorum_threshold` from the precursor design doc). This is the number of providers a node must independently agree with on a verification result — distinct from the per-chain voting threshold for add/remove. A follow-up under the same milestone.
-- **Hostname templating** for Alchemy / Infura. Chain identity for subdomain-encoded providers stays inside `base_url` rather than being structurally extracted; symmetric extraction was rejected as over-engineering with no concrete attack benefit.
+- **Chain-identity hostname templating** for Alchemy / Infura. Chain identity for subdomain-encoded providers stays inside `base_url` rather than being structurally extracted; symmetric extraction was rejected as over-engineering with no concrete attack benefit. This is distinct from the supported `{}` wildcard, which stands for an operator-chosen slug and carries no chain identity.
 - **Moving `sample_tx_id` on chain.** Stays in operator config for now; promoting it (so the whole network probes the same tx) is a candidate follow-up if operators start disagreeing on which tx to probe.
 - **Adding testnet `ForeignChain` variants** (`Sepolia`, `Goerli`, `Holesky`). The whitelist design doesn't need them and doesn't prevent them.
 


### PR DESCRIPTION
This is needed for quicknode.


Work towards: https://github.com/near/mpc/issues/4286