### PR TITLE
docs: distinguish live and archived documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,9 +152,10 @@ See `docs/engineering-standards.md` §Write helpful code comments for the full r
 
 ## Documentation alignment
 
-Archived documents are recognizable by a "Status: ARCHIVED" banner at the top. Such documents must never be modified.
+Archived documents are recognizable by a `**Status:** ARCHIVED` banner directly below the title; such documents must never be modified. When a PR archives a file, it must remove any contents at risk of becoming stale (such as file paths). The archiving procedure is described in [README.md §Documentation](README.md#documentation).
+
 All other documents are considered live and expected to be updated if invalidated by a change.
-When authoring or reviewing a change that renames, removes, or reshapes code (types, methods, contract entry points, config fields, protocol state, architecture), verify that the surrounding documentation still describes the new behavior. This covers Markdown under `docs/` and any referenced templates, as well as Rust doc comments (`///`, `//!`) on and near the changed items — names, parameters, invariants, and examples in doc comments drift just as easily as prose docs. Design documents (`docs/design/`, `docs/*-design.md`) that describe a superseded design must be updated as well (unless labeled as archived).
+
+When authoring or reviewing a change that renames, removes, or reshapes code (types, methods, contract entry points, config fields, protocol state, architecture), verify that the surrounding documentation still describes the new behavior. This covers Markdown under `docs/` and any referenced templates, as well as Rust doc comments (`///`, `//!`) on and near the changed items — names, parameters, invariants, and examples in doc comments drift just as easily as prose docs. Design documents (`docs/design/`, `docs/*-design.md`) that describe a superseded design must never be left silently stale: update them in the same PR, or — when the rewrite is too big for the PR that invalidated them — mark the stale sections with a status banner linking an issue that tracks the rewrite (e.g. `**Status:** Partially superseded — TODO(#3825): …`).
 
 If you find stale passages in a live doc, flag them with `file:line` and, when authoring, fix them in the same PR. Doc drift is a review-blocking issue, not a follow-up.
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,7 +152,7 @@ See `docs/engineering-standards.md` §Write helpful code comments for the full r
 
 ## Documentation alignment
 
-Archived documents are recognizable by a `**Status:** ARCHIVED` banner directly below the title; such documents must never be modified. When a PR archives a file, it must remove any contents at risk of becoming stale (such as file paths). The archiving procedure is described in [README.md §Documentation](README.md#documentation).
+Archived documents are recognizable by a `**Status:** ARCHIVED` banner directly below the title; such documents must never be modified. When a PR archives a file, flag contents at risk of becoming stale (such as file paths). This is non-blocking, as version history preserves the paths valid at archiving time. The archiving procedure is described in [README.md §Documentation](README.md#documentation).
 
 All other documents are considered live and expected to be updated if invalidated by a change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -152,5 +152,9 @@ See `docs/engineering-standards.md` §Write helpful code comments for the full r
 
 ## Documentation alignment
 
-When authoring or reviewing a change that renames, removes, or reshapes code (types, methods, contract entry points, config fields, protocol state, architecture), verify that the surrounding documentation still describes the new behavior. This covers Markdown under `docs/` and any referenced templates, as well as Rust doc comments (`///`, `//!`) on and near the changed items — names, parameters, invariants, and examples in doc comments drift just as easily as prose docs. Design documents (`docs/design/`, `docs/*-design.md`) that describe a superseded design must be either updated, removed, or prominently marked as outdated (e.g. a "Status: superseded by #NNNN" banner at the top) — never left silently stale. If you find stale passages, flag them with `file:line` and, when authoring, fix them in the same PR. Doc drift is a review-blocking issue, not a follow-up.
+Archived documents are recognizable by a "Status: ARCHIVED" banner at the top. Such documents must never be modified.
+All other documents are considered live and expected to be updated if invalidated by a change.
+When authoring or reviewing a change that renames, removes, or reshapes code (types, methods, contract entry points, config fields, protocol state, architecture), verify that the surrounding documentation still describes the new behavior. This covers Markdown under `docs/` and any referenced templates, as well as Rust doc comments (`///`, `//!`) on and near the changed items — names, parameters, invariants, and examples in doc comments drift just as easily as prose docs. Design documents (`docs/design/`, `docs/*-design.md`) that describe a superseded design must be updated as well (unless labeled as archived).
+
+If you find stale passages in a live doc, flag them with `file:line` and, when authoring, fix them in the same PR. Doc drift is a review-blocking issue, not a follow-up.
 

--- a/README.md
+++ b/README.md
@@ -173,3 +173,9 @@ Running all `cargo-make` supported checks:
 ```console
 cargo make check-all
 ```
+
+### Documentation
+
+Documentation in this repository falls into two categories: live documentation, aiming to explain how something works _right now_, and archived documentation records that may help future developers retrace past decisions. Live documentation _must_ be updated if invalidated by a change, but archived documentation _must not_ be updated, as doing so would undermine its purpose.
+
+Archived documentation must be labeled as such with a status banner at the top of the file (`Status: ARCHIVED`). Any document without such a banner is considered live.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ cargo make check-all
 
 Documentation in this repository falls into two categories: live documentation, aiming to explain how something works _right now_, and archived documentation records that may help future developers retrace past decisions. Live documentation _must_ be updated if invalidated by a change, but archived documentation _must not_ be updated, as doing so would undermine its purpose.
 
-Archived documentation must be labeled as such with a status banner: a `**Status:** ARCHIVED` line immediately below the document's title, optionally followed by `— superseded by <link>` naming what replaced it. Any document without such a banner is considered live.
+Archived documentation must be labeled as such with a status banner: a `**Status:** ARCHIVED` line immediately below the document's title. Any document without such a banner is considered live.
 
 To archive a file, one must open a PR adding the status banner. Additionally, the PR should make any required modifications to the file, such that its contents are useful to future readers. In particular, the PR author must remove any contents at risk of becoming stale (such as file paths).
 

--- a/README.md
+++ b/README.md
@@ -180,5 +180,5 @@ Documentation in this repository falls into two categories: live documentation, 
 
 Archived documentation must be labeled as such with a status banner: a `**Status:** ARCHIVED` line immediately below the document's title. Any document without such a banner is considered live.
 
-To archive a file, one must open a PR adding the status banner. Additionally, the PR should make any required modifications to the file, such that its contents are useful to future readers. In particular, the PR author must remove any contents at risk of becoming stale (such as file paths).
+To archive a file, one must open a PR adding the status banner.
 

--- a/README.md
+++ b/README.md
@@ -178,4 +178,7 @@ cargo make check-all
 
 Documentation in this repository falls into two categories: live documentation, aiming to explain how something works _right now_, and archived documentation records that may help future developers retrace past decisions. Live documentation _must_ be updated if invalidated by a change, but archived documentation _must not_ be updated, as doing so would undermine its purpose.
 
-Archived documentation must be labeled as such with a status banner at the top of the file (`Status: ARCHIVED`). Any document without such a banner is considered live.
+Archived documentation must be labeled as such with a status banner: a `**Status:** ARCHIVED` line immediately below the document's title, optionally followed by `— superseded by <link>` naming what replaced it. Any document without such a banner is considered live.
+
+To archive a file, one must open a PR adding the status banner. Additionally, the PR should make any required modifications to the file, such that its contents are useful to future readers. In particular, the PR author must remove any contents at risk of becoming stale (such as file paths).
+


### PR DESCRIPTION
resolves #4329 