### PR TITLE
test(inspector): cover the not found verdict in the fan out mismatch test

### DIFF
--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -48,8 +48,8 @@ pub trait ForeignChainInspector {
 
 /// The settled answer from a transaction inspection. Inspection producing a negative verdict is
 /// still a successful inspection. Failing to obtain any verdict is instead a
-/// [`ForeignChainInspectionError`]. [`ForeignChainInspector::extract`] must report every answer
-/// a provider gives about the transaction under the variant defined here, not as an error.
+/// [`ForeignChainInspectionError`]. [`ForeignChainInspector::extract`] must report every verdict
+/// given by a provider about a transaction under a variant defined here, not as an error.
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum Verdict<V> {
     #[display("extracted {} values", _0.len())]
@@ -57,8 +57,8 @@ pub enum Verdict<V> {
     #[display("the transaction's status was not success")]
     TransactionFailed,
     /// Deliberately a verdict rather than a tolerated error. Honest providers cannot extract
-    /// anything from a transaction that does not exist, so the chain's signal for an unknown
-    /// transaction must map here.
+    /// anything from a transaction that does not exist. [`ForeignChainInspector::extract`] must
+    /// map a chain's signal for an unknown transaction here.
     #[display("the transaction was not found")]
     TransactionNotFound,
     #[display(

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -38,12 +38,6 @@ pub trait ForeignChainInspector {
     type Finality;
     type Extractor;
     type ExtractedValue;
-
-    /// Inspects transactions on one foreign chain.
-    ///
-    /// Implementations must map the chain's signal for an unknown transaction to
-    /// [`Verdict::TransactionNotFound`] and pin that with a test. If left as a client error,
-    /// absence is tolerated by [`FanOut`] as a transient issue at a given provider.
     fn extract(
         &self,
         tx_id: Self::TransactionId,
@@ -54,7 +48,8 @@ pub trait ForeignChainInspector {
 
 /// The settled answer from a transaction inspection. Inspection producing a negative verdict is
 /// still a successful inspection. Failing to obtain any verdict is instead a
-/// [`ForeignChainInspectionError`].
+/// [`ForeignChainInspectionError`]. [`ForeignChainInspector::extract`] must report every answer
+/// a provider gives about the transaction under the variant defined here, not as an error.
 #[derive(Debug, Clone, PartialEq, Eq, Display)]
 pub enum Verdict<V> {
     #[display("extracted {} values", _0.len())]
@@ -62,7 +57,8 @@ pub enum Verdict<V> {
     #[display("the transaction's status was not success")]
     TransactionFailed,
     /// Deliberately a verdict rather than a tolerated error. Honest providers cannot extract
-    /// anything from a transaction that does not exist.
+    /// anything from a transaction that does not exist, so the chain's signal for an unknown
+    /// transaction must map here.
     #[display("the transaction was not found")]
     TransactionNotFound,
     #[display(

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -33,16 +33,17 @@ pub mod rpc_inspector;
 pub mod starknet;
 pub mod sui;
 
-/// Inspects transactions on one foreign chain.
-///
-/// Implementations must map the chain's signal for an unknown transaction to
-/// [`Verdict::TransactionNotFound`] and pin that with a test. Left as a client error, absence is
-/// tolerated by [`FanOut`], and one fabricating provider outvotes every honest one.
 pub trait ForeignChainInspector {
     type TransactionId;
     type Finality;
     type Extractor;
     type ExtractedValue;
+
+    /// Inspects transactions on one foreign chain.
+    ///
+    /// Implementations must map the chain's signal for an unknown transaction to
+    /// [`Verdict::TransactionNotFound`] and pin that with a test. If left as a client error,
+    /// absence is tolerated by [`FanOut`] as a transient issue at a given provider.
     fn extract(
         &self,
         tx_id: Self::TransactionId,

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -35,13 +35,9 @@ pub mod sui;
 
 /// Inspects transactions on one foreign chain.
 ///
-/// [`Self::extract`] reaches a [`Verdict`] whenever the provider answered about the transaction,
-/// and fails with a [`ForeignChainInspectionError`] only when no verdict could be reached.
-/// Implementations must map the chain's own signal for an unknown transaction, be it a `null`
-/// receipt, a dedicated JSON-RPC error code or a 404, to [`Verdict::TransactionNotFound`] rather
-/// than let it surface as a client error: [`FanOut`] tolerates errors, so an unmapped absence
-/// would let one provider fabricating a transaction outvote every honest one. Pin the mapping
-/// with a test that feeds the inspector the provider's actual answer.
+/// Implementations must map the chain's signal for an unknown transaction to
+/// [`Verdict::TransactionNotFound`] and pin that with a test. Left as a client error, absence is
+/// tolerated by [`FanOut`], and one fabricating provider outvotes every honest one.
 pub trait ForeignChainInspector {
     type TransactionId;
     type Finality;

--- a/crates/foreign-chain-inspector/src/lib.rs
+++ b/crates/foreign-chain-inspector/src/lib.rs
@@ -33,6 +33,15 @@ pub mod rpc_inspector;
 pub mod starknet;
 pub mod sui;
 
+/// Inspects transactions on one foreign chain.
+///
+/// [`Self::extract`] reaches a [`Verdict`] whenever the provider answered about the transaction,
+/// and fails with a [`ForeignChainInspectionError`] only when no verdict could be reached.
+/// Implementations must map the chain's own signal for an unknown transaction, be it a `null`
+/// receipt, a dedicated JSON-RPC error code or a 404, to [`Verdict::TransactionNotFound`] rather
+/// than let it surface as a client error: [`FanOut`] tolerates errors, so an unmapped absence
+/// would let one provider fabricating a transaction outvote every honest one. Pin the mapping
+/// with a test that feeds the inspector the provider's actual answer.
 pub trait ForeignChainInspector {
     type TransactionId;
     type Finality;

--- a/crates/foreign-chain-inspector/tests/fanout.rs
+++ b/crates/foreign-chain-inspector/tests/fanout.rs
@@ -16,6 +16,7 @@ use foreign_chain_inspector::{
 };
 use near_mpc_bounded_collections::NonEmptyVec;
 use near_mpc_contract_interface::types::ProviderId;
+use rstest::rstest;
 
 mockall::mock! {
     Inspector {}
@@ -210,12 +211,23 @@ mod extracted_values_disagree {
 mod split_extracted_and_failing {
     use super::*;
 
+    #[rstest]
+    #[case::transaction_failed(Verdict::TransactionFailed)]
+    #[case::transaction_not_found(Verdict::TransactionNotFound)]
+    #[case::non_canonical_block(Verdict::NonCanonicalBlock {
+        block_number: 1,
+        receipt_hash: HexBytes(vec![1]),
+        canonical_hash: HexBytes(vec![2]),
+    })]
+    #[case::log_index_out_of_bounds(Verdict::LogIndexOutOfBounds)]
     #[tokio::test]
-    async fn fan_out__should_return_mismatch_when_some_extract_and_others_rule_the_tx_out() {
+    async fn fan_out__should_return_mismatch_when_some_extract_and_others_rule_the_tx_out(
+        #[case] ruling_out: Verdict<u32>,
+    ) {
         // Given: one extraction, one failing verdict, one tolerated error. The error does not
         // mask the substantive disagreement.
         let extracting = mock_returning(ok(vec![1]));
-        let failing = mock_returning(verdict(|| Verdict::TransactionFailed));
+        let failing = mock_returning(verdict(move || ruling_out.clone()));
         let erring = mock_returning(err(|| ForeignChainInspectionError::NotFinalized));
         let fan_out = fan_out_of(vec![extracting, failing, erring]);
 


### PR DESCRIPTION
[NIB-590](https://github.com/near/mpc-private/blob/main/projects/near-intents-bug-bounty/findings/valid/NIB-590.md) was addressed by https://github.com/near/mpc/pull/4310.

To further guard against this issue, this PR adds test case and comments.