### PR TITLE
fix: warn about mismatched tls keys during migration

### DIFF
--- a/crates/node/src/indexer/migrations.rs
+++ b/crates/node/src/indexer/migrations.rs
@@ -41,8 +41,9 @@ pub async fn monitor_migrations(
                 let response = fetch_migrations_once(indexer_state.clone()).await;
                 tracing::debug!(target: "indexer", "fetched mpc migration state at block {}: {:?}", response.0, response.1);
 
+                let mut migration_info_changed = false;
                 migration_state_sender.send_if_modified(|watched_state| {
-                    let migration_info_changed = watched_state.1 != response.1;
+                    migration_info_changed = watched_state.1 != response.1;
                     if *watched_state != response {
                         if migration_info_changed {
                             tracing::info!("contract migration state changed: {:?}", response);
@@ -53,6 +54,12 @@ pub async fn monitor_migrations(
                         false
                     }
                 });
+
+                // Re-deriving an unchanged view would repeat its diagnostics on every tick.
+                if !migration_info_changed {
+                    continue;
+                }
+
                 let my_migration_state = MigrationInfo::from_contract_state(
                     &my_near_account_id,
                     &my_p2p_public_key,

--- a/crates/node/src/migration_service/types.rs
+++ b/crates/node/src/migration_service/types.rs
@@ -137,7 +137,7 @@ fn infer_migration_status(
             tracing::warn!(
                 registered_tls_public_key = %String::from(registered_key),
                 my_tls_public_key = %String::from(&Ed25519PublicKey::from(my_p2p_public_key)),
-                "registered destination node TLS key is not this node's key, migration stays inactive"
+                "a destination node with a different TLS key is registered for this account; this node will not onboard (expected if this node is the migration source)"
             );
             false
         }

--- a/crates/node/src/migration_service/types.rs
+++ b/crates/node/src/migration_service/types.rs
@@ -1,6 +1,8 @@
 use ed25519_dalek::VerifyingKey;
 use near_account_id::AccountId;
-use near_mpc_contract_interface::types::{BackupServiceInfo, DestinationNodeInfo};
+use near_mpc_contract_interface::types::{
+    BackupServiceInfo, DestinationNodeInfo, Ed25519PublicKey,
+};
 use near_mpc_crypto_types::Keyset;
 use serde::Serialize;
 use tokio_util::sync::CancellationToken;
@@ -125,14 +127,29 @@ fn infer_migration_status(
     my_p2p_public_key: &VerifyingKey,
     destination_node_info: &Option<DestinationNodeInfo>,
 ) -> bool {
-    destination_node_info
-        .as_ref()
-        .map(|info| {
-            ed25519_dalek::VerifyingKey::try_from(&info.destination_node_info.tls_public_key)
-                .inspect_err(|_| tracing::warn!(target: "Migration Service", "Error parsing public key from chain."))
-                .is_ok_and(|key| key == *my_p2p_public_key)
-        })
-        .unwrap_or(false)
+    let Some(info) = destination_node_info.as_ref() else {
+        return false;
+    };
+    let registered_key = &info.destination_node_info.tls_public_key;
+    match VerifyingKey::try_from(registered_key) {
+        Ok(key) if key == *my_p2p_public_key => true,
+        Ok(_) => {
+            tracing::warn!(
+                registered_tls_public_key = %String::from(registered_key),
+                my_tls_public_key = %String::from(&Ed25519PublicKey::from(my_p2p_public_key)),
+                "registered destination node TLS key is not this node's key, migration stays inactive"
+            );
+            false
+        }
+        Err(err) => {
+            tracing::error!(
+                ?err,
+                registered_tls_public_key = %String::from(registered_key),
+                "could not parse the registered destination node's TLS public key from chain"
+            );
+            false
+        }
+    }
 }
 
 #[cfg(test)]

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -459,8 +459,8 @@ destination TLS key is not its own; it names both keys. That means the `tls_publ
 new node runs with. Compare `migration_info` against
 `curl -s http://<new-node-IP>:8080/public_data | jq -r .near_p2p_public_key` and call
 `start_node_migration` again with the correct value; only the last call is retained. The node still
-holds the transferred keyshares and imports them as soon as it sees itself registered, so there is
-no need to re-run `put-keyshares`.
+holds the transferred keyshares in memory and imports them as soon as it sees itself registered,
+so `put-keyshares` only needs re-running if the node restarted in the meantime.
 
 ## Known Limitations
 

--- a/docs/node-migration-guide.md
+++ b/docs/node-migration-guide.md
@@ -451,6 +451,17 @@ If backup-cli cannot connect to your node:
 - **Verify the port**: The migration endpoint uses the node's `migration_web_ui` port, which is not always the `8079` default — read it from `http://<IP>:8080/debug/node_config`. The same endpoint shows the bind address, which must not be loopback-only.
 - **Verify firewall rules**: Ensure the backup service can reach the node's address and that the migration port is open and accessible. Test with `nc -vz <host> <port>` rather than `curl`; the endpoint is a raw TLS channel authenticated against the registered backup-service key, so it does not answer plain HTTP requests.
 
+### `put-keyshares` reports success but the node never onboards
+
+If the new node does not conclude the migration, check its logs for a warning that the registered
+destination TLS key is not its own; it names both keys. That means the `tls_public_key` passed to
+`start_node_migration` in [Step 6](#step-6-initiate-migration-state-in-contract) is not the key the
+new node runs with. Compare `migration_info` against
+`curl -s http://<new-node-IP>:8080/public_data | jq -r .near_p2p_public_key` and call
+`start_node_migration` again with the correct value; only the last call is retained. The node still
+holds the transferred keyshares and imports them as soon as it sees itself registered, so there is
+no need to re-run `put-keyshares`.
+
 ## Known Limitations
 
 The back-migration flow (returning to a previously-active node, i.e. A → B → A) has two operator-facing limitations:


### PR DESCRIPTION
Closes #4327 