### PR TITLE
feat: LLM inference request domain and contract entry points

### DIFF
--- a/crates/contract/src/api.rs
+++ b/crates/contract/src/api.rs
@@ -9,6 +9,7 @@ pub mod governance;
 pub mod key_events;
 pub mod keys;
 pub mod lifecycle;
+pub mod llm;
 pub mod node_migration;
 pub mod sign;
 pub mod tee_measurements;

--- a/crates/contract/src/api/lifecycle.rs
+++ b/crates/contract/src/api/lifecycle.rs
@@ -62,6 +62,9 @@ impl MpcContract {
             pending_verify_foreign_tx_requests: LookupMap::new(
                 StorageKey::PendingVerifyForeignTxRequestsV3,
             ),
+            pending_llm_inference_requests: LookupMap::new(
+                StorageKey::PendingLlmInferenceRequestsV1,
+            ),
             proposed_updates: ProposedUpdates::default(),
             config,
             tee_state,
@@ -150,6 +153,9 @@ impl MpcContract {
             pending_ckd_requests: LookupMap::new(StorageKey::PendingCKDRequestsV3),
             pending_verify_foreign_tx_requests: LookupMap::new(
                 StorageKey::PendingVerifyForeignTxRequestsV3,
+            ),
+            pending_llm_inference_requests: LookupMap::new(
+                StorageKey::PendingLlmInferenceRequestsV1,
             ),
             proposed_updates: Default::default(),
             tee_state,

--- a/crates/contract/src/api/llm.rs
+++ b/crates/contract/src/api/llm.rs
@@ -1,0 +1,435 @@
+//! LLM inference: the request path, its response callback and the
+//! pending-request view. Clones the foreign-tx yield/resume flow; the schema
+//! is stored and hashed opaquely and validated node-side.
+
+use crate::crypto_shared::types::PublicKeyExtended;
+use crate::dto_mapping::args_into_llm_inference_request;
+use crate::errors::{Error, InvalidState, RespondError, TeeError};
+use crate::{MpcContract, MpcContractExt, pending_requests};
+use near_mpc_contract_interface::deposits::SIGN_DEPOSIT_YOCTONEAR;
+use near_mpc_contract_interface::method_names;
+use near_mpc_contract_interface::types as dtos;
+use near_sdk::{CryptoHash, Gas, NearToken, Promise, PromiseError, PromiseOrValue, env, log, near};
+
+#[near]
+impl MpcContract {
+    fn add_llm_inference_request(
+        &mut self,
+        request: dtos::LlmInferenceRequest,
+        data_id: CryptoHash,
+    ) {
+        pending_requests::push_pending_yield(
+            &mut self.pending_llm_inference_requests,
+            request,
+            data_id,
+        );
+    }
+
+    /// Submit an LLM inference request. MPC nodes run the prompt through the
+    /// pinned model independently and sign only on byte-identical output.
+    #[handle_result]
+    #[payable]
+    pub fn request_llm_inference(&mut self, request: dtos::LlmInferenceRequestArgs) {
+        log!(
+            "request_llm_inference: predecessor={:?}, request={:?}",
+            env::predecessor_account_id(),
+            request
+        );
+
+        self.check_request_preconditions(
+            request.domain_id,
+            dtos::DomainPurpose::Llm,
+            Gas::from_tgas(self.config.sign_call_gas_attachment_requirement_tera_gas),
+            NearToken::from_yoctonear(SIGN_DEPOSIT_YOCTONEAR),
+        );
+
+        let callback_gas = Gas::from_tgas(
+            self.config
+                .return_signature_and_clean_state_on_success_call_tera_gas,
+        );
+
+        let request = args_into_llm_inference_request(request);
+        let callback_args = serde_json::to_vec(&(&request,)).unwrap();
+        self.enqueue_yield_request(
+            method_names::RETURN_LLM_INFERENCE_AND_CLEAN_STATE_ON_SUCCESS,
+            callback_args,
+            callback_gas,
+            move |this, id| this.add_llm_inference_request(request, id),
+        );
+    }
+
+    #[handle_result]
+    pub fn respond_llm_inference(
+        &mut self,
+        request: dtos::LlmInferenceRequest,
+        response: dtos::LlmInferenceResponse,
+    ) -> Result<(), Error> {
+        let signer = Self::assert_caller_is_signer();
+
+        log!(
+            "respond_llm_inference: signer={}, request={:?}",
+            &signer,
+            &request
+        );
+
+        self.assert_caller_is_attested_participant_and_protocol_active();
+
+        if !self.protocol_state.is_running_or_resharing() {
+            return Err(InvalidState::ProtocolStateNotRunning.into());
+        }
+
+        if !self.accept_requests {
+            return Err(TeeError::TeeValidationFailed.into());
+        }
+
+        let domain = request.domain_id;
+        let public_key = self.public_key_extended(domain.0.into())?;
+
+        let signature_is_valid = match (&response.signature, public_key) {
+            (
+                dtos::SignatureResponse::Secp256k1(signature_response),
+                PublicKeyExtended::Secp256k1 { near_public_key },
+            ) => {
+                let payload_hash: [u8; 32] = response.payload_hash.0;
+
+                near_mpc_signature_verifier::verify_ecdsa_signature(
+                    signature_response,
+                    &payload_hash,
+                    &near_public_key,
+                )
+                .is_ok()
+            }
+            (signature_response, public_key_requested) => {
+                return Err(RespondError::SignatureSchemeMismatch {
+                    mpc_scheme: Box::new(signature_response.clone()),
+                    user_scheme: Box::new(public_key_requested),
+                }
+                .into());
+            }
+        };
+
+        if !signature_is_valid {
+            return Err(RespondError::InvalidSignature.into());
+        }
+
+        pending_requests::resolve_yields_for(
+            &mut self.pending_llm_inference_requests,
+            &request,
+            serde_json::to_vec(&response).unwrap(),
+        )
+    }
+
+    /// Presence check for a pending LLM inference request, exposed as a view
+    /// call. Only the `Some`/`None` distinction is meaningful; see
+    /// [`Self::get_pending_verify_foreign_tx_request`].
+    pub fn get_pending_llm_inference_request(
+        &self,
+        request: &dtos::LlmInferenceRequest,
+    ) -> Option<dtos::YieldIndex> {
+        self.pending_llm_inference_requests
+            .get(request)
+            .and_then(|q| q.first().cloned())
+    }
+
+    /// Yield-resume callback for a single queued LLM inference request.
+    ///
+    /// On success, returns the signed response to the original caller. On
+    /// timeout, pops this yield's slot from the pending-request map and fires
+    /// `fail_on_timeout`.
+    #[private]
+    pub fn return_llm_inference_and_clean_state_on_success(
+        &mut self,
+        request: dtos::LlmInferenceRequest,
+        #[callback_result] response: Result<dtos::LlmInferenceResponse, PromiseError>,
+    ) -> PromiseOrValue<dtos::LlmInferenceResponse> {
+        match response {
+            Ok(response) => PromiseOrValue::Value(response),
+            Err(_) => {
+                pending_requests::pop_oldest_pending_yield(
+                    &mut self.pending_llm_inference_requests,
+                    &request,
+                );
+                let fail_on_timeout_gas = Gas::from_tgas(self.config.fail_on_timeout_tera_gas);
+                let promise = Promise::new(env::current_account_id()).function_call(
+                    method_names::FAIL_ON_TIMEOUT.to_string(),
+                    vec![],
+                    NearToken::from_near(0),
+                    fail_on_timeout_gas,
+                );
+                near_sdk::PromiseOrValue::Promise(promise.as_return())
+            }
+        }
+    }
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[cfg(test)]
+#[expect(non_snake_case)]
+mod tests {
+    use super::*;
+    use crate::api::test_utils::{SharedSecretKey, basic_setup_with_protocol};
+    use assert_matches::assert_matches;
+    use dtos::{DomainId, LlmSignPayload, Protocol};
+    use k256::ecdsa::SigningKey;
+    use k256::{Secp256k1, elliptic_curve};
+    use near_sdk::test_utils::VMContextBuilder;
+    use near_sdk::{AccountId, testing_env};
+    use rand::SeedableRng;
+    use std::str::FromStr;
+
+    fn transfer_request_args() -> dtos::LlmInferenceRequestArgs {
+        dtos::LlmInferenceRequestArgs {
+            domain_id: DomainId::default().0.into(),
+            model_id: "Qwen2.5-1.5B-Instruct-4bit".to_string(),
+            prompt: "send 1 NEAR to alice.near".to_string(),
+            schema: r#"{"action":"transfer|swap|deposit"}"#.to_string(),
+        }
+    }
+
+    fn sign_llm_payload(
+        secret_key: &k256::Scalar,
+        payload: &LlmSignPayload,
+    ) -> dtos::LlmInferenceResponse {
+        let payload_hash = payload.compute_msg_hash().unwrap();
+        let secret_key_ec: elliptic_curve::SecretKey<Secp256k1> =
+            elliptic_curve::SecretKey::from_bytes(&secret_key.to_bytes()).unwrap();
+        let signing_key = SigningKey::from_bytes(&secret_key_ec.to_bytes()).unwrap();
+        let (signature, recovery_id) = signing_key
+            .sign_prehash_recoverable(&payload_hash.0)
+            .unwrap();
+        dtos::LlmInferenceResponse {
+            payload_hash,
+            signature: dtos::SignatureResponse::Secp256k1(
+                dtos::K256Signature::from_ecdsa_recoverable(&signature, recovery_id),
+            ),
+        }
+    }
+
+    fn llm_payload(request: &dtos::LlmInferenceRequest) -> LlmSignPayload {
+        LlmSignPayload {
+            request: request.clone(),
+            model_id: request.model_id.clone(),
+            output: r#"{"action":"transfer","to":"alice.near","amount":1}"#.to_string(),
+        }
+    }
+
+    #[test]
+    fn request_llm_inference__should_queue_duplicates_from_different_callers() {
+        // Given: an Llm purpose domain.
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, _) =
+            basic_setup_with_protocol(Protocol::CaitSith, dtos::DomainPurpose::Llm, &mut rng);
+        let request_args = transfer_request_args();
+        let request = args_into_llm_inference_request(request_args.clone());
+
+        // When: caller alice submits the request.
+        let alice = AccountId::from_str("alice.near").unwrap();
+        testing_env!(
+            VMContextBuilder::new()
+                .signer_account_id(alice.clone())
+                .predecessor_account_id(alice)
+                .current_account_id(context.current_account_id.clone())
+                .attached_deposit(NearToken::from_yoctonear(1))
+                .build()
+        );
+        contract.request_llm_inference(request_args.clone());
+
+        // And: caller bob submits the identical request.
+        let bob = AccountId::from_str("bob.near").unwrap();
+        testing_env!(
+            VMContextBuilder::new()
+                .signer_account_id(bob.clone())
+                .predecessor_account_id(bob)
+                .current_account_id(context.current_account_id.clone())
+                .attached_deposit(NearToken::from_yoctonear(1))
+                .build()
+        );
+        contract.request_llm_inference(request_args);
+
+        // Then: both yields are queued under the single (caller-agnostic) request key.
+        assert_eq!(
+            contract
+                .pending_llm_inference_requests
+                .get(&request)
+                .map(|q| q.len()),
+            Some(2),
+            "duplicate LLM inference requests from different callers should fan out",
+        );
+    }
+
+    #[test]
+    fn respond_llm_inference__should_drain_pending_request_when_response_is_valid() {
+        // Given
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, secret_key) =
+            basic_setup_with_protocol(Protocol::CaitSith, dtos::DomainPurpose::Llm, &mut rng);
+        testing_env!(context.clone());
+        let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
+            unreachable!();
+        };
+        let request_args = transfer_request_args();
+        let request = args_into_llm_inference_request(request_args.clone());
+        contract.request_llm_inference(request_args);
+        assert!(
+            contract
+                .get_pending_llm_inference_request(&request)
+                .is_some()
+        );
+
+        let payload = llm_payload(&request);
+        let response = sign_llm_payload(&secret_key, &payload);
+        crate::api::test_utils::with_active_participant_and_attested_context(&contract);
+
+        // When
+        contract
+            .respond_llm_inference(request.clone(), response.clone())
+            .expect("respond_llm_inference should succeed");
+
+        // Then
+        assert!(
+            contract
+                .get_pending_llm_inference_request(&request)
+                .is_none()
+        );
+        contract
+            .return_llm_inference_and_clean_state_on_success(request, Ok(response))
+            .detach();
+    }
+
+    #[test]
+    fn respond_llm_inference__should_reject_response_with_tampered_output() {
+        // Given: a response signed over a different output than the queued request's payload.
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, secret_key) =
+            basic_setup_with_protocol(Protocol::CaitSith, dtos::DomainPurpose::Llm, &mut rng);
+        testing_env!(context.clone());
+        let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
+            unreachable!();
+        };
+        let request_args = transfer_request_args();
+        let request = args_into_llm_inference_request(request_args.clone());
+        contract.request_llm_inference(request_args);
+
+        let payload = llm_payload(&request);
+        let response = sign_llm_payload(&secret_key, &payload);
+        let tampered_request = dtos::LlmInferenceRequest {
+            prompt: "send 999 NEAR to evil.near".to_string(),
+            ..request.clone()
+        };
+        crate::api::test_utils::with_active_participant_and_attested_context(&contract);
+
+        // When
+        let result = contract.respond_llm_inference(tampered_request, response);
+
+        // Then
+        assert_matches!(
+            result.unwrap_err(),
+            Error::InvalidParameters(crate::errors::InvalidParameters::RequestNotFound)
+        );
+        assert!(
+            contract
+                .get_pending_llm_inference_request(&request)
+                .is_some(),
+            "the pending request must remain unresolved",
+        );
+    }
+
+    #[test]
+    fn respond_llm_inference__should_reject_signature_over_wrong_payload_hash() {
+        // Given
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, secret_key) =
+            basic_setup_with_protocol(Protocol::CaitSith, dtos::DomainPurpose::Llm, &mut rng);
+        testing_env!(context.clone());
+        let SharedSecretKey::Secp256k1(secret_key) = secret_key else {
+            unreachable!();
+        };
+        let request_args = transfer_request_args();
+        let request = args_into_llm_inference_request(request_args.clone());
+        contract.request_llm_inference(request_args);
+
+        let payload = llm_payload(&request);
+        let mut response = sign_llm_payload(&secret_key, &payload);
+        response.payload_hash = dtos::Hash256([7u8; 32]);
+        crate::api::test_utils::with_active_participant_and_attested_context(&contract);
+
+        // When
+        let result = contract.respond_llm_inference(request.clone(), response);
+
+        // Then
+        assert_matches!(
+            result.unwrap_err(),
+            Error::Respond(RespondError::InvalidSignature)
+        );
+        assert!(
+            contract
+                .get_pending_llm_inference_request(&request)
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn llm_sign_payload__should_hash_deterministically() {
+        // Given
+        let request = args_into_llm_inference_request(transfer_request_args());
+
+        // When
+        let payload = llm_payload(&request);
+        let hash_a = payload.compute_msg_hash().unwrap();
+        let hash_b = payload.compute_msg_hash().unwrap();
+
+        // Then
+        assert_eq!(hash_a, hash_b);
+    }
+
+    #[rstest::rstest]
+    #[case(Protocol::CaitSith, dtos::DomainPurpose::Sign)]
+    #[case(Protocol::ConfidentialKeyDerivation, dtos::DomainPurpose::CKD)]
+    #[should_panic(expected = "this method requires Llm")]
+    fn request_llm_inference__should_reject_non_llm_domain(
+        #[case] protocol: Protocol,
+        #[case] purpose: dtos::DomainPurpose,
+    ) {
+        // Given
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (_context, mut contract, _sk) = basic_setup_with_protocol(protocol, purpose, &mut rng);
+
+        // When
+        contract.request_llm_inference(transfer_request_args());
+    }
+
+    #[test]
+    fn test_llm_inference_timeout() {
+        // Given
+        let mut rng = rand::rngs::StdRng::from_seed([42u8; 32]);
+        let (context, mut contract, _) =
+            basic_setup_with_protocol(Protocol::CaitSith, dtos::DomainPurpose::Llm, &mut rng);
+        testing_env!(
+            VMContextBuilder::new()
+                .signer_account_id(context.current_account_id.clone())
+                .predecessor_account_id(context.current_account_id.clone())
+                .current_account_id(context.current_account_id.clone())
+                .attached_deposit(NearToken::from_yoctonear(1))
+                .build()
+        );
+        let request_args = transfer_request_args();
+        let request = args_into_llm_inference_request(request_args);
+
+        // When
+        contract.request_llm_inference(transfer_request_args());
+
+        // Then
+        assert!(matches!(
+            contract.return_llm_inference_and_clean_state_on_success(
+                request.clone(),
+                Err(PromiseError::Failed)
+            ),
+            PromiseOrValue::Promise(_)
+        ));
+        assert!(
+            contract
+                .get_pending_llm_inference_request(&request)
+                .is_none()
+        );
+    }
+}

--- a/crates/contract/src/api/test_utils.rs
+++ b/crates/contract/src/api/test_utils.rs
@@ -276,6 +276,9 @@ impl MpcContract {
             pending_verify_foreign_tx_requests: LookupMap::new(
                 StorageKey::PendingVerifyForeignTxRequestsV3,
             ),
+            pending_llm_inference_requests: LookupMap::new(
+                StorageKey::PendingLlmInferenceRequestsV1,
+            ),
             accept_requests: true,
             proposed_updates: Default::default(),
             node_foreign_chain_support: Default::default(),

--- a/crates/contract/src/dto_mapping.rs
+++ b/crates/contract/src/dto_mapping.rs
@@ -1084,6 +1084,17 @@ pub fn args_into_verify_foreign_tx_request(
     }
 }
 
+pub fn args_into_llm_inference_request(
+    args: dtos::LlmInferenceRequestArgs,
+) -> dtos::LlmInferenceRequest {
+    dtos::LlmInferenceRequest {
+        domain_id: args.domain_id,
+        model_id: args.model_id,
+        prompt: args.prompt,
+        schema: args.schema,
+    }
+}
+
 #[cfg(test)]
 #[expect(non_snake_case)]
 mod tests {

--- a/crates/contract/src/lib.rs
+++ b/crates/contract/src/lib.rs
@@ -39,7 +39,7 @@ use crate::{
 };
 use config::Config;
 use near_mpc_contract_interface::types::{
-    CKDRequest, SignatureRequest, VerifyForeignTransactionRequest, YieldIndex,
+    CKDRequest, LlmInferenceRequest, SignatureRequest, VerifyForeignTransactionRequest, YieldIndex,
 };
 
 use near_sdk::{
@@ -57,6 +57,7 @@ pub struct MpcContract {
     pending_signature_requests: LookupMap<SignatureRequest, Vec<YieldIndex>>,
     pending_ckd_requests: LookupMap<CKDRequest, Vec<YieldIndex>>,
     pending_verify_foreign_tx_requests: LookupMap<VerifyForeignTransactionRequest, Vec<YieldIndex>>,
+    pending_llm_inference_requests: LookupMap<LlmInferenceRequest, Vec<YieldIndex>>,
     proposed_updates: ProposedUpdates,
     // TODO(#3475): drop this once we upgrade the contract and nodes start using
     // the new API.

--- a/crates/contract/src/primitives/domain.rs
+++ b/crates/contract/src/primitives/domain.rs
@@ -20,6 +20,7 @@ pub fn is_valid_protocol_for_purpose(purpose: DomainPurpose, protocol: Protocol)
             | (DomainPurpose::Sign, Protocol::DamgardEtAl)
             | (DomainPurpose::Sign, Protocol::Frost)
             | (DomainPurpose::ForeignTx, Protocol::CaitSith)
+            | (DomainPurpose::Llm, Protocol::CaitSith)
             | (DomainPurpose::CKD, Protocol::ConfidentialKeyDerivation)
     )
 }

--- a/crates/contract/src/storage_keys.rs
+++ b/crates/contract/src/storage_keys.rs
@@ -38,4 +38,5 @@ pub enum StorageKey {
     /// V3: `VerifyForeignTransactionRequest` gained `expected_payload_hash`, changing the
     /// borsh key encoding, so entries pending at upgrade time are abandoned under V2.
     PendingVerifyForeignTxRequestsV3,
+    PendingLlmInferenceRequestsV1,
 }

--- a/crates/contract/src/v3_14_0_state.rs
+++ b/crates/contract/src/v3_14_0_state.rs
@@ -262,6 +262,9 @@ impl From<MpcContract> for crate::MpcContract {
             pending_verify_foreign_tx_requests: LookupMap::new(
                 crate::storage_keys::StorageKey::PendingVerifyForeignTxRequestsV3,
             ),
+            pending_llm_inference_requests: LookupMap::new(
+                crate::storage_keys::StorageKey::PendingLlmInferenceRequestsV1,
+            ),
             proposed_updates: old.proposed_updates,
             node_foreign_chain_support: old.node_foreign_chain_support,
             config: old.config.into(),

--- a/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
+++ b/crates/contract/tests/snapshots/abi__abi_has_not_changed.snap
@@ -395,6 +395,35 @@ expression: abi
         }
       },
       {
+        "name": "get_pending_llm_inference_request",
+        "doc": " Presence check for a pending LLM inference request, exposed as a view\n call. Only the `Some`/`None` distinction is meaningful; see\n [`Self::get_pending_verify_foreign_tx_request`].",
+        "kind": "view",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "request",
+              "type_schema": {
+                "$ref": "#/definitions/LlmInferenceRequest"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/YieldIndex"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        }
+      },
+      {
         "name": "get_pending_request",
         "doc": " Presence check for a pending signature request, exposed as a view call.\n\n **The returned [`dtos::YieldIndex`] is an arbitrary representative, not \"the\" yield\n for this request.** Since the duplicate-request fan-out feature (PR #3187),\n a single request key can have N queued yields; this method returns the head of the\n queue. Callers that need to act on the full set are wrong to use this. The\n only correct interpretation is presence: `Some(_)` vs `None`.\n\n The `Option<dtos::YieldIndex>` shape is retained for JSON wire compatibility with\n out-of-tree consumers; the in-tree caller (`tx_sender::observe_tx_result`)\n only matches on presence. Prefer a `bool`-shaped accessor if one is added.",
         "kind": "view",
@@ -1041,6 +1070,25 @@ expression: abi
               "name": "request",
               "type_schema": {
                 "$ref": "#/definitions/CKDRequestArgs"
+              }
+            }
+          ]
+        }
+      },
+      {
+        "name": "request_llm_inference",
+        "doc": " Submit an LLM inference request. MPC nodes run the prompt through the\n pinned model independently and sign only on byte-identical output.",
+        "kind": "call",
+        "modifiers": [
+          "payable"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "request",
+              "type_schema": {
+                "$ref": "#/definitions/LlmInferenceRequestArgs"
               }
             }
           ]
@@ -1755,6 +1803,33 @@ expression: abi
         }
       },
       {
+        "name": "respond_llm_inference",
+        "kind": "call",
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "request",
+              "type_schema": {
+                "$ref": "#/definitions/LlmInferenceRequest"
+              }
+            },
+            {
+              "name": "response",
+              "type_schema": {
+                "$ref": "#/definitions/LlmInferenceResponse"
+              }
+            }
+          ]
+        },
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "type": "null"
+          }
+        }
+      },
+      {
         "name": "respond_verify_foreign_tx",
         "kind": "call",
         "params": {
@@ -1811,6 +1886,39 @@ expression: abi
           "serialization_type": "json",
           "type_schema": {
             "$ref": "#/definitions/PromiseOrValueCKDResponse"
+          }
+        }
+      },
+      {
+        "name": "return_llm_inference_and_clean_state_on_success",
+        "doc": " Yield-resume callback for a single queued LLM inference request.\n\n On success, returns the signed response to the original caller. On\n timeout, pops this yield's slot from the pending-request map and fires\n `fail_on_timeout`.",
+        "kind": "call",
+        "modifiers": [
+          "private"
+        ],
+        "params": {
+          "serialization_type": "json",
+          "args": [
+            {
+              "name": "request",
+              "type_schema": {
+                "$ref": "#/definitions/LlmInferenceRequest"
+              }
+            }
+          ]
+        },
+        "callbacks": [
+          {
+            "serialization_type": "json",
+            "type_schema": {
+              "$ref": "#/definitions/LlmInferenceResponse"
+            }
+          }
+        ],
+        "result": {
+          "serialization_type": "json",
+          "type_schema": {
+            "$ref": "#/definitions/PromiseOrValueLlmInferenceResponse"
           }
         }
       },
@@ -3298,6 +3406,13 @@ expression: abi
               ]
             },
             {
+              "description": "Domain is used by `request_llm_inference()`.",
+              "type": "string",
+              "enum": [
+                "Llm"
+              ]
+            },
+            {
               "description": "Domain is used by `request_app_private_key()` (Confidential Key Derivation).",
               "type": "string",
               "enum": [
@@ -4247,6 +4362,69 @@ expression: abi
             }
           ]
         },
+        "LlmInferenceRequest": {
+          "type": "object",
+          "required": [
+            "domain_id",
+            "model_id",
+            "prompt",
+            "schema"
+          ],
+          "properties": {
+            "domain_id": {
+              "$ref": "#/definitions/DomainId"
+            },
+            "model_id": {
+              "type": "string"
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "schema": {
+              "type": "string"
+            }
+          }
+        },
+        "LlmInferenceRequestArgs": {
+          "type": "object",
+          "required": [
+            "domain_id",
+            "model_id",
+            "prompt",
+            "schema"
+          ],
+          "properties": {
+            "domain_id": {
+              "$ref": "#/definitions/DomainId"
+            },
+            "model_id": {
+              "description": "The model the caller expects, recorded in the signed payload for auditability.",
+              "type": "string"
+            },
+            "prompt": {
+              "type": "string"
+            },
+            "schema": {
+              "description": "JSON Schema the output must satisfy. Stored and hashed opaquely; validation is node-side.",
+              "type": "string"
+            }
+          }
+        },
+        "LlmInferenceResponse": {
+          "type": "object",
+          "required": [
+            "payload_hash",
+            "signature"
+          ],
+          "properties": {
+            "payload_hash": {
+              "$ref": "#/definitions/Hash256"
+            },
+            "signature": {
+              "$ref": "#/definitions/SignatureResponse"
+            }
+          }
+        },
         "MeasurementVoteAction": {
           "description": "The action a participant is voting for on an OS measurement set.",
           "oneOf": [
@@ -4516,6 +4694,21 @@ expression: abi
             },
             "big_y": {
               "$ref": "#/definitions/Bls12381G1PublicKey"
+            }
+          }
+        },
+        "PromiseOrValueLlmInferenceResponse": {
+          "type": "object",
+          "required": [
+            "payload_hash",
+            "signature"
+          ],
+          "properties": {
+            "payload_hash": {
+              "$ref": "#/definitions/Hash256"
+            },
+            "signature": {
+              "$ref": "#/definitions/SignatureResponse"
             }
           }
         },

--- a/crates/near-mpc-contract-interface/src/call_args.rs
+++ b/crates/near-mpc-contract-interface/src/call_args.rs
@@ -3,11 +3,11 @@
 use crate::types::{
     AccountId, Attestation, BackupServiceInfo, CKDRequest, CKDRequestArgs, CKDResponse, ChainEntry,
     DestinationNodeInfo, DomainConfig, Ed25519PublicKey, EpochId, ForeignChain,
-    GovernanceThresholdParameters, InitConfig, KeyEventId, Keyset,
-    ProposedGovernanceThresholdParameters, PublicKey, SignRequestArgs, SignatureRequest,
-    SignatureResponse, SupportedForeignChains, TeeVerifierCodeHash, UpdateId,
-    VerifyForeignTransactionRequest, VerifyForeignTransactionRequestArgs,
-    VerifyForeignTransactionResponse,
+    GovernanceThresholdParameters, InitConfig, KeyEventId, Keyset, LlmInferenceRequest,
+    LlmInferenceRequestArgs, LlmInferenceResponse, ProposedGovernanceThresholdParameters,
+    PublicKey, SignRequestArgs, SignatureRequest, SignatureResponse, SupportedForeignChains,
+    TeeVerifierCodeHash, UpdateId, VerifyForeignTransactionRequest,
+    VerifyForeignTransactionRequestArgs, VerifyForeignTransactionResponse,
 };
 use near_mpc_bounded_collections::NonEmptyBTreeMap;
 use serde::{Deserialize, Serialize};
@@ -31,6 +31,11 @@ pub struct RequestAppPrivateKeyArgs {
 #[derive(Serialize, Debug, derive_more::Constructor)]
 pub struct VerifyForeignTransactionArgs {
     pub request: VerifyForeignTransactionRequestArgs,
+}
+
+#[derive(Serialize, Debug, derive_more::Constructor)]
+pub struct RequestLlmInferenceArgs {
+    pub request: LlmInferenceRequestArgs,
 }
 
 #[derive(Serialize, Debug, derive_more::Constructor)]
@@ -93,6 +98,12 @@ pub struct VerifyForeignTransactionRespondArgs {
     pub response: VerifyForeignTransactionResponse,
 }
 
+#[derive(Serialize, Debug, Deserialize, Clone, derive_more::Constructor)]
+pub struct LlmInferenceRespondArgs {
+    pub request: LlmInferenceRequest,
+    pub response: LlmInferenceResponse,
+}
+
 #[derive(Serialize, Debug, derive_more::Constructor)]
 pub struct GetPendingSignatureRequestArgs {
     pub request: SignatureRequest,
@@ -106,6 +117,11 @@ pub struct GetPendingCKDRequestArgs {
 #[derive(Serialize, Debug, derive_more::Constructor)]
 pub struct GetPendingVerifyForeignTxRequestArgs {
     pub request: VerifyForeignTransactionRequest,
+}
+
+#[derive(Serialize, Debug, derive_more::Constructor)]
+pub struct GetPendingLlmInferenceRequestArgs {
+    pub request: LlmInferenceRequest,
 }
 
 #[derive(Serialize, Debug, derive_more::Constructor)]

--- a/crates/near-mpc-contract-interface/src/client.rs
+++ b/crates/near-mpc-contract-interface/src/client.rs
@@ -8,10 +8,10 @@ use near_contract_transport::{CallContract, FunctionCallArgs, NearGas, NearToken
 
 use crate::call_args::{
     InitArgs, RegisterBackupServiceArgs, RegisterForeignChainSupportArgs,
-    RegisterForeignChainsConfigArgs, RequestAppPrivateKeyArgs, SignArgs, StartNodeMigrationArgs,
-    SubmitParticipantInfoArgs, UpdateParticipantUrlArgs, VerifyForeignTransactionArgs,
-    VoteAddDomainsArgs, VoteCancelKeygenArgs, VoteNewParametersArgs, VoteTeeVerifierChangeArgs,
-    VoteUpdateArgs, VoteUpdateForeignChainProvidersArgs,
+    RegisterForeignChainsConfigArgs, RequestAppPrivateKeyArgs, RequestLlmInferenceArgs, SignArgs,
+    StartNodeMigrationArgs, SubmitParticipantInfoArgs, UpdateParticipantUrlArgs,
+    VerifyForeignTransactionArgs, VoteAddDomainsArgs, VoteCancelKeygenArgs, VoteNewParametersArgs,
+    VoteTeeVerifierChangeArgs, VoteUpdateArgs, VoteUpdateForeignChainProvidersArgs,
 };
 use crate::deposits::{
     DepositOverflowError, MINIMUM_NODE_MANAGEMENT_DEPOSIT_YOCTONEAR, SIGN_DEPOSIT_YOCTONEAR,
@@ -19,17 +19,17 @@ use crate::deposits::{
 };
 use crate::method_names::{
     CANCEL_NODE_MIGRATION, INIT, PROPOSE_UPDATE, REGISTER_BACKUP_SERVICE,
-    REGISTER_FOREIGN_CHAIN_SUPPORT, REGISTER_FOREIGN_CHAINS_CONFIG, REQUEST_APP_PRIVATE_KEY, SIGN,
-    START_NODE_MIGRATION, SUBMIT_PARTICIPANT_INFO, UPDATE_PARTICIPANT_URL,
-    VERIFY_FOREIGN_TRANSACTION, VERIFY_TEE, VOTE_ADD_DOMAINS, VOTE_CANCEL_KEYGEN,
-    VOTE_CANCEL_RESHARING, VOTE_NEW_PARAMETERS, VOTE_TEE_VERIFIER_CHANGE, VOTE_UPDATE,
-    VOTE_UPDATE_FOREIGN_CHAIN_PROVIDERS,
+    REGISTER_FOREIGN_CHAIN_SUPPORT, REGISTER_FOREIGN_CHAINS_CONFIG, REQUEST_APP_PRIVATE_KEY,
+    REQUEST_LLM_INFERENCE, SIGN, START_NODE_MIGRATION, SUBMIT_PARTICIPANT_INFO,
+    UPDATE_PARTICIPANT_URL, VERIFY_FOREIGN_TRANSACTION, VERIFY_TEE, VOTE_ADD_DOMAINS,
+    VOTE_CANCEL_KEYGEN, VOTE_CANCEL_RESHARING, VOTE_NEW_PARAMETERS, VOTE_TEE_VERIFIER_CHANGE,
+    VOTE_UPDATE, VOTE_UPDATE_FOREIGN_CHAIN_PROVIDERS,
 };
 use crate::types::{
     AccountId, Attestation, BackupServiceInfo, CKDAppPublicKey, CKDRequestArgs, ChainEntry,
     DestinationNodeInfo, DomainConfig, Ed25519PublicKey, EpochId, ForeignChain,
-    ForeignChainsConfig, GovernanceThresholdParameters, InitConfig, PayloadBytesError,
-    ProposeUpdateArgs, ProposedGovernanceThresholdParameters, SignRequestArgs,
+    ForeignChainsConfig, GovernanceThresholdParameters, InitConfig, LlmInferenceRequestArgs,
+    PayloadBytesError, ProposeUpdateArgs, ProposedGovernanceThresholdParameters, SignRequestArgs,
     SupportedForeignChains, TeeVerifierCodeHash, UpdateId, VerifyForeignTransactionRequestArgs,
 };
 use near_mpc_bounded_collections::NonEmptyBTreeMap;
@@ -131,6 +131,20 @@ impl<C: CallContract> MpcContractHandle<C> {
         let args = serde_json::to_vec(&VerifyForeignTransactionArgs::new(request))?;
         self.call(FunctionCallArgs::new(
             VERIFY_FOREIGN_TRANSACTION,
+            args,
+            SIGN_GAS,
+            NearToken::from_yoctonear(SIGN_DEPOSIT_YOCTONEAR),
+        ))
+        .await
+    }
+
+    pub async fn request_llm_inference(
+        &self,
+        request: LlmInferenceRequestArgs,
+    ) -> Result<C::Output, MpcContractHandleError<C::Error>> {
+        let args = serde_json::to_vec(&RequestLlmInferenceArgs::new(request))?;
+        self.call(FunctionCallArgs::new(
+            REQUEST_LLM_INFERENCE,
             args,
             SIGN_GAS,
             NearToken::from_yoctonear(SIGN_DEPOSIT_YOCTONEAR),
@@ -545,6 +559,15 @@ mod tests {
             .await
             .unwrap();
         handle
+            .request_llm_inference(crate::types::LlmInferenceRequestArgs {
+                domain_id: DomainId(0),
+                model_id: "test-model".to_string(),
+                prompt: "test prompt".to_string(),
+                schema: "{}".to_string(),
+            })
+            .await
+            .unwrap();
+        handle
             .propose_update(ProposeUpdateArgs {
                 code: Some(vec![7u8; 4]),
                 config: None,
@@ -633,7 +656,7 @@ mod tests {
 
         // Then
         let calls = caller.calls.lock().unwrap();
-        assert_eq!(calls.len(), 21);
+        assert_eq!(calls.len(), 22);
         let catalog = calls
             .iter()
             .map(|(contract_id, call)| render(contract_id, call))

--- a/crates/near-mpc-contract-interface/src/lib.rs
+++ b/crates/near-mpc-contract-interface/src/lib.rs
@@ -18,6 +18,9 @@ pub mod types {
     pub use participants::{ParticipantId, ParticipantInfo, Participants};
 
     pub use ckd::{CKDAppPublicKey, CKDAppPublicKeyPV, CKDRequestArgs, CkdAppId};
+    pub use llm::{
+        LlmInferenceRequest, LlmInferenceRequestArgs, LlmInferenceResponse, LlmSignPayload,
+    };
     pub use near_mpc_crypto_types::CKDResponse;
     pub use near_mpc_crypto_types::ckd::CKDRequest;
 
@@ -60,6 +63,7 @@ pub mod types {
     mod ckd;
     mod config;
     mod foreign_chain;
+    mod llm;
     mod node_migrations;
     mod participants;
     mod primitives;

--- a/crates/near-mpc-contract-interface/src/method_names.rs
+++ b/crates/near-mpc-contract-interface/src/method_names.rs
@@ -7,11 +7,13 @@
 pub const SIGN: &str = "sign";
 pub const REQUEST_APP_PRIVATE_KEY: &str = "request_app_private_key";
 pub const VERIFY_FOREIGN_TRANSACTION: &str = "verify_foreign_transaction";
+pub const REQUEST_LLM_INFERENCE: &str = "request_llm_inference";
 
 // Node response methods
 pub const RESPOND: &str = "respond";
 pub const RESPOND_CKD: &str = "respond_ckd";
 pub const RESPOND_VERIFY_FOREIGN_TX: &str = "respond_verify_foreign_tx";
+pub const RESPOND_LLM_INFERENCE: &str = "respond_llm_inference";
 
 // Vote methods
 pub const VOTE_PK: &str = "vote_pk";
@@ -67,6 +69,8 @@ pub const RETURN_SIGNATURE_AND_CLEAN_STATE_ON_SUCCESS: &str =
 pub const RETURN_CK_AND_CLEAN_STATE_ON_SUCCESS: &str = "return_ck_and_clean_state_on_success";
 pub const RETURN_VERIFY_FOREIGN_TX_AND_CLEAN_STATE_ON_SUCCESS: &str =
     "return_verify_foreign_tx_and_clean_state_on_success";
+pub const RETURN_LLM_INFERENCE_AND_CLEAN_STATE_ON_SUCCESS: &str =
+    "return_llm_inference_and_clean_state_on_success";
 pub const RESOLVE_VERIFICATION: &str = "resolve_verification";
 pub const FAIL_ATTESTATION_SUBMISSION: &str = "fail_attestation_submission";
 
@@ -84,6 +88,7 @@ pub const PROPOSED_UPDATES: &str = "proposed_updates";
 pub const GET_PENDING_REQUEST: &str = "get_pending_request";
 pub const GET_PENDING_CKD_REQUEST: &str = "get_pending_ckd_request";
 pub const GET_PENDING_VERIFY_FOREIGN_TX_REQUEST: &str = "get_pending_verify_foreign_tx_request";
+pub const GET_PENDING_LLM_INFERENCE_REQUEST: &str = "get_pending_llm_inference_request";
 pub const GET_TEE_ACCOUNTS: &str = "get_tee_accounts";
 pub const AVAILABLE_ATTESTATION_GRANTS: &str = "available_attestation_grants";
 pub const TEE_VERIFIER_ACCOUNT_ID: &str = "tee_verifier_account_id";

--- a/crates/near-mpc-contract-interface/src/snapshots/near_mpc_contract_interface__client__tests__mpc_contract_handle__should_match_the_wire_format_catalog.snap
+++ b/crates/near-mpc-contract-interface/src/snapshots/near_mpc_contract_interface__client__tests__mpc_contract_handle__should_match_the_wire_format_catalog.snap
@@ -39,6 +39,12 @@ deposit:  1 yoctoNEAR
 args:     {"request":{"request":{"Bitcoin":{"tx_id":"0707070707070707070707070707070707070707070707070707070707070707","confirmations":1,"extractors":["BlockHash"]}},"domain_id":0,"payload_version":1}}
 
 contract: mpc.near
+method:   request_llm_inference
+gas:      15.0 Tgas
+deposit:  1 yoctoNEAR
+args:     {"request":{"domain_id":0,"model_id":"test-model","prompt":"test prompt","schema":"{}"}}
+
+contract: mpc.near
 method:   propose_update
 gas:      300.0 Tgas
 deposit:  0.32772 NEAR

--- a/crates/near-mpc-contract-interface/src/types/llm.rs
+++ b/crates/near-mpc-contract-interface/src/types/llm.rs
@@ -1,0 +1,114 @@
+//! LLM inference request/response DTOs: the natural-language prompt path
+//! through the MPC contract, signed by an `Llm` purpose domain.
+
+use crate::types::{DomainId, Hash256};
+use borsh::{BorshDeserialize, BorshSerialize};
+use near_mpc_crypto_types::SignatureResponse;
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct LlmInferenceRequestArgs {
+    pub domain_id: DomainId,
+    /// The model the caller expects, recorded in the signed payload for auditability.
+    pub model_id: String,
+    pub prompt: String,
+    /// JSON Schema the output must satisfy. Stored and hashed opaquely; validation
+    /// is node-side.
+    pub schema: String,
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct LlmInferenceRequest {
+    pub domain_id: DomainId,
+    pub model_id: String,
+    pub prompt: String,
+    pub schema: String,
+}
+
+/// Everything the MPC network attests: each participating node ran the same
+/// prompt through `model_id` and produced byte-identical `output`.
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct LlmSignPayload {
+    pub request: LlmInferenceRequest,
+    pub model_id: String,
+    pub output: String,
+}
+
+impl LlmSignPayload {
+    pub fn compute_msg_hash(&self) -> std::io::Result<Hash256> {
+        let mut hasher = sha2::Sha256::new();
+        borsh::BorshSerialize::serialize(self, &mut hasher)?;
+        Ok(Hash256(hasher.finalize().into()))
+    }
+}
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    Ord,
+    PartialOrd,
+    Hash,
+    Serialize,
+    Deserialize,
+    BorshSerialize,
+    BorshDeserialize,
+)]
+#[cfg_attr(
+    all(feature = "abi", not(target_arch = "wasm32")),
+    derive(schemars::JsonSchema, borsh::BorshSchema)
+)]
+pub struct LlmInferenceResponse {
+    pub payload_hash: Hash256,
+    pub signature: SignatureResponse,
+}

--- a/crates/near-mpc-contract-interface/src/types/state.rs
+++ b/crates/near-mpc-contract-interface/src/types/state.rs
@@ -89,6 +89,8 @@ pub enum DomainPurpose {
     Sign,
     /// Domain is used by `verify_foreign_transaction()`.
     ForeignTx,
+    /// Domain is used by `request_llm_inference()`.
+    Llm,
     /// Domain is used by `request_app_private_key()` (Confidential Key Derivation).
     CKD,
 }

--- a/docs/development/localnet/args/add_domain.json
+++ b/docs/development/localnet/args/add_domain.json
@@ -27,6 +27,13 @@
       "protocol": "CaitSith",
       "reconstruction_threshold": 2,
       "purpose": "ForeignTx"
+    },
+    {
+      "id": 4,
+      "curve": "Secp256k1",
+      "protocol": "CaitSith",
+      "reconstruction_threshold": 2,
+      "purpose": "Llm"
     }
   ]
 }


### PR DESCRIPTION
Part of the MPC verified LLM intents hackathon demo. Contract side only; node side follows.

Adds a `DomainPurpose::Llm` domain paired with CaitSith, plus a yield/resume request flow cloned from the foreign tx path:

* `request_llm_inference { prompt, schema, model_id }`: payable, validates preconditions against an Llm domain, queues into `pending_llm_inference_requests`.
* `respond_llm_inference`: attested participant only, verifies the ECDSA signature over `SHA256(borsh(LlmSignPayload))` against the domain root key, drains the fan out queue.
* `return_llm_inference_and_clean_state_on_success`: private yield resume callback, pops the yield and fires `fail_on_timeout` on timeout.
* `get_pending_llm_inference_request`: presence view.
* `LlmSignPayload::compute_msg_hash` pins the signed payload as request plus model id plus output.

The schema is stored and hashed opaquely; the contract never parses it. Validation is node side, magnitudes are the consumer contract's concern.