### PR TITLE
fix(node): check participant sets match during resharing and keygen

### DIFF
--- a/crates/node/src/config.rs
+++ b/crates/node/src/config.rs
@@ -8,6 +8,7 @@ use near_account_id::AccountId;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::BTreeSet,
     fs,
     io::Write,
     os::unix::fs::{OpenOptionsExt, PermissionsExt},
@@ -152,6 +153,10 @@ impl ParticipantsConfig {
             return Some(participant_info.id);
         };
         None
+    }
+
+    pub fn participant_id_set(&self) -> BTreeSet<ParticipantId> {
+        self.participants.iter().map(|p| p.id).collect()
     }
 }
 

--- a/crates/node/src/coordinator.rs
+++ b/crates/node/src/coordinator.rs
@@ -342,12 +342,14 @@ where
         let (sender, receiver) = new_tls_mesh_network(&mpc_config, p2p_key).await?;
         let (network_client, channel_receiver, _handle) =
             run_network_client(Arc::new(sender), Box::new(receiver));
+        let participants = Arc::new(mpc_config.participants.clone());
         if mpc_config.is_leader_for_key_event() {
             keygen_leader(
                 network_client,
                 keyshare_storage,
                 key_event_receiver,
                 chain_txn_sender,
+                participants,
             )
             .await?;
         } else {
@@ -356,6 +358,7 @@ where
                 keyshare_storage,
                 key_event_receiver,
                 chain_txn_sender,
+                participants,
             )
             .await?;
         }
@@ -832,6 +835,7 @@ where
             existing_keyshares,
             old_reconstruction_thresholds,
             old_participants: current_running_state.participants,
+            new_participants: mpc_config.participants.clone(),
         });
 
         if mpc_config.is_leader_for_key_event() {

--- a/crates/node/src/coordinator.rs
+++ b/crates/node/src/coordinator.rs
@@ -342,14 +342,14 @@ where
         let (sender, receiver) = new_tls_mesh_network(&mpc_config, p2p_key).await?;
         let (network_client, channel_receiver, _handle) =
             run_network_client(Arc::new(sender), Box::new(receiver));
-        let participants = Arc::new(mpc_config.participants.clone());
+        let expected_participant_ids = mpc_config.participants.participant_id_set();
         if mpc_config.is_leader_for_key_event() {
             keygen_leader(
                 network_client,
                 keyshare_storage,
                 key_event_receiver,
                 chain_txn_sender,
-                participants,
+                expected_participant_ids,
             )
             .await?;
         } else {
@@ -358,7 +358,7 @@ where
                 keyshare_storage,
                 key_event_receiver,
                 chain_txn_sender,
-                participants,
+                expected_participant_ids,
             )
             .await?;
         }
@@ -835,7 +835,7 @@ where
             existing_keyshares,
             old_reconstruction_thresholds,
             old_participants: current_running_state.participants,
-            new_participants: mpc_config.participants.clone(),
+            new_participant_ids: mpc_config.participants.participant_id_set(),
         });
 
         if mpc_config.is_leader_for_key_event() {

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -139,7 +139,7 @@ async fn keygen_computation(
     participants: Arc<ParticipantsConfig>,
 ) -> anyhow::Result<()> {
     validate_key_event_participants(channel.participants(), &participants).inspect_err(|err| {
-        error!(
+        tracing::warn!(
             leader = %channel.leader(),
             "Refusing to take part in key generation attempt {:?}: {}", key_id, err
         )
@@ -376,7 +376,7 @@ async fn resharing_computation(
 ) -> anyhow::Result<()> {
     validate_key_event_participants(channel.participants(), &args.new_participants).inspect_err(
         |err| {
-            error!(
+            tracing::warn!(
                 leader = %channel.leader(),
                 "Refusing to take part in key resharing attempt {:?}: {}", key_id, err
             )
@@ -818,7 +818,7 @@ mod tests {
         let txn_sender = CountingTransactionSender::new();
         let txn_sender_handle = txn_sender.clone();
 
-        let keyshare_storage = make_test_keyshare_storage().await;
+        let keyshare_storage = must_create_test_keyshare_storage().await;
 
         // When
         let leader_handle = tokio::spawn(resharing_leader(
@@ -941,7 +941,7 @@ mod tests {
         let result = keygen_computation(
             rx,
             channel,
-            make_test_keyshare_storage().await,
+            must_create_test_keyshare_storage().await,
             txn_sender,
             key_event_id,
             Arc::new(make_participants(&[1, 2, 3, 4])),
@@ -949,7 +949,12 @@ mod tests {
         .await;
 
         // Then
-        assert!(result.is_err());
+        assert_matches!(
+            result
+                .unwrap_err()
+                .downcast::<InvalidKeyEventParticipants>(),
+            Ok(_)
+        );
         assert_eq!(txn_sender_handle.count(), 0);
     }
 
@@ -976,7 +981,7 @@ mod tests {
         let result = resharing_computation(
             rx,
             channel,
-            make_test_keyshare_storage().await,
+            must_create_test_keyshare_storage().await,
             txn_sender,
             key_event_id,
             args,
@@ -984,7 +989,12 @@ mod tests {
         .await;
 
         // Then
-        assert!(result.is_err());
+        assert_matches!(
+            result
+                .unwrap_err()
+                .downcast::<InvalidKeyEventParticipants>(),
+            Ok(_)
+        );
         assert_eq!(txn_sender_handle.count(), 0);
     }
 
@@ -1088,7 +1098,7 @@ mod tests {
         })
     }
 
-    async fn make_test_keyshare_storage() -> Arc<RwLock<KeyshareStorage>> {
+    async fn must_create_test_keyshare_storage() -> Arc<RwLock<KeyshareStorage>> {
         let keyshare_storage = KeyStorageConfig {
             home_dir: tempfile::tempdir().unwrap().keep(),
             local_encryption_key: [0u8; 16],

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -126,7 +126,8 @@ pub async fn keygen_computation_inner(
 }
 
 /// Wrapper around `keygen_computation_inner` which
-///  - Rejects computations whose participant set does not match the contract.
+///  - Rejects the computation if the [`NetworkTaskChannel`] participants differ from the
+///    expected participant ids.
 ///  - Waits for the key event to start.
 ///  - Interrupts the inner computation if the key event expires.
 ///  - Sends a `vote_abort_key_event_instance` transaction if the inner computation fails.
@@ -136,14 +137,15 @@ async fn keygen_computation(
     keyshare_storage: Arc<RwLock<KeyshareStorage>>,
     chain_txn_sender: impl TransactionSender,
     key_id: KeyEventId,
-    participants: Arc<ParticipantsConfig>,
+    expected_participant_ids: BTreeSet<ParticipantId>,
 ) -> anyhow::Result<()> {
-    validate_key_event_participants(channel.participants(), &participants).inspect_err(|err| {
-        tracing::warn!(
-            leader = %channel.leader(),
-            "Refusing to take part in key generation attempt {:?}: {}", key_id, err
-        )
-    })?;
+    validate_key_event_participants(channel.participants(), &expected_participant_ids)
+        .inspect_err(|err| {
+            tracing::warn!(
+                leader = %channel.leader(),
+                "Refusing to take part in key generation attempt {:?}: {}", key_id, err
+            )
+        })?;
     let key_event = wait_for_contract_catchup(&mut contract_key_event_id, key_id).await;
     let inner = keygen_computation_inner(
         channel,
@@ -180,7 +182,7 @@ pub struct ResharingArgs {
     pub old_reconstruction_thresholds: HashMap<DomainId, ReconstructionThreshold>,
     pub old_participants: ParticipantsConfig,
     /// The participant set the resharing is towards, as read from the contract.
-    pub new_participants: ParticipantsConfig,
+    pub new_participant_ids: BTreeSet<ParticipantId>,
 }
 
 /// The key resharing computation (same for both leader and follower) for a single key resharing
@@ -362,7 +364,8 @@ async fn resharing_computation_inner(
 }
 
 /// Wrapper around `resharing_computation_inner` which
-///  - Rejects computations whose participant set does not match the contract.
+///  - Rejects the computation if the [`NetworkTaskChannel`] participants differ from the
+///    expected participant ids.
 ///  - Waits for the key event to start.
 ///  - Interrupts the inner computation if the key event expires.
 ///  - Sends a `vote_abort_key_event_instance` transaction if the inner computation fails.
@@ -374,14 +377,13 @@ async fn resharing_computation(
     key_id: KeyEventId,
     args: Arc<ResharingArgs>,
 ) -> anyhow::Result<()> {
-    validate_key_event_participants(channel.participants(), &args.new_participants).inspect_err(
-        |err| {
+    validate_key_event_participants(channel.participants(), &args.new_participant_ids)
+        .inspect_err(|err| {
             tracing::warn!(
                 leader = %channel.leader(),
                 "Refusing to take part in key resharing attempt {:?}: {}", key_id, err
             )
-        },
-    )?;
+        })?;
     let key_event = wait_for_contract_catchup(&mut contract_key_event_id, key_id).await;
     let inner = resharing_computation_inner(
         channel,
@@ -412,16 +414,21 @@ async fn resharing_computation(
 
 fn validate_key_event_participants(
     channel_participants: &[ParticipantId],
-    expected: &ParticipantsConfig,
+    expected_participant_ids: &BTreeSet<ParticipantId>,
 ) -> Result<(), InvalidKeyEventParticipants> {
     let actual: BTreeSet<ParticipantId> = channel_participants.iter().copied().collect();
-    let expected: BTreeSet<ParticipantId> = expected.participants.iter().map(|p| p.id).collect();
-    if actual == expected {
+    if actual == *expected_participant_ids {
         return Ok(());
     }
     Err(InvalidKeyEventParticipants {
-        missing: expected.difference(&actual).copied().collect(),
-        unexpected: actual.difference(&expected).copied().collect(),
+        missing: expected_participant_ids
+            .difference(&actual)
+            .copied()
+            .collect(),
+        unexpected: actual
+            .difference(expected_participant_ids)
+            .copied()
+            .collect(),
     })
 }
 
@@ -483,7 +490,7 @@ pub async fn keygen_leader(
     keyshare_storage: Arc<RwLock<KeyshareStorage>>,
     mut key_event_receiver: watch::Receiver<ContractKeyEventInstance>,
     chain_txn_sender: impl TransactionSender,
-    participants: Arc<ParticipantsConfig>,
+    expected_participant_ids: BTreeSet<ParticipantId>,
 ) -> anyhow::Result<()> {
     loop {
         // Wait for all participants to be connected. Otherwise, computations are most likely going
@@ -546,7 +553,7 @@ pub async fn keygen_leader(
             keyshare_storage.clone(),
             chain_txn_sender.clone(),
             key_event_id,
-            participants.clone(),
+            expected_participant_ids.clone(),
         )
         .await
         {
@@ -566,7 +573,7 @@ pub async fn keygen_follower(
     keyshare_storage: Arc<RwLock<KeyshareStorage>>,
     key_event_receiver: watch::Receiver<ContractKeyEventInstance>,
     chain_txn_sender: impl TransactionSender + 'static,
-    participants: Arc<ParticipantsConfig>,
+    expected_participant_ids: BTreeSet<ParticipantId>,
 ) -> anyhow::Result<()> {
     let mut tasks = AutoAbortTaskCollection::new();
     loop {
@@ -595,7 +602,7 @@ pub async fn keygen_follower(
                 keyshare_storage.clone(),
                 chain_txn_sender.clone(),
                 key_event_id,
-                participants.clone(),
+                expected_participant_ids.clone(),
             ),
         );
     }
@@ -786,13 +793,11 @@ impl KeyEventLeaderClient for Arc<MeshNetworkClient> {
 #[expect(non_snake_case)]
 mod tests {
     use super::*;
-    use crate::config::ParticipantInfo;
     use crate::indexer::participants::{ContractKeyEventInstance, KeyEventIdComparisonResult};
     use crate::indexer::tx_sender::{TransactionProcessorError, TransactionStatus};
     use crate::keyshare::KeyStorageConfig;
     use crate::network::testing::new_task_channel_for_test;
     use assert_matches::assert_matches;
-    use ed25519_dalek::SigningKey;
     use mpc_primitives::domain::DomainId;
     use mpc_primitives::{AttemptId, EpochId, KeyEventId};
     use near_mpc_contract_interface::types::{
@@ -876,11 +881,12 @@ mod tests {
     #[test]
     fn validate_key_event_participants__should_accept_the_contract_participant_set() {
         // Given
-        let expected = make_participants(&[1, 2, 3, 4]);
+        let expected_participant_ids = make_participant_id_set(&[1, 2, 3, 4]);
         let channel_participants = make_participant_ids(&[4, 1, 3, 2]);
 
         // When
-        let result = validate_key_event_participants(&channel_participants, &expected);
+        let result =
+            validate_key_event_participants(&channel_participants, &expected_participant_ids);
 
         // Then
         assert_matches!(result, Ok(()));
@@ -889,11 +895,12 @@ mod tests {
     #[test]
     fn validate_key_event_participants__should_reject_a_subset_of_the_contract_participant_set() {
         // Given
-        let expected = make_participants(&[1, 2, 3, 4]);
+        let expected_participant_ids = make_participant_id_set(&[1, 2, 3, 4]);
         let channel_participants = make_participant_ids(&[1, 2, 3]);
 
         // When
-        let result = validate_key_event_participants(&channel_participants, &expected);
+        let result =
+            validate_key_event_participants(&channel_participants, &expected_participant_ids);
 
         // Then
         assert_matches!(result, Err(err) => {
@@ -906,11 +913,12 @@ mod tests {
     fn validate_key_event_participants__should_reject_a_participant_outside_the_contract_participant_set()
      {
         // Given
-        let expected = make_participants(&[1, 2, 3, 4]);
+        let expected_participant_ids = make_participant_id_set(&[1, 2, 3, 4]);
         let channel_participants = make_participant_ids(&[1, 2, 3, 4, 5]);
 
         // When
-        let result = validate_key_event_participants(&channel_participants, &expected);
+        let result =
+            validate_key_event_participants(&channel_participants, &expected_participant_ids);
 
         // Then
         assert_matches!(result, Err(err) => {
@@ -944,7 +952,7 @@ mod tests {
             must_create_test_keyshare_storage().await,
             txn_sender,
             key_event_id,
-            Arc::new(make_participants(&[1, 2, 3, 4])),
+            make_participant_id_set(&[1, 2, 3, 4]),
         )
         .await;
 
@@ -1094,7 +1102,7 @@ mod tests {
                 threshold: 3,
                 participants: vec![],
             },
-            new_participants: make_participants(&[1, 2, 3, 4]),
+            new_participant_ids: make_participant_id_set(&[1, 2, 3, 4]),
         })
     }
 
@@ -1110,24 +1118,11 @@ mod tests {
         Arc::new(RwLock::new(keyshare_storage))
     }
 
-    fn make_participants(ids: &[u32]) -> ParticipantsConfig {
-        ParticipantsConfig {
-            threshold: 3,
-            participants: ids
-                .iter()
-                .map(|&id| ParticipantInfo {
-                    id: ParticipantId::from_raw(id),
-                    address: "127.0.0.1".to_string(),
-                    port: 3000,
-                    p2p_public_key: SigningKey::from_bytes(&[u8::try_from(id).unwrap(); 32])
-                        .verifying_key(),
-                    near_account_id: format!("node{id}.near").parse().unwrap(),
-                })
-                .collect(),
-        }
+    fn make_participant_ids(ids: &[u32]) -> Vec<ParticipantId> {
+        ids.iter().copied().map(ParticipantId::from_raw).collect()
     }
 
-    fn make_participant_ids(ids: &[u32]) -> Vec<ParticipantId> {
+    fn make_participant_id_set(ids: &[u32]) -> BTreeSet<ParticipantId> {
         ids.iter().copied().map(ParticipantId::from_raw).collect()
     }
 }

--- a/crates/node/src/key_events.rs
+++ b/crates/node/src/key_events.rs
@@ -21,7 +21,7 @@ use near_mpc_contract_interface::call_args as contract_args;
 use near_mpc_contract_interface::types as dtos;
 use near_mpc_contract_interface::types::DomainConfig;
 use near_mpc_crypto_types::{KeyForDomain, Keyset};
-use std::collections::HashMap;
+use std::collections::{BTreeSet, HashMap};
 use std::sync::Arc;
 use std::time::Duration;
 use threshold_signatures::{
@@ -126,6 +126,7 @@ pub async fn keygen_computation_inner(
 }
 
 /// Wrapper around `keygen_computation_inner` which
+///  - Rejects computations whose participant set does not match the contract.
 ///  - Waits for the key event to start.
 ///  - Interrupts the inner computation if the key event expires.
 ///  - Sends a `vote_abort_key_event_instance` transaction if the inner computation fails.
@@ -135,7 +136,14 @@ async fn keygen_computation(
     keyshare_storage: Arc<RwLock<KeyshareStorage>>,
     chain_txn_sender: impl TransactionSender,
     key_id: KeyEventId,
+    participants: Arc<ParticipantsConfig>,
 ) -> anyhow::Result<()> {
+    validate_key_event_participants(channel.participants(), &participants).inspect_err(|err| {
+        error!(
+            leader = %channel.leader(),
+            "Refusing to take part in key generation attempt {:?}: {}", key_id, err
+        )
+    })?;
     let key_event = wait_for_contract_catchup(&mut contract_key_event_id, key_id).await;
     let inner = keygen_computation_inner(
         channel,
@@ -171,6 +179,8 @@ pub struct ResharingArgs {
     /// resharing protocol as the old-side `t` for each key.
     pub old_reconstruction_thresholds: HashMap<DomainId, ReconstructionThreshold>,
     pub old_participants: ParticipantsConfig,
+    /// The participant set the resharing is towards, as read from the contract.
+    pub new_participants: ParticipantsConfig,
 }
 
 /// The key resharing computation (same for both leader and follower) for a single key resharing
@@ -352,6 +362,7 @@ async fn resharing_computation_inner(
 }
 
 /// Wrapper around `resharing_computation_inner` which
+///  - Rejects computations whose participant set does not match the contract.
 ///  - Waits for the key event to start.
 ///  - Interrupts the inner computation if the key event expires.
 ///  - Sends a `vote_abort_key_event_instance` transaction if the inner computation fails.
@@ -363,6 +374,14 @@ async fn resharing_computation(
     key_id: KeyEventId,
     args: Arc<ResharingArgs>,
 ) -> anyhow::Result<()> {
+    validate_key_event_participants(channel.participants(), &args.new_participants).inspect_err(
+        |err| {
+            error!(
+                leader = %channel.leader(),
+                "Refusing to take part in key resharing attempt {:?}: {}", key_id, err
+            )
+        },
+    )?;
     let key_event = wait_for_contract_catchup(&mut contract_key_event_id, key_id).await;
     let inner = resharing_computation_inner(
         channel,
@@ -389,6 +408,30 @@ async fn resharing_computation(
         _ = expiration => anyhow::bail!("Key event expired before computation completed."),
     }
     Ok(())
+}
+
+fn validate_key_event_participants(
+    channel_participants: &[ParticipantId],
+    expected: &ParticipantsConfig,
+) -> Result<(), InvalidKeyEventParticipants> {
+    let actual: BTreeSet<ParticipantId> = channel_participants.iter().copied().collect();
+    let expected: BTreeSet<ParticipantId> = expected.participants.iter().map(|p| p.id).collect();
+    if actual == expected {
+        return Ok(());
+    }
+    Err(InvalidKeyEventParticipants {
+        missing: expected.difference(&actual).copied().collect(),
+        unexpected: actual.difference(&expected).copied().collect(),
+    })
+}
+
+#[derive(Debug, thiserror::Error)]
+#[error(
+    "key event participants do not match the contract's participant set; missing {missing:?}, unexpected {unexpected:?}"
+)]
+struct InvalidKeyEventParticipants {
+    missing: Vec<ParticipantId>,
+    unexpected: Vec<ParticipantId>,
 }
 
 /// Waits until the contract is no longer behind the key event ID.
@@ -440,6 +483,7 @@ pub async fn keygen_leader(
     keyshare_storage: Arc<RwLock<KeyshareStorage>>,
     mut key_event_receiver: watch::Receiver<ContractKeyEventInstance>,
     chain_txn_sender: impl TransactionSender,
+    participants: Arc<ParticipantsConfig>,
 ) -> anyhow::Result<()> {
     loop {
         // Wait for all participants to be connected. Otherwise, computations are most likely going
@@ -486,12 +530,11 @@ pub async fn keygen_leader(
         }
 
         // Start the keygen computation.
-        let participants = client.all_participant_ids();
         let Ok(channel) = client.new_channel_for_task(
             EcdsaTaskId::KeyGeneration {
                 key_event: key_event_id,
             },
-            participants,
+            client.all_participant_ids(),
         ) else {
             tracing::warn!("Failed to create channel for keygen computation; retrying.");
             continue;
@@ -503,6 +546,7 @@ pub async fn keygen_leader(
             keyshare_storage.clone(),
             chain_txn_sender.clone(),
             key_event_id,
+            participants.clone(),
         )
         .await
         {
@@ -522,6 +566,7 @@ pub async fn keygen_follower(
     keyshare_storage: Arc<RwLock<KeyshareStorage>>,
     key_event_receiver: watch::Receiver<ContractKeyEventInstance>,
     chain_txn_sender: impl TransactionSender + 'static,
+    participants: Arc<ParticipantsConfig>,
 ) -> anyhow::Result<()> {
     let mut tasks = AutoAbortTaskCollection::new();
     loop {
@@ -550,6 +595,7 @@ pub async fn keygen_follower(
                 keyshare_storage.clone(),
                 chain_txn_sender.clone(),
                 key_event_id,
+                participants.clone(),
             ),
         );
     }
@@ -740,10 +786,13 @@ impl KeyEventLeaderClient for Arc<MeshNetworkClient> {
 #[expect(non_snake_case)]
 mod tests {
     use super::*;
+    use crate::config::ParticipantInfo;
     use crate::indexer::participants::{ContractKeyEventInstance, KeyEventIdComparisonResult};
     use crate::indexer::tx_sender::{TransactionProcessorError, TransactionStatus};
     use crate::keyshare::KeyStorageConfig;
+    use crate::network::testing::new_task_channel_for_test;
     use assert_matches::assert_matches;
+    use ed25519_dalek::SigningKey;
     use mpc_primitives::domain::DomainId;
     use mpc_primitives::{AttemptId, EpochId, KeyEventId};
     use near_mpc_contract_interface::types::{
@@ -769,15 +818,7 @@ mod tests {
         let txn_sender = CountingTransactionSender::new();
         let txn_sender_handle = txn_sender.clone();
 
-        let keyshare_storage = KeyStorageConfig {
-            home_dir: tempfile::tempdir().unwrap().keep(),
-            local_encryption_key: [0u8; 16],
-            gcp: None,
-        }
-        .create()
-        .await
-        .unwrap();
-        let keyshare_storage = Arc::new(RwLock::new(keyshare_storage));
+        let keyshare_storage = make_test_keyshare_storage().await;
 
         // When
         let leader_handle = tokio::spawn(resharing_leader(
@@ -830,6 +871,121 @@ mod tests {
 
         // Then
         assert_matches!(result, KeyEventIdComparisonResult::RemoteMatches);
+    }
+
+    #[test]
+    fn validate_key_event_participants__should_accept_the_contract_participant_set() {
+        // Given
+        let expected = make_participants(&[1, 2, 3, 4]);
+        let channel_participants = make_participant_ids(&[4, 1, 3, 2]);
+
+        // When
+        let result = validate_key_event_participants(&channel_participants, &expected);
+
+        // Then
+        assert_matches!(result, Ok(()));
+    }
+
+    #[test]
+    fn validate_key_event_participants__should_reject_a_subset_of_the_contract_participant_set() {
+        // Given
+        let expected = make_participants(&[1, 2, 3, 4]);
+        let channel_participants = make_participant_ids(&[1, 2, 3]);
+
+        // When
+        let result = validate_key_event_participants(&channel_participants, &expected);
+
+        // Then
+        assert_matches!(result, Err(err) => {
+            assert_eq!(err.missing, make_participant_ids(&[4]));
+            assert!(err.unexpected.is_empty());
+        });
+    }
+
+    #[test]
+    fn validate_key_event_participants__should_reject_a_participant_outside_the_contract_participant_set()
+     {
+        // Given
+        let expected = make_participants(&[1, 2, 3, 4]);
+        let channel_participants = make_participant_ids(&[1, 2, 3, 4, 5]);
+
+        // When
+        let result = validate_key_event_participants(&channel_participants, &expected);
+
+        // Then
+        assert_matches!(result, Err(err) => {
+            assert!(err.missing.is_empty());
+            assert_eq!(err.unexpected, make_participant_ids(&[5]));
+        });
+    }
+
+    /// A leader-chosen subset must be refused without any contract interaction, in particular
+    /// without voting to abort the key event instance.
+    #[tokio::test]
+    async fn keygen_computation__should_reject_a_channel_that_omits_a_contract_participant() {
+        // Given
+        let key_event_id = make_key_event_id(6, 1, 1);
+        let (_tx, rx) = watch::channel(make_key_event_instance(key_event_id, true));
+        let txn_sender = CountingTransactionSender::new();
+        let txn_sender_handle = txn_sender.clone();
+        let (channel, _raw_sender) = new_task_channel_for_test(
+            MpcTaskId::EcdsaTaskId(EcdsaTaskId::KeyGeneration {
+                key_event: key_event_id,
+            }),
+            ParticipantId::from_raw(1),
+            ParticipantId::from_raw(2),
+            make_participant_ids(&[1, 2, 3]),
+        );
+
+        // When
+        let result = keygen_computation(
+            rx,
+            channel,
+            make_test_keyshare_storage().await,
+            txn_sender,
+            key_event_id,
+            Arc::new(make_participants(&[1, 2, 3, 4])),
+        )
+        .await;
+
+        // Then
+        assert!(result.is_err());
+        assert_eq!(txn_sender_handle.count(), 0);
+    }
+
+    /// A leader-chosen subset must be refused without any contract interaction, in particular
+    /// without voting to abort the key event instance.
+    #[tokio::test]
+    async fn resharing_computation__should_reject_a_channel_that_omits_a_contract_participant() {
+        // Given
+        let args = make_test_resharing_args();
+        let key_event_id = make_key_event_id(6, 1, 1);
+        let (_tx, rx) = watch::channel(make_key_event_instance(key_event_id, true));
+        let txn_sender = CountingTransactionSender::new();
+        let txn_sender_handle = txn_sender.clone();
+        let (channel, _raw_sender) = new_task_channel_for_test(
+            MpcTaskId::EcdsaTaskId(EcdsaTaskId::KeyResharing {
+                key_event: key_event_id,
+            }),
+            ParticipantId::from_raw(1),
+            ParticipantId::from_raw(2),
+            make_participant_ids(&[1, 2, 3]),
+        );
+
+        // When
+        let result = resharing_computation(
+            rx,
+            channel,
+            make_test_keyshare_storage().await,
+            txn_sender,
+            key_event_id,
+            args,
+        )
+        .await;
+
+        // Then
+        assert!(result.is_err());
+        assert_eq!(txn_sender_handle.count(), 0);
     }
 
     // -- Mocks and helpers --
@@ -928,6 +1084,40 @@ mod tests {
                 threshold: 3,
                 participants: vec![],
             },
+            new_participants: make_participants(&[1, 2, 3, 4]),
         })
+    }
+
+    async fn make_test_keyshare_storage() -> Arc<RwLock<KeyshareStorage>> {
+        let keyshare_storage = KeyStorageConfig {
+            home_dir: tempfile::tempdir().unwrap().keep(),
+            local_encryption_key: [0u8; 16],
+            gcp: None,
+        }
+        .create()
+        .await
+        .unwrap();
+        Arc::new(RwLock::new(keyshare_storage))
+    }
+
+    fn make_participants(ids: &[u32]) -> ParticipantsConfig {
+        ParticipantsConfig {
+            threshold: 3,
+            participants: ids
+                .iter()
+                .map(|&id| ParticipantInfo {
+                    id: ParticipantId::from_raw(id),
+                    address: "127.0.0.1".to_string(),
+                    port: 3000,
+                    p2p_public_key: SigningKey::from_bytes(&[u8::try_from(id).unwrap(); 32])
+                        .verifying_key(),
+                    near_account_id: format!("node{id}.near").parse().unwrap(),
+                })
+                .collect(),
+        }
+    }
+
+    fn make_participant_ids(ids: &[u32]) -> Vec<ParticipantId> {
+        ids.iter().copied().map(ParticipantId::from_raw).collect()
     }
 }

--- a/crates/node/src/network.rs
+++ b/crates/node/src/network.rs
@@ -733,6 +733,10 @@ impl NetworkTaskChannel {
         self.sender.my_participant_id
     }
 
+    pub fn leader(&self) -> ParticipantId {
+        self.sender.leader
+    }
+
     /// Receives a single MPC message from any participant from the network, without processing it.
     /// This will return error early if any connection is broken.
     async fn receive_raw(&mut self) -> anyhow::Result<MpcPeerMessage> {


### PR DESCRIPTION
Closes #4231

Notice the PR was extended slightly to cover the same problem for the keygen path.